### PR TITLE
chore(ci): add typos.yml — typo-check via crate-ci/typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,23 @@
+name: typos
+
+# Spell / typo check across the repo. doiget is heavily docs-driven (ADRs,
+# NORMATIVE policy docs, READMEs), so a typo guard is high-value low-cost.
+# Read-only: the action defaults to fail-on-typos (no auto-fix).
+# To allow a flagged word, add it under [default.extend-words] in .typos.toml.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      - uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274     # v1.46.0

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,16 @@
+# Configuration for crate-ci/typos (.github/workflows/typos.yml).
+# Docs: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-words]
+# To allow a word that typos flags as a misspelling, add an entry here:
+#   misspelling = "correction"
+# For project-specific jargon that is intentionally spelled this way, map the
+# token to itself, e.g.:
+#   doiget = "doiget"
+# Keep the table sorted; prefer fixing the typo over adding an exception.
+
+[files]
+# Generated / vendored / fixture files where typo enforcement is not useful.
+# Add new globs here (NOT new code paths) when typos has false positives in
+# fixtures or third-party blobs.
+extend-exclude = ["Cargo.lock", "tests/fixtures/**", "*.lock"]


### PR DESCRIPTION
## Summary

Add a read-only typo / spell-check CI workflow using `crate-ci/typos`.

doiget is heavily docs-driven — ADRs, NORMATIVE policy documents (LEGAL,
SCOPE, CONTACT, CONTRIBUTING), the README marketing surface, and
issue/PR templates all live in this repo. A typo guard catches
embarrassing misspellings at PR time for negligible cost (~5 s per run).

## Files

- **`.github/workflows/typos.yml`**
  - Triggers: `pull_request` and `push: branches: [main]`
  - Permissions: `contents: read`
  - Single `typos` job on `ubuntu-latest` with a 5-minute timeout
  - `actions/checkout` reuses the SHA already pinned in `ci.yml`
    (`de0fac2e…` / v6.0.2) for consistency
  - `crate-ci/typos` pinned to commit
    `bbaefadf97b0ec5fdc942684b647f1a6ab250274` (v1.46.0)
  - Read-only: the action defaults to fail-on-typos with no auto-fix
- **`.typos.toml`**
  - Empty `[default.extend-words]` table with a comment explaining how
    to allowlist a word (prefer fixing typos over exceptions)
  - `[files]` `extend-exclude = ["Cargo.lock", "tests/fixtures/**", "*.lock"]`

## SHA pin rationale

Per ADR-0013 and the existing pattern in `.github/workflows/ci.yml`,
third-party actions are pinned by full commit SHA with a `# vX.Y.Z`
trailing comment so dependabot updates remain reviewable.

The `v1.46.0` tag on `crate-ci/typos` is an annotated tag, so it was
resolved through two hops:

```
v1.46.0  →  tag object 6ac2ebd1b93eade61faf7e12688ad87a073fea59
         →  commit     bbaefadf97b0ec5fdc942684b647f1a6ab250274
```

(Note: the canonical action repo is `crate-ci/typos`, which ships
`action.yml` at its root. There is no separate `crate-ci/typos-action`
repo — `gh api repos/crate-ci/typos-action` returns 404.)

## Test plan

- [ ] CI green on this PR — the new `typos` job runs and either passes
      or surfaces real typos in existing files (which can be fixed in a
      follow-up PR or allowlisted in `.typos.toml`)
- [ ] No other workflow regresses (this PR adds a new job; it does not
      modify existing workflows)
- [ ] Locally validated:
  - `python -c "import yaml; yaml.safe_load(open('.github/workflows/typos.yml'))"`  → ok
  - `python -c "import tomllib; tomllib.load(open('.typos.toml','rb'))"`  → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)