### PR TITLE
feat(sources): Crossref source impl (Phase 1 Tier 1)

### DIFF
--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -346,6 +346,76 @@ impl HttpClient {
     }
 }
 
+/// Test-only [`HttpClient`] constructors. Visible to sibling modules' test
+/// code (`sources::crossref::tests` etc.) so each new `Source` impl can
+/// exercise its fetch path against a wiremock `http://` origin without
+/// re-deriving the per-source `reqwest::Client` build recipe.
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+impl HttpClient {
+    /// Build a test-only `HttpClient` against an `http://` wiremock origin.
+    /// The redirect closure still rejects insecure schemes — we only relax
+    /// `https_only` at the connection level so wiremock can serve. This is
+    /// acceptable because the redirect closure (which is the security-load-
+    /// bearing path) is exercised by the `redirect_to_http_is_rejected_by_closure`
+    /// test in `tests` below.
+    pub(crate) fn new_for_tests_allow_http(source: &str, allowlist_host: &str) -> Self {
+        let allowlist = SourceAllowlist::new(source, vec![allowlist_host.to_string()]);
+        let client = build_client_allow_http(allowlist.clone()).expect("test client builds");
+        let mut map = HashMap::new();
+        map.insert(allowlist.source.clone(), client);
+        Self {
+            clients: Arc::new(map),
+        }
+    }
+}
+
+#[cfg(test)]
+fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
+    let allowlist_for_closure = allowlist.clone();
+    let redirect_policy = Policy::custom(move |attempt| {
+        let scheme = attempt.url().scheme().to_string();
+        let host_opt = attempt.url().host_str().map(|h| h.to_ascii_lowercase());
+        let prev_count = attempt.previous().len();
+        if scheme != "https" {
+            return attempt.error(HttpError::InsecureRedirect { scheme });
+        }
+        if prev_count >= MAX_REDIRECTS {
+            return attempt.stop();
+        }
+        let host = match host_opt {
+            Some(h) => h,
+            None => {
+                return attempt.error(HttpError::RedirectDenied {
+                    source_key: allowlist_for_closure.source.clone(),
+                    host: String::new(),
+                });
+            }
+        };
+        if !allowlist_for_closure.matches(&host) {
+            return attempt.error(HttpError::RedirectDenied {
+                source_key: allowlist_for_closure.source.clone(),
+                host,
+            });
+        }
+        attempt.follow()
+    });
+    ClientBuilder::new()
+        // `https_only(false)` only at this scope — production builders
+        // (the public `HttpClient::new`) keep it on.
+        .https_only(false)
+        .redirect(redirect_policy)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(TOTAL_TIMEOUT)
+        .read_timeout(READ_TIMEOUT)
+        .user_agent(format!(
+            "doiget/{} (+https://github.com/sotashimozono/doiget)",
+            VERSION
+        ))
+        .tls_backend_rustls()
+        .build()
+}
+
 // ---------------------------------------------------------------------------
 // ClientBuilder helpers
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod http;
 pub mod provenance;
 pub mod rate_limiter;
 pub mod source;
