### PR TITLE
chore: add .github/SECURITY.md — disclosure pointer (Phase 0)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,59 @@
+# Security policy
+
+doiget treats security reports seriously. This file is a pointer so GitHub's
+Security tab can find the disclosure path. The full normative security policy
+(threat surfaces, supply-chain controls, and posture) lives in
+[`docs/SECURITY.md`](../docs/SECURITY.md); the contact channel and SLA live in
+[`CONTACT.md`](../CONTACT.md).
+
+## Reporting a Vulnerability
+
+Please use **GitHub Private Vulnerability Reporting**:
+
+  https://github.com/sotashimozono/doiget/security/advisories/new
+
+Public issues, public discussions, and public pull requests are **not** the
+right channel for security reports. If GitHub PVR is unavailable to you, see
+[`CONTACT.md`](../CONTACT.md) §"Security disclosures" for the documented email
+fallback.
+
+## Acknowledgement timeline
+
+Per [`CONTACT.md`](../CONTACT.md) §"Service-Level Agreement":
+
+- **First response:** within **7 calendar days** of receipt (extending up to
+  14 days during documented extended absence).
+- **Substantive response:** within **30 calendar days**.
+- Coordinated disclosure is preferred. Reporters who wish to be credited will
+  be acknowledged in `CHANGELOG.md` and any subsequent advisory.
+
+## Scope
+
+**In scope:** `doiget-core`, `doiget-cli`, `doiget-mcp` (under `crates/`).
+
+**Out of scope:**
+
+- Third-party services queried by doiget (Crossref, Unpaywall, arXiv, etc.).
+  Report those to the respective providers.
+- TDM features (Phase 5; opt-in user builds gated by a Cargo feature flag per
+  [ADR-0002](../docs/DECISIONS/0002-tdm-feature-gated.md)) unless the issue
+  also affects the default build.
+- The contents of fetched PDFs ([ADR-0003](../docs/DECISIONS/0003-pdf-content-out-of-scope.md)).
+
+## Supported versions
+
+| Version                    | Status        |
+|----------------------------|---------------|
+| Latest released version    | Supported     |
+| Pre-1.0 development (0.x)  | Best-effort   |
+| Older 0.x releases         | Not supported |
+
+See [`CHANGELOG.md`](../CHANGELOG.md) for the current release state.
+
+## Reference
+
+- [`docs/SECURITY.md`](../docs/SECURITY.md) — **NORMATIVE** security policy
+  (threat surfaces, supply-chain controls, eight-safeguard legal stance per
+  [ADR-0019](../docs/DECISIONS/0019-eight-safeguards.md), no telemetry per
+  [ADR-0015](../docs/DECISIONS/0015-no-telemetry.md)).
+- [`CONTACT.md`](../CONTACT.md) — contact channel, SLA, and email fallback.


### PR DESCRIPTION
## Summary

- Adds `.github/SECURITY.md` so the GitHub Security tab surfaces the existing `docs/SECURITY.md` policy via GitHub's standard convention. No source changes.

## Why this file is separate from `docs/SECURITY.md`

GitHub specifically reads `.github/SECURITY.md` (or root `SECURITY.md`) to populate the repository's Security tab and the inline "Report a vulnerability" CTA. It does **not** read `docs/SECURITY.md`.

`docs/SECURITY.md` remains the **NORMATIVE** source of truth (threat surfaces, supply-chain controls, eight-safeguard legal posture per ADR-0019, no-telemetry per ADR-0015) and is owned by the maintainer per ADR-0014's docs class system. The new `.github/SECURITY.md` is a short pointer (~60 lines) that:

- Directs reporters to GitHub Private Vulnerability Reporting as the primary channel.
- References `CONTACT.md` for the documented email fallback and the existing SLA (7-day acknowledgement, 30-day substantive response).
- Links back to `docs/SECURITY.md` as the normative reference.

This file does not restate or duplicate the normative posture — it links to it.

## Scope

**In scope:** `doiget-core`, `doiget-cli`, `doiget-mcp`.

**Out of scope:** third-party services queried by doiget (Crossref, Unpaywall, arXiv) report to their providers; TDM features (Phase 5, opt-in feature-gated builds per ADR-0002); fetched PDF contents (ADR-0003).

## Test plan

- [x] Only `.github/SECURITY.md` is added; `docs/SECURITY.md` is untouched.
- [x] All relative links in the new file resolve to real paths in the repo (`../docs/SECURITY.md`, `../CONTACT.md`, `../CHANGELOG.md`, `../docs/DECISIONS/000{2,3,15,19}-*.md`).
- [x] No contact email or phone number introduced beyond what `CONTACT.md` already documents — GitHub PVR is the primary mechanism with `CONTACT.md` as the fallback.
- [ ] CI green (no source change, but Markdown/posture-lint workflows still apply).
- [ ] After merge, the GitHub Security tab on `sotashimozono/doiget` surfaces this policy text (verified manually post-merge; cannot be checked in CI).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>