### PR TITLE
feat(cli): doiget config show/path/doctor (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,9 @@ name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "cc"
@@ -469,6 +472,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,11 +512,14 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
+ "dirs",
  "doiget-core",
  "predicates",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1181,6 +1208,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1336,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1550,6 +1592,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ reqwest = { version = "0.13", default-features = false, features = [
 camino    = "1"
 fs2       = "0.4"
 tempfile  = "3"
+# Cross-platform XDG / known-folder lookup for $HOME, $XDG_CONFIG_HOME,
+# %USERPROFILE%, %APPDATA%, etc. Used by `doiget config` resolution.
+# See docs/CONFIG.md §2.
+dirs      = "6"
 
 # Concurrency
 parking_lot = "0.12"

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -37,9 +37,19 @@ tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde              = { workspace = true }
 serde_json         = { workspace = true }
-camino             = { workspace = true }
+# Enable the `serde1` feature here (workspace default omits it) so that
+# `ResolvedConfig`'s `Utf8PathBuf` fields serialize for `config show`.
+camino             = { workspace = true, features = ["serde1"] }
 chrono             = { workspace = true }
+# `doiget config` introspection — TOML serialization for `config show` and
+# cross-platform $HOME / $XDG_CONFIG_HOME / %APPDATA% resolution.
+# See docs/CONFIG.md §2 and crates/doiget-cli/src/commands/config.rs.
+toml               = { workspace = true }
+dirs               = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = { workspace = true }
-predicates = { workspace = true }
+assert_cmd  = { workspace = true }
+predicates  = { workspace = true }
+# `doiget config` tests mutate process-global env vars; serialize them.
+# Same convention as `doiget-core/Cargo.toml`.
+serial_test = "3"

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -1,0 +1,265 @@
+//! `doiget config <action>` — config introspection.
+//!
+//! This subcommand is intentionally read-only and does NOT touch the network
+//! or instantiate the Store. Phase 1 resolves config from environment
+//! variables only with default fallbacks; the user `config.toml` reader
+//! lands in a follow-up. See `docs/CONFIG.md` for the canonical schema.
+//!
+//! `print_stdout` is denied workspace-wide for MCP stdio safety (ADR-0001 /
+//! `docs/SECURITY.md` §3). The `config show` and `config path` actions are
+//! the *spec'd* stdout channel for human-facing introspection — they are
+//! never invoked from inside an MCP session (`doiget serve` runs a
+//! different code path), so the lint is locally relaxed below.
+
+use anyhow::{bail, Result};
+use camino::Utf8PathBuf;
+
+/// Snapshot of the env-var + default-fallback config that `doiget` would
+/// use on the current machine.
+///
+/// Phase 1 surface: env vars only (`DOIGET_STORE_ROOT`, `DOIGET_LOG_DIR`,
+/// `DOIGET_CONTACT_EMAIL`, `DOIGET_UNPAYWALL_EMAIL`) layered over
+/// XDG / known-folder defaults. Phase 2 will layer the user config.toml
+/// underneath the env vars per `docs/CONFIG.md` §1.
+#[derive(Debug, serde::Serialize)]
+pub struct ResolvedConfig {
+    /// Root of the on-disk paper store. Default: `$HOME/papers`.
+    pub store_root: Utf8PathBuf,
+    /// Directory holding doiget's append-only logs.
+    pub log_dir: Utf8PathBuf,
+    /// JSON-Lines provenance log file path. Always `<log_dir>/access.jsonl`.
+    pub log_path: Utf8PathBuf,
+    /// Directory holding `config.toml` and `credentials.toml`.
+    pub config_dir: Utf8PathBuf,
+    /// Path of the user config file (may not exist on disk yet).
+    pub config_path: Utf8PathBuf,
+    /// Contact email for the polite User-Agent header (and Unpaywall fallback).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact_email: Option<String>,
+    /// Unpaywall-specific contact email; falls back to `contact_email` when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unpaywall_email: Option<String>,
+}
+
+impl ResolvedConfig {
+    /// Resolve the live config from process environment + platform defaults.
+    ///
+    /// Errors only if neither a home directory nor a config directory can
+    /// be determined for the current user (e.g. an unknown / locked-down
+    /// platform); on every realistic POSIX or Windows host this returns
+    /// `Ok` even with no `DOIGET_*` env vars set.
+    pub fn from_env() -> Result<Self> {
+        // `dirs::home_dir()` / `dirs::config_dir()` return `std::path::PathBuf`;
+        // hoist them into `Utf8PathBuf` immediately at the OS boundary so the
+        // rest of the function (and the public struct) stays UTF-8-only per
+        // the workspace `disallowed-types` clippy rule. A non-UTF-8 home dir
+        // is exotic and unsupported; surface it as an explicit error.
+        let home =
+            Utf8PathBuf::try_from(dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?)?;
+        let cfg = Utf8PathBuf::try_from(
+            dirs::config_dir().ok_or_else(|| anyhow::anyhow!("no config dir"))?,
+        )?;
+
+        let store_root = std::env::var("DOIGET_STORE_ROOT")
+            .map(Utf8PathBuf::from)
+            .unwrap_or_else(|_| home.join("papers"));
+        let log_dir = std::env::var("DOIGET_LOG_DIR")
+            .map(Utf8PathBuf::from)
+            .unwrap_or_else(|_| cfg.join("doiget"));
+
+        let log_path = log_dir.join("access.jsonl");
+        let config_dir = cfg.join("doiget");
+        let config_path = config_dir.join("config.toml");
+
+        Ok(Self {
+            store_root,
+            log_dir,
+            log_path,
+            config_dir,
+            config_path,
+            contact_email: std::env::var("DOIGET_CONTACT_EMAIL").ok(),
+            unpaywall_email: std::env::var("DOIGET_UNPAYWALL_EMAIL").ok(),
+        })
+    }
+}
+
+/// Dispatch entrypoint for `doiget config <action>`.
+///
+/// `action` is one of `show`, `path`, `doctor`. Anything else returns
+/// `Err`; clap currently passes the raw string through.
+//
+// `print_stdout` and `print_stderr` are workspace-deny / workspace-warn for
+// MCP stdio safety. The `config` subcommand is the explicit human-facing
+// stdout channel for the resolved config; `doctor`'s checklist lines also
+// belong on stderr by design (stdout stays clean for `| jq` style pipes
+// when we add `--json` later).
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+pub fn run(action: String) -> Result<()> {
+    let cfg = ResolvedConfig::from_env()?;
+    match action.as_str() {
+        "show" => {
+            let s = toml::to_string_pretty(&cfg)?;
+            print!("{s}");
+        }
+        "path" => {
+            println!("{}", cfg.config_path);
+        }
+        "doctor" => {
+            let mut all_ok = true;
+            check(
+                "store_root parent exists",
+                cfg.store_root.parent().map(|p| p.exists()).unwrap_or(true),
+                &mut all_ok,
+            );
+            check(
+                "log_dir parent exists",
+                cfg.log_dir.parent().map(|p| p.exists()).unwrap_or(true),
+                &mut all_ok,
+            );
+            check(
+                "contact_email set",
+                cfg.contact_email.is_some(),
+                &mut all_ok,
+            );
+            // Trying to actually create the dirs would have side-effects;
+            // keep doctor read-only and just check existence of parents.
+            if !all_ok {
+                bail!("config doctor: one or more checks failed");
+            }
+        }
+        other => bail!("unknown config action: {other}; expected `show` / `path` / `doctor`"),
+    }
+    Ok(())
+}
+
+/// Emit one `[ ok ]` / `[FAIL]` checklist line to stderr and update the
+/// running pass/fail flag. Stderr is used so that `doiget config doctor`
+/// stdout stays empty for green runs (script-friendly).
+#[allow(clippy::print_stderr)]
+fn check(label: &str, ok: bool, all_ok: &mut bool) {
+    let mark = if ok { "[ ok ]" } else { "[FAIL]" };
+    eprintln!("{mark} {label}");
+    if !ok {
+        *all_ok = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — env-mutating, serialized via serial_test (same convention as
+// `doiget-core::tests`). Each test resets the four env vars it touches via
+// an EnvGuard RAII drop guard so that prior values are restored on panic.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+    use super::*;
+
+    /// RAII guard that captures the prior value of an env var on
+    /// construction and restores it on drop. Mirrors the convention in
+    /// `crates/doiget-core/src/lib.rs::tests`.
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            // SAFETY: tests are serialized via `#[serial_test::serial]`;
+            // no other thread reads/writes env state concurrently.
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
+        }
+    }
+
+    /// Unset every env var the `config` subcommand reads. Returns guards
+    /// that restore prior values on drop.
+    fn unset_all_doiget_config_env() -> Vec<EnvGuard> {
+        [
+            "DOIGET_STORE_ROOT",
+            "DOIGET_LOG_DIR",
+            "DOIGET_CONTACT_EMAIL",
+            "DOIGET_UNPAYWALL_EMAIL",
+        ]
+        .iter()
+        .map(|v| EnvGuard::unset(v))
+        .collect()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_uses_home_default_when_unset() {
+        let _g = unset_all_doiget_config_env();
+        let cfg = ResolvedConfig::from_env().expect("home dir must resolve on test host");
+        assert!(
+            cfg.store_root.as_str().ends_with("papers"),
+            "store_root should fall back to <home>/papers when DOIGET_STORE_ROOT is unset; got {}",
+            cfg.store_root
+        );
+        assert_eq!(cfg.contact_email, None);
+        assert_eq!(cfg.unpaywall_email, None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_overrides_via_env() {
+        let _g = unset_all_doiget_config_env();
+        // Use a platform-appropriate absolute path so Utf8PathBuf::try_from
+        // succeeds on Windows too (where "/tmp/foo" is a relative path on
+        // the current drive — still UTF-8, still fine for this assertion).
+        let _override = EnvGuard::set("DOIGET_STORE_ROOT", "/tmp/foo");
+        let cfg = ResolvedConfig::from_env().expect("home dir must resolve on test host");
+        assert_eq!(cfg.store_root.as_str(), "/tmp/foo");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn doctor_fails_without_contact_email() {
+        let _g = unset_all_doiget_config_env();
+        let err = run("doctor".into())
+            .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("config doctor"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn doctor_passes_with_contact_email() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+        // home_dir() / config_dir() resolve to real, existing parents on
+        // every supported test host (CI runners always have $HOME).
+        run("doctor".into()).expect("doctor should pass with contact email + real home dir");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unknown_action_errors() {
+        let _g = unset_all_doiget_config_env();
+        let err = run("bogus".into()).expect_err("bogus action should error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("unknown config action"),
+            "unexpected error message: {msg}"
+        );
+    }
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -1,0 +1,7 @@
+//! `doiget` subcommand implementations.
+//!
+//! Each module under this namespace owns a single subcommand from
+//! `crates/doiget-cli/src/main.rs`. Phase 1 ships the read-only
+//! introspection commands first; fetcher-bound commands follow.
+
+pub mod config;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -2,6 +2,11 @@
 //!
 //! Phase 0 ships the CLI skeleton: `doiget --help` works, and each subcommand
 //! returns a Phase-1-pending error message. Real implementations land in Phase 1+.
+//!
+//! Phase 1 progressively replaces the Phase-0 bail-out per subcommand. The
+//! `config` subcommand is the first to land — see `commands/config.rs`.
+
+mod commands;
 
 use clap::{Parser, Subcommand};
 
@@ -85,6 +90,7 @@ fn main() -> anyhow::Result<()> {
         None => {
             anyhow::bail!("no subcommand. Run `doiget --help` for available commands.");
         }
+        Some(Command::Config { action }) => commands::config::run(action),
         Some(_cmd) => {
             anyhow::bail!(
                 "doiget {} (Phase 0): subcommands are not yet implemented. \

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -174,6 +174,14 @@ criteria = "safe-to-run"
 version = "0.11.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.dirs]]
+version = "2.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-sys]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
 [[exemptions.fastrand]]
 version = "2.4.1"
 criteria = "safe-to-deploy"
@@ -370,6 +378,10 @@ criteria = "safe-to-deploy"
 version = "0.2.186"
 criteria = "safe-to-deploy"
 
+[[exemptions.libredox]]
+version = "0.1.16"
+criteria = "safe-to-deploy"
+
 [[exemptions.linux-raw-sys]]
 version = "0.12.1"
 criteria = "safe-to-deploy"
@@ -464,6 +476,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
 version = "0.5.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_users]]
+version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1369,6 +1369,18 @@ delta = "0.1.1 -> 0.2.1"
 notes = "Very minor changes."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.dirs]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "4.0.0 -> 6.0.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.dirs-sys]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.7 -> 0.5.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.errno]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1436,6 +1448,12 @@ who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.26 -> 0.4.29"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.option-ext]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.percent-encoding]]
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
@@ -1671,6 +1689,13 @@ delta = "1.4.0 -> 1.5.0"
 notes = "Filesystem change is to remove the generated LLVM IR output file after probing."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[[audits.zcash.audits.dirs]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "2.0.2 -> 4.0.0"
+notes = "Some paths change across this upgrade (AFAICT they were bugfixes)."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
 [[audits.zcash.audits.dunce]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -1735,6 +1760,38 @@ who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.redox_users]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.4.3 -> 0.4.4"
+notes = "Switches from `redox_syscall` crate to `libredox` crate for syscalls."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.redox_users]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.4 -> 0.4.5"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.redox_users]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.4.5 -> 0.5.0"
+notes = """
+Changes `Config` from using scheme prefixes (with a default of `file:`) to root
+FS prefixes (with a default of `/`). The behaviour of `Config::scheme` changed
+correspondingly but without being renamed. The effect on the rest of the crate
+is that the passwd, shadow, and group files now default to UNIX-style paths
+(`/etc/passwd`) instead of scheme syntax (`file:etc/passwd`).
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.redox_users]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.5.2"
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.rustc_version]]
 who = "Jack Grigg <jack@electriccoin.co>"


### PR DESCRIPTION
## Summary

Implements `doiget config <action>` for the three Phase-1 actions defined in `docs/CONFIG.md` §7:

- `doiget config show` — print the resolved config to stdout (TOML).
- `doiget config path` — print the path of the config file in use.
- `doiget config doctor` — health checks (store_root parent exists, log_dir parent exists, contact_email set). Exit 0 if all green; exit 1 with `config doctor: one or more checks failed` on any failure.

This subcommand is intentionally read-only: no network, no Store, no filesystem mutation. Resolution layers env vars (`DOIGET_STORE_ROOT`, `DOIGET_LOG_DIR`, `DOIGET_CONTACT_EMAIL`, `DOIGET_UNPAYWALL_EMAIL`) over XDG / known-folder defaults. The user `config.toml` reader is a Phase 2 follow-up per the prompt.

## Surface

- `crates/doiget-cli/src/commands/{mod,config}.rs` — new module tree. `ResolvedConfig` is `serde::Serialize` and uses `Utf8PathBuf` throughout (workspace `disallowed-types` clippy rule bans `std::path::PathBuf`; the `dirs` crate's `PathBuf` returns are hoisted to `Utf8PathBuf` at the OS boundary).
- `main.rs` gains `mod commands;` + `Some(Command::Config { action }) => commands::config::run(action)` arm. Other Phase-0 arms unchanged.

## Lint relaxation

- `clippy::print_stdout` (workspace deny) and `clippy::print_stderr` (workspace warn) are denied for MCP stdio safety per ADR-0001 / `docs/SECURITY.md` §3. `config show` and `config path` are the spec'd human-facing stdout channel and are never reached from inside an MCP session, so `#[allow(clippy::print_stdout, clippy::print_stderr)]` is applied locally to `run` and `check`.

## Cargo / supply-chain

- workspace: `dirs = "6"` for cross-platform `$HOME` / `%APPDATA%` lookup.
- `doiget-cli`: `dirs`, `toml`, and `camino` with the `serde1` feature (enables `Utf8PathBuf: Serialize` for `config show`).
- `doiget-cli` dev-deps: `serial_test = "3"` (matches `doiget-core`).
- `cargo vet regenerate exemptions` covers `dirs`, `dirs-sys`, `libredox`, `redox_users` via mozilla/zcash audit deltas already in `supply-chain/imports.lock`. Vetting Succeeded: 85 fully audited, 5 partially audited, 230 exempted.

## Test plan

5 new unit tests in `commands::config::tests`, env-mutation serialized via `#[serial_test::serial]` and an `EnvGuard` RAII pattern lifted from `doiget-core/src/lib.rs::tests`:

- [x] `from_env_uses_home_default_when_unset` — clear `DOIGET_STORE_ROOT`, assert `store_root` ends with `papers`.
- [x] `from_env_overrides_via_env` — set `DOIGET_STORE_ROOT=/tmp/foo`, assert `store_root == "/tmp/foo"`.
- [x] `doctor_fails_without_contact_email` — clear env, assert `run("doctor")` returns `Err`.
- [x] `doctor_passes_with_contact_email` — set `DOIGET_CONTACT_EMAIL=alice@example.org`, assert `Ok`.
- [x] `unknown_action_errors` — `run("bogus")` errors with message containing `unknown config action`.

Existing `cli_smoke.rs` integration tests (`--help`, `--version`) still pass.

## Validation gates (all green locally)

- [x] `cargo build  --workspace --no-default-features --features oa-only`
- [x] `cargo test   --workspace --no-default-features --features oa-only`
- [x] `cargo clippy --workspace --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only`
- [x] `cargo vet`

## Manual smoke

```
$ DOIGET_CONTACT_EMAIL=alice@example.org doiget config show
store_root = 'C:\Users\souta\papers'
log_dir = 'C:\Users\souta\AppData\Roaming\doiget'
log_path = 'C:\Users\souta\AppData\Roaming\doiget\access.jsonl'
config_dir = 'C:\Users\souta\AppData\Roaming\doiget'
config_path = 'C:\Users\souta\AppData\Roaming\doiget\config.toml'
contact_email = "alice@example.org"

$ doiget config path
C:\Users\souta\AppData\Roaming\doiget\config.toml

$ DOIGET_CONTACT_EMAIL=alice@example.org doiget config doctor   # exit 0
[ ok ] store_root parent exists
[ ok ] log_dir parent exists
[ ok ] contact_email set

$ unset DOIGET_CONTACT_EMAIL && doiget config doctor             # exit 1
[ ok ] store_root parent exists
[ ok ] log_dir parent exists
[FAIL] contact_email set
Error: config doctor: one or more checks failed
```

Generated with [Claude Code](https://claude.com/claude-code)