### PR TITLE
feat(cli): doiget search <query> (Phase 1 read path)

### DIFF
--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -11,14 +11,16 @@
 //! - [`fetch`] — `doiget fetch <ref>` orchestrator (arXiv E2E + DOI metadata-only).
 //! - [`info`] — prints a stored entry's `Metadata` as TOML on stdout.
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
+//! - [`search`] — case-insensitive substring search over stored metadata.
 //!
-//! Other subcommands (`search`, `batch`, `bib`, `csl`, `audit-log`, `serve`)
-//! land in separate PRs.
+//! Other subcommands (`batch`, `bib`, `csl`, `audit-log`, `serve`) land in
+//! separate PRs.
 
 pub mod config;
 pub mod fetch;
 pub mod info;
 pub mod list_recent;
+pub mod search;
 
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -1,0 +1,72 @@
+//! `doiget search <query>` subcommand — case-insensitive substring search
+//! over stored metadata.
+//!
+//! Phase 1 is a linear scan over `<store-root>/.metadata/*.toml` (per
+//! [`FsStore::search`](doiget_core::store::FsStore) — see
+//! `crates/doiget-core/src/store/fs_store.rs`). Phase 2+ swaps in a
+//! tantivy / sqlite-fts index when the corpus grows past the point where
+//! O(N) per query becomes noticeable in CLI latency.
+//!
+//! Output is a tab-separated table with a header line, mirroring
+//! [`list_recent`](super::list_recent) so the two subcommands stay
+//! `cut(1)`-compatible. Future fields will be APPENDED, not inserted.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+
+use doiget_core::store::{FsStore, Store};
+
+use super::resolve_store_root;
+
+/// Phase 1 default cap on the number of returned rows. Picked to match the
+/// "small CLI table" feel — large enough to be useful for an ad-hoc
+/// `doiget search foo`, small enough that an unbounded scan over a
+/// pathological store still terminates promptly. A `--limit` flag lands
+/// alongside the Phase 2 index work.
+const DEFAULT_LIMIT: usize = 50;
+
+/// Format string for [`chrono::DateTime`] columns. RFC3339-shaped, UTC, no
+/// fractional seconds — identical to the [`list_recent`](super::list_recent)
+/// table so downstream pipelines can treat both outputs uniformly.
+const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
+
+/// Run the `search` subcommand against the configured store.
+///
+/// Empty / whitespace-only queries are rejected with a non-zero exit and an
+/// error on stderr — the on-disk `Store::search` would otherwise return
+/// every entry up to `DEFAULT_LIMIT`, which is almost never what the caller
+/// intended.
+pub fn run(query: String) -> Result<()> {
+    if query.trim().is_empty() {
+        anyhow::bail!("search query is empty");
+    }
+
+    let store_root = resolve_store_root()?;
+    let store = FsStore::new(store_root)?;
+    let entries = store
+        .search(&query, DEFAULT_LIMIT)
+        .with_context(|| format!("search failed for query {query:?}"))?;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    writeln!(out, "safekey\tyear\ttitle\tfetched_at")
+        .context("failed to write search header to stdout")?;
+    for e in entries {
+        let year = e.year.map(|y| y.to_string()).unwrap_or_else(|| "-".into());
+        let fetched = e
+            .fetched_at
+            .map(|t| t.format(FETCHED_AT_FMT).to_string())
+            .unwrap_or_else(|| "-".into());
+        writeln!(
+            out,
+            "{}\t{}\t{}\t{}",
+            e.safekey.as_str(),
+            year,
+            e.title,
+            fetched
+        )
+        .context("failed to write search row to stdout")?;
+    }
+    Ok(())
+}

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -4,9 +4,9 @@
 //! returns a Phase-1-pending error message. Real implementations land in Phase 1+.
 //!
 //! Phase 1 progressively replaces the Phase-0 bail-out per subcommand. The
