### PR TITLE
chore: add .github/CODEOWNERS — auto-review assignment for NORMATIVE files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# CODEOWNERS for doiget
+#
+# GitHub auto-assigns the matching owners as required reviewers on every PR
+# that touches the listed paths (last matching pattern wins per CODEOWNERS rules).
+# NORMATIVE files require maintainer review per ADR-0014 (docs/DECISIONS/0014-docs-class-system.md).
+# This file does NOT enforce review — branch protection rules do (see PHASES.md §2 last subsection).
+
+# Default catch-all (least specific; explicit entries below override).
+*  @sotashimozono
+
+# ---- NORMATIVE docs (per docs/PHASES.md §2) ----
+/docs/LEGAL.md            @sotashimozono
+/docs/SCOPE.md            @sotashimozono
+/docs/SECURITY.md         @sotashimozono
+/docs/STORE.md            @sotashimozono
+/docs/SAFEKEY.md          @sotashimozono
+/docs/CAPABILITY.md       @sotashimozono
+/docs/PROVENANCE_LOG.md   @sotashimozono
+/docs/ERRORS.md           @sotashimozono
+/docs/CONFIG.md           @sotashimozono
+/docs/CACHE.md            @sotashimozono
+/docs/PUBLIC_API.md       @sotashimozono
+/docs/MCP_TOOLS.md        @sotashimozono
+/docs/SOURCES.md          @sotashimozono
+
+# ---- ADR directory ----
+# ADRs are append-only NORMATIVE; no in-place edits, only supersedes.
+/docs/DECISIONS/  @sotashimozono
+
+# ---- CI workflows ----
+/.github/workflows/  @sotashimozono
+
+# ---- Cargo workspace ----
+/Cargo.toml  @sotashimozono
+/Cargo.lock  @sotashimozono
+
+# ---- Crate roots ----
+/crates/doiget-core/  @sotashimozono
+/crates/doiget-cli/   @sotashimozono
+/crates/doiget-mcp/   @sotashimozono


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so PRs that touch NORMATIVE docs and ADRs auto-request maintainer review (per ADR-0014, docs class system). Single-file change; no source code touched.

## Coverage

- **Catch-all**: `*  @sotashimozono`
- **NORMATIVE docs (13 files, per `docs/PHASES.md` §2)**: `LEGAL.md`, `SCOPE.md`, `SECURITY.md`, `STORE.md`, `SAFEKEY.md`, `CAPABILITY.md`, `PROVENANCE_LOG.md`, `ERRORS.md`, `CONFIG.md`, `CACHE.md`, `PUBLIC_API.md`, `MCP_TOOLS.md`, `SOURCES.md`
- **ADR directory**: `/docs/DECISIONS/` (append-only NORMATIVE; no in-place edits, only supersedes)
- **CI workflows**: `/.github/workflows/`
- **Cargo workspace**: `/Cargo.toml`, `/Cargo.lock`
- **Crate roots**: `/crates/doiget-core/`, `/crates/doiget-cli/`, `/crates/doiget-mcp/`

Order is least-specific → most-specific so explicit NORMATIVE entries override the catch-all (last matching pattern wins per CODEOWNERS rules).

## Why

ADR-0014 (`docs/DECISIONS/0014-docs-class-system.md`) defines the NORMATIVE / INFORMATIVE split: changes to NORMATIVE content require a matching ADR. CODEOWNERS gives us an automatic, low-effort safety net — every PR touching a NORMATIVE file now auto-requests maintainer review, minimizing accidental NORMATIVE drift without explicit ADR coverage.

## Scope note

This is a single-maintainer repo today; every path is owned by `@sotashimozono`. Even though CODEOWNERS is therefore "redundant" in terms of routing, it serves three purposes:

1. **Forward compatibility** — when a second maintainer or team is added, scoping is already in place.
2. **Visibility** — the file documents which paths are considered NORMATIVE/critical.
3. **Hooks `Require review from Code Owners` branch protection** — this PR enables auto-review-request only; the actual enforcement lives in repo-level branch protection rules (per PHASES.md §2 last subsection: "Repo-level settings (manual; cannot be committed)").

## Test plan

- [ ] CI green (no source change; workflows that exist should pass unchanged)
- [ ] GitHub parses CODEOWNERS without warnings (check the PR's "Code owners" sidebar)
- [ ] After merge, open a throwaway PR touching `docs/SECURITY.md` and confirm `@sotashimozono` is auto-requested as reviewer

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>