### PR TITLE
chore: add .github/ISSUE_TEMPLATE/ — bug + feature + question forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: "Bug report"
+description: "Report a defect in doiget (CLI, MCP server, or core library)."
+title: "[Bug] "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please complete the form below; if you've hit a security issue, see `.github/SECURITY.md` instead — do NOT report it here.
+  - type: dropdown
+    id: component
+    attributes:
+      label: "Component"
+      description: "Which part of doiget is affected?"
+      options:
+        - doiget-cli
+        - doiget-core
+        - doiget-mcp
+        - docs/specs
+        - CI/build
+        - other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: "Version / commit"
+      description: "Which version or commit of doiget are you running?"
+      placeholder: "e.g., 0.1.0 or commit abc1234"
+    validations:
+      required: true
+  - type: dropdown
+    id: phase
+    attributes:
+      label: "Phase"
+      description: "Which Phase from `docs/PHASES.md` does this defect belong to?"
+      options:
+        - Phase 0
+        - Phase 1
+        - Phase 2
+        - Phase 3
+        - Phase 4
+        - Phase 5+
+        - unknown
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "Steps to reproduce"
+      description: "Exact commands or input sequence to reproduce the bug."
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "Expected behavior"
+      description: "What did you expect to happen?"
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: "Actual behavior"
+      description: "What actually happened? Include error output and stack traces."
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      description: "OS, Rust toolchain, network constraints, anything else relevant."
+      placeholder: |
+        OS: macOS 14.5 / Ubuntu 22.04 / Windows 11
+        Rust: 1.86.0 (rustup show)
+        Network: behind corporate proxy, on-campus IP, etc.
+    validations:
+      required: false
+  - type: checkboxes
+    id: pre-flight
+    attributes:
+      label: "Pre-flight checks"
+      options:
+        - label: "I confirmed this is not a security issue (those go via Private Vulnerability Reporting per `.github/SECURITY.md`)"
+          required: true
+        - label: "I searched existing issues and Discussions and didn't find a duplicate"
+        - label: "I'm willing to test a fix"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Question / Discussion"
+    url: "https://github.com/sotashimozono/doiget/discussions"
+    about: "For general questions, design conversations, and brainstorming, please use Discussions."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: "Feature request"
+description: "Propose a feature, behavior change, or enhancement."
+title: "[Feature] "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please skim `docs/SCOPE.md` — doiget has a deliberately narrow scope (no PDF content processing, no telemetry, no marketing). Out-of-scope ideas should go to Discussions instead.
+  - type: dropdown
+    id: phase-target
+    attributes:
+      label: "Phase target"
+      description: "Which Phase would this feature land in?"
+      options:
+        - Phase 1 (resolver/sources)
+        - Phase 2 (store)
+        - Phase 3 (MCP)
+        - Phase 4 (Tier 2)
+        - Phase 5+ (TDM)
+        - Phase 7 (optional features)
+        - unknown
+    validations:
+      required: true
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: "Problem statement"
+      description: "What problem does this solve? Whose problem?"
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: "Proposed solution"
+      description: "Describe the proposed change in enough detail that a reviewer could evaluate scope and effort."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: "Alternatives considered"
+      description: "What other approaches did you consider? Why did you reject them? (Optional but encouraged.)"
+    validations:
+      required: false
+  - type: textarea
+    id: adr-implication
+    attributes:
+      label: "ADR implication"
+      description: "Does this change a NORMATIVE doc or imply a new ADR? If yes, link the relevant ADR(s)."
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope-sanity
+    attributes:
+      label: "Scope sanity"
+      options:
+        - label: "I read `docs/SCOPE.md` and this proposal is in-scope (or I argue here why scope should expand)"
+          required: true
+        - label: "This does not introduce telemetry / phone-home / self-update (ADR-0015)"
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,23 @@
+name: "Question (use Discussions instead)"
+description: "Have a question? Please open a Discussion rather than filing an issue."
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Please consider opening a Discussion
+
+        For general questions, design conversations, and brainstorming, the right place is **Discussions**, not Issues:
+
+        https://github.com/sotashimozono/doiget/discussions
+
+        Issues are tracked as defects or actionable change requests. If you fill out this form anyway, the maintainer will likely convert it to a Discussion.
+  - type: input
+    id: question-title
+    attributes:
+      label: "If you really must file here, give a one-line summary"
+      description: "A short summary of what you want to ask."
+      placeholder: "e.g., How does doiget handle proxies?"
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Add GitHub Issue Forms under `.github/ISSUE_TEMPLATE/` so issue creation is structured rather than freeform, blank issues are disabled, and questions are redirected to Discussions.

## Files added

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; links Discussions as the contact channel.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — form: component / version / phase / steps / expected / actual / env / pre-flight checks (security redirect, dup search, willing-to-test).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — form: phase target / problem / proposed solution / alternatives / ADR implication / scope-sanity checks (`docs/SCOPE.md` read, ADR-0015 telemetry guard).
- `.github/ISSUE_TEMPLATE/question.yml` — thin redirect to Discussions; surfaces a "Question" card so users who land on "New issue" still see the option.

## Why

- **Issue triage hygiene.** Form inputs (`id:`-anchored sections) give the maintainer a consistent shape: every bug arrives with component, version, phase, and explicit repro / expected / actual blocks — no more "doesn't work, plz help".
- **Channels questions to Discussions.** `config.yml` puts a Discussion link in the issue chooser, and `question.yml` is a deliberate nudge for users who skim past it.
- **Surfaces ADR-0015 (no telemetry / no self-update) at issue-creation time.** Feature requests can't be filed without acknowledging the telemetry guard. Catches scope-creep proposals before they become PRs.
- **Surfaces `docs/SCOPE.md`** the same way — by making "I read SCOPE.md" a required checkbox, out-of-scope ideas self-route to Discussions instead of consuming review cycles.

## Test plan

- [x] All 4 YAML files parse with `yaml.safe_load` (validated locally before push).
- [x] `gh api repos/sotashimozono/doiget/contents/.github/ISSUE_TEMPLATE/bug_report.yml --ref chore/issue-templates` returns 200 (verified post-push).
- [ ] CI green on this PR (no Rust changes; only fmt/clippy/posture-lint workflows trigger, and none of them touch `.github/ISSUE_TEMPLATE/`).
- [ ] After merge, browse `https://github.com/sotashimozono/doiget/issues/new/choose` to confirm the chooser renders 3 forms + the Discussions contact link, with no blank-issue option.
- [ ] No assignees default — single-maintainer repo; CODEOWNERS handles PR auto-assignment, not issues.

## Constraints honored

- Touched only new files under `.github/ISSUE_TEMPLATE/`. No existing files modified.
- Every input element has a stable `id:` for anchored issue-body sections.
- `assignees:` intentionally omitted on every form.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>