### PR TITLE
docs(changelog): enrich [Unreleased] with Phase 0 itemized entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,110 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+Phase 0 (design + scaffolding). No version tag is published in this phase; the
+workspace stays at `0.0.0` until Phase 6. See [docs/PHASES.md](docs/PHASES.md)
+for the full Phase 0 deliverable checklist.
+
 ### Added
-- Phase 0: Repository structure, normative specs, ADRs, Cargo workspace skeleton, CI
-  workflows. See [docs/PHASES.md](docs/PHASES.md) for the full Phase 0 deliverable
-  checklist.
+
+#### Workspace skeleton
+- Cargo workspace with three published members: `doiget-core`, `doiget-cli`,
+  `doiget-mcp`. Optional Phase 7 `doiget-obsidian` crate is declared as
+  `exclude`d (off by default per [ADR-0008](docs/DECISIONS/0008-crate-decomposition.md)
+  and [docs/SCOPE.md](docs/SCOPE.md)).
+- `Cargo.lock` baselined at the workspace root so `cargo audit` and reproducible
+  builds run against a pinned dependency graph.
+- `rust-toolchain.toml` pinning the `stable` channel; declared MSRV `1.86`
+  (workspace `rust-version`).
+- `clippy.toml` and `deny.toml` shared at the workspace root; `deny.toml` bans
+  `openssl` / `native-tls` so the rustls-only TLS posture is enforced by CI.
+
+#### Normative specs ([docs/](docs/))
+- [LEGAL.md](docs/LEGAL.md), [SCOPE.md](docs/SCOPE.md),
+  [SECURITY.md](docs/SECURITY.md), [STORE.md](docs/STORE.md),
+  [SAFEKEY.md](docs/SAFEKEY.md), [CAPABILITY.md](docs/CAPABILITY.md),
+  [PROVENANCE_LOG.md](docs/PROVENANCE_LOG.md), [ERRORS.md](docs/ERRORS.md),
+  [CONFIG.md](docs/CONFIG.md), [CACHE.md](docs/CACHE.md),
+  [PUBLIC_API.md](docs/PUBLIC_API.md), [MCP_TOOLS.md](docs/MCP_TOOLS.md),
+  [SOURCES.md](docs/SOURCES.md).
+- Supporting docs: [ARCHITECTURE.md](docs/ARCHITECTURE.md),
+  [PHASES.md](docs/PHASES.md), [MIGRATION.md](docs/MIGRATION.md),
+  plus [docs/INTEGRATION/](docs/INTEGRATION/).
+
+#### Architecture Decision Records ([docs/DECISIONS/](docs/DECISIONS/))
+- ADR-0001 stdio-only transport
+- ADR-0002 TDM feature-gated, never in published binaries
+- ADR-0003 PDF content out of scope
+- ADR-0004 BiblioFetch coexistence
+- ADR-0005 capability profile as a type-gate
+- ADR-0006 provenance log fail-closed
+- ADR-0007 safekey algorithm
+- ADR-0008 crate decomposition
+- ADR-0009 MVP = Tier 1 only
+- ADR-0010 citation-graph hard cap
+- ADR-0011 phase plan v1
+- ADR-0012 MCP tool naming
+- ADR-0013 CI baseline
+- ADR-0014 docs class system
+- ADR-0015 no telemetry
+- ADR-0016 foundation crates
+- ADR-0017 output mode resolution
+- ADR-0018 Obsidian one-direction
+- ADR-0019 eight safeguards
+- [INDEX.md](docs/DECISIONS/INDEX.md)
+
+#### CI workflows ([.github/workflows/](.github/workflows/))
+- `ci.yml` — fmt, clippy (deny warnings; `expect` / `unwrap` allowed in tests),
+  build, test against the declared MSRV.
+- `audit.yml` — `cargo audit` against pinned `Cargo.lock`; `CDLA-Permissive-2.0`
+  whitelisted.
+- `posture-lint.yml` — repo-posture invariants (scoped to source paths).
+- `codeql.yml` — CodeQL static analysis (Phase 0 baseline).
+- `msrv-drift.yml` — weekly MSRV-vs-stable drift check; Phase 6 release-plz
+  slot reserved.
+- `cross-tool-compat.yml` — Phase 2 placeholder (BiblioFetch.jl ↔ doiget
+  cross-tool round-trip).
+- `mcp-smoke.yml` — Phase 3 placeholder (MCP stdio smoke test).
+- `safekey-vectors.yml` — schema validation for
+  `tests/fixtures/safekey/vectors.json`.
+
+#### Repo hygiene
+- `.github/dependabot.yml` — weekly cargo + github-actions updates, no
+  auto-merge.
+- `.github/FUNDING.yml`.
+- `.github/CODEOWNERS` — auto-review assignment for NORMATIVE files.
+- `.github/SECURITY.md` — disclosure pointer (Phase 0).
+- `.github/PULL_REQUEST_TEMPLATE.md`.
+- `.github/ISSUE_TEMPLATE/` — `bug_report.yml`, `feature_request.yml`,
+  `question.yml`, `config.yml`.
+- `.gitattributes` — LF normalization.
+- `.editorconfig`.
+- Root ignore for `*.tmp.*` (Dropbox / editor autosave artifacts).
+
+#### Test fixtures scaffold
+- `tests/fixtures/golden/` layout documented for Phase 1 (see
+  `tests/fixtures/golden/README.md`).
+- `tests/fixtures/safekey/vectors.json` — 13/100 reference vectors for the
+  safekey algorithm; the remaining 87 are a Phase 0 deliverable generated in
+  coordination with BiblioFetch.jl per [docs/SAFEKEY.md](docs/SAFEKEY.md).
+
+### Changed
+- Bumped `reqwest` from `0.12` to `0.13` (#30). The umbrella `rustls-tls`
+  feature was removed upstream and replaced with composable pieces; switched
+  to `rustls + webpki-roots` (rustls backend + bundled Mozilla WebPKI roots),
+  preserving the rustls-only TLS posture. `openssl` / `native-tls` remain
+  banned by `deny.toml`.
+- Dependabot dependency refreshes: `thiserror` 1 → 2, `toml` 0.8 → 1.1,
+  `sha2` 0.10 → 0.11, `toml_edit` 0.22 → 0.25, `actions/checkout` 4.1.1 →
+  6.0.2.
+- CI: bumped MSRV to `1.85` then aligned with declared MSRV `1.86`; refreshed
+  action SHAs; scoped `posture-lint` to source paths; allow `expect` / `unwrap`
+  in tests; whitelisted `CDLA-Permissive-2.0`.
+
+### Fixed
+- `audit.yml`: removed the temporary in-CI `cargo generate-lockfile` step now
+  that `Cargo.lock` is checked in (commit `cf94535`).
+- Removed an accidentally-committed editor temp file and added `*.tmp.*` to
+  `.gitignore` to prevent recurrence.
 
 [Unreleased]: https://github.com/sotashimozono/doiget/compare/main...HEAD


### PR DESCRIPTION
## Summary

Replaces the single-bullet `[Unreleased]` entry in `CHANGELOG.md` with a fully itemized Keep a Changelog 1.1.0 layout (Added / Changed / Fixed) that reflects what has actually landed on `main`. The goal is to make the upcoming Phase 0 -> Phase 1 cutover legible to anyone reading the changelog cold.

No new version heading is introduced; the workspace stays at `0.0.0` until Phase 6 per ADR-0011 / docs/PHASES.md.

### Added (highlights)
- Cargo workspace skeleton (`doiget-core`, `doiget-cli`, `doiget-mcp`; Phase 7 `doiget-obsidian` excluded), `Cargo.lock` baseline, MSRV pin (`1.86`).
- All normative specs: LEGAL, SCOPE, SECURITY, STORE, SAFEKEY, CAPABILITY, PROVENANCE_LOG, ERRORS, CONFIG, CACHE, PUBLIC_API, MCP_TOOLS, SOURCES.
- ADRs 0001-0019 + INDEX.md.
- Eight CI workflows: `ci`, `audit`, `posture-lint`, `codeql`, `msrv-drift`, `cross-tool-compat` (Phase 2 placeholder), `mcp-smoke` (Phase 3 placeholder), `safekey-vectors`.
- Repo hygiene: Dependabot, FUNDING, CODEOWNERS, SECURITY disclosure pointer, PR template, issue templates, `.gitattributes`, `.editorconfig`.
- Test fixtures scaffold: `tests/fixtures/golden/` and `tests/fixtures/safekey/vectors.json` (13/100 vectors; remainder is a Phase 0 deliverable coordinated with BiblioFetch.jl).

### Changed
- `reqwest` 0.12 -> 0.13 (#30) with feature rename `rustls-tls` -> `rustls + webpki-roots`. Rustls-only TLS posture preserved; `openssl` / `native-tls` remain banned by `deny.toml`.
- Dependabot refreshes: `thiserror` 1 -> 2, `toml` 0.8 -> 1.1, `sha2` 0.10 -> 0.11, `toml_edit` 0.22 -> 0.25, `actions/checkout` 4.1.1 -> 6.0.2.
- CI: MSRV alignment, action SHA refresh, `posture-lint` scoping, `expect`/`unwrap` allowed in tests, `CDLA-Permissive-2.0` whitelisted.

### Fixed
- `audit.yml`: removed temporary in-CI `cargo generate-lockfile` now that `Cargo.lock` is checked in (`cf94535`).
- Removed an accidentally-committed editor temp file and ignored `*.tmp.*`.

All entries were verified against `git log --oneline origin/main` and direct inspection of the `main` worktree (no fabricated content).

## Test plan

- [ ] Markdown renders correctly on the GitHub PR view (headings, nested lists, ADR / docs links resolve).
- [ ] `[Unreleased]` is the only version heading (no `[X.Y.Z]` introduced).
- [ ] All linked docs paths exist on `main` (LEGAL/SCOPE/SECURITY/STORE/SAFEKEY/CAPABILITY/PROVENANCE_LOG/ERRORS/CONFIG/CACHE/PUBLIC_API/MCP_TOOLS/SOURCES, ADR 0001-0019 + INDEX, the eight workflow files, fixture paths).
- [ ] CI (`ci`, `audit`, `posture-lint`, `codeql`, `msrv-drift`, `safekey-vectors`) is green on the branch.

Do NOT merge yet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>