### PR TITLE
docs(phases): tick Phase 0 checkboxes for shipped deliverables

### DIFF
--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -36,19 +36,19 @@ Phase 0 is complete when **all** of the following are committed.
 
 ### Code
 
-- [ ] Cargo workspace with members `doiget-core`, `doiget-cli`, `doiget-mcp`.
-- [ ] `cargo build` succeeds (default features = `oa-only`).
-- [ ] `cargo build --no-default-features` succeeds (sanity: nothing under `oa-only` is actually load-bearing for compilation in Phase 0).
-- [ ] `doiget --help` runs (no subcommands implemented yet).
+- [x] Cargo workspace with members `doiget-core`, `doiget-cli`, `doiget-mcp`.
+- [x] `cargo build` succeeds (default features = `oa-only`).
+- [x] `cargo build --no-default-features` succeeds (sanity: nothing under `oa-only` is actually load-bearing for compilation in Phase 0).
+- [x] `doiget --help` runs (no subcommands implemented yet).
 
 ### Configuration files
 
-- [ ] [`Cargo.toml`](../Cargo.toml) workspace + features matrix.
-- [ ] `Cargo.lock` committed.
-- [ ] [`rust-toolchain.toml`](../rust-toolchain.toml) — MSRV 1.86 declared (channel: stable).
-- [ ] [`deny.toml`](../deny.toml) — banned crate list.
-- [ ] [`clippy.toml`](../clippy.toml) — workspace lints.
-- [ ] [`.cargo/config.toml`](../.cargo/config.toml) — build flags.
+- [x] [`Cargo.toml`](../Cargo.toml) workspace + features matrix.
+- [x] `Cargo.lock` committed.
+- [x] [`rust-toolchain.toml`](../rust-toolchain.toml) — MSRV 1.86 declared (channel: stable).
+- [x] [`deny.toml`](../deny.toml) — banned crate list.
+- [x] [`clippy.toml`](../clippy.toml) — workspace lints.
+- [x] [`.cargo/config.toml`](../.cargo/config.toml) — build flags.
 
 ### NORMATIVE docs
 
@@ -75,17 +75,17 @@ Phase 0 is complete when **all** of the following are committed.
 - [x] [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 - [x] [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
 - [x] [`docs/PHASES.md`](.) (this document)
-- [ ] [`docs/MIGRATION.md`](MIGRATION.md) (placeholder; full content Phase 2)
-- [ ] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0019
+- [x] [`docs/MIGRATION.md`](MIGRATION.md) (placeholder; full content Phase 2)
+- [x] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0019
 
 ### CI workflows
 
-- [ ] `.github/workflows/ci.yml` (fmt, clippy, test on a 3 OS × 3 features matrix)
-- [ ] `.github/workflows/audit.yml` (cargo audit + cargo deny)
-- [ ] `.github/workflows/posture-lint.yml` (forbidden term / crate guard)
-- [ ] `.github/workflows/codeql.yml` (Phase 0 onward)
-- [ ] `.github/workflows/safekey-vectors.yml` (vector-set parity)
-- [ ] `.github/workflows/cross-tool-compat.yml` (BiblioFetch.jl round-trip; placeholder until Phase 2)
+- [x] `.github/workflows/ci.yml` (fmt, clippy, test on a 3 OS × 3 features matrix)
+- [x] `.github/workflows/audit.yml` (cargo audit + cargo deny)
+- [x] `.github/workflows/posture-lint.yml` (forbidden term / crate guard)
+- [x] `.github/workflows/codeql.yml` (Phase 0 onward)
+- [x] `.github/workflows/safekey-vectors.yml` (vector-set parity)
+- [x] `.github/workflows/cross-tool-compat.yml` (BiblioFetch.jl round-trip; placeholder until Phase 2)
 - [x] `.github/workflows/msrv-drift.yml` (weekly: detect transitive-dep MSRV bumps past declared 1.86)
 - [x] `.github/dependabot.yml` (auto-merge disabled)
 
@@ -98,8 +98,8 @@ Phase 0 is complete when **all** of the following are committed.
 
 ### Test fixtures
 
-- [ ] `tests/fixtures/safekey/vectors.json` — 100 reference test vectors.
-- [ ] `tests/fixtures/golden/` — placeholder.
+- [ ] `tests/fixtures/safekey/vectors.json` — 100 reference test vectors. (13/100; full set Phase 0 final)
+- [x] `tests/fixtures/golden/` — placeholder.
 
 ### Pre-flight items (must be confirmed before Phase 0 begins)
 


### PR DESCRIPTION
## Summary

Sync the Phase 0 deliverable checklist in `docs/PHASES.md` with the actual state of `main`. Many items have already shipped but their boxes were still unchecked. This PR ticks only what is verifiable from the working tree.

## Boxes ticked

### Code (all four — verified locally)
- [x] **Cargo workspace with members `doiget-core`, `doiget-cli`, `doiget-mcp`** — all three exist under `crates/`.
- [x] **`cargo build` succeeds (default features = `oa-only`)** — ran `cargo build`, finished cleanly in ~1m.
- [x] **`cargo build --no-default-features` succeeds** — ran and finished cleanly.
- [x] **`doiget --help` runs** — runs and prints subcommand list (no impl yet, as expected).

### Configuration files (all six)
- [x] `Cargo.toml` workspace + features matrix — present.
- [x] `Cargo.lock` committed — present at repo root.
- [x] `rust-toolchain.toml` — present, declares `channel = "stable"`.
- [x] `deny.toml` — present.
- [x] `clippy.toml` — present.
- [x] `.cargo/config.toml` — present.

### INFORMATIVE docs (two)
- [x] `docs/MIGRATION.md` — placeholder with INFORMATIVE banner + scenario stubs.
- [x] `docs/DECISIONS/INDEX.md` + ADRs 0001–0019 — all 19 ADRs (0001 … 0019) plus `INDEX.md` exist.

### CI workflows (six)
- [x] `.github/workflows/ci.yml`
- [x] `.github/workflows/audit.yml`
- [x] `.github/workflows/posture-lint.yml`
- [x] `.github/workflows/codeql.yml`
- [x] `.github/workflows/safekey-vectors.yml`
- [x] `.github/workflows/cross-tool-compat.yml`

### Test fixtures (one)
- [x] `tests/fixtures/golden/` — directory exists with `README.md`.

## Boxes left unchecked (with reasons)

- [ ] **`tests/fixtures/safekey/vectors.json` — 100 reference test vectors.** Currently 13 vectors. Bullet annotated `(13/100; full set Phase 0 final)` instead of ticking, per task instructions.
- [ ] **Repo-level settings (branch protection on `main`; 2FA; SHA pinning policy).** Manual GitHub settings — not observable from the working tree, so left unchecked per the "do not invent state" constraint.
- [ ] **Pre-flight items (BiblioFetch.jl safekey/schema_version coordination; crates.io OIDC; release Environment).** Not yet confirmed; left unchecked.

## Files touched

- `docs/PHASES.md` — only file modified.

## Test plan

- [ ] Render `docs/PHASES.md` on GitHub and confirm Phase 0 checklist now reflects shipped state.
- [ ] Confirm no other files were modified (`git diff main..chore/phases-checkbox-sync --stat` shows only `docs/PHASES.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)