### PR TITLE
feat(core): Safekey derivation per docs/SAFEKEY.md (Phase 1)

### DIFF
--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -12,6 +12,7 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
 
 /// Crate version. Used by `doiget-cli --version` and `doiget_health`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -119,6 +120,78 @@ impl Safekey {
     /// Returns the safekey as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl Ref {
+    /// Derives a deterministic, filesystem-safe key from this reference.
+    ///
+    /// The algorithm is the NORMATIVE binding spec in `docs/SAFEKEY.md` §3.
+    /// Both Rust and Julia implementations MUST produce bit-identical output
+    /// for every entry in `tests/fixtures/safekey/vectors.json`.
+    ///
+    /// # Algorithm summary
+    ///
+    /// 1. Prefix with `doi_` or `arxiv_` (per variant).
+    /// 2. Replace any character outside `[A-Za-z0-9._-]` with `_`.
+    /// 3. Collapse consecutive `_` runs to a single `_`.
+    /// 4. Trim leading/trailing `_`.
+    /// 5. If the result exceeds 192 bytes, take the first 192 bytes plus
+    ///    `_` plus the first 8 hex chars of `SHA-256(raw)` (where `raw` is
+    ///    the step-1 output, before escaping).
+    ///
+    /// The bound on `as_str()` after step 4 is pure ASCII (steps 1-3 produce
+    /// only ASCII bytes), so the byte-slice in step 5 cannot split a
+    /// multibyte char.
+    pub fn safekey(&self) -> Safekey {
+        // Step 0: prefix per variant. Doi/ArxivId hold the bare identifier
+        // (no `doi:` / `arxiv:` URI scheme — that is stripped by Ref::parse,
+        // not relevant here).
+        let raw = match self {
+            Ref::Doi(d) => format!("doi_{}", d.as_str()),
+            Ref::Arxiv(a) => format!("arxiv_{}", a.as_str()),
+        };
+
+        // Step 1: replace unsafe chars with '_'. Non-ASCII chars (emitted by
+        // String::chars() as full Unicode code points) all hit the wildcard
+        // arm and become a single '_'.
+        let escaped: String = raw
+            .chars()
+            .map(|c| match c {
+                'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '-' | '_' => c,
+                _ => '_',
+            })
+            .collect();
+
+        // Step 2: collapse consecutive '_' runs to a single '_'.
+        let mut collapsed = String::with_capacity(escaped.len());
+        let mut last_was_underscore = false;
+        for c in escaped.chars() {
+            if c == '_' {
+                if !last_was_underscore {
+                    collapsed.push('_');
+                }
+                last_was_underscore = true;
+            } else {
+                collapsed.push(c);
+                last_was_underscore = false;
+            }
+        }
+
+        // Step 3: trim leading/trailing '_'.
+        let trimmed = collapsed.trim_matches('_');
+
+        // Step 4: length-bound. After steps 1-3 `trimmed` is pure ASCII, so
+        // `len()` (bytes) == char count and `&trimmed[..192]` is char-safe.
+        let key = if trimmed.len() > 192 {
+            let digest = sha2::Sha256::digest(raw.as_bytes());
+            let hash = hex::encode(&digest[..4]);
+            format!("{}_{}", &trimmed[..192], hash)
+        } else {
+            trimmed.to_string()
+        };
+
+        Safekey(key)
     }
 }
 
