### PR TITLE
chore: add .gitattributes for LF normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Enforce LF line endings across the repo to prevent CRLF drift on Windows checkouts.
+# Added per Phase 0 hygiene cleanup (Wave 1 agent feedback flagged CRLF warnings on Windows commits).
+
+# Catch-all default: detect text vs binary, normalize text to LF in-tree.
+* text=auto eol=lf
+
+# Source / config — explicit LF
+*.rs            text eol=lf
+*.toml          text eol=lf
+*.json          text eol=lf
+*.yml           text eol=lf
+*.yaml          text eol=lf
+*.md            text eol=lf
+*.sh            text eol=lf
+*.lock          text eol=lf
+Cargo.lock      text eol=lf
+Cargo.toml      text eol=lf
+*.cargo/config.toml text eol=lf
+
+# Windows-script files keep CRLF (cmd.exe / batch interpreters require it).
+# PowerShell stays LF — modern pwsh handles LF fine on linux/macos checkouts.
+*.bat           text eol=crlf
+*.cmd           text eol=crlf
+*.ps1           text eol=lf
+
+# Binary assets — never normalize, never diff as text.
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.pdf           binary
+*.zip           binary
+*.tar.gz        binary
+*.ico           binary
+
+# Lockfile diff suppression in PRs (still tracked + LF-normalized; only inline diff hidden).
+Cargo.lock      -diff
+Cargo.lock      linguist-generated=true


### PR DESCRIPTION
## Summary
- Adds a single new file `.gitattributes` at repo root enforcing LF line endings repo-wide (with explicit CRLF carve-out for `*.bat` / `*.cmd`, binary block for images/archives, and `Cargo.lock -diff` + `linguist-generated=true` for cleaner PR diffs and language stats).
- No source files touched; this is purely a hygiene config drop.

## Why
Wave 1 agents repeatedly hit CRLF/LF warnings when committing from Windows (see PR #26 and PR #28 reports). Without `.gitattributes`, every Windows contributor's `core.autocrlf` setting silently rewrites line endings in the index, producing noisy diffs and "warning: in the working copy of ..., LF will be replaced by CRLF" spam. This file pins LF in-tree so checkouts stay clean regardless of contributor OS.

## Scope note
This PR ONLY adds the new `.gitattributes` file. It deliberately does NOT run `git add --renormalize .` — that sweep would touch files currently being edited in the in-flight Wave 1 / Wave 2 PRs and is tracked as a separate hygiene concern to be done after the wave merges.

## Test plan
- [x] CI green (no source change, only a new config file)
- [x] Existing files unchanged (`git diff main..HEAD` shows only `.gitattributes` added, +37 / -0)
- [x] No `git add --renormalize` performed

## References
- `docs/PHASES.md` §2 (Phase 0 hygiene deliverable context)
- Wave 1 PR reports #26, #28 (CRLF warning evidence)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>