### PR TITLE
chore(ci): add cross-tool-compat.yml — Phase 2 placeholder (Phase 0)

### DIFF
--- a/.github/workflows/cross-tool-compat.yml
+++ b/.github/workflows/cross-tool-compat.yml
@@ -1,0 +1,50 @@
+# ---
+# Phase 0 placeholder. Phase 2 implementation will:
+#   (a) install julia + BiblioFetch.jl,
+#   (b) write a TOML store entry from BiblioFetch.jl,
+#   (c) read it via doiget-core::store,
+#   (d) assert byte-for-byte parity per docs/STORE.md schema_version.
+# Reserved by ADR-0004 (BiblioFetch.jl coexistence — shared store contract).
+#
+# Until Phase 2 lands, this workflow only prints an identifying message and
+# exits 0. It exists now so the required-status-check slot is reserved and
+# branch protection can reference a stable workflow name from Phase 0 onward.
+# ---
+
+name: cross-tool-compat
+
+on:
+  pull_request:
+    paths:
+      - 'crates/doiget-core/src/store/**'
+      - 'docs/STORE.md'
+      - 'docs/DECISIONS/0004-bibliofetch-coexistence.md'
+      - '.github/workflows/cross-tool-compat.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/doiget-core/src/store/**'
+      - 'docs/STORE.md'
+      - 'docs/DECISIONS/0004-bibliofetch-coexistence.md'
+      - '.github/workflows/cross-tool-compat.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-tool-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  placeholder:
+    name: placeholder (Phase 2 will replace)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   # v4.1.1
+
+      - name: Announce placeholder status
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "cross-tool-compat: Phase 0 placeholder — no round-trip executed."
+          echo "Phase 2 will add BiblioFetch.jl <-> doiget Store round-trip parity (ADR-0004)."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/cross-tool-compat.yml` as a Phase 2 placeholder.
Reserves the workflow slot (and the required-status-check name) for the
BiblioFetch.jl ↔ doiget Store round-trip parity test mandated by ADR-0004.
Phase 0 ships a job that prints an identifying message and exits 0 — no
real round-trip is exercised yet. Phase 2 will replace the body with:
install julia + BiblioFetch.jl, write a TOML store entry from
BiblioFetch.jl, read it via `doiget-core::store`, and assert byte-for-byte
parity per `docs/STORE.md` `schema_version`.

## Phase 0 deliverable closed

Closes the final unchecked CI workflow item under `docs/PHASES.md` §2:

> - [ ] `.github/workflows/cross-tool-compat.yml` (BiblioFetch.jl round-trip; placeholder until Phase 2)

## Scope note (placeholder only — real parity test in Phase 2)

This PR is intentionally narrow:

- One new file: `.github/workflows/cross-tool-compat.yml`. No other path is touched.
- The job does not install Julia, does not invoke BiblioFetch.jl, does not write to
  `~/papers/`, and does not assert any parity. It is a stable name + green status
  check, nothing more.
- Triggers are scoped via `paths:` to the surfaces that can affect the shared
  store contract: `crates/doiget-core/src/store/**`, `docs/STORE.md`,
  `docs/DECISIONS/0004-bibliofetch-coexistence.md`, and the workflow file itself.
- Least-privilege `permissions: contents: read`, plus a concurrency group with
  `cancel-in-progress: true`.
- `actions/checkout` is SHA-pinned (per ADR-0013) to the same `v4.1.1` SHA already
  used by `ci.yml`, `posture-lint.yml`, etc., for drop-in consistency.

## ADR-0004 link

[`docs/DECISIONS/0004-bibliofetch-coexistence.md`](../blob/main/docs/DECISIONS/0004-bibliofetch-coexistence.md)
— BiblioFetch.jl coexistence — shared store contract. The round-trip CI test is
also called out in [`docs/STORE.md` §9](../blob/main/docs/STORE.md).

## Test plan

- [ ] CI workflow `cross-tool-compat / placeholder (Phase 2 will replace)` runs and reports success on this PR.
- [ ] Workflow only triggers for the listed paths (no broad PR-wide noise).
- [ ] `actions/checkout` SHA matches the pin used elsewhere in the repo.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>