### PR TITLE
docs(integration): add Phase-3 placeholder stubs for planned hosts

### DIFF
--- a/docs/INTEGRATION/README.md
+++ b/docs/INTEGRATION/README.md
@@ -16,12 +16,12 @@ server and the corresponding host snippets in this directory.
 
 | File | Host | Status |
 |---|---|---|
-| `claude-desktop.md` | Claude Desktop (stdio MCP) | Phase 3 |
-| `cursor.md` | Cursor | Phase 3 |
-| `codex.md` | OpenAI Codex CLI | Phase 3 |
-| `claude-code.md` | Claude Code (this tool) | Phase 3 |
-| `obsidian.md` | Obsidian backend export | Phase 7 (optional) |
-| `chain-with-paperqa.md` | Composition with paper-qa for content processing | Phase 3+ |
+| `claude-desktop.md` | Claude Desktop (stdio MCP) | Phase 3 (stub) |
+| `cursor.md` | Cursor | Phase 3 (stub) |
+| `codex.md` | OpenAI Codex CLI | Phase 3 (stub) |
+| `claude-code.md` | Claude Code (this tool) | Phase 3 (stub) |
+| `obsidian.md` | Obsidian backend export | Phase 7 (optional, stub) |
+| `chain-with-paperqa.md` | Composition with paper-qa for content processing | Phase 3+ (stub) |
 
 ## What to read in the meantime
 

