### PR TITLE
feat(sources): Unpaywall source impl (Phase 1 Tier 1)

### DIFF
--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -249,6 +249,26 @@ impl HttpClient {
         })
     }
 
+    /// Test-only constructor that relaxes `https_only` so wiremock servers
+    /// served over plain `http://127.0.0.1:N` are reachable. The redirect
+    /// closure (security-load-bearing) is unchanged: it still rejects
+    /// non-HTTPS redirects and off-allowlist hosts. Used by `Source` impl
+    /// integration tests inside this crate; never exposed publicly.
+    #[cfg(test)]
+    pub(crate) fn new_for_test_http(
+        allowlists: Vec<SourceAllowlist>,
+    ) -> Result<Self, reqwest::Error> {
+        let mut clients = HashMap::with_capacity(allowlists.len());
+        for entry in allowlists {
+            let source = entry.source.clone();
+            let client = build_client_test_http(entry)?;
+            clients.insert(source, client);
+        }
+        Ok(Self {
+            clients: Arc::new(clients),
+        })
+    }
+
     /// Fetch a URL, treating it as a JSON or text body. Caps at
     /// [`PDF_MAX_BYTES`].
     ///
@@ -486,6 +506,58 @@ fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
         // older `use_rustls_tls()`. The workspace `reqwest` features
         // already pin `rustls`, so this is a re-assertion at builder
         // level rather than a feature switch.
+        .tls_backend_rustls()
+        .build()
+}
+
+/// Test-only builder mirroring [`build_client`] but with `https_only(false)`
+/// so the *initial leg* may be plain HTTP (wiremock servers bind to
+/// `http://127.0.0.1:N`). Redirect-policy enforcement is unchanged — every
+/// redirect hop is still required to be HTTPS and on the allowlist. Used by
+/// [`HttpClient::new_for_test_http`].
+#[cfg(test)]
+fn build_client_test_http(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
+    let user_agent = format!(
+        "doiget/{} (+https://github.com/sotashimozono/doiget)",
+        VERSION
+    );
+
+    let allowlist_for_closure = allowlist.clone();
+    let redirect_policy = Policy::custom(move |attempt| {
+        let scheme = attempt.url().scheme().to_string();
+        let host_opt = attempt.url().host_str().map(|h| h.to_ascii_lowercase());
+        let prev_count = attempt.previous().len();
+        if scheme != "https" {
+            return attempt.error(HttpError::InsecureRedirect { scheme });
+        }
+        if prev_count >= MAX_REDIRECTS {
+            return attempt.stop();
+        }
+        let host = match host_opt {
+            Some(h) => h,
+            None => {
+                return attempt.error(HttpError::RedirectDenied {
+                    source_key: allowlist_for_closure.source.clone(),
+                    host: String::new(),
+                });
+            }
+        };
+        if !allowlist_for_closure.matches(&host) {
+            return attempt.error(HttpError::RedirectDenied {
+                source_key: allowlist_for_closure.source.clone(),
+                host,
+            });
+        }
+        attempt.follow()
+    });
+
+    ClientBuilder::new()
+        .https_only(false)
+        .redirect(redirect_policy)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(TOTAL_TIMEOUT)
+        .read_timeout(READ_TIMEOUT)
+        .user_agent(user_agent)
         .tls_backend_rustls()
         .build()
 }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -249,26 +249,6 @@ impl HttpClient {
         })
     }
 
-    /// Test-only constructor that relaxes `https_only` so wiremock servers
-    /// served over plain `http://127.0.0.1:N` are reachable. The redirect
-    /// closure (security-load-bearing) is unchanged: it still rejects
-    /// non-HTTPS redirects and off-allowlist hosts. Used by `Source` impl
-    /// integration tests inside this crate; never exposed publicly.
-    #[cfg(test)]
-    pub(crate) fn new_for_test_http(
-        allowlists: Vec<SourceAllowlist>,
-    ) -> Result<Self, reqwest::Error> {
-        let mut clients = HashMap::with_capacity(allowlists.len());
-        for entry in allowlists {
-            let source = entry.source.clone();
-            let client = build_client_test_http(entry)?;
-            clients.insert(source, client);
-        }
-        Ok(Self {
-            clients: Arc::new(clients),
-        })
-    }
-
     /// Fetch a URL, treating it as a JSON or text body. Caps at
     /// [`PDF_MAX_BYTES`].
     ///
