### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.rs]
+indent_size = 4
+max_line_length = 100
+
+[*.toml]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{bat,cmd}]
+end_of_line = crlf


### PR DESCRIPTION
## Summary

- Adds repo-root `.editorconfig` so EditorConfig-aware editors apply consistent indentation, charset, and line endings without per-developer overrides.

## Settings

- Global (`[*]`): UTF-8, LF line endings, final newline, trim trailing whitespace, space indents.
- `*.rs`: 4-space indent, max line length 100 (matches Rust 2021 / `rustfmt` defaults; no `rustfmt.toml` in tree, so defaults apply).
- `*.toml`, `*.{yml,yaml}`, `*.json`, `*.md`: 2-space indent.
- `*.md`: `trim_trailing_whitespace = false` (Markdown uses trailing two spaces for `<br>`).
- `*.{bat,cmd}`: CRLF line endings (Windows shell scripts).
- No `[Makefile]` block — repo has no Makefile (verified).

## Why

Cross-platform editor consistency complementing the `.gitattributes` from PR-2A (Wave 2). Where `.gitattributes` enforces normalization at git boundaries (checkin/checkout), `.editorconfig` enforces what the editor types into a file as you edit. They are complementary: together they prevent "fixed indentation in commit N, reverted in commit N+1" churn and make contributor onboarding (especially Windows ↔ Unix) friction-free.

Verified against existing in-tree style:
- `crates/doiget-core/src/lib.rs` already uses 4-space indent (matches `[*.rs]`).
- `clippy.toml` declares MSRV 1.86 and `disallowed-types`; no indent/line-width settings, so this PR introduces none of those concerns into clippy's scope.

## Test plan

- [ ] CI green (no source change — pure config file).
- [ ] Settings match existing in-tree style (verified locally: no `*.rs` file under `crates/` uses 2-space indent; no rustfmt drift).
- [ ] `.editorconfig` validates as INI (28 lines, ASCII, LF-only line endings on disk).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>