### PR TITLE
feat(core): rate limiter (5/sec global + 200ms per-source backoff)

### DIFF
--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -53,3 +53,6 @@ futures-util = { workspace = true }
 [dev-dependencies]
 wiremock   = { workspace = true }
 proptest   = { workspace = true }
+# `test-util` enables `tokio::test(start_paused = true)` and the
+# `tokio::time::pause()` / `advance()` API used by rate_limiter tests.
+tokio      = { workspace = true, features = ["test-util"] }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -14,7 +14,9 @@
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
+// --- Modules ---
 pub mod http;
+pub mod rate_limiter;
 
 /// Crate version. Used by `doiget-cli --version` and `doiget_health`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/doiget-core/src/rate_limiter.rs
+++ b/crates/doiget-core/src/rate_limiter.rs
@@ -1,0 +1,311 @@
+//! Process-wide rate limiter for HTTP fetches across all `Source` impls.
+//!
+//! See `docs/SECURITY.md` (per-session fetch flood mitigation) and
+//! `docs/SOURCES.md` §6 (Politeness defaults). The constants enforced here
+//! are the load-bearing safeguards from `docs/LEGAL.md` §6 safeguard 8.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::time::{sleep_until, Instant};
+
+use crate::RateLimits;
+
+/// Process-wide async rate limiter.
+///
+/// Enforces three invariants on every [`acquire`](RateLimiter::acquire):
+///   1. **Global concurrency** — at most
+///      [`RateLimits::max_concurrent_fetches`](crate::RateLimits::max_concurrent_fetches)
+///      in flight at once.
+///   2. **Global rate** — at most
+///      [`RateLimits::max_fetches_per_second`](crate::RateLimits::max_fetches_per_second)
+///      starts in any rolling one-second window.
+///   3. **Per-source backoff** — at least
+///      [`RateLimits::per_source_backoff_ms`](crate::RateLimits::per_source_backoff_ms)
+///      between consecutive starts to the same source name.
+///
+/// The returned [`Permit`] holds the concurrency slot for the lifetime of the
+/// value; drop it when the fetch is done.
+///
+/// 429 / `Retry-After` handling is split: the limiter only exposes the admin
+/// hook [`sleep_for`](RateLimiter::sleep_for); the actual `Retry-After`
+/// header parse and call lives at the `Source::fetch` call site, per
+/// `docs/SOURCES.md` §6.
+#[derive(Debug)]
+pub struct RateLimiter {
+    limits: RateLimits,
+    sem: Arc<Semaphore>,
+    // Global rolling-second window: timestamps of starts within the last second.
+    global_starts: Arc<Mutex<Vec<Instant>>>,
+    // Earliest-allowed start time per source name.
+    per_source_next: Arc<Mutex<HashMap<String, Instant>>>,
+}
+
+/// Held while a fetch is in flight; releases the concurrency slot on drop.
+#[derive(Debug)]
+pub struct Permit {
+    _slot: OwnedSemaphorePermit,
+}
+
+impl RateLimiter {
+    /// Construct from the hard-coded [`RateLimits`] (the only public path).
+    pub fn new(limits: RateLimits) -> Self {
+        let max = limits.max_concurrent_fetches() as usize;
+        Self {
+            limits,
+            sem: Arc::new(Semaphore::new(max)),
+            global_starts: Arc::new(Mutex::new(Vec::new())),
+            per_source_next: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Block until a slot is available, then return a [`Permit`].
+    ///
+    /// Order of waits, in this exact sequence:
+    ///   1. global concurrency (semaphore acquire),
+    ///   2. global rate cap (sleep if the rolling-second window is full),
+    ///   3. per-source backoff (sleep until the source's `next` time).
+    ///
+    /// Lock-acquisition order is always `global_starts` first, THEN
+    /// `per_source_next`. Any future call site that needs both locks MUST
+    /// follow the same order to keep the system deadlock-free.
+    pub async fn acquire(&self, source: &str) -> Permit {
+        // Step 1: global concurrency — bounded by Semaphore::new(max).
+        // `acquire_owned` only errors when the semaphore is closed; this
+        // type never closes it (no `close()` call exists), so the Err arm
+        // is structurally unreachable. The local `allow` is the documented
+        // exception to the workspace `expect_used` lint.
+        #[allow(clippy::expect_used)]
+        let slot = self
+            .sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("rate-limiter semaphore is never closed");
+
+        // Step 2: global rate cap. Loop until the rolling-second window has
+        // room, sleeping until the oldest entry ages out if it does not.
+        let max_per_sec = self.limits.max_fetches_per_second() as usize;
+        let one_sec = Duration::from_secs(1);
+        loop {
+            let mut starts = self.global_starts.lock().await;
+            let now = Instant::now();
+            // Prune entries older than 1 s. starts is FIFO so we can drop
+            // a contiguous prefix.
+            let cutoff = now.checked_sub(one_sec).unwrap_or(now);
+            let drop_count = starts.iter().take_while(|t| **t <= cutoff).count();
+            if drop_count > 0 {
+                starts.drain(..drop_count);
+            }
+            if starts.len() < max_per_sec {
+                break;
+            }
+            // Window is full — wake at the moment the oldest entry ages out.
+            // starts.len() >= max_per_sec >= 1 here, so [0] is safe.
+            let wake = starts[0] + one_sec;
+            drop(starts);
+            sleep_until(wake).await;
+        }
+
+        // Step 3: per-source backoff. Acquire `per_source_next` strictly
+        // after dropping `global_starts` above (lock order documented).
+        let backoff = Duration::from_millis(self.limits.per_source_backoff_ms());
+        let mut next_map = self.per_source_next.lock().await;
+        let now = Instant::now();
+        if let Some(&next) = next_map.get(source) {
+            if now < next {
+                drop(next_map);
+                sleep_until(next).await;
+                next_map = self.per_source_next.lock().await;
+            }
+        }
+        // Record this start in both ledgers. We re-read `Instant::now()`
+        // because we may have slept in step 2 or step 3.
+        let start = Instant::now();
+        next_map.insert(source.to_string(), start + backoff);
+        drop(next_map);
+
+        // Push the start timestamp into the global window. Done AFTER
+        // releasing per_source_next to keep the documented lock order
+        // (global → per-source) on every code path.
+        let mut starts = self.global_starts.lock().await;
+        starts.push(start);
+        drop(starts);
+
+        Permit { _slot: slot }
+    }
+
+    /// Tell the limiter to delay further starts to `source` by at least
+    /// `dur`. Used when the source returns 429 with `Retry-After`.
+    pub async fn sleep_for(&self, source: &str, dur: Duration) {
+        let mut next_map = self.per_source_next.lock().await;
+        let target = Instant::now() + dur;
+        let entry = next_map.entry(source.to_string()).or_insert(target);
+        if *entry < target {
+            *entry = target;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::{RateLimits, MAX_CONCURRENT_FETCHES, MAX_FETCHES_PER_SECOND};
+
+    /// Convenience: shared `Arc<RateLimiter>` initialized from
+    /// `RateLimits::HARD_CODED`.
+    fn limiter() -> Arc<RateLimiter> {
+        Arc::new(RateLimiter::new(RateLimits::HARD_CODED))
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn concurrent_acquires_respect_max_concurrency() {
+        // Spawn 10 tasks racing to acquire; assert the live count never
+        // exceeds MAX_CONCURRENT_FETCHES.
+        let rl = limiter();
+        let live = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for i in 0..10u32 {
+            let rl = rl.clone();
+            let live = live.clone();
+            let max_seen = max_seen.clone();
+            let src = format!("src-{}", i);
+            handles.push(tokio::spawn(async move {
+                let permit = rl.acquire(&src).await;
+                let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(now, Ordering::SeqCst);
+                // Hold the permit briefly so peers contend.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                live.fetch_sub(1, Ordering::SeqCst);
+                drop(permit);
+            }));
+        }
+        for h in handles {
+            h.await.expect("task ok");
+        }
+        let max = max_seen.load(Ordering::SeqCst);
+        assert!(
+            max <= MAX_CONCURRENT_FETCHES as usize,
+            "max concurrent live = {}, expected <= {}",
+            max,
+            MAX_CONCURRENT_FETCHES
+        );
+        assert!(max > 0, "at least one acquire should succeed");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn same_source_starts_separated_by_backoff() {
+        // Two acquires for the same source must be at least
+        // per_source_backoff_ms apart.
+        let rl = limiter();
+        let backoff_ms = RateLimits::HARD_CODED.per_source_backoff_ms();
+
+        let t0 = Instant::now();
+        let p0 = rl.acquire("crossref").await;
+        drop(p0);
+        let _p1 = rl.acquire("crossref").await;
+        let elapsed = Instant::now().duration_since(t0);
+
+        assert!(
+            elapsed >= Duration::from_millis(backoff_ms),
+            "elapsed {:?} < backoff {} ms",
+            elapsed,
+            backoff_ms
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn different_sources_no_per_source_wait() {
+        // Acquire source A, then source B back-to-back: per-source backoff
+        // must not apply between distinct sources. (Global rate still
+        // applies; with only two starts it does not bind.)
+        let rl = limiter();
+        let backoff = Duration::from_millis(RateLimits::HARD_CODED.per_source_backoff_ms());
+
+        let t0 = Instant::now();
+        let _p_a = rl.acquire("source-a").await;
+        let _p_b = rl.acquire("source-b").await;
+        let elapsed = Instant::now().duration_since(t0);
+
+        assert!(
+            elapsed < backoff,
+            "elapsed {:?} should be well under per-source backoff {:?}",
+            elapsed,
+            backoff
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn global_rate_caps_starts_per_second() {
+        // Acquire 10 distinct sources back-to-back, dropping each permit
+        // immediately so the concurrency cap (5) does not collide with the
+        // rate cap we're trying to observe. Only MAX_FETCHES_PER_SECOND
+        // starts may complete in the first second; the remainder must wait
+        // for the rolling-second window to free.
+        let rl = limiter();
+        let max_per_sec = MAX_FETCHES_PER_SECOND as usize;
+
+        let t0 = Instant::now();
+        let mut completion_offsets: Vec<Duration> = Vec::with_capacity(10);
+        for i in 0..10u32 {
+            let src = format!("src-{}", i);
+            let p = rl.acquire(&src).await;
+            completion_offsets.push(Instant::now().duration_since(t0));
+            drop(p); // release immediately — we are testing rate, not concurrency.
+        }
+
+        // Within the first second from t0, at most max_per_sec acquires
+        // should have completed.
+        let in_first_sec = completion_offsets
+            .iter()
+            .filter(|d| **d < Duration::from_secs(1))
+            .count();
+        assert!(
+            in_first_sec <= max_per_sec,
+            "{} starts completed in first second, expected <= {}",
+            in_first_sec,
+            max_per_sec
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn sleep_for_delays_target_source() {
+        // sleep_for("X", 500ms) then acquire("X") must take at least 500
+        // ms; acquire("Y") in the same window must NOT be delayed by it.
+        let rl = limiter();
+        let delay = Duration::from_millis(500);
+        rl.sleep_for("X", delay).await;
+
+        // Y is unaffected.
+        let t_y = Instant::now();
+        let _p_y = rl.acquire("Y").await;
+        let elapsed_y = Instant::now().duration_since(t_y);
+        assert!(
+            elapsed_y < delay,
+            "Y elapsed {:?} should be far less than {:?}",
+            elapsed_y,
+            delay
+        );
+
+        // X is delayed by at least `delay`.
+        let t_x = Instant::now();
+        let _p_x = rl.acquire("X").await;
+        let elapsed_x = Instant::now().duration_since(t_x);
+        assert!(
+            elapsed_x >= delay,
+            "X elapsed {:?} < requested delay {:?}",
+            elapsed_x,
+            delay
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the process-wide async `RateLimiter` that the `Source` trait will use for politeness control. Phase 1 deliverable, blocking real `Source::fetch` impls.

References:
- `docs/SECURITY.md` — per-session fetch flood mitigation (`MAX_CONCURRENT_FETCHES = 5` row at the §1.4 table; mitigates the documented hard cap)
- `docs/SOURCES.md` §6 (Politeness defaults) — 5 fetches/sec, 200 ms per-source backoff, `Retry-After` honored
- `docs/LEGAL.md` §6 safeguard 8 — load-bearing constants (already `pub const` in `doiget-core`; reused, not redeclared)

## Invariants tested (5)

The new `crates/doiget-core/src/rate_limiter.rs` ships with five `tokio::test(start_paused = true)` tests:

1. `concurrent_acquires_respect_max_concurrency` — 10 racing tasks; live count never exceeds `MAX_CONCURRENT_FETCHES = 5`.
2. `same_source_starts_separated_by_backoff` — two acquires on the same source are >= `per_source_backoff_ms` (200 ms) apart.
3. `different_sources_no_per_source_wait` — back-to-back acquires on distinct sources do not incur the per-source backoff.
4. `global_rate_caps_starts_per_second` — 10 distinct sources back-to-back; at most `MAX_FETCHES_PER_SECOND = 5` complete in any 1 s window.
5. `sleep_for_delays_target_source` — admin hook delays only the named source; other sources are unaffected.

## Design notes

- Returned `Permit` (newtype around `OwnedSemaphorePermit`) holds the concurrency slot until dropped.
- `Retry-After` parse + call to `sleep_for(source, dur)` lives at the `Source::fetch` call site (Phase 1 W4+); the limiter only exposes the admin hook.
- **Lock order**: `global_starts` first, THEN `per_source_next`. Documented in the `acquire()` rustdoc — any future code that needs both locks must follow the same order to avoid deadlocks.
- `expect_used` on the never-closed semaphore is locally `#[allow]`'d with a SAFETY-style comment (workspace lints `expect_used = warn`, but tests `--tests -D warnings` makes it deny).

## Files touched

- NEW: `crates/doiget-core/src/rate_limiter.rs` (lib + 5 tests, single file).
- `crates/doiget-core/src/lib.rs` — single `pub mod rate_limiter;` line under a new `// --- Modules ---` group at the top of the file. Minimal edit; parallel PRs adding `provenance` / `http` modules will conflict at merge time as anticipated in the brief.
- `crates/doiget-core/Cargo.toml` — `tokio = { workspace = true, features = ["test-util"] }` added to `[dev-dependencies]` to enable `tokio::test(start_paused = true)`. `tokio` `sync` + `time` features were already present at workspace level. No production deps changed.

## Validation

Local toolchain: `rust-toolchain.toml` pins `channel = "stable"`; resolves to `stable-x86_64-pc-windows-msvc`. Cargo invoked at the user-noted absolute path `C:\Users\souta\.cargo\bin\cargo.exe`.

- [x] `cargo build --workspace --no-default-features --features oa-only` — clean.
- [x] `cargo test -p doiget-core --no-default-features --features oa-only` — 56 unit + 2 integration tests pass; rate-limiter contributes 5 new ones.
- [x] `cargo clippy -p doiget-core --tests --no-default-features --features oa-only -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean (rustfmt's import-ordering applied; lib code unchanged in semantics).

## Test plan

- [x] `concurrent_acquires_respect_max_concurrency` exercises invariant 1 with 10-way contention.
- [x] `same_source_starts_separated_by_backoff` exercises invariant 3 (per-source backoff).
- [x] `different_sources_no_per_source_wait` proves the per-source ledger is keyed by source name, not global.
- [x] `global_rate_caps_starts_per_second` exercises invariant 2 by acquiring 10 distinct sources and counting completions inside a 1-s window.
- [x] `sleep_for_delays_target_source` exercises the admin hook used for `Retry-After` 429 enforcement.

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)