### PR TITLE
chore(fuzz): cargo-fuzz harness for Doi/ArxivId/Ref::parse + smoke CI

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -1,0 +1,45 @@
+name: fuzz-smoke
+# Smoke-fuzz the input-validation surface. NOT exhaustive — 60 s per target.
+# Long fuzz runs happen out-of-band; this CI catches harness compilation
+# breaks and immediate panics. See docs/SECURITY.md §1.1.
+
+on:
+  pull_request:
+    paths:
+      - "crates/doiget-core/src/**"
+      - "crates/doiget-core/fuzz/**"
+      - ".github/workflows/fuzz-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/doiget-core/src/**"
+      - "crates/doiget-core/fuzz/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: cargo fuzz smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [doi_parse, arxiv_parse, ref_parse]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4   # v2.9.1
+        with:
+          workspaces: "crates/doiget-core/fuzz -> target"
+      - name: Install cargo-fuzz
+        run: cargo install --locked cargo-fuzz
+      - name: cargo fuzz run ${{ matrix.target }} (60 s)
+        run: cargo fuzz run ${{ matrix.target }} --fuzz-dir crates/doiget-core/fuzz -- -max_total_time=60

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -41,5 +41,11 @@ jobs:
           workspaces: "crates/doiget-core/fuzz -> target"
       - name: Install cargo-fuzz
         run: cargo install --locked cargo-fuzz
+      # `rust-toolchain.toml` at the repo root pins `channel = "stable"`, which
+      # would otherwise override the nightly we just installed. cargo-fuzz
+      # needs nightly for `-Zsanitizer`, so force nightly via env for this
+      # step. Equivalent to `cargo +nightly fuzz run ...`.
       - name: cargo fuzz run ${{ matrix.target }} (60 s)
+        env:
+          RUSTUP_TOOLCHAIN: nightly
         run: cargo fuzz run ${{ matrix.target }} --fuzz-dir crates/doiget-core/fuzz -- -max_total_time=60

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
 exclude = [
     # Phase 7 optional, default OFF (see ADR-0008 / docs/SCOPE.md)
     "crates/doiget-obsidian",
+    # cargo-fuzz harness — requires nightly toolchain (libfuzzer-sys),
+    # so it lives outside the stable workspace. See
+    # crates/doiget-core/fuzz/README.md and docs/SECURITY.md §1.1.
+    "crates/doiget-core/fuzz",
 ]
 
 [workspace.package]

--- a/crates/doiget-core/fuzz/.gitignore
+++ b/crates/doiget-core/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/crates/doiget-core/fuzz/Cargo.toml
+++ b/crates/doiget-core/fuzz/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "doiget-core-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+# Force cargo to treat this crate as its own one-crate workspace so
+# `cargo fuzz` (which invokes the manifest directly via `--manifest-path`)
+# does not try to claim membership in the parent doiget workspace, which
+# pins stable Rust. The parent `Cargo.toml` also lists this directory in
+# `workspace.exclude`; both belt and suspenders are required.
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+doiget-core = { path = ".." }
+
+# This crate is intentionally excluded from the main workspace
+# (see workspace `Cargo.toml`) because libfuzzer-sys requires the nightly
+# toolchain. See `crates/doiget-core/fuzz/README.md` and
+# `docs/SECURITY.md` §1.1.
+
+[[bin]]
+name = "doi_parse"
+path = "fuzz_targets/doi_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "arxiv_parse"
+path = "fuzz_targets/arxiv_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "ref_parse"
+path = "fuzz_targets/ref_parse.rs"
+test = false
+doc = false
+bench = false