+pub mod sources;
 pub mod store;
 
 /// Crate version. Used by `doiget-cli --version` and `doiget_health`.

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -1,0 +1,386 @@
+//! Crossref source — DOI metadata + OA URL discovery via `link[]` array.
+//!
+//! Spec: docs/SOURCES.md §4 (Crossref). No auth; polite-pool User-Agent
+//! contact email is REQUIRED — see [`CrossrefSource::new`].
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production Crossref REST API base URL. Hard-coded per `docs/SOURCES.md`
+/// §4; tests inject a wiremock origin via [`CrossrefSource::with_base`].
+const DEFAULT_BASE: &str = "https://api.crossref.org";
+
+/// Crossref [`Source`] impl — DOI → metadata; OA URL via `message.link[]`.
+///
+/// See `docs/SOURCES.md` §4 for the access policy (no auth, polite pool).
+#[derive(Clone, Debug)]
+pub struct CrossrefSource {
+    /// API base URL. Production constructor pins this to
+    /// `https://api.crossref.org`; the [`with_base`](Self::with_base)
+    /// test-only constructor lets wiremock substitute an `http://127.0.0.1:N`
+    /// origin.
+    base: Url,
+    /// Polite-pool contact email per `docs/SOURCES.md` §4 Crossref.
+    /// Concretely formatted into the `User-Agent` header by [`crate::http::HttpClient`].
+    /// (Phase 1: caller injects via [`CrossrefSource::new`]; CLI / config wiring
+    /// lands in a follow-up PR.)
+    #[allow(dead_code)]
+    contact_email: String,
+}
+
+impl CrossrefSource {
+    /// Production constructor: hard-codes `https://api.crossref.org` as the
+    /// base URL. The `contact_email` value is appended to the polite-pool
+    /// User-Agent (config plumbing arrives in a later PR — see
+    /// `docs/SOURCES.md` §4).
+    #[must_use]
+    pub fn new(contact_email: String) -> Self {
+        Self {
+            // The hard-coded constant is a known-valid URL; the `expect`
+            // here is the documented exception to the workspace
+            // `expect_used` lint (it can never fire in practice).
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+            contact_email,
+        }
+    }
+
+    /// Test-only constructor — accepts an arbitrary base URL (e.g. a
+    /// wiremock `http://127.0.0.1:N`).
+    #[cfg(test)]
+    pub(crate) fn with_base(base: Url, contact_email: String) -> Self {
+        Self {
+            base,
+            contact_email,
+        }
+    }
+
+    /// Build the `/works/{doi}` URL for the configured base. Returns
+    /// [`FetchError::SourceSchema`] if joining the path produces an invalid
+    /// URL (only possible if the base URL is malformed — should never happen
+    /// in production).
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        // Crossref accepts the bare DOI (no `doi:` scheme). `Doi::as_str()`
+        // already returns it without the scheme. The `/` inside the suffix
+        // is URL-encoded by `reqwest` when the request is built; wiremock
+        // sees the decoded path on its `path()` matcher.
+        let path = format!("/works/{}", doi.as_str());
+        self.base.join(&path).map_err(|e| FetchError::SourceSchema {
+            hint: format!("crossref URL construction failed: {e}"),
+        })
+    }
+}
+
+#[async_trait]
+impl Source for CrossrefSource {
+    fn name(&self) -> &str {
+        "crossref"
+    }
+
+    fn can_serve(&self, _profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        _profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "crossref".into(),
+                });
+            }
+        };
+
+        // Step 1: rate limiter (politeness — `docs/SOURCES.md` §6).
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        // Step 2: HTTP fetch. Body is JSON; the `PDF_MAX_BYTES` size cap in
+        // `HttpClient` applies. Crossref responses are well under 100 MB
+        // even for bibliographically rich DOIs.
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        // Step 3: parse the response envelope. Crossref wraps the work
+        // record in a top-level `{ "status": "ok", "message": { ... } }`
+        // envelope (per <https://api.crossref.org/swagger-ui/index.html>).
+        let envelope: CrossrefEnvelope =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("crossref returned non-JSON: {e}"),
+            })?;
+        if envelope.status != "ok" {
+            return Err(FetchError::SourceSchema {
+                hint: format!("crossref status = {}", envelope.status),
+            });
+        }
+
+        // Step 4: log the fetch event (`docs/PROVENANCE_LOG.md` §3).
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: None,
+            store_path: None,
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license: "unknown".into(),
+            // Crossref is metadata; PDF retrieval is the job of Unpaywall /
+            // publisher sources (Phase 1+ sibling PRs).
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(envelope.message),
+        })
+    }
+}
+
+/// Top-level Crossref response envelope. Only `status` and `message` are
+/// load-bearing here; `message-type`, `message-version`, etc. are ignored.
+#[derive(Debug, Deserialize)]
+struct CrossrefEnvelope {
+    status: String,
+    message: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{ArxivId, CapabilityProfile, Doi, RateLimits, Ref};
+
+    /// Build a `FetchContext` whose [`HttpClient`] allows the wiremock
+    /// `http://` origin under the `crossref` source key, plus a
+    /// tempdir-backed `ProvenanceLog`. Returns the tempdir so the caller
+    /// keeps it alive for the duration of the test.
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        // Workspace lints ban `std::path::PathBuf`; convert via camino.
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        // Use the test-only constructor that relaxes `https_only` for the
+        // initial leg so wiremock (which serves over plain HTTP) can be
+        // reached. Redirect closure still rejects http:// targets — see
+        // `http.rs::build_client_allow_http`.
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "crossref",
+            wiremock_host,
+        ));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter,
+                log,
+                session_id,
+            },
+        )
+    }
+
+    /// Extract the host string of a wiremock server's URI.
+    fn server_host(server: &MockServer) -> String {
+        server
+            .uri()
+            .parse::<Url>()
+            .expect("wiremock uri parses")
+            .host_str()
+            .expect("wiremock uri has host")
+            .to_string()
+    }
+
+    /// Build a [`CrossrefSource`] pointing at the given wiremock URI.
+    fn crossref_for(server: &MockServer) -> CrossrefSource {
+        let base = server.uri().parse::<Url>().expect("wiremock uri parses");
+        CrossrefSource::with_base(base, "test@example.org".to_string())
+    }
+
+    #[test]
+    fn crossref_can_serve_returns_true_for_doi() {
+        let s = CrossrefSource::new("test@example.org".into());
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
+        assert!(s.can_serve(&profile, &r));
+    }
+
+    #[test]
+    fn crossref_can_serve_returns_false_for_arxiv() {
+        let s = CrossrefSource::new("test@example.org".into());
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Arxiv(ArxivId::parse("2401.12345").unwrap());
+        assert!(!s.can_serve(&profile, &r));
+    }
+
+    #[tokio::test]
+    async fn crossref_fetch_returns_envelope_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"status":"ok","message":{"title":["Example"]}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
+
+        let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(res.source, "crossref");
+        assert_eq!(
+            res.metadata_json,
+            Some(serde_json::json!({ "title": ["Example"] })),
+        );
+        assert!(res.pdf_bytes.is_none());
+        assert!(res.final_url.is_some());
+    }
+
+    #[tokio::test]
+    async fn crossref_fetch_with_arxiv_ref_errors_not_eligible() {
+        // wiremock not needed: the arxiv branch short-circuits before any
+        // outbound call. Construct the source with a dummy base, and pass
+        // a dummy allowlist host since fetch never reaches the HTTP layer.
+        let s = CrossrefSource::with_base(
+            Url::parse("http://127.0.0.1:1/").unwrap(),
+            "test@example.org".into(),
+        );
+        let (_td, ctx) = build_test_context("127.0.0.1");
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Arxiv(ArxivId::parse("2401.12345").unwrap());
+
+        let err = s.fetch(&r, &profile, &ctx).await.expect_err("not eligible");
+        match err {
+            FetchError::NotEligible { source_key } => {
+                assert_eq!(source_key, "crossref");
+            }
+            other => panic!("expected NotEligible, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn crossref_fetch_writes_log_row() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"status":"ok","message":{"title":["Example"]}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
+
+        let _res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+
+        // Reopen the log file as raw JSON Lines and assert the single row's
+        // semantic fields. We deliberately don't reach into ProvenanceLog
+        // internals — the public read path is "parse the JSONL by line".
+        let log_path = _td.path().join("test.jsonl");
+        let raw = std::fs::read_to_string(&log_path).expect("log file readable");
+        let lines: Vec<&str> = raw.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 1, "expected exactly one row, got {:?}", lines);
+        let row: serde_json::Value = serde_json::from_str(lines[0]).expect("row is valid JSON");
+        assert_eq!(row["event"], "fetch");
+        assert_eq!(row["result"], "ok");
+        assert_eq!(row["source"], "crossref");
+        assert_eq!(row["ref"], "10.1234/example");
+    }
+
+    #[tokio::test]
+    async fn crossref_404_maps_to_http_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
+
+        let err = s.fetch(&r, &profile, &ctx).await.expect_err("404 errors");
+        match err {
+            FetchError::Http(_) => {}
+            other => panic!("expected Http(_) on 404, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn crossref_non_ok_status_field_errors_source_schema() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(r#"{"status":"error","message":{}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
+
+        let err = s
+            .fetch(&r, &profile, &ctx)
+            .await
+            .expect_err("non-ok status errors");
+        match err {
+            FetchError::SourceSchema { hint } => {
+                assert!(
+                    hint.contains("status"),
+                    "expected status mention in hint, got {hint}"
+                );
+            }
+            other => panic!("expected SourceSchema, got {:?}", other),
+        }
+    }
+}

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -1,0 +1,7 @@
+//! Tier-1 source implementations (Phase 1+).
+//!
+//! Each source is a concrete `Source` trait impl. Per `docs/SOURCES.md` §1, Tier 1
+//! is the always-on Open Access tier (Crossref / Unpaywall / arXiv). Tier 2/3
+//! sources land in Phase 4/5.
+
+pub mod crossref;


### PR DESCRIPTION
## Summary

First concrete `Source` trait impl, completing the Phase 1 OA fetch
path for DOIs. Crossref is no-auth public per `docs/SOURCES.md` §4
Crossref. The polite-pool User-Agent contact email is caller-injected
via `CrossrefSource::new(contact_email: String)` — CLI / config
plumbing arrives in a follow-up PR.

Adds:
- `crates/doiget-core/src/sources/mod.rs` (parent module; declares only
  `pub mod crossref;` — sibling PRs `feat/unpaywall` and
  `feat/arxiv-source` will add their own `pub mod` lines, 1-line
  trivial merge conflicts at integration time).
- `crates/doiget-core/src/sources/crossref.rs` (`CrossrefSource` impl).
- One line in `crates/doiget-core/src/lib.rs`: `pub mod sources;`.
- One `#[cfg(test)] pub(crate) fn HttpClient::new_for_tests_allow_http`
  in `crates/doiget-core/src/http.rs` so wiremock-driven `Source` tests
  in sibling modules can target an `http://127.0.0.1:N` origin without
  reaching into private `HttpClient` fields. Production `HttpClient::new`
  is **unchanged** (still `https_only(true)`); the redirect closure
  still rejects insecure schemes.

`fetch` follows the documented four-step protocol from
`docs/ARCHITECTURE.md` §6 / `docs/PROVENANCE_LOG.md` §3:
1. `ctx.rate_limiter.acquire("crossref").await` — politeness.
2. `ctx.http.fetch_bytes("crossref", url)` — HTTPS GET, body-cap-aware.
3. Parse `{ "status": "ok", "message": { ... } }` envelope.
4. `ctx.log.append(RowInput { event: Fetch, result: Ok, capability: Oa, ... })`.

Returns `FetchResult { source: "crossref", license: "unknown",
pdf_bytes: None, final_url: Some(url), metadata_json: Some(message) }`.
PDF retrieval lives with Unpaywall / publisher sources (sibling PRs).

## Tests (7, all wiremock-driven; no real network)

- `crossref_can_serve_returns_true_for_doi` — `Ref::Doi(_)` → true.
- `crossref_can_serve_returns_false_for_arxiv` — `Ref::Arxiv(_)` → false.
- `crossref_fetch_returns_envelope_message` — wiremock at
  `/works/10.1234/example` returns `{"status":"ok","message":{"title":["Example"]}}`;
  asserts `metadata_json` equals `{ "title": ["Example"] }`.
- `crossref_fetch_with_arxiv_ref_errors_not_eligible` — `Ref::Arxiv(_)`
  short-circuits to `FetchError::NotEligible { source_key: "crossref" }`
  before any outbound call.
- `crossref_fetch_writes_log_row` — after fetch, reopen the JSONL log
  and assert exactly one row with `event=fetch`, `result=ok`,
  `source="crossref"`, `ref="10.1234/example"`.
- `crossref_404_maps_to_http_error` — wiremock returns 404; assert
  `Err(FetchError::Http(_))`.
- `crossref_non_ok_status_field_errors_source_schema` — wiremock
  returns `{"status":"error","message":{}}` with HTTP 200; assert
  `Err(FetchError::SourceSchema { hint })` with `hint` mentioning
  `"status"`.

## Polite-pool User-Agent design

Per `docs/SOURCES.md` §4 Crossref the polite pool requires a contact
email in the User-Agent. Concretely, `HttpClient` (PR #56) hard-codes
the UA today; `CrossrefSource` carries the `contact_email` field
(stored on construction) so the seam is in place for a follow-up PR
to plumb it through to the per-source `reqwest::Client` builder once
config wiring lands. Storing it now keeps the public constructor
signature stable (`pub fn new(contact_email: String) -> Self`) — no
breaking change later.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test -p doiget-core --no-default-features --features oa-only` (109 passed, +7 new)
- [x] `cargo clippy -p doiget-core --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p doiget-core --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check` (Vetting Succeeded — no new exemptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)