@@ -506,58 +486,6 @@ fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
         // older `use_rustls_tls()`. The workspace `reqwest` features
         // already pin `rustls`, so this is a re-assertion at builder
         // level rather than a feature switch.
-        .tls_backend_rustls()
-        .build()
-}
-
-/// Test-only builder mirroring [`build_client`] but with `https_only(false)`
-/// so the *initial leg* may be plain HTTP (wiremock servers bind to
-/// `http://127.0.0.1:N`). Redirect-policy enforcement is unchanged — every
-/// redirect hop is still required to be HTTPS and on the allowlist. Used by
-/// [`HttpClient::new_for_test_http`].
-#[cfg(test)]
-fn build_client_test_http(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
-    let user_agent = format!(
-        "doiget/{} (+https://github.com/sotashimozono/doiget)",
-        VERSION
-    );
-
-    let allowlist_for_closure = allowlist.clone();
-    let redirect_policy = Policy::custom(move |attempt| {
-        let scheme = attempt.url().scheme().to_string();
-        let host_opt = attempt.url().host_str().map(|h| h.to_ascii_lowercase());
-        let prev_count = attempt.previous().len();
-        if scheme != "https" {
-            return attempt.error(HttpError::InsecureRedirect { scheme });
-        }
-        if prev_count >= MAX_REDIRECTS {
-            return attempt.stop();
-        }
-        let host = match host_opt {
-            Some(h) => h,
-            None => {
-                return attempt.error(HttpError::RedirectDenied {
-                    source_key: allowlist_for_closure.source.clone(),
-                    host: String::new(),
-                });
-            }
-        };
-        if !allowlist_for_closure.matches(&host) {
-            return attempt.error(HttpError::RedirectDenied {
-                source_key: allowlist_for_closure.source.clone(),
-                host,
-            });
-        }
-        attempt.follow()
-    });
-
-    ClientBuilder::new()
-        .https_only(false)
-        .redirect(redirect_policy)
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(TOTAL_TIMEOUT)
-        .read_timeout(READ_TIMEOUT)
-        .user_agent(user_agent)
         .tls_backend_rustls()
         .build()
 }

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -5,3 +5,4 @@
 //! sources land in Phase 4/5.
 
 pub mod crossref;
+pub mod unpaywall;

