### PR TITLE
chore: add .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,79 @@
+<!--
+Thanks for opening a PR against doiget. Please fill out each section
+below — delete a section only if it genuinely does not apply.
+
+Background reading:
+  * CONTRIBUTING.md           — local dev loop, commit style, sign-off
+  * docs/PHASES.md            — current phase, what's in/out of scope
+  * docs/DECISIONS/INDEX.md   — accepted ADRs (cite them when relevant)
+
+NORMATIVE doc edits (those marked `Status: NORMATIVE` per ADR-0014)
+require a matching ADR. If your PR touches one, link it below.
+-->
+
+## Summary
+
+<!--
+1–3 bullets focused on WHY this change exists, not what the diff is.
+The diff already shows what; the description should answer "why now,
+why this shape, what does it unlock or fix?"
+-->
+
+-
+
+## Phase / scope
+
+<!--
+Reference the relevant entry from docs/PHASES.md (e.g.
+"Phase 0 deliverable: codeql.yml"), or "n/a (hygiene)", or "Bug fix".
+-->
+
+## Changes
+
+<!--
+High-level list of files added / modified / removed. Group by area
+(crate, doc, workflow). Don't paste the diff — just the shape.
+-->
+
+## ADR references
+
+<!--
+Link any ADR(s) this PR locks-in or implements
+(e.g. ADR-0007 safekey algorithm, ADR-0013 CI baseline).
+If this PR introduces a new architectural decision, open the ADR
+in the same PR or in a paired PR and link it here.
+-->
+
+## Test plan
+
+- [ ] CI green on this branch
+- [ ] No accidental NORMATIVE doc edits (per ADR-0014)
+- [ ] If a workflow file is added/modified, all third-party Actions are SHA-pinned (ADR-0013)
+- [ ] If Cargo.toml/Cargo.lock changed, dep churn reviewed
+- [ ] Reviewer checklist: maintainer auto-assigned via CODEOWNERS
+
+## Posture checks
+
+<!--
+doiget has a small, audited posture surface. Confirm both items below
+or call out the exception explicitly.
+-->
+
+- [ ] No telemetry / phone-home added (ADR-0015)
+- [ ] No marketing copy in code, docs, or commit messages (per `.github/workflows/posture-lint.yml`)
+
+## Notes for the reviewer
+
+<!--
+Free-form: anything reviewers should look at first, known follow-ups,
+flaky-CI caveats, or context that didn't fit above.
+-->
+
+<!--
+If this PR was authored with AI assistance (Claude Code, Copilot, etc.),
+please add a trailer to your commit(s) so attribution lands in `git log`:
+
+    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+(Substitute the appropriate co-author identity for the assistant you used.)
+-->


### PR DESCRIPTION
## Summary

- Contributors currently write PR descriptions free-form, so reviewers re-ask the same questions (which ADR? which Phase? posture surface affected?). A template removes that friction at the editor.
- The shape mirrors Wave 1 PRs (#26–#32) so it codifies an already-working convention rather than inventing a new one.
- Each section is comment-only / fill-in-the-blank; nothing is pre-answered, so the template is reusable for any change type (feature, hygiene, bug fix, ADR, workflow).

## Phase / scope

n/a (hygiene). Wave 2 repo-hygiene batch — independent of `docs/PHASES.md` Phase 0/1 deliverables.

## Changes

- **Added**: `.github/PULL_REQUEST_TEMPLATE.md` (79 lines).

No other files touched.

## ADR references

- ADR-0013 (CI baseline) — referenced in the test-plan checklist for SHA-pinned third-party Actions.
- ADR-0014 (NORMATIVE/INFORMATIVE doc class system) — referenced in the test-plan checklist to flag accidental NORMATIVE edits.
- ADR-0015 (no telemetry) — referenced in the posture-checks section.

This PR does not lock-in or supersede any ADR; it only cites them so contributors are reminded of the constraints they impose.

## Test plan

- [x] CI green on this branch
- [x] No accidental NORMATIVE doc edits (per ADR-0014) — only `.github/PULL_REQUEST_TEMPLATE.md` is added
- [x] If a workflow file is added/modified, all third-party Actions are SHA-pinned (ADR-0013) — n/a, no workflow file changed
- [x] If Cargo.toml/Cargo.lock changed, dep churn reviewed — n/a, no Cargo files changed
- [ ] Reviewer checklist: maintainer auto-assigned via CODEOWNERS
- [ ] **Meta-validation**: GitHub auto-loaded this very template into the PR description editor when the PR was opened

## Posture checks

- [x] No telemetry / phone-home added (ADR-0015)
- [x] No marketing copy in code, docs, or commit messages (per `.github/workflows/posture-lint.yml`)

## Notes for the reviewer

- Single-template path used: `.github/PULL_REQUEST_TEMPLATE.md`. If we later want type-specific templates (feature / bug / ADR), GitHub also supports a `.github/PULL_REQUEST_TEMPLATE/` directory with multiple files selected via a `?template=` query string — out of scope here.
- Em dashes are used inside the comment-only HTML blocks for readability; they are never rendered to the contributor (they live inside `<!-- ... -->`), so posture-lint will not see them as marketing copy.
- The closing block is a *reminder*, not an auto-trailer. Contributors must still add the `Co-Authored-By:` line manually to commits; we do not have a commit-msg hook for it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>