### PR TITLE
test(core): defensive vector count + truncation branch coverage (PR #39 follow-up)

### DIFF
--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -532,11 +532,12 @@ mod tests {
             serde_json::from_str(raw).expect("vectors.json is valid JSON matching schema");
 
         // Phase 1 Wave 3 ships the 13-entry placeholder set. The full
-        // 100-entry set is a follow-up gated on BiblioFetch.jl pre-flight.
-        assert_eq!(
-            parsed.vectors.len(),
-            13,
-            "expected 13 reference vectors; got {} (vectors.json drift?)",
+        // 100-entry NORMATIVE set (docs/SAFEKEY.md §5) is a follow-up gated
+        // on BiblioFetch.jl pre-flight. Use a minimum-count guard so the
+        // test catches truncation but does not break when vectors.json grows.
+        assert!(
+            parsed.vectors.len() >= 13,
+            "vectors.json has fewer entries than expected ({}); fixture may be truncated",
             parsed.vectors.len()
         );
 
@@ -559,5 +560,45 @@ mod tests {
             parsed.vectors.len(),
             failures.join("\n")
         );
+    }
+
+    #[test]
+    fn safekey_truncates_long_inputs_with_sha256_suffix() {
+        // Construct a synthetic DOI whose suffix produces a `trimmed` longer than
+        // 192 chars after step 3. 220 ASCII-safe chars + the `doi_10.1234/`
+        // prefix easily exceeds 192. The resulting key must be exactly 201 chars:
+        // 192 (trimmed prefix) + 1 (`_` separator) + 8 (hex of first 4 bytes of
+        // SHA-256(raw)). Per docs/SAFEKEY.md §3 step 5.
+        let suffix = "a".repeat(220);
+        let doi = Doi(format!("10.1234/{}", suffix));
+        let key = Ref::Doi(doi).safekey();
+        let s = key.as_str();
+
+        // Shape: <192 ASCII chars from {A-Za-z0-9._-}> + "_" + <8 hex chars>
+        assert_eq!(s.len(), 201, "expected 201-char truncated key, got {}: {}", s.len(), s);
+        assert_eq!(&s[192..193], "_", "expected '_' separator at byte 192");
+        let hash_part = &s[193..];
+        assert_eq!(hash_part.len(), 8, "hash suffix must be 8 hex chars");
+        assert!(
+            hash_part.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "hash suffix must be lowercase hex: {}", hash_part
+        );
+
+        // Determinism: same input twice must produce the same key.
+        let key2 = Ref::Doi(Doi(format!("10.1234/{}", "a".repeat(220)))).safekey();
+        assert_eq!(s, key2.as_str(), "safekey must be deterministic");
+
+        // Hash content: must equal hex(sha256(raw)[..4]) where raw is the
+        // pre-escape prefixed form per docs/SAFEKEY.md §3 step 5.
+        use sha2::Digest;
+        let raw = format!("doi_10.1234/{}", "a".repeat(220));
+        let expected_hash = {
+            let digest = sha2::Sha256::digest(raw.as_bytes());
+            format!(
+                "{:02x}{:02x}{:02x}{:02x}",
+                digest[0], digest[1], digest[2], digest[3]
+            )
+        };
+        assert_eq!(hash_part, expected_hash, "hash must match SHA-256 of raw form");
     }
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -575,13 +575,22 @@ mod tests {
         let s = key.as_str();
 
         // Shape: <192 ASCII chars from {A-Za-z0-9._-}> + "_" + <8 hex chars>
-        assert_eq!(s.len(), 201, "expected 201-char truncated key, got {}: {}", s.len(), s);
+        assert_eq!(
+            s.len(),
+            201,
+            "expected 201-char truncated key, got {}: {}",
+            s.len(),
+            s
+        );
         assert_eq!(&s[192..193], "_", "expected '_' separator at byte 192");
         let hash_part = &s[193..];
         assert_eq!(hash_part.len(), 8, "hash suffix must be 8 hex chars");
         assert!(
-            hash_part.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
-            "hash suffix must be lowercase hex: {}", hash_part
+            hash_part
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "hash suffix must be lowercase hex: {}",
+            hash_part
         );
 
         // Determinism: same input twice must produce the same key.
@@ -599,6 +608,9 @@ mod tests {
                 digest[0], digest[1], digest[2], digest[3]
             )
         };
-        assert_eq!(hash_part, expected_hash, "hash must match SHA-256 of raw form");
+        assert_eq!(
+            hash_part, expected_hash,
+            "hash must match SHA-256 of raw form"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `assert_eq!(parsed.vectors.len(), 13, ...)` with `assert!(parsed.vectors.len() >= 13, ...)` in `safekey_matches_reference_vectors` so the test catches fixture truncation but does not break when `vectors.json` grows to its NORMATIVE 100-entry set.
- Add `safekey_truncates_long_inputs_with_sha256_suffix` exercising the `if trimmed.len() > 192 { format!("{}_{}", &trimmed[..192], hex(sha256(raw)[..4])) }` branch that current reference vectors (max 34 chars) leave fully uncovered.

## Why
Two findings from the post-PR-#39 critical review:

1. **Hardcoded count is brittle.** `assert_eq!(parsed.vectors.len(), 13, ...)` will fail the test the moment `vectors.json` is expanded to the 100-entry NORMATIVE set required by [`docs/SAFEKEY.md` §5](../blob/feat/safekey-algorithm/docs/SAFEKEY.md). That expansion is supposed to be a clean operation. Switching to a minimum-count guard preserves the truncation check (the only failure mode the assertion was actually catching) without coupling the test to the current fixture size.

2. **Truncation+SHA-256 branch is untested by reference vectors.** The 13 reference vectors max out at 34 characters, so the `len() > 192` branch in `Ref::safekey()` ships completely uncovered. Adding a long-DOI vector to `vectors.json` would require BiblioFetch.jl coordination per ADR-0007 (still `Status: Proposed`), which is out of scope for this PR. The new Rust-only unit test covers the branch independently: constructs a synthetic 220-char DOI suffix, asserts the resulting key is exactly 201 chars (192 prefix + `_` + 8 hex), verifies the `_` separator at byte 192, checks the suffix is lowercase ASCII hex, asserts determinism, and re-derives the expected hash via `sha2::Sha256::digest` to verify exact content per `docs/SAFEKEY.md` §3 step 5.

No new dependencies — `sha2` is already a regular dep of `doiget-core` (the impl uses it), and `#[cfg(test)]` modules see the parent crate's deps.

## Test plan
- [x] `cargo build -p doiget-core` succeeds
- [x] `cargo test -p doiget-core safekey` — both `safekey_matches_reference_vectors` (13/13 vectors still pass with the relaxed count guard) AND the new `safekey_truncates_long_inputs_with_sha256_suffix` pass
- [x] `cargo test -p doiget-core` full suite — 6 passed, 0 failed (was 5 + 1 new)
- [x] `cargo clippy -p doiget-core --all-targets -- -D warnings` clean (no new allows needed)
- [x] Touches only `crates/doiget-core/src/lib.rs` — no `Cargo.toml`, no docs, no fixture changes

## Merge guidance for the maintainer
This PR targets `feat/safekey-algorithm` (PR #39's branch), **not** `main`. PR #39 is still open and the code being patched only exists on that branch. Merging this PR brings the fix into PR #39's branch; PR #39 then merges to `main` as a single unit, so reviewers see one cohesive Safekey introduction including the test improvements.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>