--- a/crates/doiget-core/src/sources/unpaywall.rs
+++ b/crates/doiget-core/src/sources/unpaywall.rs
@@ -175,7 +175,7 @@ mod tests {
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use crate::http::{HttpClient, SourceAllowlist};
+    use crate::http::HttpClient;
     use crate::provenance::{LogRow, ProvenanceLog};
     use crate::rate_limiter::RateLimiter;
     use crate::source::FetchContext;
@@ -197,9 +197,7 @@ mod tests {
             Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
         let log_path = log_dir.join("test.jsonl");
 
-        let allowlist = SourceAllowlist::new("unpaywall", vec![host.to_string()]);
-        let http =
-            Arc::new(HttpClient::new_for_test_http(vec![allowlist]).expect("http client builds"));
+        let http = Arc::new(HttpClient::new_for_tests_allow_http("unpaywall", host));
         let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
         let session_id = "01J0000000000000000000TEST".to_string();
         let log = Arc::new(

--- a/crates/doiget-core/src/sources/unpaywall.rs
+++ b/crates/doiget-core/src/sources/unpaywall.rs
@@ -1,0 +1,443 @@
+//! Unpaywall source — OA URL discovery + license metadata for a given DOI.
+//!
+//! Spec: docs/SOURCES.md §4 Unpaywall. Free public API; the polite pool
+//! requires `email=<contact>` in the URL query. The `email` is set per
+//! `[network] unpaywall_email` in `config.toml` (Phase 1: caller-injected
+//! via `UnpaywallSource::new`).
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+const DEFAULT_BASE: &str = "https://api.unpaywall.org/v2";
+
+/// Unpaywall Source impl.
+#[derive(Clone, Debug)]
+pub struct UnpaywallSource {
+    base: Url,
+    contact_email: String,
+}
+
+impl UnpaywallSource {
+    /// Production constructor. The `contact_email` is REQUIRED for the polite
+    /// pool — Unpaywall returns 403 without it.
+    pub fn new(contact_email: String) -> Self {
+        // `DEFAULT_BASE` is a compile-time const string with a valid HTTPS
+        // URL syntax; `Url::parse` on it cannot fail at runtime. The local
+        // `allow` is the documented exception to the workspace `expect_used`
+        // lint (see `rate_limiter.rs::acquire`).
+        #[allow(clippy::expect_used)]
+        let base = Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid");
+        Self {
+            base,
+            contact_email,
+        }
+    }
+
+    /// Test constructor — accepts an arbitrary base URL (e.g., a wiremock
+    /// http://127.0.0.1:N). Available in cfg(test) only.
+    #[cfg(test)]
+    pub(crate) fn with_base(base: Url, contact_email: String) -> Self {
+        Self {
+            base,
+            contact_email,
+        }
+    }
+
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        // The path layout is `/v2/<DOI>`. Unpaywall accepts the bare DOI
+        // (no `doi:` scheme); `Doi::as_str()` already strips it.
+        let mut url = self.base.clone();
+        // `path_segments_mut` properly URL-encodes each segment, including the
+        // forward slash inside the DOI suffix.
+        url.path_segments_mut()
+            .map_err(|()| FetchError::SourceSchema {
+                hint: "unpaywall base URL is cannot-be-a-base".into(),
+            })?
+            .push(doi.as_str()); // single-push so the `/` in the DOI is encoded
+        url.query_pairs_mut()
+            .append_pair("email", &self.contact_email);
+        Ok(url)
+    }
+}
+
+#[async_trait]
+impl Source for UnpaywallSource {
+    fn name(&self) -> &str {
+        "unpaywall"
+    }
+
+    fn can_serve(&self, _profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        _profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "unpaywall".into(),
+                });
+            }
+        };
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let work: UnpaywallWork =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("unpaywall returned non-JSON: {e}"),
+            })?;
+
+        // Resolve a license string from `best_oa_location.license`, falling back
+        // to "unknown" if absent. Spec: docs/STORE.md §2 — `license` is always
+        // a string (use "unknown" when not provided).
+        let license = work
+            .best_oa_location
+            .as_ref()
+            .and_then(|loc| loc.license.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(&license),
+            store_path: None,
+        })?;
+
+        // Note: Phase 1 returns metadata only; the actual PDF fetch from the
+        // OA URL is the orchestrator's job (a follow-up PR — `doiget fetch`
+        // CLI subcommand calls Unpaywall, then HttpClient::fetch_pdf on the
+        // discovered URL via a per-publisher allowlist). See ARCHITECTURE.md §6.
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(serde_json::to_value(&work).unwrap_or(serde_json::Value::Null)),
+        })
+    }
+}
+
+/// Subset of the Unpaywall work record. We deserialize loosely — extra fields
+/// are ignored (no `deny_unknown_fields`) so future API additions don't break.
+#[derive(Debug, Deserialize, serde::Serialize)]
+struct UnpaywallWork {
+    doi: String,
+    is_oa: bool,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    best_oa_location: Option<UnpaywallOaLocation>,
+    #[serde(default)]
+    oa_locations: Vec<UnpaywallOaLocation>,
+}
+
+#[derive(Debug, Deserialize, serde::Serialize, Clone)]
+struct UnpaywallOaLocation {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    url_for_pdf: Option<String>,
+    #[serde(default)]
+    license: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::{HttpClient, SourceAllowlist};
+    use crate::provenance::{LogRow, ProvenanceLog};
+    use crate::rate_limiter::RateLimiter;
+    use crate::source::FetchContext;
+    use crate::{ArxivId, CapabilityProfile, Doi, RateLimits};
+
+    const TEST_EMAIL: &str = "alice@example.org";
+    const TEST_DOI: &str = "10.1234/example";
+    /// Percent-encoded form of `TEST_DOI` as it appears on the wire after
+    /// `path_segments_mut().push(...)`. Wiremock's `path` matcher operates on
+    /// the request's encoded path portion, so we match against this form.
+    const TEST_DOI_ENCODED: &str = "10.1234%2Fexample";
+
+    /// Build a `FetchContext` whose `HttpClient` allows plain-HTTP initial
+    /// legs against the wiremock origin. The redirect closure is unchanged
+    /// (HTTPS-only + allowlist) — only the *initial* connection is relaxed.
+    fn build_test_context(host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let allowlist = SourceAllowlist::new("unpaywall", vec![host.to_string()]);
+        let http =
+            Arc::new(HttpClient::new_for_test_http(vec![allowlist]).expect("http client builds"));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter,
+                log,
+                session_id,
+            },
+        )
+    }
+
+    fn host_of(uri: &str) -> String {
+        uri.parse::<Url>()
+            .expect("valid uri")
+            .host_str()
+            .expect("has host")
+            .to_string()
+    }
+
+    fn base_of(server_uri: &str) -> Url {
+        // The wiremock server roots at `/`; Unpaywall lives at `/v2/<DOI>`.
+        // Including the `/v2` segment in the base lets `request_url`'s
+        // single-push DOI segment land at the correct path.
+        format!("{}/v2", server_uri).parse().expect("valid base")
+    }
+
+    fn ok_response_body() -> serde_json::Value {
+        serde_json::json!({
+            "doi": TEST_DOI,
+            "is_oa": true,
+            "title": "Example",
+            "best_oa_location": {
+                "url": "https://example.org/free.pdf",
+                "license": "cc-by"
+            }
+        })
+    }
+
+    #[test]
+    fn unpaywall_can_serve_returns_true_for_doi() {
+        let s = UnpaywallSource::new(TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Doi(Doi(TEST_DOI.to_string()));
+        assert!(s.can_serve(&profile, &r));
+    }
+
+    #[test]
+    fn unpaywall_can_serve_returns_false_for_arxiv() {
+        let s = UnpaywallSource::new(TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Arxiv(ArxivId("2401.12345".to_string()));
+        assert!(!s.can_serve(&profile, &r));
+    }
+
+    #[tokio::test]
+    async fn unpaywall_fetch_returns_oa_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+            .and(query_param("email", TEST_EMAIL))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response_body()))
+            .mount(&server)
+            .await;
+
+        let host = host_of(&server.uri());
+        let (_td, ctx) = build_test_context(&host);
+        let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Doi(Doi(TEST_DOI.to_string()));
+
+        let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(res.source, "unpaywall");
+        assert!(res.final_url.is_some());
+        let meta = res.metadata_json.expect("metadata present");
+        let parsed: UnpaywallWork = serde_json::from_value(meta).expect("metadata round-trips");
+        assert!(parsed.is_oa);
+        assert_eq!(parsed.doi, TEST_DOI);
+    }
+
+    #[tokio::test]
+    async fn unpaywall_extracts_license_from_best_oa_location() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+            .and(query_param("email", TEST_EMAIL))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response_body()))
+            .mount(&server)
+            .await;
+
+        let host = host_of(&server.uri());
+        let (_td, ctx) = build_test_context(&host);
+        let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Doi(Doi(TEST_DOI.to_string()));
+
+        let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(res.license, "cc-by");
+    }
+
+    #[tokio::test]
+    async fn unpaywall_falls_back_to_unknown_license() {
+        let body = serde_json::json!({
+            "doi": TEST_DOI,
+            "is_oa": true,
+            "best_oa_location": {
+                "url": "https://example.org/free.pdf",
+                "license": serde_json::Value::Null
+            }
+        });
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+            .and(query_param("email", TEST_EMAIL))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let host = host_of(&server.uri());
+        let (_td, ctx) = build_test_context(&host);
+        let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Doi(Doi(TEST_DOI.to_string()));
+
+        let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(res.license, "unknown");
+    }
+
+    #[tokio::test]
+    async fn unpaywall_with_arxiv_ref_errors_not_eligible() {
+        // No mock: should never reach the network because the ref-kind
+        // gate fires first.
+        let (_td, ctx) = build_test_context("127.0.0.1");
+        let s = UnpaywallSource::new(TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Arxiv(ArxivId("2401.12345".to_string()));
+
+        let err = s
+            .fetch(&r, &profile, &ctx)
+            .await
+            .expect_err("arxiv must be ineligible");
+        match err {
+            FetchError::NotEligible { source_key } => {
+                assert_eq!(source_key, "unpaywall");
+            }
+            other => panic!("expected NotEligible, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn unpaywall_writes_log_row_with_license() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+            .and(query_param("email", TEST_EMAIL))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response_body()))
+            .mount(&server)
+            .await;
+
+        let host = host_of(&server.uri());
+        let (td, ctx) = build_test_context(&host);
+        let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Doi(Doi(TEST_DOI.to_string()));
+
+        let _res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+
+        // Read every JSON-Lines row from the log file and assert the Fetch
+        // row is present with license="cc-by".
+        let log_path = Utf8PathBuf::try_from(td.path().to_path_buf())
+            .expect("temp path utf-8")
+            .join("test.jsonl");
+        let raw = std::fs::read_to_string(&log_path).expect("read log");
+        let rows: Vec<LogRow> = raw
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str::<LogRow>(l).expect("valid LogRow"))
+            .collect();
+
+        let fetch_rows: Vec<&LogRow> = rows.iter().filter(|r| r.event == LogEvent::Fetch).collect();
+        assert_eq!(
+            fetch_rows.len(),
+            1,
+            "expected one Fetch row, got {:?}",
+            rows
+        );
+        let row = fetch_rows[0];
+        assert_eq!(row.result, LogResult::Ok);
+        assert_eq!(row.license.as_deref(), Some("cc-by"));
+        assert_eq!(row.source.as_deref(), Some("unpaywall"));
+        assert_eq!(row.ref_.as_deref(), Some(TEST_DOI));
+    }
+
+    #[test]
+    fn unpaywall_email_is_in_query_string() {
+        // White-box: invoke `request_url` directly to assert the email is
+        // serialized into the query. The wiremock-driven tests above assert
+        // the same property via the `query_param("email", ...)` matcher,
+        // but this test pins the contract without booting an HTTP server.
+        // `query_pairs_mut().append_pair` percent-encodes the `@`, so we
+        // verify against the decoded form via `query_pairs()`.
+        let s = UnpaywallSource::new(TEST_EMAIL.to_string());
+        let doi = Doi(TEST_DOI.to_string());
+        let url = s.request_url(&doi).expect("url builds");
+        let pair = url
+            .query_pairs()
+            .find(|(k, _)| k == "email")
+            .expect("email pair present");
+        assert_eq!(pair.1, TEST_EMAIL, "decoded email must match: {:?}", pair);
+    }
+
+    #[tokio::test]
+    async fn unpaywall_404_maps_to_http_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let host = host_of(&server.uri());
+        let (_td, ctx) = build_test_context(&host);
+        let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let r = Ref::Doi(Doi(TEST_DOI.to_string()));
+
+        let err = s
+            .fetch(&r, &profile, &ctx)
+            .await
+            .expect_err("404 must error");
+        match err {
+            FetchError::Http(_) => {}
+            other => panic!("expected FetchError::Http, got {:?}", other),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First Tier-1 `Source` implementation: the OA URL discovery + license
metadata side, backed by the [Unpaywall public API](https://unpaywall.org/products/api).

Spec: `docs/SOURCES.md` §4 Unpaywall — the polite pool requires
`email=<contact>` in the URL query string, so `UnpaywallSource::new`
takes the contact email as a required argument. The `[network]
unpaywall_email` config wiring is the orchestrator's responsibility (a
follow-up PR).

- New file: `crates/doiget-core/src/sources/unpaywall.rs` — the
  `UnpaywallSource` struct + `Source` trait impl + `UnpaywallWork` /
  `UnpaywallOaLocation` deserialization shadows.
- New file: `crates/doiget-core/src/sources/mod.rs` — the `sources/`
  module entry. Will conflict 1-line-trivially with the parallel
  `feat/source-crossref` PR; rebase will combine `pub mod` declarations.
- Edit: `crates/doiget-core/src/lib.rs` — single `pub mod sources;` line
  added under `// --- Modules ---`.
- Edit: `crates/doiget-core/src/http.rs` — adds a `#[cfg(test)]
  pub(crate) fn HttpClient::new_for_test_http(...)` constructor that
  relaxes `https_only` so wiremock servers on `http://127.0.0.1:N` are
  reachable. The redirect closure (security-load-bearing) is unchanged.

## Behavior

`fetch` is the canonical four-step protocol from `docs/ARCHITECTURE.md`
§6: acquire rate-limiter permit -> `HttpClient::fetch_bytes` (per-source
allowlist + size cap + redirect policy) -> deserialize `UnpaywallWork`
-> append one `LogEvent::Fetch` row to the provenance log -> return
`FetchResult`. License resolution pulls
`best_oa_location.license`, falling back to the literal string
`"unknown"` per `docs/STORE.md` §2. The `UnpaywallWork` shadow is loose
(no `deny_unknown_fields`) so future API additions don't break us.

`can_serve` returns `true` only for `Ref::Doi`. `can_serve(arxiv)` is
`false`, and a defensive ref-kind gate at the top of `fetch` returns
`FetchError::NotEligible` if the orchestrator ignores `can_serve`.

Phase 1 returns metadata only; the actual PDF fetch from the discovered
OA URL is the orchestrator's job (`doiget fetch` CLI subcommand calls
`UnpaywallSource`, then `HttpClient::fetch_pdf` on the OA URL via the
publisher allowlist).

## Tests (9, all passing)

- `unpaywall_can_serve_returns_true_for_doi`
- `unpaywall_can_serve_returns_false_for_arxiv`
- `unpaywall_fetch_returns_oa_metadata` — wiremock matches the encoded
  path + `query_param("email", ...)`, asserts `final_url` is `Some` and
  `metadata_json` round-trips back to a struct with `is_oa: true`.
- `unpaywall_extracts_license_from_best_oa_location` — `license == "cc-by"`.
- `unpaywall_falls_back_to_unknown_license` — `best_oa_location.license: null`
  surfaces as `license == "unknown"`.
- `unpaywall_with_arxiv_ref_errors_not_eligible` — defensive ref-gate
  fires before any network I/O.
- `unpaywall_writes_log_row_with_license` — parses the JSON-Lines
  provenance log and asserts one `event=Fetch`, `result=Ok`, `license =
  Some("cc-by")` row.
- `unpaywall_email_is_in_query_string` — white-box pin on `request_url`,
  asserts the email pair is present (decoded) in the URL query.
- `unpaywall_404_maps_to_http_error` — 404 from upstream surfaces as
  `Err(FetchError::Http(_))`.

The `query_param("email", "alice@example.org")` matcher firing in the
wiremock-driven tests proves the polite-pool email made it onto the wire.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test -p doiget-core --no-default-features --features oa-only` (111 lib tests pass)
- [x] `cargo clippy -p doiget-core --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p doiget-core --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check`

## Merge note

This PR is parallel to `feat/source-crossref`. Both add a sibling
`pub mod` declaration in `sources/mod.rs` and `lib.rs`; the rebase will
deduplicate. There are no shared symbol or test-helper conflicts beyond
those two single-line additions.