--- a/crates/doiget-core/fuzz/README.md
+++ b/crates/doiget-core/fuzz/README.md
@@ -1,0 +1,59 @@
+# doiget-core fuzz harness
+
+`cargo-fuzz` (libFuzzer) coverage of the input-validation surface that
+guards every untrusted-input entry point in `doiget`:
+
+- `doiget_core::Doi::parse`
+- `doiget_core::ArxivId::parse`
+- `doiget_core::Ref::parse`
+
+These three functions are the trust boundary documented in
+[`docs/SECURITY.md`](../../../docs/SECURITY.md) §1.1. Anything that
+panics or unbounded-allocates here is a defect in defense-in-depth, so
+this harness exists to catch regressions early.
+
+## Why a separate workspace
+
+`libfuzzer-sys` requires nightly Rust. The main `doiget` workspace pins
+stable (see [`rust-toolchain.toml`](../../../rust-toolchain.toml) /
+`Cargo.toml` `rust-version = "1.86"`), so this fuzz crate is
+**deliberately excluded** from the main workspace via the root
+`[workspace] exclude = [...]` entry. It is its own one-crate workspace
+that you only ever invoke through `cargo +nightly fuzz`.
+
+## Running locally
+
+One-time install:
+
+```sh
+cargo +nightly install cargo-fuzz
+```
+
+Run a single target (default 60 s smoke; pass `-max_total_time=N` to
+extend, or omit `--` to run open-ended until you Ctrl-C):
+
+```sh
+# from the repo root
+cargo +nightly fuzz run doi_parse   --fuzz-dir crates/doiget-core/fuzz -- -max_total_time=60
+cargo +nightly fuzz run arxiv_parse --fuzz-dir crates/doiget-core/fuzz -- -max_total_time=60
+cargo +nightly fuzz run ref_parse   --fuzz-dir crates/doiget-core/fuzz -- -max_total_time=60
+```
+
+Each target accepts an arbitrary byte slice, decodes it as UTF-8 (the
+parsers take `&str`), and calls the corresponding `parse` function. A
+panic, abort, or libFuzzer-detected memory fault is a fuzzing failure;
+returning either `Ok(_)` or `Err(RefParseError)` is success.
+
+## CI
+
+The [`fuzz-smoke` workflow](../../../.github/workflows/fuzz-smoke.yml)
+runs each target for 60 seconds on every PR that touches
+`crates/doiget-core/src/**` or `crates/doiget-core/fuzz/**`. This is a
+*compile + smoke* check, not an exhaustive fuzz session — long fuzz runs
+happen out-of-band.
+
+## Corpus / artifacts
+
+`corpus/` (seed inputs) and `artifacts/` (crash reproducers) are
+git-ignored. Add representative inputs there if you want to seed a
+campaign; otherwise libFuzzer starts cold and discovers structure.

--- a/crates/doiget-core/fuzz/fuzz_targets/arxiv_parse.rs
+++ b/crates/doiget-core/fuzz/fuzz_targets/arxiv_parse.rs
@@ -1,0 +1,17 @@
+#![no_main]
+//! Fuzz target for [`doiget_core::ArxivId::parse`].
+//!
+//! Parsing is the trust boundary for untrusted input received via the CLI
+//! and the MCP server. See `docs/SECURITY.md` §1.1.
+//!
+//! The harness asserts that `ArxivId::parse` never panics on arbitrary
+//! input; it must always return either `Ok(ArxivId)` or
+//! `Err(RefParseError)`.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = doiget_core::ArxivId::parse(s);
+    }
+});

--- a/crates/doiget-core/fuzz/fuzz_targets/doi_parse.rs
+++ b/crates/doiget-core/fuzz/fuzz_targets/doi_parse.rs
@@ -1,0 +1,19 @@
+#![no_main]
+//! Fuzz target for [`doiget_core::Doi::parse`].
+//!
+//! Parsing is the trust boundary for untrusted input received via the CLI
+//! and the MCP server. See `docs/SECURITY.md` §1.1.
+//!
+//! The harness asserts that `Doi::parse` never panics on arbitrary input;
+//! it must always return either `Ok(Doi)` or `Err(RefParseError)`.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // `parse` takes `&str`, so reject non-UTF-8 inputs early. libFuzzer
+    // explores both the UTF-8 and non-UTF-8 input spaces; the cheap
+    // `from_utf8` check just routes the latter past the validator.
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = doiget_core::Doi::parse(s);
+    }
+});

