### PR TITLE
feat(core): CapabilityProfile::from_env real impl (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,9 @@ for the full Phase 0 deliverable checklist.
   `#[non_exhaustive]` and funnels to `ErrorCode::InvalidRef` at the public
   MCP / CLI boundary via `impl From<RefParseError> for ErrorCode`, so the
   `INVALID_REF` surface seen by external callers is unchanged.
+- `CapabilityProfile::from_env` resolves TDM env vars per
+  [`docs/CAPABILITY.md`](docs/CAPABILITY.md) §2 (Phase 1; supersedes the
+  Phase 0 always-tier-1 stub).
 
 ### Fixed
 - `audit.yml`: removed the temporary in-CI `cargo generate-lockfile` step now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -503,6 +503,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror",
@@ -550,7 +551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1248,7 +1249,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1647,7 +1648,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1704,7 +1705,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1753,6 +1754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1776,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secrecy"
@@ -1859,6 +1875,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,7 +1977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1997,7 +2039,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2580,7 +2622,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -51,8 +51,13 @@ bytes        = { workspace = true }
 futures-util = { workspace = true }
 
 [dev-dependencies]
-wiremock   = { workspace = true }
-proptest   = { workspace = true }
+wiremock     = { workspace = true }
+proptest     = { workspace = true }
+# Serializes tests that mutate process-global env state (used by the
+# `CapabilityProfile::from_env` resolution tests, which call
+# `std::env::set_var` / `remove_var`). See docs/CAPABILITY.md §2 and the
+# `EnvGuard` RAII guard in `crates/doiget-core/src/lib.rs::tests`.
+serial_test  = "3"
 # `test-util` enables `tokio::test(start_paused = true)` and the
 # `tokio::time::pause()` / `advance()` API used by rate_limiter tests.
-tokio      = { workspace = true, features = ["test-util"] }
+tokio        = { workspace = true, features = ["test-util"] }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -738,60 +738,210 @@ pub enum CapabilityError {
 impl CapabilityProfile {
     /// Read the runtime profile from environment variables.
     ///
-    /// **Phase 0 stub.** Returns a Tier-1-only profile and emits a `tracing::warn!`
-    /// breadcrumb so that any environment with TDM env vars set will surface
-    /// loudly in CI / logs as "Phase 0 stub did not honor your TDM env vars".
-    /// Phase 1 must replace this body with the resolution algorithm specified
-    /// in `docs/CAPABILITY.md` §2 and exercise both `CapabilityError` variants
-    /// in tests.
+    /// Implements the resolution algorithm specified in
+    /// [`docs/CAPABILITY.md`](../../../docs/CAPABILITY.md) §2.
+    ///
+    /// # Tier 1 (Open Access)
+    ///
+    /// Always permitted; not gated on any env var or feature.
+    ///
+    /// # Tier 2 (metadata)
+    ///
+    /// Each metadata source becomes available when its env var is set
+    /// (presence-checked, value ignored) **and** the `metadata` Cargo feature
+    /// was compiled in. If the env var is set but the feature is not compiled
+    /// in, a `tracing::warn!` is emitted and the source is left disabled —
+    /// this is not an error so that users can move binaries between machines
+    /// (or switch feature sets between cargo invocations) without breaking
+    /// startup. See `docs/CAPABILITY.md` §3 for the env var list.
+    ///
+    /// # Tier 3 (TDM)
+    ///
+    /// For each publisher in `{ELSEVIER, APS, SPRINGER}`, the
+    /// `DOIGET_AGREE_TDM_<X>` agreement env var is paired with
+    /// `DOIGET_KEY_<X>`. Resolution rules (per `docs/CAPABILITY.md` §2):
+    ///
+    /// - both unset → `tdm_<x> = None` (no error);
+    /// - `agree == "1"` and key set → `Some(TdmGrant { .. })` (subject to the
+    ///   feature gate below);
+    /// - `agree == "1"` and key unset → [`CapabilityError::AgreedButNoKey`];
+    /// - key set but `agree` unset (or `agree != "1"`) →
+    ///   [`CapabilityError::KeyButNotAgreed`].
+    ///
+    /// When both env vars are set correctly **but** the corresponding
+    /// `tdm-<x>` Cargo feature is not compiled in, this function emits a
+    /// `tracing::warn!` and sets the grant to `None` rather than returning an
+    /// error — same rationale as for the Tier 2 warn-and-skip behavior.
     ///
     /// # Precondition: tracing subscriber must be installed first
     ///
-    /// The Phase-0 audit signal is delivered via `tracing::warn!`. Callers
-    /// MUST install a `tracing-subscriber` (or equivalent) **before** invoking
-    /// this function, otherwise the warn is silently dropped and a
-    /// misconfigured user will see no signal that their TDM env vars were
-    /// ignored. The `doiget-cli` binary already does this in `main.rs`.
+    /// Warn breadcrumbs are delivered via `tracing::warn!`. Callers MUST
+    /// install a `tracing-subscriber` (or equivalent) **before** invoking
+    /// this function, otherwise warnings are silently dropped. The
+    /// `doiget-cli` binary does this in `main.rs`.
     ///
-    /// # Warn message format (for log filtering)
+    /// # Errors
     ///
-    /// Each detected env var emits a `WARN`-level event with structured field
-    /// `env_var = "<NAME>"` and a message starting with
-    /// `"doiget-core Phase 0 stub: <NAME> is set but env-driven \
-    ///  CapabilityProfile resolution is not implemented yet."`.
-    /// Grep your log aggregator for `env_var=DOIGET_AGREE_TDM_*` to surface
-    /// affected sessions.
+    /// Returns [`CapabilityError::AgreedButNoKey`] or
+    /// [`CapabilityError::KeyButNotAgreed`] when the TDM env-var pair for any
+    /// publisher is misconfigured. See the variant docs for the precise
+    /// trigger conditions.
+    ///
+    /// # Note on `api_key` storage
+    ///
+    /// The [`TdmGrant`] struct does not yet carry an `api_key` field — it is
+    /// a marker that the user agreed and supplied a key, but the key value is
+    /// not threaded through `CapabilityProfile` at this phase. Sources that
+    /// need the key read it from the same env var directly. See the
+    /// [`TdmGrant`] doc-comment for the rationale and roadmap.
     pub fn from_env() -> Result<Self, CapabilityError> {
-        // Detect any Phase-1-relevant env var and warn loudly. This is
-        // intentionally not a hard error in Phase 0 so that local development
-        // and CI can run before Phase 1 resolution lands.
-        for var in [
+        // TODO Phase 1+: thread api_key through TdmGrant. The key would be
+        // read here and stored as `secrecy::Secret<String>`; deferred for now
+        // because adding a field to `TdmGrant` requires a coordinated
+        // `secrecy` design (the dep is `optional = true` and only compiled in
+        // under `tdm-*` features). See the `TdmGrant` doc-comment above and
+        // `docs/CAPABILITY.md` §1.
+
+        // -- Tier 2 metadata -------------------------------------------------
+        let metadata = MetadataAccess {
+            openalex: resolve_metadata_flag(
+                "DOIGET_ENABLE_OPENALEX",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            semantic_scholar: resolve_metadata_flag(
+                "DOIGET_ENABLE_S2",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            doaj: resolve_metadata_flag(
+                "DOIGET_ENABLE_DOAJ",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+        };
+
+        // -- Tier 3 TDM grants ----------------------------------------------
+        let tdm_elsevier = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_AGREE_TDM_APS",
-            "DOIGET_AGREE_TDM_SPRINGER",
             "DOIGET_KEY_ELSEVIER",
+            "tdm-elsevier",
+            cfg!(feature = "tdm-elsevier"),
+        )?;
+        let tdm_aps = resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_APS",
             "DOIGET_KEY_APS",
+            "tdm-aps",
+            cfg!(feature = "tdm-aps"),
+        )?;
+        let tdm_springer = resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_SPRINGER",
             "DOIGET_KEY_SPRINGER",
-        ] {
-            if std::env::var_os(var).is_some() {
-                tracing::warn!(
-                    env_var = var,
-                    "doiget-core Phase 0 stub: {} is set but env-driven \
-                     CapabilityProfile resolution is not implemented yet. \
-                     The TDM source will be silently disabled. Track in \
-                     docs/PHASES.md and ADR-0005.",
-                    var
-                );
-            }
-        }
+            "tdm-springer",
+            cfg!(feature = "tdm-springer"),
+        )?;
+
         Ok(Self {
             oa: AlwaysOn,
-            metadata: MetadataAccess::default(),
-            tdm_elsevier: None,
-            tdm_aps: None,
-            tdm_springer: None,
+            metadata,
+            tdm_elsevier,
+            tdm_aps,
+            tdm_springer,
             rate_limits: RateLimits::HARD_CODED,
         })
+    }
+}
+
+/// Resolve a Tier 2 metadata flag from its env var and compile-in feature.
+///
+/// Returns `true` only when both the env var is present and the feature is
+/// compiled in. When the env var is set without the feature, emits a
+/// `tracing::warn!` and returns `false` — see [`CapabilityProfile::from_env`]
+/// for the rationale (binaries may move between hosts / feature sets).
+fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) -> bool {
+    let env_set = std::env::var_os(env_var).is_some();
+    match (env_set, feature_enabled) {
+        (true, true) => true,
+        (true, false) => {
+            tracing::warn!(
+                env_var,
+                feature,
+                "{} is set but feature {} was not compiled in; the source will be unavailable",
+                env_var,
+                feature
+            );
+            false
+        }
+        (false, _) => false,
+    }
+}
+
+/// Resolve a Tier 3 TDM grant from the `agree`/`key` env-var pair and the
+/// per-publisher Cargo feature.
+///
+/// Implements the rules in `docs/CAPABILITY.md` §2:
+///
+/// - both unset → `Ok(None)`.
+/// - `agree == "1"` and `key` set → `Ok(Some(TdmGrant { .. }))` (when the
+///   feature is enabled), or warn-and-`Ok(None)` (when the feature is not
+///   compiled in).
+/// - `agree == "1"` and `key` unset →
+///   [`CapabilityError::AgreedButNoKey`].
+/// - `key` set and `agree` unset OR `agree` set to anything other than `"1"`
+///   → [`CapabilityError::KeyButNotAgreed`].
+fn resolve_tdm_grant(
+    agree_var: &str,
+    key_var: &str,
+    feature: &str,
+    feature_enabled: bool,
+) -> Result<Option<TdmGrant>, CapabilityError> {
+    // `agree` is "agreed" iff the value is exactly the literal "1"; any other
+    // value (including "true", "yes", empty) is treated as not-agreed per
+    // `docs/CAPABILITY.md` §2.
+    let agree_raw = std::env::var(agree_var).ok();
+    let agreed = matches!(agree_raw.as_deref(), Some("1"));
+    let agree_present = agree_raw.is_some();
+    // The key value itself is not stored in `TdmGrant` at this phase; we only
+    // care whether it is set. See the TODO in `from_env`.
+    let key_present = std::env::var_os(key_var).is_some();
+
+    match (agreed, agree_present, key_present) {
+        (true, _, true) => {
+            if feature_enabled {
+                Ok(Some(TdmGrant {
+                    agree_env_var: agree_var.to_string(),
+                    agreed_at: chrono::Utc::now(),
+                }))
+            } else {
+                tracing::warn!(
+                    env_var = agree_var,
+                    feature,
+                    "{} is set but feature {} was not compiled in; the source will be unavailable",
+                    agree_var,
+                    feature
+                );
+                Ok(None)
+            }
+        }
+        (true, _, false) => Err(CapabilityError::AgreedButNoKey {
+            agree_var: agree_var.to_string(),
+            key_var: key_var.to_string(),
+        }),
+        // agree set to non-"1", key also set: KeyButNotAgreed (the key would
+        // otherwise authorize the source without an explicit agreement).
+        (false, true, true) => Err(CapabilityError::KeyButNotAgreed {
+            agree_var: agree_var.to_string(),
+        }),
+        // agree unset, key set: KeyButNotAgreed (same rule).
+        (false, false, true) => Err(CapabilityError::KeyButNotAgreed {
+            agree_var: agree_var.to_string(),
+        }),
+        // agree set to non-"1" and no key: treat as no-grant. The user
+        // expressed something but did not opt in and provided no credential,
+        // so silent skip is the safe default (no source enabled).
+        (false, true, false) => Ok(None),
+        // Neither env var set: no grant, no error.
+        (false, false, false) => Ok(None),
     }
 }
 
@@ -834,16 +984,203 @@ mod tests {
         assert_eq!(SCHEMA_VERSION, "1.0");
     }
 
+    // -----------------------------------------------------------------
+    // CapabilityProfile::from_env — Phase 1 resolution algorithm tests.
+    //
+    // These tests mutate process-global env state via std::env::set_var /
+    // remove_var, so each test holds an `EnvGuard` RAII drop guard that
+    // captures the pre-test value of every env var it touches and restores
+    // it on drop (even on panic). They also use `#[serial_test::serial]` so
+    // that no two tests in this module touch env state concurrently — the
+    // workspace's test runner defaults to multi-threaded.
+    //
+    // Spec: docs/CAPABILITY.md §2 (resolution algorithm) and §3 (env var
+    // reference table).
+    // -----------------------------------------------------------------
+
+    /// RAII guard that captures the prior value of an env var on construction
+    /// and restores it on drop. Use one guard per touched var per test.
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        /// Capture and clear `var`. Use `set` afterwards to install a value.
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            // SAFETY (env mutation): tests are serialized via
+            // `#[serial_test::serial]`. `remove_var` is sound when no other
+            // thread reads or writes the environment concurrently.
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+
+        /// Capture, then set `var` to `value`.
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
+        }
+    }
+
+    /// Convenience: unset every Tier 2 / Tier 3 env var the resolution
+    /// algorithm reads, returning a vector of guards that restore them on
+    /// drop. Callers can then `EnvGuard::set` individual vars on top.
+    fn unset_all_capability_env_vars() -> Vec<EnvGuard> {
+        [
+            "DOIGET_ENABLE_OPENALEX",
+            "DOIGET_ENABLE_S2",
+            "DOIGET_ENABLE_DOAJ",
+            "DOIGET_AGREE_TDM_ELSEVIER",
+            "DOIGET_KEY_ELSEVIER",
+            "DOIGET_AGREE_TDM_APS",
+            "DOIGET_KEY_APS",
+            "DOIGET_AGREE_TDM_SPRINGER",
+            "DOIGET_KEY_SPRINGER",
+        ]
+        .iter()
+        .map(|v| EnvGuard::unset(v))
+        .collect()
+    }
+
     #[test]