-//! `config`, `info`, and `list-recent` subcommands have landed; the write /
-//! network paths (`fetch`, `batch`, `serve`, `bib`, `csl`, `audit-log`)
-//! follow in subsequent PRs.
+//! `config`, `info`, `list-recent`, `search`, and `fetch` subcommands have
+//! landed; the remaining write / network paths (`batch`, `serve`, `bib`,
+//! `csl`, `audit-log`) follow in subsequent PRs.
 
 use clap::{Parser, Subcommand};
 
@@ -97,6 +97,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Config { action }) => doiget_cli::commands::config::run(action),
         Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_),
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit),
+        Some(Command::Search { query }) => doiget_cli::commands::search::run(query),
         Some(Command::Fetch { ref_ }) => doiget_cli::commands::fetch::run(ref_).await,
         // Other subcommands remain Phase-1-pending; they land in their own
         // dedicated PRs to keep the diff scoped.

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -1,0 +1,168 @@
+//! End-to-end tests for `doiget search <query>`.
+//!
+//! Strategy mirrors `tests/info_list_recent_e2e.rs`: seed a `FsStore`
+//! rooted at a per-test `tempfile::TempDir`, then invoke the freshly-built
+//! `doiget` binary as a subprocess with `DOIGET_STORE_ROOT` pointing at
+//! that tempdir. This guarantees no test ever touches the real
+//! `~/papers/`, and because env mutation happens ONLY on the child
+//! process (via `assert_cmd::Command::env`), the tests are safe to run
+//! in parallel without `serial_test` coordination.
+//!
+//! Coverage:
+//!
+//! 1. Title-substring hit (`search_finds_by_title_substring`).
+//! 2. Authors-substring hit (`search_finds_by_authors_substring`).
+//! 3. No-match → header-only stdout (`search_returns_no_match_for_unknown_query`).
+//! 4. Empty query → non-zero exit (`search_rejects_empty_query`).
+//!
+//! No assertion is made on the exact byte-for-byte stdout layout beyond
+//! the header line; the underlying serializer is free to evolve without
+//! breaking these tests.
+
+// Tests are panic-on-failure by design; relax the workspace-wide lints
+// that ban `expect`/`unwrap`/`panic` in production code.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+use assert_cmd::Command;
+use camino::Utf8PathBuf;
+use chrono::TimeZone;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use doiget_core::store::{DoigetExtension, FsStore, Metadata, Store};
+use doiget_core::{Doi, Safekey, SCHEMA_VERSION};
+
+/// Convert a `TempDir`'s path to a `Utf8PathBuf` so it can drive
+/// `FsStore::new` (which is camino-only). Panics if the temp path is not
+/// UTF-8 — on every platform we test, the system temp dir is ASCII.
+fn utf8_path(dir: &TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir path must be UTF-8")
+}
+
+/// Build a `Metadata` fixture with caller-supplied `title` and `authors`.
+/// All other fields are constant. The DOI suffix doubles as the per-entry
+/// uniqueness handle.
+fn fixture(doi_suffix: &str, title: &str, authors: Vec<String>) -> (Safekey, Metadata) {
+    let doi = format!("10.1234/{doi_suffix}");
+    let ref_ = doiget_core::Ref::Doi(Doi::parse(&doi).expect("valid DOI"));
+    let safekey = ref_.safekey();
+    let m = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: title.to_string(),
+        authors,
+        year: Some(2025),
+        doi: Some(Doi::parse(&doi).expect("valid DOI")),
+        arxiv_id: None,
+        abstract_: None,
+        venue: Some("Phys. Rev. X".to_string()),
+        publisher: None,
+        issn: None,
+        isbn: None,
+        type_: Some("journal-article".to_string()),
+        keywords: vec![],
+        url: None,
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: chrono::Utc
+                .with_ymd_and_hms(2025, 5, 6, 12, 0, 0)
+                .single()
+                .expect("valid timestamp"),
+            source: "unpaywall".to_string(),
+            license: "CC-BY-4.0".to_string(),
+            size_bytes: 1234,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+    (safekey, m)
+}
+
+/// Seed a temp store with two distinct entries that exercise both the
+/// `title` and `authors` haystacks of `Store::search`. Returns the
+/// (TempDir guard, store-root) pair. The guard MUST be kept alive for the
+/// duration of the test — dropping it deletes the tempdir.
+fn seeded_store() -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+
+    // Entry 1: distinctive title ("Quantum Stuff"), generic author.
+    let (k1, m1) = fixture("quantum", "Quantum Stuff", vec!["Bob Generic".to_string()]);
+    // Entry 2: generic title, distinctive author ("Alice Researcher").
+    let (k2, m2) = fixture(
+        "researcher",
+        "An Unrelated Title",
+        vec!["Alice Researcher".to_string()],
+    );
+    store.write(&k1, &m1, None).expect("seed entry 1");
+    store.write(&k2, &m2, None).expect("seed entry 2");
+
+    (dir, root)
+}
+
+/// Configure a `doiget` subprocess to use `root` as its store. Sets
+/// `DOIGET_STORE_ROOT` (the primary resolution hook) and clears
+/// `HOME` / `USERPROFILE` to belt-and-suspenders against any fallback
+/// codepath leaking the developer's real home directory into the test.
+fn doiget(root: &Utf8PathBuf) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("DOIGET_STORE_ROOT", root.as_str())
+        .env("HOME", root.as_str())
+        .env("USERPROFILE", root.as_str());
+    cmd
+}
+
+#[test]
+fn search_finds_by_title_substring() {
+    let (_dir_guard, root) = seeded_store();
+
+    doiget(&root)
+        .args(["search", "quantum"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Quantum Stuff"))
+        .stdout(predicate::str::contains("doi_10.1234_quantum"));
+}
+
+#[test]
+fn search_finds_by_authors_substring() {
+    let (_dir_guard, root) = seeded_store();
+
+    doiget(&root)
+        .args(["search", "Researcher"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("An Unrelated Title"))
+        .stdout(predicate::str::contains("doi_10.1234_researcher"));
+}
+
+#[test]
+fn search_returns_no_match_for_unknown_query() {
+    let (_dir_guard, root) = seeded_store();
+
+    let assert = doiget(&root)
+        .args(["search", "ZZZ-no-such-token"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())
+        .expect("doiget search stdout was not UTF-8");
+    // Header only, no data rows.
+    assert_eq!(
+        stdout, "safekey\tyear\ttitle\tfetched_at\n",
+        "no-match search should produce header-only stdout, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn search_rejects_empty_query() {
+    let (_dir_guard, root) = seeded_store();
+
+    doiget(&root)
+        .args(["search", ""])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("search query is empty"));
+}


### PR DESCRIPTION
## Summary

- New `doiget search <query>` Phase 1 read-path subcommand, driving the existing `FsStore::search` linear scan over `<store-root>/.metadata/*.toml`.
- Tab-separated output (`safekey\tyear\ttitle\tfetched_at`) matches `doiget list-recent`, keeping the two read paths cut(1)-compatible.
- Empty / whitespace-only queries fail fast with a non-zero exit and a clear stderr message; no-match queries produce header-only stdout so callers can `| tail -n +2` unconditionally.

## Files

- NEW `crates/doiget-cli/src/commands/search.rs` — subcommand implementation (no changes to the `Store::search` engine).
- NEW `crates/doiget-cli/tests/search_e2e.rs` — 4 assert_cmd e2e tests, mirrors `tests/info_list_recent_e2e.rs`.
- `crates/doiget-cli/src/commands/mod.rs` — `pub mod search;` (alphabetical) + doc-comment refresh.
- `crates/doiget-cli/src/main.rs` — one new dispatch arm; doc comment updated.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test --workspace --no-default-features --features oa-only` (all 4 `search_e2e` tests pass)
- [x] `cargo clippy --workspace --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check`

## Notes

- Phase 1 only — engine remains the linear scan. Phase 2+ will swap in a tantivy / sqlite-fts index when corpus latency demands it.
- A parallel PR (`feat/cli-batch`) touches `commands/mod.rs` and `main.rs` with 1-line additions; trivial conflict at merge time.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
