### PR TITLE
chore: add justfile mirroring CI commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,45 @@
+# justfile — dev shortcuts that mirror what CI runs.
+#
+# Cargo invocations don't need a shell, so this file works on bash and
+# PowerShell without a `set shell` directive. Toolchain is intentionally
+# unpinned here; rust-toolchain.toml is the single source of truth.
+
+# Default: list available recipes.
+default:
+    @just --list
+
+# Format the workspace in place (local-only; CI runs fmt-check instead).
+fmt:
+    cargo fmt --all
+
+# Mirrors CI `fmt` job (.github/workflows/ci.yml).
+fmt-check:
+    cargo fmt --all -- --check
+
+# Mirrors CI `clippy` job. Feature surface (oa-only) matches the published
+# build per ADR-0002; lint and test exercise an identical surface.
+lint:
+    cargo clippy --workspace --all-targets --no-default-features --features oa-only -- -D warnings
+
+# Mirrors CI `test` job.
+test:
+    cargo test --workspace --all-targets --no-default-features --features oa-only
+
+# Mirrors CI `msrv` job (build of the published surface).
+build:
+    cargo build --workspace --no-default-features --features oa-only
+
+# Mirrors `cargo audit` job in .github/workflows/audit.yml.
+audit:
+    cargo audit
+
+# Mirrors `cargo deny` job in .github/workflows/audit.yml.
+deny:
+    cargo deny check
+
+# Mirrors CI `docs` job.
+doc:
+    cargo doc --workspace --no-deps
+
+# Composite local pre-push gate: fmt-check + lint + test.
+ci: fmt-check lint test


### PR DESCRIPTION
## Summary

Adds a top-level `justfile` so local dev commands match what CI runs.
Each recipe maps 1:1 to a job in `.github/workflows/ci.yml` or
`.github/workflows/audit.yml`, keeping dev<->CI parity in one place.

### Recipes

| recipe       | command                                                                                            | mirrors CI job                  |
| ------------ | -------------------------------------------------------------------------------------------------- | ------------------------------- |
| `default`    | `just --list`                                                                                      | (help)                          |
| `fmt`        | `cargo fmt --all`                                                                                  | (local-only formatter)          |
| `fmt-check`  | `cargo fmt --all -- --check`                                                                       | ci.yml `fmt`                    |
| `lint`       | `cargo clippy --workspace --all-targets --no-default-features --features oa-only -- -D warnings`   | ci.yml `clippy`                 |
| `test`       | `cargo test --workspace --all-targets --no-default-features --features oa-only`                    | ci.yml `test`                   |
| `build`      | `cargo build --workspace --no-default-features --features oa-only`                                 | ci.yml `msrv`                   |
| `audit`      | `cargo audit`                                                                                      | audit.yml `cargo audit`         |
| `deny`       | `cargo deny check`                                                                                 | audit.yml `cargo deny`          |
| `doc`        | `cargo doc --workspace --no-deps`                                                                  | ci.yml `docs`                   |
| `ci`         | composite: `fmt-check` + `lint` + `test`                                                           | local pre-push gate             |

### Notes

- Cargo invocations don't need a shell, so the file works on bash and PowerShell without a `set shell` directive.
- Toolchain is not pinned in the justfile; `rust-toolchain.toml` remains the single source of truth.
- Feature surface (`--no-default-features --features oa-only`) matches CI per ADR-0002 — lint and test exercise the same surface as the published build.

## Test plan

- [ ] `just --summary` lists all recipes without parse errors
- [ ] `just fmt-check` matches CI `fmt` output
- [ ] `just lint` matches CI `clippy` output (oa-only)
- [ ] `just test` matches CI `test` output (oa-only)
- [ ] `just ci` runs fmt-check + lint + test in sequence and is suitable as a pre-push gate