-    fn capability_profile_from_env_is_tier_1_only_in_phase_0() {
-        // Phase 0 stub guarantee: TDM is never enabled regardless of env vars.
-        // Phase 1 must update this test to cover the real resolution algorithm
-        // (including AgreedButNoKey / KeyButNotAgreed Err branches).
-        let p = CapabilityProfile::from_env().expect("Phase 0 stub never errors");
+    #[serial_test::serial]
+    fn from_env_no_env_vars_set_returns_tier_1_only() {
+        // Rule: with every relevant env var unset, the resolved profile has
+        // all TDM grants `None` and all metadata flags `false`. Hard-coded
+        // rate limits still apply. (Replaces the old Phase 0 stub test.)
+        let _g = unset_all_capability_env_vars();
+
+        let p = CapabilityProfile::from_env().expect("clean env never errors");
         assert!(p.tdm_elsevier.is_none());
         assert!(p.tdm_aps.is_none());
         assert!(p.tdm_springer.is_none());
+        assert!(!p.metadata.openalex);
+        assert!(!p.metadata.semantic_scholar);
+        assert!(!p.metadata.doaj);
         assert_eq!(p.rate_limits.max_concurrent_fetches(), 5);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_no_tdm_returns_tier_1_profile() {
+        // Rule (CAPABILITY.md §2): with every TDM env var unset, all
+        // `tdm_*` fields are `None` and no error is produced.
+        let _g = unset_all_capability_env_vars();
+
+        let p = CapabilityProfile::from_env().expect("no TDM env -> Ok");
+        assert!(p.tdm_elsevier.is_none());
+        assert!(p.tdm_aps.is_none());
+        assert!(p.tdm_springer.is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_agreed_but_no_key_errs() {
+        // Rule (CAPABILITY.md §2): agree=1 + key unset -> AgreedButNoKey.
+        let _g = unset_all_capability_env_vars();
+        let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
+
+        let result = CapabilityProfile::from_env();
+        match result {
+            Err(CapabilityError::AgreedButNoKey { agree_var, key_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+                assert_eq!(key_var, "DOIGET_KEY_ELSEVIER");
+            }
+            other => panic!("expected AgreedButNoKey, got {:?}", other),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_key_but_not_agreed_errs() {
+        // Rule (CAPABILITY.md §2): key set + agree unset -> KeyButNotAgreed.
+        // A leaked DOIGET_KEY_ELSEVIER must not silently enable a source.
+        let _g = unset_all_capability_env_vars();
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
+
+        let result = CapabilityProfile::from_env();
+        match result {
+            Err(CapabilityError::KeyButNotAgreed { agree_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            }
+            other => panic!("expected KeyButNotAgreed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_agree_not_one_errs() {
+        // Rule (CAPABILITY.md §2): the agree var must be exactly "1". Any
+        // other value (here: "true") is treated as not-agreed; combined
+        // with a key set, that triggers KeyButNotAgreed.
+        let _g = unset_all_capability_env_vars();
+        let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "true");
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
+
+        let result = CapabilityProfile::from_env();
+        match result {
+            Err(CapabilityError::KeyButNotAgreed { agree_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            }
+            other => panic!("expected KeyButNotAgreed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_both_set_correctly_returns_grant() {
+        // Rule (CAPABILITY.md §2): agree=1 + key set -> Some(TdmGrant) when
+        // the corresponding feature is compiled in; else None (warn-and-skip).
+        // The feature gate for elsevier is `tdm-elsevier`; this test asserts
+        // both branches via `cfg!`.
+        let _g = unset_all_capability_env_vars();
+        let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
+
+        let p = CapabilityProfile::from_env().expect("agree=1 + key -> Ok");
+
+        if cfg!(feature = "tdm-elsevier") {
+            let grant = p
+                .tdm_elsevier
+                .as_ref()
+                .expect("feature tdm-elsevier compiled in -> Some(TdmGrant)");
+            assert_eq!(grant.agree_env_var, "DOIGET_AGREE_TDM_ELSEVIER");
+        } else {
+            assert!(
+                p.tdm_elsevier.is_none(),
+                "feature tdm-elsevier NOT compiled in -> None (warn-and-skip)"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_metadata_env_warns_without_feature() {
+        // Rule (CAPABILITY.md §2): metadata env var without the `metadata`
+        // feature -> source disabled (warn-and-skip, not an error).
+        // We don't capture the tracing warn here; we just assert the field
+        // is `false` when the feature is absent and `true` when present.
+        let _g = unset_all_capability_env_vars();
+        let _enable = EnvGuard::set("DOIGET_ENABLE_OPENALEX", "1");
+
+        let p = CapabilityProfile::from_env().expect("metadata env never errors");
+
+        if cfg!(feature = "metadata") {
+            assert!(p.metadata.openalex);
+        } else {
+            assert!(!p.metadata.openalex);
+        }
     }
 
     // -----------------------------------------------------------------

--- a/crates/doiget-core/tests/no_outbound_network.rs
+++ b/crates/doiget-core/tests/no_outbound_network.rs
@@ -1,10 +1,10 @@
-//! Phase 0 sanity: assert that the doiget-core library does not initiate
-//! network connections during construction or any non-fetch path.
+//! Sanity test: `doiget-core` does not initiate network connections during
+//! construction or any non-fetch path.
 //!
 //! This test does NOT use a real socket sandbox (those are kernel-level
 //! features). It instead verifies that:
 //!   1. `CapabilityProfile::from_env()` does not panic on an env that has
-//!      no network env vars set.
+//!      no relevant env vars set.
 //!   2. `Doi::parse` / `ArxivId::parse` / `Ref::parse` are pure (no clock,
 //!      no env, no network).
 //!
@@ -28,10 +28,12 @@ fn parse_functions_make_no_outbound_calls() {
 }
 
 #[test]
-fn capability_profile_from_env_phase_0_returns_tier_1_only() {
-    // Re-pin the Phase-0 stub guarantee from the doctest in lib.rs:
-    // no env -> tier-1 profile, no error, no network.
-    let p = doiget_core::CapabilityProfile::from_env().expect("Phase 0 stub never errors");
+fn capability_profile_from_env_returns_tier_1_in_clean_env() {
+    // CI environments do not set any DOIGET_* env vars, so this integration
+    // test pins the no-env contract: `from_env()` returns Ok with all TDM
+    // grants `None`. The granular unit tests in `lib.rs::tests` cover the
+    // env-var-mutating branches under `serial_test::serial` isolation.
+    let p = doiget_core::CapabilityProfile::from_env().expect("clean env -> Ok");
     assert!(p.tdm_elsevier.is_none());
     assert!(p.tdm_aps.is_none());
     assert!(p.tdm_springer.is_none());

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -518,6 +518,10 @@ criteria = "safe-to-run"
 version = "1.0.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.scc]]
+version = "2.4.0"
+criteria = "safe-to-run"
+
 [[exemptions.schannel]]
 version = "0.1.29"
 criteria = "safe-to-deploy"
@@ -525,6 +529,10 @@ criteria = "safe-to-deploy"
 [[exemptions.scopeguard]]
 version = "1.2.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.sdd]]
+version = "3.0.10"
+criteria = "safe-to-run"
 
 [[exemptions.secrecy]]
 version = "0.10.3"
@@ -549,6 +557,14 @@ criteria = "safe-to-deploy"
 [[exemptions.serde_spanned]]
 version = "1.1.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.serial_test]]
+version = "3.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.serial_test_derive]]
+version = "3.4.0"
+criteria = "safe-to-run"
 
 [[exemptions.sha2]]
 version = "0.11.0"


### PR DESCRIPTION
## Summary

Replaces the Phase 0 stub `CapabilityProfile::from_env` (which always returned a Tier-1-only profile and warned when TDM env vars were set) with the resolution algorithm specified in [`docs/CAPABILITY.md`](../blob/feat/capability-from-env/docs/CAPABILITY.md) §2.

- Tier 1 (Open Access): always permitted.
- Tier 2 metadata flags (`DOIGET_ENABLE_OPENALEX` / `_S2` / `_DOAJ`): require the `metadata` Cargo feature; env-var-without-feature is `tracing::warn!` + skip (not an error), so users can move binaries between hosts / feature sets.
- Tier 3 TDM grants: pair `DOIGET_AGREE_TDM_<X>` with `DOIGET_KEY_<X>` for `{ELSEVIER, APS, SPRINGER}`. Both `CapabilityError::AgreedButNoKey` and `CapabilityError::KeyButNotAgreed` are produced per spec; feature-not-compiled-in is also warn-and-skip.

## Resolution rules (per `docs/CAPABILITY.md` §2)

| `agree` value | `key` set | Outcome |
|---|---|---|
| unset | unset | `Ok(None)` |
| `"1"` | yes | `Ok(Some(TdmGrant))` if feature enabled, else warn + `Ok(None)` |
| `"1"` | no | `Err(AgreedButNoKey { agree_var, key_var })` |
| `"1"` not literal (e.g. `"true"`) | yes | `Err(KeyButNotAgreed { agree_var })` |
| unset | yes | `Err(KeyButNotAgreed { agree_var })` |
| `"1"` not literal (e.g. `"true"`) | no | `Ok(None)` |

## `api_key` deliberately deferred

The existing `TdmGrant` struct is `#[non_exhaustive]` and intentionally does not yet carry `api_key`. Adding a field requires a coordinated `secrecy::Secret<String>` design (the dep is `optional = true` and only compiled in under `tdm-*` features) and is explicitly deferred per the `TdmGrant` doc-comment. Sources that need the key read it from the env var directly. A `TODO Phase 1+` line in `from_env` and the variant-doc comment record this; pointer to `docs/CAPABILITY.md` §1 included.

## Tests added

All env-mutating tests use a per-test `EnvGuard` RAII drop guard (captures the prior value, restores on drop even on panic) plus `#[serial_test::serial]` to ensure no two env-mutating tests run concurrently.

- `from_env_no_env_vars_set_returns_tier_1_only` — replaces the old Phase 0 stub-contract test with the still-valid "no env" assertions.
- `from_env_no_tdm_returns_tier_1_profile`
- `from_env_agreed_but_no_key_errs` — `agree=1` + key unset.
- `from_env_key_but_not_agreed_errs` — key set + agree unset.
- `from_env_agree_not_one_errs` — `agree="true"` + key set still triggers `KeyButNotAgreed` (the agree var must be exactly the literal `"1"` per spec).
- `from_env_both_set_correctly_returns_grant` — `cfg!`-branched: asserts `Some(TdmGrant)` when `feature = "tdm-elsevier"` is compiled in, `None` otherwise (warn-and-skip path).
- `from_env_metadata_env_warns_without_feature` — `cfg!`-branched on `feature = "metadata"`.

The integration test `tests/no_outbound_network.rs` is also updated: the test name and comment now reflect Phase 1 (the assertion — clean env -> `tdm_*.is_none()` — still holds).

## Other changes

- `crates/doiget-core/Cargo.toml`: adds `serial_test = "3"` to `[dev-dependencies]`.
- `CHANGELOG.md`: one bullet under `[Unreleased] / Changed`.
- `docs/PUBLIC_API.md`: unchanged. §5 already documents the binding signature `from_env() -> Result<Self, CapabilityError>` and both `CapabilityError` variants, which the new impl satisfies — nothing stale.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo build --workspace --features metadata,tdm-elsevier,tdm-aps,tdm-springer`
- [x] `cargo test  -p doiget-core --no-default-features --features oa-only` (87 unit + 2 integration tests pass)
- [x] `cargo test  -p doiget-core --features tdm-elsevier` (exercises the feature-gated branch in `from_env_both_set_correctly_returns_grant`)
- [x] `cargo test  -p doiget-core --features tdm-elsevier,tdm-aps,tdm-springer,metadata`
- [x] `cargo clippy -p doiget-core --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo clippy -p doiget-core --tests --features tdm-elsevier,tdm-aps,tdm-springer,metadata -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p doiget-core --no-deps --no-default-features --features oa-only`