--- a/crates/doiget-core/fuzz/fuzz_targets/ref_parse.rs
+++ b/crates/doiget-core/fuzz/fuzz_targets/ref_parse.rs
@@ -1,0 +1,17 @@
+#![no_main]
+//! Fuzz target for [`doiget_core::Ref::parse`].
+//!
+//! `Ref::parse` is the dispatcher used by the CLI (`doiget fetch <ref>`)
+//! and the MCP `doiget_fetch` tool to interpret untrusted input. It
+//! auto-detects DOI vs arXiv shape; see `docs/SECURITY.md` §1.1.
+//!
+//! The harness asserts that `Ref::parse` never panics on arbitrary input;
+//! it must always return either `Ok(Ref)` or `Err(RefParseError)`.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = doiget_core::Ref::parse(s);
+    }
+});


### PR DESCRIPTION
## Summary

Adds a libFuzzer harness for the input-validation trust boundary
documented in [`docs/SECURITY.md`](../blob/main/docs/SECURITY.md) §1.1.
Three targets exercise the three parsers landed in PR #55:

- `doiget_core::Doi::parse`
- `doiget_core::ArxivId::parse`
- `doiget_core::Ref::parse`

Each target accepts an arbitrary byte slice from libFuzzer, decodes it
as UTF-8 (the parsers take `&str`), and asserts only that the call
never panics / aborts / unbounded-allocates. Returning either `Ok(_)`
or `Err(RefParseError)` is success. This is **defense-in-depth** for
untrusted CLI and MCP input, not a correctness oracle.

## Layout

```
crates/doiget-core/fuzz/
  Cargo.toml                # standalone one-crate workspace
  .gitignore                # corpus/ artifacts/ target/
  README.md                 # local-run instructions, SECURITY.md pointer
  fuzz_targets/
    doi_parse.rs
    arxiv_parse.rs
    ref_parse.rs
```

The fuzz crate is **deliberately excluded** from the main workspace
because `libfuzzer-sys` requires nightly Rust while the main workspace
pins stable (`rust-version = "1.86"`). The exclusion is belt-and-suspenders:

- root `Cargo.toml` lists `crates/doiget-core/fuzz` in `[workspace] exclude`,
- the fuzz `Cargo.toml` carries its own empty `[workspace]` table so
  `cargo fuzz`'s direct `--manifest-path` invocation does not try to
  claim membership in the parent workspace.

## CI

New workflow `.github/workflows/fuzz-smoke.yml` runs each target for
60 s on PRs that touch `crates/doiget-core/src/**` or
`crates/doiget-core/fuzz/**`. This is a *compile + smoke* gate, not an
exhaustive campaign — long fuzz runs happen out-of-band. Action SHAs
are pinned to match `.github/workflows/ci.yml` (`actions/checkout` v6.0.2,
`dtolnay/rust-toolchain`, `Swatinem/rust-cache` v2.9.1).

## Validation

Run on the local Windows worktree:

- ` + "`cargo build --workspace --no-default-features --features oa-only`" + `:
  finished cleanly — main workspace unaffected by the new
  `[workspace] exclude` entry.
- ` + "`cargo clippy --workspace --no-default-features --features oa-only -- -D warnings`" + `:
  no warnings.
- ` + "`cargo +nightly metadata --manifest-path crates/doiget-core/fuzz/Cargo.toml`" + `:
  resolves the fuzz crate as its own one-crate workspace with the three
  expected ` + "`[[bin]]`" + ` targets.
- ` + "`cargo +nightly fuzz build`" + ` was **not** run locally because
  ` + "`cargo-fuzz`" + ` is not installed on this machine and the workflow
  is the source of truth for the harness build. CI ` + "`fuzz-smoke`" + ` will
  be the first end-to-end compile signal.

## Test plan

- [ ] `fuzz-smoke` workflow runs on this PR and all three matrix legs
      (`doi_parse`, `arxiv_parse`, `ref_parse`) finish under the 15-min
      job timeout, each completing the 60 s libFuzzer run without a
      panic / abort / OOM.
- [ ] Existing CI (`ci`, `audit`, `codeql`, `msrv-drift`,
      `safekey-vectors`, `cross-tool-compat`, `mcp-smoke`,
      `posture-lint`, `typos`) stays green — the workspace `exclude`
      change is the only main-workspace edit.
- [ ] (Optional, follow-up) Run a longer out-of-band fuzz session
      (`-max_total_time=600`) and seed `corpus/` from
      `crates/doiget-core/src/lib.rs` test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)