### PR TITLE
docs: sync PHASES.md ADR range + PUBLIC_API.md ParseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,13 @@ for the full Phase 0 deliverable checklist.
   (`thiserror 2.0.18` only). Reduces future RUSTSEC exposure surface by
   proactively eliminating the dual-version `thiserror 1.x` transitive before
   any advisory lands (#49).
+- `Doi::parse` / `ArxivId::parse` / `Ref::parse` return
+  `Result<Self, RefParseError>` (renamed from the documented `ErrorCode`
+  placeholder; see PR #55,
+  [`docs/PUBLIC_API.md`](docs/PUBLIC_API.md) §4). `RefParseError` is
+  `#[non_exhaustive]` and funnels to `ErrorCode::InvalidRef` at the public
+  MCP / CLI boundary via `impl From<RefParseError> for ErrorCode`, so the
+  `INVALID_REF` surface seen by external callers is unchanged.
 
 ### Fixed
 - `audit.yml`: removed the temporary in-CI `cargo generate-lockfile` step now

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -77,7 +77,7 @@ Phase 0 is complete when **all** of the following are committed.
 - [x] [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
 - [x] [`docs/PHASES.md`](.) (this document)
 - [x] [`docs/MIGRATION.md`](MIGRATION.md) (placeholder; full content Phase 2)
-- [x] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0019
+- [x] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0020
 
 ### CI workflows
 

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -109,22 +109,37 @@ pub struct DoigetExtension {
 
 ```rust
 impl Doi {
-    pub fn parse(s: &str) -> Result<Self, ErrorCode>;
+    pub fn parse(s: &str) -> Result<Self, RefParseError>;
     pub fn as_str(&self) -> &str;
 }
 
 impl ArxivId {
-    pub fn parse(s: &str) -> Result<Self, ErrorCode>;
+    pub fn parse(s: &str) -> Result<Self, RefParseError>;
     pub fn as_str(&self) -> &str;
 }
 
 impl Ref {
-    pub fn parse(s: &str) -> Result<Self, ErrorCode>;
+    pub fn parse(s: &str) -> Result<Self, RefParseError>;
     pub fn safekey(&self) -> Safekey;
 }
 ```
 
-`parse` returns `Err(ErrorCode::InvalidRef)` for malformed input.
+`parse` returns a [`RefParseError`] variant naming the specific rejection
+category (`Empty`, `MissingDoiPrefix`, `MissingDoiSuffixSeparator`,
+`InvalidDoiRegistrant`, `EmptyDoiSuffix`, `DoiSuffixTooLong { len, max }`,
+`InvalidDoiSuffixChar { ch }`, `InvalidArxivShape`). The granular shape is
+preserved for tests and future log breadcrumbs; at the public MCP / CLI
+boundary, all variants funnel to [`ErrorCode::InvalidRef`] via the
+`impl From<RefParseError> for ErrorCode` blanket conversion, so `?`
+propagation collapses to `INVALID_REF` automatically.
+
+`RefParseError` is `#[non_exhaustive]`; adding new categories is a
+non-breaking change. Pattern-match with a wildcard arm.
+
+History: prior revisions of this section documented the signature as
+`Result<Self, ErrorCode>` (a Phase 0 placeholder before the parse impls
+landed). PR #55 introduced the dedicated `RefParseError` type; see also
+the [`Unreleased`] entry in [`CHANGELOG.md`](../CHANGELOG.md).
 
 ## 5. CapabilityProfile
 


### PR DESCRIPTION
## Summary

Two small docs follow-up fixes flagged after PR #50 (ADR-0020) and PR #55
(Phase 1 parse impls) merged but not yet reflected in the documentation
surface.

- **`docs/PHASES.md`** — Phase 0 deliverable bullet bumped from
  "ADRs 0001 to 0019" to "0001 to 0020". `docs/DECISIONS/INDEX.md` already
  has the 0020 row (reqwest TLS feature stack, Proposed, PR #30 / PR #49)
  and `ls docs/DECISIONS/*.md | wc -l` is 21 (20 ADRs + INDEX.md).
- **`docs/PUBLIC_API.md` §4** — replace the Phase 0 placeholder
  `Result<Self, ErrorCode>` with the actual signature
  `Result<Self, RefParseError>` for `Doi::parse` / `ArxivId::parse` /
  `Ref::parse` (PR #55). Documents the variant set
  (`Empty`, `MissingDoiPrefix`, `MissingDoiSuffixSeparator`,
  `InvalidDoiRegistrant`, `EmptyDoiSuffix`, `DoiSuffixTooLong`,
  `InvalidDoiSuffixChar`, `InvalidArxivShape`), the `#[non_exhaustive]`
  posture (so adding new categories is non-breaking), and the
  `impl From<RefParseError> for ErrorCode` collapse to
  `ErrorCode::InvalidRef` at the public MCP / CLI boundary — i.e. the
  external `INVALID_REF` surface is unchanged.
- **`CHANGELOG.md`** — `[Unreleased]` `Changed` bullet added,
  cross-referencing PR #55 and `docs/PUBLIC_API.md` §4 per §6
  Stability-guarantees ("breaking changes…must still be documented in
  CHANGELOG.md and an ADR").

### Note on the type name

The original task description referenced the type as `ParseError`. The
actual type in `crates/doiget-core/src/lib.rs` is `RefParseError`
(reasons-a-`Doi::parse`/`ArxivId::parse`/`Ref::parse`-call-can-fail enum,
defined at the crate root, `#[non_exhaustive]`, with
`impl From<RefParseError> for ErrorCode`). Per the directive "find the
actual current signatures…update PUBLIC_API.md §4 wherever it lists those
signatures" and "reflect reality", the docs use `RefParseError`.

### Scope

Touches only `docs/PHASES.md`, `docs/PUBLIC_API.md`, and `CHANGELOG.md`.
No `.rs` changes. No ADR changes. No other docs touched.

## Verification

- [x] `grep -rn "0001-0019" docs/` (en-dash form too) returns no matches.
- [x] `grep -n "ErrorCode" docs/PUBLIC_API.md` returns only the
      re-export (line 28), the `From`-impl description (lines 132-133),
      and an explicit history note (line 140). No parse signature
      mentions `ErrorCode`.
- [x] `ls docs/DECISIONS/*.md | wc -l` = 21 (20 ADRs + INDEX.md);
      INDEX.md row 36 contains the 0020 entry.
- [x] `git diff --stat` = 3 files, +27 / -5; no unrelated changes.

## Test plan

- [ ] Confirm CI green on PR (in particular the `typos` workflow, since
      the only added prose is in the three docs files).
- [ ] Spot-check rendered Markdown on the PR's `Files changed` tab —
      especially the §4 RefParseError block and the `Unreleased / Changed`
      bullet — to make sure nothing wraps oddly.
- [ ] Re-confirm `grep -n "ErrorCode" docs/PUBLIC_API.md` post-merge
      shows no parse-signature occurrences.

Companion to PR #50 (ADR-0020) and PR #55 (parse impls).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