--- a/docs/INTEGRATION/chain-with-paperqa.md
+++ b/docs/INTEGRATION/chain-with-paperqa.md
@@ -1,0 +1,43 @@
+# Chaining with paper-qa
+
+> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
+> configuration lands when `doiget serve` is real. See
+> [`README.md`](./README.md) for the planned-files table and rationale.
+> Note: per the planned-files table this composition guide is scoped to
+> **Phase 3+** — `doiget serve` ships first, then a verified chain recipe.
+
+[paper-qa](https://github.com/Future-House/paper-qa) is a retrieval-augmented
+question-answering system over scientific papers. The chain pattern this
+guide will document keeps `doiget`'s role narrow — DOI resolution, metadata,
+and content fetch via the tools in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — and
+hands the resulting documents to paper-qa for embedding, retrieval, and
+answer synthesis. Composition keeps each tool single-purpose and avoids
+duplicating retrieval logic inside `doiget`.
+
+## Configuration (Phase 3)
+
+The example below is intentionally empty. The chain shape depends on the
+final Phase 3 tool surface and on paper-qa's MCP/CLI ingestion entry point.
+
+```toml
+<!-- TODO Phase 3: paste verified doiget + paper-qa chain config here. -->
+```
+
+```toml
+<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+```
+
+## What to read in the meantime
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
+  Phase 3 exposes, including JSON-Schema for inputs and outputs.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
+  the `~/.config/doiget/` layout that any host wiring must respect.
+- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
+  and capability-gate context for MCP integration.
+
+## Contributing
+
+If you have a working `doiget` + paper-qa chain ahead of Phase 3, open a
+GitHub Discussion with the orchestration script and any host-specific quirks
+rather than a PR — see [`README.md`](./README.md) §Contributing a snippet.

--- a/docs/INTEGRATION/claude-code.md
+++ b/docs/INTEGRATION/claude-code.md
@@ -1,0 +1,40 @@
+# Claude Code integration
+
+> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
+> configuration lands when `doiget serve` is real. See
+> [`README.md`](./README.md) for the planned-files table and rationale.
+
+[Claude Code](https://www.anthropic.com/claude-code) is Anthropic's official
+CLI and supports MCP servers. Once `doiget serve` ships in Phase 3, this guide
+will document how to register `doiget` as an MCP server in Claude Code (via
+`claude mcp add` or a project-scoped `.mcp.json`) so that the tool surface
+listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) is callable from Claude Code
+sessions.
+
+## Configuration (Phase 3)
+
+The example below is intentionally empty. Do not copy speculative JSON from
+elsewhere — wait for the verified Phase 3 snippet.
+
+```json
+<!-- TODO Phase 3: paste verified Claude Code .mcp.json entry here. -->
+```
+
+```toml
+<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+```
+
+## What to read in the meantime
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
+  Phase 3 exposes, including JSON-Schema for inputs and outputs.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
+  the `~/.config/doiget/` layout that any host wiring must respect.
+- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
+  and capability-gate context for MCP integration.
+
+## Contributing
+
+If you have a working Claude Code integration ahead of Phase 3, open a GitHub
+Discussion with the JSON-RPC trace and host-side config rather than a PR — see
+[`README.md`](./README.md) §Contributing a snippet.

--- a/docs/INTEGRATION/claude-desktop.md
+++ b/docs/INTEGRATION/claude-desktop.md
@@ -1,0 +1,39 @@
+# Claude Desktop integration
+
+> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
+> configuration lands when `doiget serve` is real. See
+> [`README.md`](./README.md) for the planned-files table and rationale.
+
+[Claude Desktop](https://claude.ai/download) is Anthropic's desktop client and
+hosts MCP servers over stdio. Once `doiget serve` ships in Phase 3, this guide
+will document how to register `doiget` as a tool provider in Claude Desktop's
+MCP configuration so that `resolve_doi`, `fetch_metadata`, and the rest of the
+tool surface in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are callable from a chat.
+
+## Configuration (Phase 3)
+
+The example below is intentionally empty. Do not copy speculative JSON from
+elsewhere — wait for the verified Phase 3 snippet.
+
+```json
+<!-- TODO Phase 3: paste verified Claude Desktop MCP server entry here. -->
+```
+
+```toml
+<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+```
+
+## What to read in the meantime
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
+  Phase 3 exposes, including JSON-Schema for inputs and outputs.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
+  the `~/.config/doiget/` layout that any host wiring must respect.
+- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
+  and capability-gate context for MCP integration.
+
+## Contributing
+
+If you have a working Claude Desktop integration ahead of Phase 3, open a
+GitHub Discussion with the JSON-RPC trace and host-side config rather than a
+PR — see [`README.md`](./README.md) §Contributing a snippet.

--- a/docs/INTEGRATION/codex.md
+++ b/docs/INTEGRATION/codex.md
@@ -1,0 +1,39 @@
+# OpenAI Codex CLI integration
+
+> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
+> configuration lands when `doiget serve` is real. See
+> [`README.md`](./README.md) for the planned-files table and rationale.
+
+[OpenAI Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-native
+coding agent and supports MCP servers. Once `doiget serve` ships in Phase 3,
+this guide will document how to register `doiget` as an MCP server in Codex
+CLI so that the tools enumerated in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
+callable from Codex sessions.
+
+## Configuration (Phase 3)
+
+The example below is intentionally empty. Do not copy speculative TOML from
+elsewhere — wait for the verified Phase 3 snippet.
+
+```toml
+<!-- TODO Phase 3: paste verified Codex CLI MCP server entry here. -->
+```
+
+```toml
+<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+```
+
+## What to read in the meantime
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
+  Phase 3 exposes, including JSON-Schema for inputs and outputs.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
+  the `~/.config/doiget/` layout that any host wiring must respect.
+- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
+  and capability-gate context for MCP integration.
+
+## Contributing
+
+If you have a working Codex CLI integration ahead of Phase 3, open a GitHub
+Discussion with the JSON-RPC trace and host-side config rather than a PR — see
+[`README.md`](./README.md) §Contributing a snippet.

--- a/docs/INTEGRATION/cursor.md
+++ b/docs/INTEGRATION/cursor.md
@@ -1,0 +1,39 @@
+# Cursor integration
+
+> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
+> configuration lands when `doiget serve` is real. See
+> [`README.md`](./README.md) for the planned-files table and rationale.
+
+[Cursor](https://www.cursor.com/) is an AI-first code editor that supports MCP
+servers. Once `doiget serve` ships in Phase 3, this guide will show how to
+register `doiget` as an MCP server in Cursor so that DOI resolution, metadata
+fetch, and the other tools listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
+callable from Cursor's agent.
+
+## Configuration (Phase 3)
+
+The example below is intentionally empty. Do not copy speculative JSON from
+elsewhere — wait for the verified Phase 3 snippet.
+
+```json
+<!-- TODO Phase 3: paste verified Cursor MCP server entry here. -->
+```
+
+```toml
+<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+```
+
+## What to read in the meantime
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
+  Phase 3 exposes, including JSON-Schema for inputs and outputs.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
+  the `~/.config/doiget/` layout that any host wiring must respect.
+- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
+  and capability-gate context for MCP integration.
+
+## Contributing
+
+If you have a working Cursor integration ahead of Phase 3, open a GitHub
+Discussion with the JSON-RPC trace and host-side config rather than a PR — see
+[`README.md`](./README.md) §Contributing a snippet.

--- a/docs/INTEGRATION/obsidian.md
+++ b/docs/INTEGRATION/obsidian.md
@@ -1,0 +1,42 @@
+# Obsidian backend export
+
+> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
+> configuration lands when `doiget serve` is real. See
+> [`README.md`](./README.md) for the planned-files table and rationale.
+> Note: per the planned-files table, an Obsidian backend export is scoped to
+> **Phase 7 (optional)** — this stub exists so future contributors have an
+> obvious landing place rather than a 404.
+
+[Obsidian](https://obsidian.md/) is a markdown-based knowledge base. The
+Phase 7 Obsidian backend export will, when shipped, let `doiget` write
+metadata and citation records into an Obsidian vault as plain Markdown notes
+with frontmatter, so that the same data exposed by the MCP tools in
+[`../MCP_TOOLS.md`](../MCP_TOOLS.md) can be browsed inside Obsidian.
+
+## Configuration (Phase 3)
+
+The example below is intentionally empty. The Obsidian backend export is a
+Phase 7 deliverable; even the Phase 3 wiring is not yet implemented.
+
+```toml
+<!-- TODO Phase 3: paste verified Obsidian export config block here. -->
+```
+
+```toml
+<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+```
+
+## What to read in the meantime
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
+  Phase 3 exposes, including JSON-Schema for inputs and outputs.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
+  the `~/.config/doiget/` layout that any host wiring must respect.
+- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
+  and capability-gate context for MCP integration.
+
+## Contributing
+
+If you have a working Obsidian export workflow ahead of Phase 7, open a
+GitHub Discussion describing the vault layout and frontmatter shape rather
+than a PR — see [`README.md`](./README.md) §Contributing a snippet.


### PR DESCRIPTION
## Summary

- `docs/INTEGRATION/README.md` listed six planned host-integration guides (claude-desktop, cursor, codex, claude-code, obsidian, chain-with-paperqa) but only `README.md` existed, so the table's filename references 404'd.
- Adds a ~40-line **PLACEHOLDER** stub per row. Each stub opens with a `> **Status: PLACEHOLDER (Phase 3).**` blockquote pointing back to `INTEGRATION/README.md`, gives a brief one-paragraph host description, contains an empty `Configuration (Phase 3)` section with `<!-- TODO Phase 3 -->` markers (no speculative config invented), and points readers at `docs/MCP_TOOLS.md` for the tool surface and `docs/CONFIG.md` for env-var precedence.
- Updates the planned-files table in `docs/INTEGRATION/README.md`: rightmost Status column changes from `Phase 3` -> `Phase 3 (stub)` for each created row, signalling that a placeholder file exists rather than the file being absent.

## Out of scope

- No host-specific JSON/TOML config snippets are invented; code blocks are intentionally empty TODOs to be filled in Phase 3 once `doiget serve` is real and snippets can be verified end-to-end.
- No new hosts beyond those already listed in `INTEGRATION/README.md`'s planned-files table.

## Test plan

- [ ] `typos` workflow passes on this PR (the stubs use plain English with no jargon that needs adding to `.typos.toml`).
- [ ] Manual: open each new file on the PR's Files Changed tab and confirm the relative links to `../MCP_TOOLS.md`, `../CONFIG.md`, `../ARCHITECTURE.md`, and `./README.md` resolve.
- [ ] Manual: confirm the planned-files table in `docs/INTEGRATION/README.md` now reads `Phase 3 (stub)` (or `Phase 7 (optional, stub)` / `Phase 3+ (stub)`) for every row, and that each filename in the table corresponds to a real file in `docs/INTEGRATION/`.

Generated with [Claude Code](https://claude.com/claude-code).