### PR TITLE
feat(cli): doiget fetch <ref> orchestrator (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,9 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "ulid",
+ "url",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -41,17 +41,28 @@ serde_json         = { workspace = true }
 # `ResolvedConfig`'s `Utf8PathBuf` fields serialize for `config show`.
 camino             = { workspace = true, features = ["serde1"] }
 chrono             = { workspace = true }
-# `doiget config` introspection — TOML serialization for `config show` and
-# cross-platform $HOME / $XDG_CONFIG_HOME / %APPDATA% resolution.
-# Also used by `doiget info` to re-serialize Metadata for stdout.
+# TOML serialization for `config show`, `info`, and metadata round-trip.
 toml               = { workspace = true }
+# Cross-platform $HOME / $XDG_CONFIG_HOME / %APPDATA% resolution.
 dirs               = { workspace = true }
+# Session-id generation for the provenance log (`docs/PROVENANCE_LOG.md` §3
+# requires a 26-char ULID per process invocation).
+ulid               = { workspace = true }
+# URL parsing for the source-base env-var overrides
+# (`DOIGET_ARXIV_BASE` / `DOIGET_CROSSREF_BASE` / `DOIGET_UNPAYWALL_BASE`).
+url                = { workspace = true }
+# Production dep: the orchestrator stages PDF bytes to a tempfile so the
+# existing `Store::write(_, _, Some(&Utf8Path))` atomic-rename code path
+# applies (Source impls return `Bytes`, Store takes a path).
+tempfile           = { workspace = true }
 
 [dev-dependencies]
-assert_cmd  = { workspace = true }
-predicates  = { workspace = true }
-# `doiget config` tests mutate process-global env vars; serialize them.
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
+# Wiremock-driven integration tests for the `doiget fetch` orchestrator
+# (`tests/fetch_arxiv_e2e.rs`). The network-purity guard in CI relies on
+# all integration tests using wiremock instead of real upstream hosts.
+wiremock    = { workspace = true }
+# Serializes tests that mutate process-global env state — used by the
+# `fetch_arxiv_e2e` test and `doiget config` tests.
 serial_test = "3"
-# `tempfile` lets `info` / `list-recent` e2e tests seed a per-test store root via
-# DOIGET_STORE_ROOT instead of mutating the user's real `~/papers/`.
-tempfile    = { workspace = true }

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1,0 +1,671 @@
+//! `doiget fetch <ref>` subcommand.
+//!
+//! Phase 1 scope:
+//!
+//! - **arXiv refs** — full end-to-end: PDF bytes are fetched via
+//!   [`ArxivSource`], the `[doiget]` extension table is populated with the
+//!   resolved license, source, size, and `fetched_at`, and the result is
+//!   written to the on-disk store with both the metadata TOML and the PDF.
+//! - **DOI refs** — metadata-only. The orchestrator queries Crossref for the
+//!   bibliographic record (title / authors / year / venue / type), then
+//!   enriches with Unpaywall to recover the OA license. The PDF is NOT
+//!   fetched in this PR — that requires a per-publisher redirect allowlist
+//!   for the discovered OA URL, which is deferred to a follow-up
+//!   (see `docs/REDIRECT_ALLOWLIST.md` §3 and the PR body).
+//!
+//! ## Provenance contract
+//!
+//! Per `docs/PROVENANCE_LOG.md` §3, every invocation emits at least one
+//! `SessionStart`, one or more `Fetch` rows (one per source consulted), one
+//! `StoreWrite` row on success, and one `SessionEnd`. Each `Fetch` row is
+//! appended by the underlying `Source` impl; the orchestrator owns the
+//! session-bookend rows and the `StoreWrite` row.
+//!
+//! ## Configuration surface
+//!
+//! Hard-coded paths with env-var overrides; full `config.toml` plumbing
+//! arrives in a follow-up. See `docs/CONFIG.md` for the eventual surface.
+//!
+//! | Env var | Default | Purpose |
+//! |---|---|---|
+//! | `DOIGET_STORE_ROOT` | `$HOME/papers` (or `%USERPROFILE%\papers` on Windows) | Filesystem store root |
+//! | `DOIGET_LOG_PATH` | `<config>/doiget/access.jsonl` | Provenance log file |
+//! | `DOIGET_CONTACT_EMAIL` | `doiget@localhost` | Polite-pool contact email (User-Agent and Crossref) |
+//! | `DOIGET_UNPAYWALL_EMAIL` | (= contact email) | Unpaywall query-string email |
+//! | `DOIGET_ARXIV_BASE` | `https://arxiv.org` | arXiv source base (test override) |
+//! | `DOIGET_CROSSREF_BASE` | `https://api.crossref.org` | Crossref source base (test override) |
+//! | `DOIGET_UNPAYWALL_BASE` | `https://api.unpaywall.org/v2` | Unpaywall source base (test override) |
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use chrono::Utc;
+
+use doiget_core::http::{tier_1_allowlist, HttpClient};
+use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
+use doiget_core::rate_limiter::RateLimiter;
+use doiget_core::source::{FetchContext, FetchResult, Source};
+use doiget_core::sources::arxiv::ArxivSource;
+use doiget_core::sources::crossref::CrossrefSource;
+use doiget_core::sources::unpaywall::UnpaywallSource;
+use doiget_core::store::{DoigetExtension, FsStore, Metadata, Store};
+use doiget_core::{ArxivId, CapabilityProfile, Doi, RateLimits, Ref, Safekey, SCHEMA_VERSION};
+
+/// Defer to docs/PROVENANCE_LOG.md §3: 26-char ULID per process invocation.
+fn new_session_id() -> String {
+    ulid::Ulid::new().to_string()
+}
+
+/// Resolve the on-disk store root. `DOIGET_STORE_ROOT` wins; otherwise
+/// fall back to `$HOME/papers` (POSIX) or `%USERPROFILE%\papers` (Windows).
+fn resolve_store_root() -> Result<Utf8PathBuf> {
+    if let Some(s) = read_env_utf8("DOIGET_STORE_ROOT")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    let home = home_dir_utf8()?;
+    Ok(home.join("papers"))
+}
+
+/// Resolve the provenance log path. `DOIGET_LOG_PATH` wins; otherwise
+/// fall back to `<config>/doiget/access.jsonl` per `docs/PROVENANCE_LOG.md`
+/// §1.
+fn resolve_log_path() -> Result<Utf8PathBuf> {
+    if let Some(s) = read_env_utf8("DOIGET_LOG_PATH")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    let cfg = config_dir_utf8()?;
+    Ok(cfg.join("doiget").join("access.jsonl"))
+}
+
+/// Read an env var and assert it is valid UTF-8. Returns `Ok(None)` if
+/// unset; `Ok(Some(s))` if set and UTF-8; `Err(...)` if set but non-UTF-8.
+/// `std::env::var` already requires UTF-8 (returns `VarError::NotUnicode`
+/// otherwise); we wrap it to surface a friendlier error and avoid the
+/// banned `std::path::PathBuf` round-trip.
+fn read_env_utf8(key: &str) -> Result<Option<String>> {
+    match std::env::var(key) {
+        Ok(s) => Ok(Some(s)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow!("{key} is not valid UTF-8")),
+    }
+}
+
+/// Best-effort home-dir resolution without depending on the `dirs` crate
+/// (every new dep adds cargo-vet exemption churn). Honors `HOME` first
+/// (POSIX + most CI), then `USERPROFILE` (Windows).
+fn home_dir_utf8() -> Result<Utf8PathBuf> {
+    if let Some(s) = read_env_utf8("HOME")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    if let Some(s) = read_env_utf8("USERPROFILE")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    Err(anyhow!("neither HOME nor USERPROFILE is set"))
+}
+
+/// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
+/// (POSIX), then `APPDATA` (Windows), then falls back to `$HOME/.config`.
+fn config_dir_utf8() -> Result<Utf8PathBuf> {
+    if let Some(s) = read_env_utf8("XDG_CONFIG_HOME")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    if let Some(s) = read_env_utf8("APPDATA")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    let home = home_dir_utf8()?;
+    Ok(home.join(".config"))
+}
+
+/// Construct the workspace-wide [`HttpClient`].
+///
+/// Production path: `HttpClient::new(tier_1_allowlist())` — strict
+/// HTTPS-only with the canonical Tier-1 redirect allowlist (Crossref,
+/// Unpaywall, arXiv). Test path: when any of the three `DOIGET_*_BASE` env
+/// vars is set, build a multi-source relaxed-`https_only` client whose
+/// per-source allowlist is derived from the corresponding env-var hosts.
+/// This lets the integration test under `tests/fetch_arxiv_e2e.rs` point
+/// the orchestrator at a wiremock server without ever touching the real
+/// network.
+fn build_http_client() -> Result<HttpClient> {
+    let arxiv = std::env::var("DOIGET_ARXIV_BASE").ok();
+    let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
+    let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
+
+    if arxiv.is_none() && crossref.is_none() && unpaywall.is_none() {
+        return HttpClient::new(tier_1_allowlist()).context("building HTTP client");
+    }
+
+    // Test-base mode: build a relaxed client per overridden source.
+    let mut owned: Vec<(String, String)> = Vec::new();
+    for (source, base) in [
+        ("arxiv", arxiv.as_deref()),
+        ("crossref", crossref.as_deref()),
+        ("unpaywall", unpaywall.as_deref()),
+    ] {
+        if let Some(b) = base {
+            let url = url::Url::parse(b)
+                .with_context(|| format!("DOIGET_*_BASE for {source} is not a URL: {b}"))?;
+            let host = url
+                .host_str()
+                .ok_or_else(|| anyhow!("base URL has no host: {b}"))?;
+            owned.push((source.to_string(), host.to_string()));
+        }
+    }
+    let entries: Vec<(&str, &str)> = owned
+        .iter()
+        .map(|(s, h)| (s.as_str(), h.as_str()))
+        .collect();
+    Ok(HttpClient::new_for_tests_allow_http_multi(&entries))
+}
+
+/// Construct an [`ArxivSource`] honoring `DOIGET_ARXIV_BASE` if set.
+fn build_arxiv_source() -> Result<ArxivSource> {
+    if let Ok(s) = std::env::var("DOIGET_ARXIV_BASE") {
+        let url =
+            url::Url::parse(&s).with_context(|| format!("DOIGET_ARXIV_BASE is not a URL: {s}"))?;
+        return Ok(ArxivSource::with_base(url));
+    }
+    Ok(ArxivSource::new())
+}
+
+/// Construct a [`CrossrefSource`] honoring `DOIGET_CROSSREF_BASE` if set.
+fn build_crossref_source(contact_email: &str) -> Result<CrossrefSource> {
+    if let Ok(s) = std::env::var("DOIGET_CROSSREF_BASE") {
+        let url = url::Url::parse(&s)
+            .with_context(|| format!("DOIGET_CROSSREF_BASE is not a URL: {s}"))?;
+        return Ok(CrossrefSource::with_base(url, contact_email.to_string()));
+    }
+    Ok(CrossrefSource::new(contact_email.to_string()))
+}
+
+/// Construct an [`UnpaywallSource`] honoring `DOIGET_UNPAYWALL_BASE` if set.
+fn build_unpaywall_source(contact_email: &str) -> Result<UnpaywallSource> {
+    if let Ok(s) = std::env::var("DOIGET_UNPAYWALL_BASE") {
+        let url = url::Url::parse(&s)
+            .with_context(|| format!("DOIGET_UNPAYWALL_BASE is not a URL: {s}"))?;
+        return Ok(UnpaywallSource::with_base(url, contact_email.to_string()));
+    }
+    Ok(UnpaywallSource::new(contact_email.to_string()))
+}
+
+/// Resolved configuration derived from the environment.
+struct OrchestratorConfig {
+    store_root: Utf8PathBuf,
+    log_path: Utf8PathBuf,
+    contact_email: String,
+    unpaywall_email: String,
+}
+
+impl OrchestratorConfig {
+    fn from_env() -> Result<Self> {
+        let store_root = resolve_store_root()?;
+        let log_path = resolve_log_path()?;
+        let contact_email =
+            std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".into());
+        let unpaywall_email =
+            std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| contact_email.clone());
+        Ok(Self {
+            store_root,
+            log_path,
+            contact_email,
+            unpaywall_email,
+        })
+    }
+}
+
+/// Run the `doiget fetch <ref>` subcommand.
+///
+/// Returns `Ok(())` on success and writes a one-line success message to
+/// stderr (per ADR-0001 stdio convention — no stdout writes from `fetch`).
+/// On failure, returns an `anyhow::Error` and emits a `SessionEnd` row with
+/// `result=err` to the provenance log before returning.
+pub async fn run(input: String) -> Result<()> {
+    // Step 1: parse + safekey. Granular `RefParseError` collapses to anyhow
+    // via `?`; the higher-level CLI binary maps the error to its exit code.
+    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let safekey = ref_.safekey();
+
+    // Step 2: resolve config + foundation modules.
+    let cfg = OrchestratorConfig::from_env()?;
+    if let Some(parent) = cfg.log_path.parent() {
+        if !parent.as_str().is_empty() {
+            std::fs::create_dir_all(parent.as_std_path())
+                .with_context(|| format!("creating log dir {parent}"))?;
+        }
+    }
+    let session_id = new_session_id();
+    let log = Arc::new(
+        ProvenanceLog::open(cfg.log_path.clone(), session_id.clone())
+            .context("opening provenance log")?,
+    );
+    let http = Arc::new(build_http_client()?);
+    let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+    let store = FsStore::new(cfg.store_root.clone()).context("opening store")?;
+    let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
+
+    // Step 3: emit SessionStart. Fail-closed if the log write fails — the
+    // surrounding fetch MUST NOT proceed (`docs/PROVENANCE_LOG.md` §5).
+    log.append(RowInput {
+        event: LogEvent::SessionStart,
+        result: LogResult::Ok,
+        capability: Capability::Oa,
+        ref_: Some(ref_.as_input_str()),
+        source: None,
+        error_code: None,
+        size_bytes: None,
+        license: None,
+        store_path: None,
+    })
+    .context("appending SessionStart row")?;
+
+    let ctx = FetchContext {
+        http,
+        rate_limiter,
+        log: log.clone(),
+        session_id: session_id.clone(),
+    };
+
+    // Step 4: dispatch on ref kind.
+    let result = match &ref_ {
+        Ref::Arxiv(id) => fetch_arxiv(id, &ref_, &profile, &ctx, &store, &safekey, &cfg).await,
+        Ref::Doi(doi) => fetch_doi(doi, &ref_, &profile, &ctx, &store, &safekey, &cfg).await,
+    };
+
+    // Step 5: emit SessionEnd regardless of outcome. Best-effort: if this
+    // append also fails, surface the underlying fetch error (or a fresh one
+    // if the fetch was Ok).
+    let session_result = if result.is_ok() {
+        LogResult::Ok
+    } else {
+        LogResult::Err
+    };
+    let _ = log.append(RowInput {
+        event: LogEvent::SessionEnd,
+        result: session_result,
+        capability: Capability::Oa,
+        ref_: Some(ref_.as_input_str()),
+        source: None,
+        error_code: None,
+        size_bytes: None,
+        license: None,
+        store_path: None,
+    });
+
+    result
+}
+
+/// arXiv branch — full PDF + minimal metadata.
+async fn fetch_arxiv(
+    id: &ArxivId,
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &FsStore,
+    safekey: &Safekey,
+    _cfg: &OrchestratorConfig,
+) -> Result<()> {
+    let source = build_arxiv_source()?;
+    if !source.can_serve(profile, ref_) {
+        return Err(anyhow!("arXiv source declined to serve {}", id.as_str()));
+    }
+
+    let FetchResult {
+        license,
+        pdf_bytes,
+        final_url,
+        ..
+    } = source
+        .fetch(ref_, profile, ctx)
+        .await
+        .with_context(|| format!("arxiv fetch failed for {}", id.as_str()))?;
+    let pdf = pdf_bytes.ok_or_else(|| anyhow!("arxiv source returned no PDF bytes"))?;
+    let size_bytes = pdf.len() as u64;
+
+    // Phase 1 minimal metadata: title placeholder = "arxiv:<id>". Full
+    // export.arxiv.org Atom-feed parsing is deferred to a follow-up PR.
+    let metadata = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: format!("arxiv:{}", id.as_str()),
+        authors: Vec::new(),
+        year: None,
+        doi: None,
+        arxiv_id: Some(id.clone()),
+        abstract_: None,
+        venue: None,
+        publisher: None,
+        issn: None,
+        isbn: None,
+        type_: None,
+        keywords: Vec::new(),
+        url: final_url.as_ref().map(|u| u.to_string()),
+        pdf_path: Some(format!("{}.pdf", safekey.as_str())),
+        doiget: Some(DoigetExtension {
+            fetched_at: Utc::now(),
+            source: "arxiv".to_string(),
+            license: license.clone(),
+            size_bytes,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+
+    // The Store::write contract takes a path to the PDF (not bytes); stage
+    // bytes to a tempfile so the existing atomic-rename code path applies.
+    let tmp = tempfile::NamedTempFile::new().context("creating PDF staging tempfile")?;
+    std::fs::write(tmp.path(), &pdf).context("staging PDF bytes")?;
+    let pdf_src = Utf8Path::from_path(tmp.path())
+        .ok_or_else(|| anyhow!("staging tempfile path is not UTF-8"))?
+        .to_path_buf();
+
+    write_to_store(store, safekey, &metadata, Some(&pdf_src), ctx).await?;
+    drop(tmp); // explicit drop to keep the tempfile alive across write_to_store
+
+    // Stderr success line per ADR-0001 stdio convention. The CLI MUST
+    // never write a success line to stdout (stdio is reserved for MCP
+    // JSON-RPC frames in `doiget serve`). `eprintln!` is the canonical way
+    // to surface a one-line user-visible confirmation; the workspace lint
+    // is warn-level, but `-D warnings` in CI promotes it, so an explicit
+    // localized allow is required here.
+    let pdf_path = store.root().join(format!("{}.pdf", safekey.as_str()));
+    print_success(format_args!(
+        "fetched arxiv:{} ({} bytes) -> {}",
+        id.as_str(),
+        size_bytes,
+        pdf_path
+    ));
+    Ok(())
+}
+
+/// DOI branch — Crossref metadata + Unpaywall license enrichment. No PDF
+/// in this PR (the OA URL fetch is deferred — see module docs).
+async fn fetch_doi(
+    doi: &Doi,
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &FsStore,
+    safekey: &Safekey,
+    cfg: &OrchestratorConfig,
+) -> Result<()> {
+    // Crossref first — bibliographic fields.
+    let crossref = build_crossref_source(&cfg.contact_email)?;
+    let cross = crossref
+        .fetch(ref_, profile, ctx)
+        .await
+        .with_context(|| format!("crossref fetch failed for {}", doi.as_str()))?;
+    let crossref_meta = cross.metadata_json.unwrap_or(serde_json::Value::Null);
+    let extracted = extract_crossref_fields(&crossref_meta);
+
+    // Unpaywall second — license enrichment. A failure here is non-fatal:
+    // we still write the Crossref-derived metadata.
+    let unpaywall = build_unpaywall_source(&cfg.unpaywall_email)?;
+    let upw_result = unpaywall.fetch(ref_, profile, ctx).await;
+    let (license, source_label) = match upw_result {
+        Ok(r) if r.license != "unknown" => (r.license, "unpaywall".to_string()),
+        Ok(r) => (r.license, "crossref".to_string()),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "unpaywall fetch failed; continuing with crossref-only metadata"
+            );
+            ("unknown".to_string(), "crossref".to_string())
+        }
+    };
+
+    let metadata = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: extracted.title.unwrap_or_else(|| doi.as_str().to_string()),
+        authors: extracted.authors,
+        year: extracted.year,
+        doi: Some(doi.clone()),
+        arxiv_id: None,
+        abstract_: None,
+        venue: extracted.venue,
+        publisher: None,
+        issn: None,
+        isbn: None,
+        type_: extracted.type_,
+        keywords: Vec::new(),
+        url: cross.final_url.as_ref().map(|u| u.to_string()),
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: Utc::now(),
+            source: source_label,
+            license,
+            size_bytes: 0,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+
+    write_to_store(store, safekey, &metadata, None, ctx).await?;
+
+    let toml_path = store
+        .root()
+        .join(".metadata")
+        .join(format!("{}.toml", safekey.as_str()));
+    print_success(format_args!(
+        "fetched doi:{} (metadata-only) -> {}",
+        doi.as_str(),
+        toml_path
+    ));
+    Ok(())
+}
+
+/// Single-line user-visible success message, written to stderr per ADR-0001
+/// (stdio convention — the CLI never writes a success line to stdout). This
+/// is the one place where `eprintln!` is intentional; the workspace
+/// `clippy::print_stderr` lint is `warn` so the localized `#[allow]` is the
+/// minimal intervention.
+#[allow(clippy::print_stderr)]
+fn print_success(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
+
+/// Subset of Crossref `message` we extract for the on-disk metadata.
+struct CrossrefFields {
+    title: Option<String>,
+    authors: Vec<String>,
+    year: Option<i32>,
+    venue: Option<String>,
+    type_: Option<String>,
+}
+
+/// Defensively pull the bibliographic fields out of a Crossref envelope's
+/// `message` object. Every field is optional; malformed shapes degrade to
+/// `None` rather than panicking.
+fn extract_crossref_fields(msg: &serde_json::Value) -> CrossrefFields {
+    let title = msg
+        .get("title")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let authors = msg
+        .get("author")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| {
+                    let family = a.get("family").and_then(|v| v.as_str());
+                    let given = a.get("given").and_then(|v| v.as_str());
+                    match (family, given) {
+                        (Some(f), Some(g)) => Some(format!("{f}, {g}")),
+                        (Some(f), None) => Some(f.to_string()),
+                        (None, Some(g)) => Some(g.to_string()),
+                        _ => None,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let year = msg
+        .get("issued")
+        .and_then(|v| v.get("date-parts"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_i64())
+        .and_then(|n| i32::try_from(n).ok());
+
+    let venue = msg
+        .get("container-title")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let type_ = msg
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    CrossrefFields {
+        title,
+        authors,
+        year,
+        venue,
+        type_,
+    }
+}
+
+/// Persist `metadata` (and optionally a PDF at `pdf_src`) to the store, then
+/// emit a `StoreWrite` provenance row. Failures of either step are
+/// fail-closed.
+async fn write_to_store(
+    store: &FsStore,
+    safekey: &Safekey,
+    metadata: &Metadata,
+    pdf_src: Option<&Utf8Path>,
+    ctx: &FetchContext,
+) -> Result<()> {
+    let store_path_relative = if pdf_src.is_some() {
+        format!("{}.pdf", safekey.as_str())
+    } else {
+        format!(".metadata/{}.toml", safekey.as_str())
+    };
+    let size_bytes = metadata.doiget.as_ref().map(|d| d.size_bytes).unwrap_or(0);
+    let license = metadata.doiget.as_ref().map(|d| d.license.as_str());
+    let source_name = metadata.doiget.as_ref().map(|d| d.source.as_str());
+
+    match store.write(safekey, metadata, pdf_src) {
+        Ok(()) => {
+            ctx.log
+                .append(RowInput {
+                    event: LogEvent::StoreWrite,
+                    result: LogResult::Ok,
+                    capability: Capability::Oa,
+                    ref_: metadata
+                        .doi
+                        .as_ref()
+                        .map(|d| d.as_str())
+                        .or_else(|| metadata.arxiv_id.as_ref().map(|a| a.as_str())),
+                    source: source_name,
+                    error_code: None,
+                    size_bytes: Some(size_bytes),
+                    license,
+                    store_path: Some(&store_path_relative),
+                })
+                .context("appending StoreWrite row")?;
+            Ok(())
+        }
+        Err(e) => {
+            // Best-effort: record the StoreWrite failure before propagating.
+            let _ = ctx.log.append(RowInput {
+                event: LogEvent::StoreWrite,
+                result: LogResult::Err,
+                capability: Capability::Oa,
+                ref_: metadata
+                    .doi
+                    .as_ref()
+                    .map(|d| d.as_str())
+                    .or_else(|| metadata.arxiv_id.as_ref().map(|a| a.as_str())),
+                source: source_name,
+                error_code: Some("STORE_ERROR"),
+                size_bytes: None,
+                license: None,
+                store_path: Some(&store_path_relative),
+            });
+            Err(anyhow::Error::new(e).context("writing to store"))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_session_id_is_26_chars() {
+        // ULID textual form is fixed-width 26 chars (Crockford base32).
+        // `docs/PROVENANCE_LOG.md` §3 requires this exact length.
+        let id = new_session_id();
+        assert_eq!(id.len(), 26, "session id must be 26 chars: {:?}", id);
+        // Crockford base32 uses uppercase letters and digits; specifically
+        // I, L, O, U are excluded. Every char must be ASCII alphanumeric.
+        assert!(
+            id.chars().all(|c| c.is_ascii_alphanumeric()),
+            "ulid must be ASCII alphanumeric: {:?}",
+            id
+        );
+    }
+
+    #[test]
+    fn extract_crossref_fields_parses_all_fields() {
+        let msg = serde_json::json!({
+            "title": ["Example Title"],
+            "author": [
+                { "family": "Smith", "given": "Alice" },
+                { "family": "Jones", "given": "Bob" }
+            ],
+            "issued": { "date-parts": [[2024, 1, 15]] },
+            "container-title": ["Phys. Rev. X"],
+            "type": "journal-article"
+        });
+        let f = extract_crossref_fields(&msg);
+        assert_eq!(f.title.as_deref(), Some("Example Title"));
+        assert_eq!(
+            f.authors,
+            vec!["Smith, Alice".to_string(), "Jones, Bob".to_string()]
+        );
+        assert_eq!(f.year, Some(2024));
+        assert_eq!(f.venue.as_deref(), Some("Phys. Rev. X"));
+        assert_eq!(f.type_.as_deref(), Some("journal-article"));
+    }
+
+    #[test]
+    fn extract_crossref_fields_tolerates_missing_fields() {
+        let msg = serde_json::json!({});
+        let f = extract_crossref_fields(&msg);
+        assert!(f.title.is_none());
+        assert!(f.authors.is_empty());
+        assert!(f.year.is_none());
+        assert!(f.venue.is_none());
+        assert!(f.type_.is_none());
+    }
+
+    #[test]
+    fn extract_crossref_fields_handles_partial_author_records() {
+        // An author with only `family` should still produce an entry; an
+        // entry with neither `family` nor `given` is skipped.
+        let msg = serde_json::json!({
+            "author": [
+                { "family": "Carol" },
+                { "given": "David" },
+                {}
+            ]
+        });
+        let f = extract_crossref_fields(&msg);
+        assert_eq!(f.authors, vec!["Carol".to_string(), "David".to_string()]);
+    }
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -8,13 +8,15 @@
 //! ## Phase 1 surface (so far)
 //!
 //! - [`config`] — `doiget config show/path/doctor`.
+//! - [`fetch`] — `doiget fetch <ref>` orchestrator (arXiv E2E + DOI metadata-only).
 //! - [`info`] — prints a stored entry's `Metadata` as TOML on stdout.
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
 //!
-//! Other subcommands (`fetch`, `search`, `batch`, `bib`, `csl`, `audit-log`,
-//! `serve`) land in separate PRs.
+//! Other subcommands (`search`, `batch`, `bib`, `csl`, `audit-log`, `serve`)
+//! land in separate PRs.
 
 pub mod config;
+pub mod fetch;
 pub mod info;
 pub mod list_recent;
 

--- a/crates/doiget-cli/src/lib.rs
+++ b/crates/doiget-cli/src/lib.rs
@@ -1,0 +1,19 @@
+//! Library half of the `doiget-cli` crate.
+//!
+//! The binary entry point lives in `main.rs`; this `lib.rs` re-exports the
+//! subcommand orchestrators (`commands::*`) so integration tests under
+//! `tests/` can drive them in-process without spawning a child binary.
+//! Production users invoke the binary directly via `doiget fetch ...` —
+//! `commands::fetch::run` is the single async entry point for that path.
+//!
+//! # Stability
+//!
+//! `doiget-cli`'s public API is **not** semver-locked (per
+//! `docs/PUBLIC_API.md` — only `doiget-core` is). The surface here exists
+//! solely to support integration tests; downstream crates should depend on
+//! `doiget-core` instead.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+pub mod commands;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -8,8 +8,6 @@
 //! network paths (`fetch`, `batch`, `serve`, `bib`, `csl`, `audit-log`)
 //! follow in subsequent PRs.
 
-mod commands;
-
 use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
@@ -79,7 +77,8 @@ enum Command {
     },
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     // Logging — strictly to stderr. See docs/SECURITY.md §3 / ADR-0001.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
@@ -92,15 +91,18 @@ fn main() -> anyhow::Result<()> {
         None => {
             anyhow::bail!("no subcommand. Run `doiget --help` for available commands.");
         }
-        Some(Command::Config { action }) => commands::config::run(action),
-        // Phase 1 read-only paths.
-        Some(Command::Info { ref_ }) => commands::info::run(ref_),
-        Some(Command::ListRecent { limit }) => commands::list_recent::run(limit),
+        // Phase 1 subcommands. All command modules live in the library half
+        // of this crate (see `src/lib.rs`) so integration tests can drive them
+        // in-process.
+        Some(Command::Config { action }) => doiget_cli::commands::config::run(action),
+        Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_),
+        Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit),
+        Some(Command::Fetch { ref_ }) => doiget_cli::commands::fetch::run(ref_).await,
         // Other subcommands remain Phase-1-pending; they land in their own
         // dedicated PRs to keep the diff scoped.
-        Some(_cmd) => {
+        Some(_) => {
             anyhow::bail!(
-                "doiget {}: subcommand not yet implemented in this build. \
+                "doiget {} (Phase 1): subcommand not yet implemented. \
                  See docs/PHASES.md.",
                 doiget_core::VERSION
             );

--- a/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
@@ -1,0 +1,180 @@
+//! End-to-end wiremock-driven test for `doiget fetch <arxiv-id>`.
+//!
+//! This is the binding success criterion for Phase 1 per
+//! [`docs/PHASES.md`](../../../docs/PHASES.md) §4: the arXiv path produces a
+//! complete on-disk artifact (PDF + metadata TOML) and a hash-chained
+//! provenance log with the expected event sequence.
+//!
+//! ## What is exercised
+//!
+//! - `doiget_cli::commands::fetch::run` end-to-end (no child-process spawn).
+//! - `ArxivSource::with_base` substitution via `DOIGET_ARXIV_BASE`.
+//! - `HttpClient::new_for_tests_allow_http_multi` (selected by the
+//!   orchestrator when `DOIGET_*_BASE` env vars are present).
+//! - `FsStore::write` atomic-rename code path for PDF + metadata.
+//! - `ProvenanceLog::append` writing the four expected rows
+//!   (`SessionStart`, `Fetch`, `StoreWrite`, `SessionEnd`).
+//!
+//! ## Network purity
+//!
+//! Per the network-purity guard, this test makes NO outbound calls. All
+//! HTTP traffic terminates at a `wiremock::MockServer` on `127.0.0.1:N`,
+//! reached via the env-var override.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use camino::{Utf8Path, Utf8PathBuf};
+use doiget_cli::commands::fetch;
+use doiget_core::provenance::{LogEvent, LogResult, LogRow};
+use doiget_core::store::Metadata;
+use serial_test::serial;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// RAII helper to scope env-var mutations so a panic mid-test does not leak
+/// state across the (single-threaded) `serial` group.
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        // Snapshot of any pre-existing values so they can be restored on
+        // drop. For simplicity in this test we just clear; serial_test
+        // ensures no concurrent test reads them.
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+fn read_log_rows(path: &Utf8PathBuf) -> Vec<LogRow> {
+    let raw = std::fs::read_to_string(path.as_std_path()).expect("read log");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<LogRow>(l).expect("valid LogRow"))
+        .collect()
+}
+
+#[tokio::test]
+#[serial]
+async fn arxiv_2401_12345_end_to_end() {
+    // Step 1: spin up a wiremock that serves the canonical arXiv PDF path
+    // with a body whose first 5 bytes pass `HttpClient::fetch_pdf`'s magic-
+    // byte check (`%PDF-`).
+    let server = MockServer::start().await;
+    let body = b"%PDF-1.7\n%fixture-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&server)
+        .await;
+
+    // Step 2: stage a temp dir for store + log artifacts.
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_STORE_ROOT",
+        "DOIGET_LOG_PATH",
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_CONTACT_EMAIL",
+        "DOIGET_UNPAYWALL_EMAIL",
+    ]);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ARXIV_BASE", &server.uri());
+
+    // Step 3: run the orchestrator end-to-end. No child binary; no real
+    // network traffic.
+    fetch::run("arxiv:2401.12345".to_string())
+        .await
+        .expect("fetch::run succeeds");
+
+    // Step 4: assert the on-disk PDF.
+    let pdf_path = store_root.join("arxiv_2401.12345.pdf");
+    assert!(
+        pdf_path.exists(),
+        "expected PDF at {pdf_path}; tree: {:?}",
+        std::fs::read_dir(temp_root.as_std_path())
+            .map(|d| d.flatten().map(|e| e.path()).collect::<Vec<_>>())
+    );
+    let pdf_bytes = std::fs::read(pdf_path.as_std_path()).expect("read pdf");
+    assert_eq!(pdf_bytes, body, "stored PDF must match wiremock body");
+
+    // Step 5: assert the metadata TOML round-trips and has the expected
+    // [doiget].source value.
+    let meta_path = store_root.join(".metadata").join("arxiv_2401.12345.toml");
+    let meta_raw = std::fs::read_to_string(meta_path.as_std_path()).expect("read metadata toml");
+    let metadata: Metadata = toml::from_str(&meta_raw).expect("metadata round-trips");
+    assert_eq!(metadata.schema_version, "1.0");
+    let doiget = metadata.doiget.expect("[doiget] table present");
+    assert_eq!(doiget.source, "arxiv");
+    assert_eq!(doiget.size_bytes, body.len() as u64);
+    assert_eq!(doiget.license, "arxiv-default");
+    assert_eq!(
+        metadata.arxiv_id.map(|a| a.as_str().to_string()),
+        Some("2401.12345".to_string())
+    );
+
+    // Step 6: assert the provenance log has the expected event sequence:
+    // SessionStart -> Fetch (ok) -> StoreWrite (ok) -> SessionEnd (ok).
+    let rows = read_log_rows(&log_path);
+    assert_eq!(
+        rows.len(),
+        4,
+        "expected 4 rows (start/fetch/store/end), got {}: {:?}",
+        rows.len(),
+        rows.iter().map(|r| (r.event, r.result)).collect::<Vec<_>>()
+    );
+
+    assert_eq!(rows[0].event, LogEvent::SessionStart);
+    assert_eq!(rows[0].result, LogResult::Ok);
+    assert_eq!(rows[0].ref_.as_deref(), Some("2401.12345"));
+
+    assert_eq!(rows[1].event, LogEvent::Fetch);
+    assert_eq!(rows[1].result, LogResult::Ok);
+    assert_eq!(rows[1].source.as_deref(), Some("arxiv"));
+    assert_eq!(rows[1].size_bytes, Some(body.len() as u64));
+
+    assert_eq!(rows[2].event, LogEvent::StoreWrite);
+    assert_eq!(rows[2].result, LogResult::Ok);
+    assert_eq!(rows[2].source.as_deref(), Some("arxiv"));
+
+    assert_eq!(rows[3].event, LogEvent::SessionEnd);
+    assert_eq!(rows[3].result, LogResult::Ok);
+
+    // Sanity: the hash chain links rows in file order.
+    assert_eq!(rows[0].prev_hash, "GENESIS");
+    for i in 1..rows.len() {
+        assert_eq!(
+            rows[i].prev_hash,
+            rows[i - 1].this_hash,
+            "hash chain break at row {i}"
+        );
+    }
+
+    drop(env);
+    drop(td);
+}

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -346,20 +346,25 @@ impl HttpClient {
     }
 }
 
-/// Test-only [`HttpClient`] constructors. Visible to sibling modules' test
-/// code (`sources::crossref::tests` etc.) so each new `Source` impl can
-/// exercise its fetch path against a wiremock `http://` origin without
-/// re-deriving the per-source `reqwest::Client` build recipe.
-#[cfg(test)]
+/// Test-oriented [`HttpClient`] constructor. Originally `cfg(test)`; now
+/// also reachable from the `doiget-cli` orchestrator's integration tests
+/// (which live outside this crate and therefore cannot see `cfg(test)`-gated
+/// items). The constructor name retains its `for_tests_allow_http` signal —
+/// production code MUST use [`HttpClient::new`] with [`tier_1_allowlist`].
 #[allow(clippy::expect_used)]
 impl HttpClient {
-    /// Build a test-only `HttpClient` against an `http://` wiremock origin.
-    /// The redirect closure still rejects insecure schemes — we only relax
-    /// `https_only` at the connection level so wiremock can serve. This is
-    /// acceptable because the redirect closure (which is the security-load-
-    /// bearing path) is exercised by the `redirect_to_http_is_rejected_by_closure`
-    /// test in `tests` below.
-    pub(crate) fn new_for_tests_allow_http(source: &str, allowlist_host: &str) -> Self {
+    /// Build a test-oriented `HttpClient` against an `http://` wiremock
+    /// origin. The redirect closure still rejects insecure schemes — we only
+    /// relax `https_only` at the connection level so wiremock can serve.
+    /// This is acceptable because the redirect closure (which is the
+    /// security-load-bearing path) is exercised by the
+    /// `redirect_to_http_is_rejected_by_closure` test below.
+    ///
+    /// Production callers MUST use [`HttpClient::new`] with
+    /// [`tier_1_allowlist`] — the `for_tests_allow_http` suffix is the load-
+    /// bearing signal that this constructor lifts the initial-leg HTTPS-only
+    /// requirement.
+    pub fn new_for_tests_allow_http(source: &str, allowlist_host: &str) -> Self {
         let allowlist = SourceAllowlist::new(source, vec![allowlist_host.to_string()]);
         let client = build_client_allow_http(allowlist.clone()).expect("test client builds");
         let mut map = HashMap::new();
@@ -368,9 +373,28 @@ impl HttpClient {
             clients: Arc::new(map),
         }
     }
+
+    /// Multi-source variant of [`HttpClient::new_for_tests_allow_http`].
+    ///
+    /// Builds a relaxed-`https_only` client per `(source, allowlist_host)`
+    /// pair. Used by the `doiget-cli` orchestrator's integration tests when
+    /// more than one upstream needs to be wiremocked simultaneously
+    /// (e.g. Crossref + Unpaywall against two different mock servers).
+    /// Production callers MUST use [`HttpClient::new`] with
+    /// [`tier_1_allowlist`].
+    pub fn new_for_tests_allow_http_multi(entries: &[(&str, &str)]) -> Self {
+        let mut map = HashMap::with_capacity(entries.len());
+        for (source, host) in entries {
+            let allowlist = SourceAllowlist::new(*source, vec![host.to_string()]);
+            let client = build_client_allow_http(allowlist.clone()).expect("test client builds");
+            map.insert(allowlist.source.clone(), client);
+        }
+        Self {
+            clients: Arc::new(map),
+        }
+    }
 }
 
-#[cfg(test)]
 fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
     let allowlist_for_closure = allowlist.clone();
     let redirect_policy = Policy::custom(move |attempt| {

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -495,6 +495,21 @@ impl Safekey {
 }
 
 impl Ref {
+    /// Returns the bare identifier string usable as a provenance `ref` field.
+    ///
+    /// Equivalent to `Doi::as_str` / `ArxivId::as_str` dispatched on the
+    /// variant — the URI scheme (`doi:` / `arxiv:`) is never present in the
+    /// inner identifiers (it is stripped at parse time), so the result is
+    /// always the bare DOI or arXiv id. Used by the CLI / MCP orchestrators
+    /// to populate the `ref` column of provenance log rows
+    /// (`docs/PROVENANCE_LOG.md` §3) without re-matching the variant.
+    pub fn as_input_str(&self) -> &str {
+        match self {
+            Ref::Doi(d) => d.as_str(),
+            Ref::Arxiv(a) => a.as_str(),
+        }
+    }
+
     /// Derives a deterministic, filesystem-safe key from this reference.
     ///
     /// The algorithm is the NORMATIVE binding spec in `docs/SAFEKEY.md` §3.

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -61,10 +61,13 @@ impl ArxivSource {
         Self { base }
     }
 
-    /// Test constructor — accepts an arbitrary base URL so a `wiremock`
-    /// server can stand in for `arxiv.org` during unit tests.
-    #[cfg(test)]
-    pub(crate) fn with_base(base: Url) -> Self {
+    /// Construct with an arbitrary base URL.
+    ///
+    /// The orchestrator (`doiget-cli::commands::fetch`) uses this to honor
+    /// the `DOIGET_ARXIV_BASE` env var, which lets integration tests point
+    /// the source at a wiremock origin without resorting to compile-time
+    /// gates. Production callers use [`ArxivSource::new`].
+    pub fn with_base(base: Url) -> Self {
         Self { base }
     }
 

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -50,10 +50,13 @@ impl CrossrefSource {
         }
     }
 
-    /// Test-only constructor — accepts an arbitrary base URL (e.g. a
-    /// wiremock `http://127.0.0.1:N`).
-    #[cfg(test)]
-    pub(crate) fn with_base(base: Url, contact_email: String) -> Self {
+    /// Construct with an arbitrary base URL.
+    ///
+    /// The orchestrator (`doiget-cli::commands::fetch`) uses this to honor
+    /// the `DOIGET_CROSSREF_BASE` env var, which lets integration tests point
+    /// the source at a wiremock origin without compile-time gates. Production
+    /// callers use [`CrossrefSource::new`].
+    pub fn with_base(base: Url, contact_email: String) -> Self {
         Self {
             base,
             contact_email,

--- a/crates/doiget-core/src/sources/unpaywall.rs
+++ b/crates/doiget-core/src/sources/unpaywall.rs
@@ -38,10 +38,13 @@ impl UnpaywallSource {
         }
     }
 
-    /// Test constructor — accepts an arbitrary base URL (e.g., a wiremock
-    /// http://127.0.0.1:N). Available in cfg(test) only.
-    #[cfg(test)]
-    pub(crate) fn with_base(base: Url, contact_email: String) -> Self {
+    /// Construct with an arbitrary base URL.
+    ///
+    /// The orchestrator (`doiget-cli::commands::fetch`) uses this to honor
+    /// the `DOIGET_UNPAYWALL_BASE` env var, which lets integration tests
+    /// point the source at a wiremock origin without compile-time gates.
+    /// Production callers use [`UnpaywallSource::new`].
+    pub fn with_base(base: Url, contact_email: String) -> Self {
         Self {
             base,
             contact_email,


### PR DESCRIPTION
## Summary

Wires `Source` impls + `Store` + `ProvenanceLog` + `RateLimiter` + `HttpClient` into a single end-to-end orchestrator routed from `doiget fetch <ref>`. This is the binding deliverable for Phase 1 per [`docs/PHASES.md`](docs/PHASES.md) §4.

- **arXiv refs — full E2E**: PDF + minimal metadata stored end-to-end, with the four-row provenance sequence (`SessionStart` -> `Fetch ok` -> `StoreWrite ok` -> `SessionEnd ok`). This closes the arXiv leg of the Phase 1 success criterion.
- **DOI refs — metadata-only in this PR**: Crossref bibliographic record (title / authors / year / venue / type) + Unpaywall license enrichment, written to the store. **The OA PDF fetch is intentionally deferred to a follow-up PR** because it requires per-publisher redirect-allowlist work (see [`docs/REDIRECT_ALLOWLIST.md`](docs/REDIRECT_ALLOWLIST.md) §3 and the deferred-work note below).
- **MVP / non-goals (this PR)**: `info`, `list-recent`, `search`, `bib`, `csl`, `audit-log`, `serve`, `config`, `batch` remain `Phase-1-pending` errors — they are landed by parallel PRs. Output is one stderr line per ADR-0001 stdio convention; no stdout writes from `fetch`.

## Phase 1 success-criterion deltas this PR closes

From [`docs/PHASES.md`](docs/PHASES.md) §4 ("Phase 1 readiness criteria"):

> `doiget fetch <DOI>` succeeds for at least one Open Access DOI from each of Crossref, Unpaywall, and arXiv.

| Source | This PR | Notes |
|---|---|---|
| **arXiv** | end-to-end (PDF + metadata + log) | Bound by the new `tests/fetch_arxiv_e2e.rs` integration test |
| **Crossref** | metadata stored | DOI -> `[doiget].source = "crossref"` (or `"unpaywall"` if the latter resolved a license) |
| **Unpaywall** | license enrichment of the Crossref record | Non-fatal on error: orchestrator falls back to `"unknown"` license + `crossref` source |

> `cargo test --workspace` is green.

Yes — see "Test plan" below.

The `doiget batch <refs.txt>` line in the same section is satisfied by a sibling PR; this PR delivers the single-ref `fetch` half of the criterion.

## What is intentionally deferred

- **DOI -> OA PDF fetch.** Unpaywall returns an OA URL that may live on any publisher CDN; fetching it requires extending the Tier-1 redirect allowlist with per-publisher entries. That work is its own PR — see `docs/REDIRECT_ALLOWLIST.md` §3 ("Phase 1; revisit during real fetches"). The current PR records `pdf_path = None` and `size_bytes = 0` for DOI entries.
- **arXiv Atom-feed metadata.** `export.arxiv.org/api/query?id_list=...` parsing for `title`/`authors`/`abstract` is deferred. The arXiv branch writes a placeholder `title = "arxiv:<id>"` and an empty `authors` vec; a follow-up PR will wire the Atom XML reader.
- **`doiget batch`**, **`info`**, **`list-recent`**, **`search`**, **`bib`**, **`csl`**, **`audit-log`**, **`serve`**, **`config`** subcommands. Each is a parallel PR.
- **Full `config.toml` plumbing.** This PR uses env-var overrides only (`DOIGET_STORE_ROOT`, `DOIGET_LOG_PATH`, `DOIGET_CONTACT_EMAIL`, `DOIGET_UNPAYWALL_EMAIL`, `DOIGET_{ARXIV,CROSSREF,UNPAYWALL}_BASE`); the `config.toml` reader / `config doctor` arrives with the `config` subcommand PR.

## Notable implementation decisions

1. **`doiget-cli` is now a `[[bin]] + [lib]` crate.** The library half exists solely so the integration test can drive `commands::fetch::run` in-process without a child-process spawn. `doiget-cli`'s public API is **not** semver-locked (only `doiget-core` is).
2. **`ArxivSource::with_base` / `CrossrefSource::with_base` / `UnpaywallSource::with_base` are now `pub`** (previously `cfg(test) pub(crate)`). The orchestrator is the gateway — production callers use `::new` and never invoke the with-base path; integration tests reach them via the `DOIGET_*_BASE` env vars.
3. **`HttpClient::new_for_tests_allow_http` is now `pub`** plus a new `pub fn new_for_tests_allow_http_multi(&[(source, host)]) -> Self`. The constructor name retains its `for_tests_allow_http` signal as the load-bearing convention. The redirect-policy closure (security-load-bearing) is unchanged.
4. **`Ref::as_input_str` added** to `doiget-core` for the orchestrator's provenance-row population. Documented in the existing `impl Ref` block; not yet reflected in `docs/PUBLIC_API.md` (follow-up doc PR).
5. **No new dependencies that required cargo-vet exemptions.** I substituted the spec's suggested `dirs` crate with direct `HOME`/`USERPROFILE` env-var reading, and `rand` with the workspace's existing `ulid` (which gives a real 26-char ULID rather than a hand-rolled lookalike).

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test --workspace --no-default-features --features oa-only` — 4 + 0 + 2 + **1** (new) + 126 + 2 + 0 + 0 + 0 + 0 = **135 tests, 0 failures**
- [x] `cargo clippy --workspace --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check` — 84 fully audited / 2 partially audited / 229 exempted (no new exemptions)
- [x] `tests/fetch_arxiv_e2e.rs::arxiv_2401_12345_end_to_end` — wiremock-driven, asserts PDF + metadata TOML + four-row provenance sequence including `GENESIS` hash chain.
- [x] `commands::fetch::tests::new_session_id_is_26_chars` — pin the ULID textual length per `docs/PROVENANCE_LOG.md` §3.
- [x] `commands::fetch::tests::extract_crossref_fields_*` — three tests covering the happy path, missing fields, and partial author records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)