### PR TITLE
feat(core): Source trait + FetchContext + FetchResult + FetchError (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -132,6 +132,17 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -490,6 +501,7 @@ dependencies = [
 name = "doiget-core"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "camino",
  "chrono",
@@ -550,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1248,7 +1260,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1647,7 +1659,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1704,7 +1716,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1935,7 +1947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1997,7 +2009,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2580,7 +2592,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ clap = { version = "4", features = ["derive", "env", "string"] }
 thiserror = "2"
 anyhow    = "1"
 
+# Async-fn-in-trait shim. Native `async fn` in traits is stable since
+# 1.75, but `#[async_trait::async_trait]` is still required to make
+# the public `Source` trait dyn-compatible (`Box<dyn Source>`), since
+# native dyn-safety for async fn in traits is unstable.
+async-trait = "0.1"
+
 # Logging
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -29,6 +29,7 @@ tdm-springer = ["dep:secrecy"]
 [dependencies]
 tokio       = { workspace = true }
 thiserror   = { workspace = true }
+async-trait = { workspace = true }
 tracing     = { workspace = true }
 secrecy     = { workspace = true, optional = true }
 reqwest     = { workspace = true }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -18,6 +18,7 @@ use sha2::Digest;
 pub mod http;
 pub mod provenance;
 pub mod rate_limiter;
+pub mod source;
 
 /// Crate version. Used by `doiget-cli --version` and `doiget_health`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -1,0 +1,332 @@
+//! Source abstraction. Each Tier 1/2/3 fetcher implements this trait.
+//!
+//! Binding spec: `docs/PUBLIC_API.md` §2 (trait surface),
+//! `docs/ARCHITECTURE.md` §6 (per-fetch data flow), and
+//! `docs/PROVENANCE_LOG.md` §3 (the `Fetch` row source impls emit).
+//!
+//! Phase 1 ships the trait + supporting types; concrete impls (Crossref,
+//! Unpaywall, arXiv) land in follow-up PRs (see `docs/SOURCES.md` for the
+//! source matrix and tiering).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use thiserror::Error;
+
+use crate::http::{HttpClient, HttpError};
+use crate::provenance::{LogError, ProvenanceLog};
+use crate::rate_limiter::RateLimiter;
+use crate::{CapabilityProfile, Ref, RefParseError};
+
+/// What a successful fetch returns to the caller.
+///
+/// Whether `pdf_bytes` is `None` depends on the source: metadata-only
+/// sources (Phase 4) leave it unset; OA sources (Phase 1) return PDF bytes
+/// when an OA URL was discovered.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FetchResult {
+    /// Source's name (matches `Source::name()`); set for the audit trail.
+    pub source: String,
+    /// OA license string (`"CC-BY-4.0"`, `"unknown"`, etc.).
+    pub license: String,
+    /// PDF bytes; `None` for metadata-only sources.
+    pub pdf_bytes: Option<Bytes>,
+    /// Final URL after redirect resolution; useful for the metadata
+    /// `[doiget].url` field.
+    pub final_url: Option<url::Url>,
+    /// Source-side metadata payload as a serde_json value. The Source impl
+    /// is responsible for the shape; the caller (Phase 1+ orchestrator)
+    /// maps it into `Metadata` when one exists (Phase 1+).
+    pub metadata_json: Option<serde_json::Value>,
+}
+
+/// Per-fetch context shared by all `Source` impls.
+///
+/// Held by the orchestrator (CLI / MCP server) and passed by reference into
+/// each [`Source::fetch`]. Sources MUST NOT construct their own
+/// [`HttpClient`] / [`RateLimiter`] / [`ProvenanceLog`] — they go through
+/// this context for uniform politeness, redirect allowlisting, and audit
+/// logging.
+#[derive(Clone)]
+pub struct FetchContext {
+    /// Shared, allowlist-aware HTTP client. See [`HttpClient`].
+    pub http: Arc<HttpClient>,
+    /// Process-wide async rate limiter. See [`RateLimiter`].
+    pub rate_limiter: Arc<RateLimiter>,
+    /// Append-only, hash-chained provenance log. Source impls MUST emit
+    /// one `LogEvent::Fetch` row per attempt via `log.append`. See
+    /// [`ProvenanceLog`].
+    pub log: Arc<ProvenanceLog>,
+    /// 26-char ULID identifying this process invocation. Mirrors the
+    /// `session_id` stamped into every provenance row by the writer; held
+    /// here so source impls can include it in their own structured logs
+    /// without re-reading the env.
+    pub session_id: String,
+}
+
+impl std::fmt::Debug for FetchContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Avoid printing the full HTTP / rate-limiter / log internals; only
+        // the session_id is human-meaningful for log breadcrumbs.
+        f.debug_struct("FetchContext")
+            .field("session_id", &self.session_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Errors returned by [`Source::fetch`].
+///
+/// At the public CLI / MCP boundary, every variant collapses to an
+/// [`crate::ErrorCode`] via the `From<FetchError>` impl below — mirroring
+/// the [`RefParseError`] → [`crate::ErrorCode::InvalidRef`] collapse from
+/// PR #55.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FetchError {
+    /// The source does not handle the given ref under the runtime
+    /// capability profile (covers both `can_serve = false` outcomes and
+    /// runtime denials raised inside `fetch`).
+    #[error("source {source_key} cannot serve this ref")]
+    NotEligible {
+        /// The source key that declined.
+        source_key: String,
+    },
+    /// Tier 1 sources reported no OA URL for this ref.
+    #[error("Tier 1 sources reported no OA URL for this ref")]
+    NoOaAvailable,
+    /// Underlying HTTP / network failure. See [`HttpError`].
+    #[error("network error: {0}")]
+    Http(#[from] HttpError),
+    /// Provenance log write failed. Per `docs/SECURITY.md` §1.8 this is a
+    /// fail-closed signal; the surrounding fetch MUST be aborted.
+    #[error("provenance log error: {0}")]
+    Log(#[from] LogError),
+    /// Ref re-parse / validation failed inside the source (e.g. when a
+    /// source receives a borrowed string from upstream and re-validates).
+    #[error("invalid ref: {0}")]
+    InvalidRef(#[from] RefParseError),
+    /// Source-side schema mismatch (unexpected JSON shape, missing
+    /// required field). Surfaces to [`crate::ErrorCode::InternalError`]
+    /// at the public boundary.
+    #[error("source-side schema error: {hint}")]
+    SourceSchema {
+        /// Human-readable hint at the offending field/path; not parsed.
+        hint: String,
+    },
+}
+
+/// Map [`FetchError`] to the closed [`crate::ErrorCode`] set surfaced at
+/// the public CLI / MCP boundary. Mirrors the
+/// `From<RefParseError> for ErrorCode` collapse from PR #55.
+impl From<FetchError> for crate::ErrorCode {
+    fn from(e: FetchError) -> crate::ErrorCode {
+        match e {
+            FetchError::NotEligible { .. } => crate::ErrorCode::CapabilityDenied,
+            FetchError::NoOaAvailable => crate::ErrorCode::NoOaAvailable,
+            FetchError::Http(_) => crate::ErrorCode::NetworkError,
+            FetchError::Log(_) => crate::ErrorCode::LogError,
+            FetchError::InvalidRef(_) => crate::ErrorCode::InvalidRef,
+            FetchError::SourceSchema { .. } => crate::ErrorCode::InternalError,
+        }
+    }
+}
+
+/// The trait implemented by every Tier 1 / 2 / 3 fetcher.
+///
+/// Binding signature: `docs/PUBLIC_API.md` §2 (NORMATIVE — the wire shape
+/// of these three methods is semver-locked).
+#[async_trait]
+pub trait Source: Send + Sync {
+    /// Stable name used in metadata (`[doiget].source`) and provenance
+    /// rows. Conventional values: `"crossref"`, `"unpaywall"`, `"arxiv"`,
+    /// `"openalex"`, `"semantic-scholar"`, `"doaj"`, `"tdm-elsevier"`,
+    /// etc. (see `docs/SOURCES.md`).
+    fn name(&self) -> &str;
+
+    /// True if this source can plausibly serve the given ref under the
+    /// runtime capability profile. Implementations MUST be fast and
+    /// non-blocking; the orchestrator calls `can_serve` to decide whether
+    /// to invoke `fetch` at all.
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool;
+
+    /// Perform the source-specific fetch.
+    ///
+    /// Implementations:
+    ///   1. acquire `ctx.rate_limiter.acquire(self.name()).await`,
+    ///   2. fetch via `ctx.http.fetch_bytes` / `ctx.http.fetch_pdf`,
+    ///   3. emit one `LogEvent::Fetch` row via `ctx.log.append`,
+    ///   4. return a [`FetchResult`].
+    ///
+    /// The trait does NOT enforce these steps; it documents the protocol
+    /// so concrete impls produce uniform audit trails (per
+    /// `docs/ARCHITECTURE.md` §6 and `docs/PROVENANCE_LOG.md` §3).
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+
+    use crate::http::{tier_1_allowlist, HttpClient};
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, ErrorCode, RateLimits, Ref};
+
+    /// Minimal `Source` impl exercised purely to pin the trait shape and
+    /// verify dispatch through `Box<dyn Source>`. Concrete sources land in
+    /// follow-up PRs (Crossref / Unpaywall / arXiv).
+    struct MockSource;
+
+    #[async_trait]
+    impl Source for MockSource {
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn can_serve(&self, _: &CapabilityProfile, _: &Ref) -> bool {
+            true
+        }
+        async fn fetch(
+            &self,
+            _: &Ref,
+            _: &CapabilityProfile,
+            _: &FetchContext,
+        ) -> Result<FetchResult, FetchError> {
+            Ok(FetchResult {
+                source: "mock".into(),
+                license: "unknown".into(),
+                pdf_bytes: None,
+                final_url: None,
+                metadata_json: None,
+            })
+        }
+    }
+
+    /// Build a `FetchContext` backed by real (but inert) Round-A
+    /// foundation modules: a `HttpClient` over the Tier-1 allowlist, a
+    /// `RateLimiter` at hard-coded politeness, and a `ProvenanceLog` in
+    /// a tempdir. Returns the dir as well so the caller keeps it alive
+    /// for the duration of the test.
+    fn build_test_context() -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        // Workspace lints ban `std::path::PathBuf` for log paths; convert
+        // via camino's `Utf8PathBuf::try_from`.
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let http = Arc::new(HttpClient::new(tier_1_allowlist()).expect("http client builds"));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter,
+                log,
+                session_id,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn mock_source_compiles_as_trait_object() {
+        // Trait-shape pin: a `Source` impl is dyn-safe and can be boxed.
+        let s: Box<dyn Source> = Box::new(MockSource);
+        assert_eq!(s.name(), "mock");
+        let profile = CapabilityProfile::from_env().expect("Phase 0 stub");
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        assert!(s.can_serve(&profile, &r));
+
+        let (_td, ctx) = build_test_context();
+        let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(res.source, "mock");
+    }
+
+    #[tokio::test]
+    async fn mock_source_fetch_returns_result() {
+        // Direct dispatch (not through `dyn`) to exercise the async fn
+        // body and assert the populated FetchResult fields.
+        let s = MockSource;
+        let profile = CapabilityProfile::from_env().expect("Phase 0 stub");
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        let (_td, ctx) = build_test_context();
+
+        let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(res.source, "mock");
+        assert_eq!(res.license, "unknown");
+        assert!(res.pdf_bytes.is_none());
+        assert!(res.final_url.is_none());
+        assert!(res.metadata_json.is_none());
+    }
+
+    #[test]
+    fn fetch_error_collapses_to_error_code() {
+        // Mirrors `docs/PUBLIC_API.md` §4 / PR #55 boundary collapse.
+        // Each variant must map to its documented code.
+        let e: ErrorCode = FetchError::NotEligible {
+            source_key: "mock".into(),
+        }
+        .into();
+        assert_eq!(e, ErrorCode::CapabilityDenied);
+
+        let e: ErrorCode = FetchError::NoOaAvailable.into();
+        assert_eq!(e, ErrorCode::NoOaAvailable);
+
+        let e: ErrorCode = FetchError::Http(HttpError::UnknownSource {
+            source_key: "mock".into(),
+        })
+        .into();
+        assert_eq!(e, ErrorCode::NetworkError);
+
+        let e: ErrorCode = FetchError::Log(LogError::Io(std::io::Error::other("synthetic"))).into();
+        assert_eq!(e, ErrorCode::LogError);
+
+        let e: ErrorCode = FetchError::InvalidRef(RefParseError::Empty).into();
+        assert_eq!(e, ErrorCode::InvalidRef);
+
+        let e: ErrorCode = FetchError::SourceSchema {
+            hint: "missing field 'license'".into(),
+        }
+        .into();
+        assert_eq!(e, ErrorCode::InternalError);
+    }
+
+    #[test]
+    fn fetch_context_debug_redacts_internals() {
+        // Pin the Debug shape — only `session_id` is printed, the rest is
+        // elided. Prevents accidental log leakage when a context is
+        // included in a `tracing::debug!` event.
+        let (_td, ctx) = build_test_context();
+        let s = format!("{:?}", ctx);
+        assert!(
+            s.contains("session_id"),
+            "session_id must be in Debug: {}",
+            s
+        );
+        assert!(s.contains("01J0000000000000000000TEST"));
+        assert!(
+            !s.contains("HttpClient") && !s.contains("RateLimiter") && !s.contains("ProvenanceLog"),
+            "FetchContext Debug must not dump foundation internals: {}",
+            s,
+        );
+    }
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -66,6 +66,10 @@ criteria = "safe-to-run"
 version = "0.4.42"
 criteria = "safe-to-deploy"
 
+[[exemptions.async-trait]]
+version = "0.1.78"
+criteria = "safe-to-deploy"
+
 [[exemptions.aws-lc-rs]]
 version = "1.16.3"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1279,6 +1279,12 @@ criteria = "safe-to-deploy"
 delta = "2.0.0 -> 2.0.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.async-trait]]
+who = "Benjamin Beurdouche <bbeurdouche@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.80 -> 0.1.89"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.bit-set]]
 who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1651,6 +1657,12 @@ This code DOES contain unsafe code required to internally call volatiles
 for deleting data. This is expected and documented behavior.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.zcash.audits.async-trait]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.78 -> 0.1.80"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.autocfg]]
 who = "Jack Grigg <jack@electriccoin.co>"


### PR DESCRIPTION
## Summary

Defines the abstract `Source` trait the rest of Phase 1 will plug into.
Binding spec: [`docs/PUBLIC_API.md`](../blob/main/docs/PUBLIC_API.md) §2
(NORMATIVE, semver-locked signature) and
[`docs/ARCHITECTURE.md`](../blob/main/docs/ARCHITECTURE.md) §6 (per-fetch
data flow). Integrates with the Round-A foundation modules already on
`main`: `HttpClient` (#62), `RateLimiter` (#63), `ProvenanceLog` (#61).

- New module `crates/doiget-core/src/source.rs` declaring:
  - `pub trait Source: Send + Sync` with `name`, `can_serve`, and
    `async fn fetch(&self, &Ref, &CapabilityProfile, &FetchContext)
    -> Result<FetchResult, FetchError>`. Decorated with
    `#[async_trait]` so impls stay dyn-compatible (`Box<dyn Source>`).
  - `pub struct FetchContext` carrying `Arc<HttpClient>`,
    `Arc<RateLimiter>`, `Arc<ProvenanceLog>`, and `session_id`. Custom
    `Debug` redacts everything except `session_id` so a context held in
    a `tracing::debug!` event cannot leak the foundation internals.
  - `pub struct FetchResult` (`#[non_exhaustive]`) — `source`,
    `license`, `pdf_bytes: Option<Bytes>`, `final_url: Option<url::Url>`,
    `metadata_json: Option<serde_json::Value>` (PDF optional so Phase 4
    metadata-only sources fit the same shape).
  - `pub enum FetchError` (`#[non_exhaustive]`) — `NotEligible`,
    `NoOaAvailable`, `Http(HttpError)`, `Log(LogError)`,
    `InvalidRef(RefParseError)`, `SourceSchema { hint }`, with
    `#[from]` on the wrapping variants for `?` propagation in
    concrete impls.
- `From<FetchError> for crate::ErrorCode` collapse mirrors the
  `RefParseError -> ErrorCode::InvalidRef` collapse from #55:
  `CapabilityDenied`, `NoOaAvailable`, `NetworkError`, `LogError`,
  `InvalidRef`, `InternalError`.
- `crates/doiget-core/src/lib.rs` gets ONE new line: `pub mod source;`
  alongside the existing `http` / `provenance` / `rate_limiter` modules.
  Crate-root re-export per `docs/PUBLIC_API.md` §1 is deferred so
  parallel PRs that add `pub mod store;` can rebase trivially.
- `Cargo.toml`: workspace adds `async-trait = "0.1"`; `doiget-core`
  inherits it. `bytes` and `url` were already present.

Out of scope (per the brief): no concrete `Source` impl
(Crossref/Unpaywall/arXiv land in Round C per `docs/SOURCES.md`); no
edits to `CapabilityProfile` (a parallel PR is changing its body).

## Test plan

New tests in `src/source.rs::tests` (all green, 4/4):

- [x] `mock_source_compiles_as_trait_object` — instantiate
      `MockSource` through `Box<dyn Source>` and dispatch `name` /
      `can_serve` / `fetch`, pinning dyn-safety + async dispatch.
- [x] `mock_source_fetch_returns_result` — exercise the `async fn`
      body end-to-end against a `FetchContext` built from
      `HttpClient::new(tier_1_allowlist())`,
      `RateLimiter::new(RateLimits::HARD_CODED)`, and
      `ProvenanceLog::open(temp, session_id)`. Uses
      `Utf8PathBuf::try_from(td.path().to_path_buf())` so the
      workspace ban on `std::path::PathBuf` is respected.
- [x] `fetch_error_collapses_to_error_code` — every `FetchError`
      variant maps to its documented `ErrorCode`.
- [x] `fetch_context_debug_redacts_internals` — `Debug` only prints
      `session_id`; the foundation internals stay redacted.

Validation gates (all pass on this branch):

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test -p doiget-core --no-default-features --features oa-only`
      (85/85 pass, +4 new)
- [x] `cargo clippy -p doiget-core --tests --no-default-features
      --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc -p doiget-core --no-deps
      --no-default-features --features oa-only`

Spec citations: `docs/PUBLIC_API.md` §2 (trait surface),
`docs/ARCHITECTURE.md` §6 (data flow), `docs/PROVENANCE_LOG.md` §3
(`Fetch` row source impls emit), `docs/SOURCES.md` (source matrix).

Refs #55 (boundary-collapse precedent), #61, #62, #63 (Round-A
foundation modules this trait integrates with).