### PR TITLE
chore: commit Cargo.lock and drop temporary generate-lockfile CI step

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,11 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      # rustsec/audit-check requires Cargo.lock; Phase 0 keeps it uncommitted
-      # (see PR description), so generate it on the runner. Drop this step
-      # once Cargo.lock lands in-tree.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Commit `Cargo.lock` per Phase 0 deliverable checklist (`docs/PHASES.md` §2 Configuration files).
- Remove the temporary `cargo generate-lockfile` step from `audit.yml` (commit 3b6ea0e), now that the lockfile is in-tree.

## Phase 0 deliverable closed

`Cargo.lock` (Configuration files row).

## Test plan

- [ ] `cargo audit` job green using committed lockfile
- [ ] CI matrix (3-OS × oa-only) still green
- [ ] No unexpected dep drift vs the runner-side resolution from PR #20

## Notes

This PR completes the audit-side cleanup loop started in commit [3b6ea0e](https://github.com/sotashimozono/doiget/commit/3b6ea0e): the temporary runner-side lockfile generation step is no longer needed now that `Cargo.lock` is committed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>