@@ -364,7 +437,7 @@ impl CapabilityProfile {
 // The workspace lints deny them in production code; relax for the test module
 // only.
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
 
@@ -403,5 +476,88 @@ mod tests {
         assert!(p.tdm_aps.is_none());
         assert!(p.tdm_springer.is_none());
         assert_eq!(p.rate_limits.max_concurrent_fetches(), 5);
+    }
+
+    // -----------------------------------------------------------------
+    // Safekey reference vectors (docs/SAFEKEY.md §3, NORMATIVE).
+    //
+    // The vectors.json file is the binding cross-tool contract with
+    // BiblioFetch.jl: every entry MUST round-trip identically through
+    // both implementations. Phase 0 ships 13 entries; the full 100-entry
+    // set is gated on the BiblioFetch.jl pre-flight (ADR-0007 Status:
+    // Proposed at the time of this Phase 1 implementation).
+    //
+    // `Ref::parse` is concurrent W3-A work and is not on `main` yet, so
+    // this test branches on the input prefix (`doi:` / `arxiv:`) and
+    // constructs the variant directly via the in-crate `pub(crate)`
+    // tuple constructor.
+    // -----------------------------------------------------------------
+
+    #[derive(Deserialize)]
+    struct SafekeyVector {
+        input: String,
+        expected: String,
+    }
+
+    #[derive(Deserialize)]
+    struct SafekeyVectorFile {
+        vectors: Vec<SafekeyVector>,
+    }
+
+    /// In-crate test helper: build a `Ref` from the user-facing form used
+    /// in the vectors file, by stripping the `doi:` / `arxiv:` URI scheme
+    /// and wrapping the remainder. This bypasses validation; it is fine
+    /// here because the vectors are hand-curated and the test asserts the
+    /// derivation algorithm, not parser semantics.
+    fn ref_from_vector_input(input: &str) -> Ref {
+        if let Some(rest) = input.strip_prefix("doi:") {
+            Ref::Doi(Doi(rest.to_string()))
+        } else if let Some(rest) = input.strip_prefix("arxiv:") {
+            Ref::Arxiv(ArxivId(rest.to_string()))
+        } else {
+            panic!(
+                "vectors.json entry has unknown ref scheme (expected doi: or arxiv: prefix): {}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn safekey_matches_reference_vectors() {
+        // include_str! resolves relative to the file containing this macro
+        // call (crates/doiget-core/src/lib.rs), so we go up three levels
+        // to reach the workspace root, then down to tests/fixtures.
+        let raw = include_str!("../../../tests/fixtures/safekey/vectors.json");
+        let parsed: SafekeyVectorFile =
+            serde_json::from_str(raw).expect("vectors.json is valid JSON matching schema");
+
+        // Phase 1 Wave 3 ships the 13-entry placeholder set. The full
+        // 100-entry set is a follow-up gated on BiblioFetch.jl pre-flight.
+        assert_eq!(
+            parsed.vectors.len(),
+            13,
+            "expected 13 reference vectors; got {} (vectors.json drift?)",
+            parsed.vectors.len()
+        );
+
+        let mut failures: Vec<String> = Vec::new();
+        for v in &parsed.vectors {
+            let r = ref_from_vector_input(&v.input);
+            let got = r.safekey().as_str().to_string();
+            if got != v.expected {
+                failures.push(format!(
+                    "input={:?}\n  expected={:?}\n  got     ={:?}",
+                    v.input, v.expected, got
+                ));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "{}/{} safekey reference vectors failed:\n{}",
+            failures.len(),
+            parsed.vectors.len(),
+            failures.join("\n")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements `impl Ref { pub fn safekey(&self) -> Safekey }` in `crates/doiget-core/src/lib.rs` per the NORMATIVE algorithm in `docs/SAFEKEY.md` §3, validated against all 13 reference vectors in `tests/fixtures/safekey/vectors.json`. Phase 1 foundation work for Wave 3 (W3-B).

## Phase 1 deliverable

- New public method `Ref::safekey(&self) -> Safekey` derives a deterministic, filesystem-safe key.
- `Safekey(pub(crate) String)` wire format unchanged: still `#[serde(transparent)]`, bare-string serialization preserved.
- Inline implementation in `lib.rs` (~50 lines including doc comment) — separate `safekey_algo.rs` module would be over-engineered for an algorithm this small.
- No changes to `crates/doiget-core/Cargo.toml` — `serde_json`, `sha2`, `hex` are already in `[dependencies]`.

## Algorithm summary

Per `docs/SAFEKEY.md` §3: (1) prefix the bare identifier with `doi_` or `arxiv_` per variant; (2) iterate `chars()` and replace any char outside `[A-Za-z0-9._-]` with `_` (non-ASCII multibyte chars each map to a single `_`); (3) collapse consecutive `_` runs to one; (4) trim leading/trailing `_`; (5) if the result exceeds 192 chars, append `_` plus the first 8 hex chars of `SHA-256(raw)` (where `raw` is the step-1 output, before escaping) to the 192-byte prefix. After steps 1–3 the buffer is pure ASCII, so the byte-slice `&trimmed[..192]` is char-boundary-safe.

## Test coverage (13/13 reference vectors)

`safekey_matches_reference_vectors` loads `tests/fixtures/safekey/vectors.json` via `include_str!`, parses with `serde_json`, and asserts every entry's `Ref::parse(input).safekey().as_str()` (well, the in-crate equivalent — see Notes) equals `expected`. All 13 vectors pass:

- 7 DOI cases: basic, special chars, parens, spaces, double-space collapse, leading-`_` trim, trailing-`_` trim
- 3 arXiv cases: bare, versioned, slash-bearing legacy `cond-mat/9501001`
- 3 non-ASCII DOI suffix cases: each correctly degrades to `doi_<prefix>` after escape+collapse+trim

Test harness output: `test result: ok. 5 passed; 0 failed` (the new test plus 4 pre-existing Phase-0 smoke tests, none regressed). `cargo clippy -p doiget-core --all-targets -- -D warnings` is also clean.

## ADR-0007

ADR-0007 is currently `Status: Proposed` pending BiblioFetch.jl pre-flight. This implementation aligns with `docs/SAFEKEY.md` §3 as the binding source until that pre-flight resolves and the ADR is promoted to `Accepted`. No semantics here depend on the ADR's eventual `Accepted` form beyond what §3 already specifies — if pre-flight surfaces a spec change, the change will land in `docs/SAFEKEY.md` first and this implementation will track it.

## Notes for follow-up

- **`Ref::parse` integration**: W3-A is concurrently implementing `Ref::parse`. The test currently uses an in-crate `ref_from_vector_input` helper that strips the `doi:` / `arxiv:` URI scheme and wraps the remainder via the `pub(crate)` tuple constructor. Once W3-A merges, a follow-up PR should replace the helper with `Ref::parse(&v.input).expect(...)` so the test exercises the parser plus the algorithm end-to-end (this is the form the W3-B brief originally requested; `Ref::parse` simply isn't on `main` yet).
- **100-vector expansion**: gated on the BiblioFetch.jl pre-flight per ADR-0007. The test asserts `vectors.len() == 13` so a stealth expansion will fail loudly; bumping that constant is the only edit required when the full set lands.
- **No spec ambiguities found**: the 13 vectors map cleanly to the §3 algorithm with no reinterpretation needed. The non-ASCII collision caveat (vectors 11–13 all share an ASCII prefix and would collide if their non-ASCII suffixes differed only) is already documented in `vectors.json`'s `notes` field as a Phase-1 caller responsibility.

## Test plan

- [ ] CI green on `safekey-vectors.yml` and `cross-tool-compat.yml` workflows
- [ ] `cargo build -p doiget-core` clean
- [ ] `cargo test -p doiget-core safekey` passes — all 13 vectors
- [ ] `cargo clippy -p doiget-core --all-targets -- -D warnings` clean
- [ ] No regression on the 4 pre-existing Phase-0 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)