### PR TITLE
feat(cli): doiget audit-log --verify (Phase 1)

### DIFF
--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -1,0 +1,238 @@
+//! `doiget audit-log --verify` — re-validate the SHA-256 hash chain.
+//!
+//! The provenance log on disk is JSON Lines + a SHA-256 hash chain
+//! (`docs/PROVENANCE_LOG.md` §4). This subcommand recomputes the chain via
+//! [`doiget_core::provenance::verify`] and reports any mismatches. It is the
+//! ONLY tool that detects log tampering; per `docs/SECURITY.md` §1.8 the
+//! hash chain is "best-effort tamper-evident" — it does not prevent
+//! rewriting, only makes rewrites detectable.
+//!
+//! # Phase 1 surface
+//!
+//! Only `--verify` is implemented in Phase 1. `--since`, `--source`, and
+//! `--session` (per `docs/PROVENANCE_LOG.md` §7) ship in later phases. The
+//! current entry point bails out with a clear message if `--verify` is
+//! omitted.
+//!
+//! # Output (stdout)
+//!
+//! Three header lines followed by zero or more issue lines:
+//!
+//! ```text
+//! audit-log verify: 42 rows
+//!   ok:     41
+//!   issues: 1
+//!   line 17: this-hash — this_hash mismatch: stored=…, recomputed=…
+//! ```
+//!
+//! On a clean log the issue list is empty and the process exits zero. With
+//! one or more issues the process exits non-zero so shell pipelines can
+//! treat tampering as a hard failure.
+//!
+//! `print_stdout` is denied workspace-wide for MCP stdio safety (ADR-0001 /
+//! `docs/SECURITY.md` §3). `audit-log` is a human-facing CLI surface, never
+//! invoked from inside an MCP session, so we use `writeln!` against an
+//! explicit `stdout().lock()` — the sanctioned escape hatch.
+
+use std::io::Write;
+
+use anyhow::{bail, Context, Result};
+use camino::Utf8PathBuf;
+
+use doiget_core::provenance::{verify, VerifyIssueKind};
+
+/// Run the `audit-log` subcommand.
+///
+/// `verify_flag` corresponds to the `--verify` clap flag. Phase 1 requires
+/// it: any other invocation bails with an explanatory error.
+///
+/// Returns `Ok(())` on a clean log (zero issues), or an error whose Display
+/// summarizes the failure when one or more chain issues are detected. The
+/// per-issue breakdown is always written to stdout BEFORE returning, so a
+/// caller scripting this subcommand can inspect both the structured stdout
+/// and the non-zero exit code.
+pub fn run(verify_flag: bool) -> Result<()> {
+    if !verify_flag {
+        bail!(
+            "doiget audit-log: --verify is required (Phase 1 ships only \
+             --verify; --since / --source / --session land later)"
+        );
+    }
+
+    let log_path = resolve_log_path()?;
+    let report = verify(&log_path)
+        .with_context(|| format!("failed to read provenance log at {log_path}"))?;
+
+    // `print_stdout` is workspace-deny for MCP stdio safety — see module docs.
+    // The `audit-log` CLI is the explicit human-facing channel; locking
+    // `stdout()` and using `writeln!` is the sanctioned way to emit lines.
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    writeln!(out, "audit-log verify: {} rows", report.total_rows)
+        .context("failed to write header to stdout")?;
+    writeln!(out, "  ok:     {}", report.ok_rows)
+        .context("failed to write ok-row count to stdout")?;
+    writeln!(out, "  issues: {}", report.errors.len())
+        .context("failed to write issue count to stdout")?;
+
+    for issue in &report.errors {
+        // `VerifyIssueKind` is `#[non_exhaustive]` (forward-compat for
+        // future variants like `SessionIdChange`); the wildcard arm uses a
+        // generic label so older CLI builds keep producing well-formed
+        // output even when run against a newer core that adds variants.
+        let kind = match issue.kind {
+            VerifyIssueKind::ParseError => "parse",
+            VerifyIssueKind::PrevHashMismatch => "prev-hash",
+            VerifyIssueKind::ThisHashMismatch => "this-hash",
+            VerifyIssueKind::SequenceJump => "sequence",
+            _ => "other",
+        };
+        writeln!(out, "  line {}: {} — {}", issue.line, kind, issue.message)
+            .context("failed to write issue line to stdout")?;
+    }
+
+    if report.errors.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "audit-log: {} chain issue(s) detected — see stdout for details",
+            report.errors.len()
+        )
+    }
+}
+
+/// Resolve the on-disk provenance-log path.
+///
+/// Resolution order (subset of `docs/CONFIG.md` §4 — full CLI-flag /
+/// config-file resolution lands with the `config` subcommand):
+///
+/// 1. `DOIGET_LOG_PATH` env var, if set and non-empty.
+/// 2. `<config_dir>/doiget/access.jsonl` (cross-platform via `dirs::config_dir`).
+///
+/// Note: the writer's default in `commands/config.rs::ResolvedConfig` is
+/// `DOIGET_LOG_DIR` + `access.jsonl`. We accept the more direct
+/// `DOIGET_LOG_PATH` here too because §1 of `docs/PROVENANCE_LOG.md`
+/// specifies `DOIGET_LOG_PATH` as the spec'd override. Tests rely on
+/// `DOIGET_LOG_PATH` to point at a per-test tempdir.
+fn resolve_log_path() -> Result<Utf8PathBuf> {
+    if let Ok(s) = std::env::var("DOIGET_LOG_PATH") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s));
+        }
+    }
+    // Fall back to the same convention as `ResolvedConfig::from_env`:
+    // <config_dir>/doiget/access.jsonl.
+    let cfg = Utf8PathBuf::try_from(
+        dirs::config_dir().ok_or_else(|| anyhow::anyhow!("no config dir on this platform"))?,
+    )
+    .context("config directory path is not valid UTF-8")?;
+    Ok(cfg.join("doiget").join("access.jsonl"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests — env-mutating, serialized via serial_test (DOIGET_LOG_PATH is process
+// global). Each test scopes its env mutation to a TempDir-backed log file.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+    use super::*;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+
+    use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
+
+    /// RAII guard that captures the prior value of an env var on
+    /// construction and restores it on drop. Mirrors the convention in
+    /// `crates/doiget-cli/src/commands/config.rs::tests`.
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
+        }
+    }
+
+    fn tmp_dir_utf8(dir: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir path must be UTF-8")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn run_without_verify_flag_errors() {
+        // Even with no log file at all, the absence of --verify is a
+        // user-error guard that fires before we touch the disk.
+        let _g = EnvGuard::unset("DOIGET_LOG_PATH");
+        let err = run(false).expect_err("--verify must be required in Phase 1");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("--verify is required"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn run_verifies_clean_log() {
+        // Build a small valid log via the real writer, point
+        // DOIGET_LOG_PATH at it, run --verify; expect success.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("access.jsonl");
+
+        let log = ProvenanceLog::open(path.clone(), "01JCKZ7Q0000000000000000AB".to_string())
+            .expect("open log");
+        for _ in 0..3 {
+            log.append(RowInput {
+                event: LogEvent::Fetch,
+                result: LogResult::Ok,
+                capability: Capability::Oa,
+                ref_: None,
+                source: None,
+                error_code: None,
+                size_bytes: None,
+                license: None,
+                store_path: None,
+            })
+            .expect("append");
+        }
+        drop(log);
+
+        let _g = EnvGuard::set("DOIGET_LOG_PATH", path.as_str());
+        run(true).expect("verify must pass on a clean log");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn run_verifies_missing_log_as_clean() {
+        // Spec contract: missing log is treated as empty/clean — the bytes
+        // that don't exist cannot have been tampered with.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("never-created.jsonl");
+        assert!(!path.exists(), "precondition: log must not exist");
+
+        let _g = EnvGuard::set("DOIGET_LOG_PATH", path.as_str());
+        run(true).expect("verify must succeed on missing log");
+    }
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -7,15 +7,18 @@
 //!
 //! ## Phase 1 surface (so far)
 //!
+//! - [`audit_log`] — `doiget audit-log --verify` recomputes the SHA-256 hash
+//!   chain on the provenance log and reports any mismatches.
 //! - [`config`] — `doiget config show/path/doctor`.
 //! - [`fetch`] — `doiget fetch <ref>` orchestrator (arXiv E2E + DOI metadata-only).
 //! - [`info`] — prints a stored entry's `Metadata` as TOML on stdout.
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
 //! - [`search`] — case-insensitive substring search over stored metadata.
 //!
-//! Other subcommands (`batch`, `bib`, `csl`, `audit-log`, `serve`) land in
+//! Other subcommands (`batch`, `bib`, `csl`, `serve`) land in
 //! separate PRs.
 
+pub mod audit_log;
 pub mod config;
 pub mod fetch;
 pub mod info;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -4,9 +4,9 @@
 //! returns a Phase-1-pending error message. Real implementations land in Phase 1+.
 //!
 //! Phase 1 progressively replaces the Phase-0 bail-out per subcommand. The
-//! `config`, `info`, `list-recent`, `search`, and `fetch` subcommands have
-//! landed; the remaining write / network paths (`batch`, `serve`, `bib`,
-//! `csl`, `audit-log`) follow in subsequent PRs.
+//! `config`, `info`, `list-recent`, `search`, `fetch`, and `audit-log`
+//! subcommands have landed; the remaining write / network paths (`batch`,
+//! `serve`, `bib`, `csl`) follow in subsequent PRs.
 
 use clap::{Parser, Subcommand};
 
@@ -94,6 +94,7 @@ async fn main() -> anyhow::Result<()> {
         // Phase 1 subcommands. All command modules live in the library half
         // of this crate (see `src/lib.rs`) so integration tests can drive them
         // in-process.
+        Some(Command::AuditLog { verify }) => doiget_cli::commands::audit_log::run(verify),
         Some(Command::Config { action }) => doiget_cli::commands::config::run(action),
         Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_),
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit),

--- a/crates/doiget-cli/tests/audit_log_e2e.rs
+++ b/crates/doiget-cli/tests/audit_log_e2e.rs
@@ -1,0 +1,192 @@
+//! End-to-end tests for `doiget audit-log --verify`.
+//!
+//! Strategy: build a small valid provenance log via the real
+//! `doiget_core::provenance::ProvenanceLog` writer, point `DOIGET_LOG_PATH`
+//! at it via a per-test `tempfile::TempDir`, then invoke the freshly-built
+//! `doiget` binary as a subprocess. Tests assert exit status and the
+//! human-readable stdout shape produced by `commands::audit_log::run`.
+//!
+//! Each test sets `DOIGET_LOG_PATH` ONLY on the child process (via
+//! `assert_cmd::Command::env`), so they are safe to run in parallel and
+//! don't need `serial_test` — same convention as `info_list_recent_e2e.rs`.
+//! Other env vars touched by the resolver fallback (`HOME`, `USERPROFILE`)
+//! are explicitly clobbered to a tempdir for belt-and-suspenders against
+//! a fallback codepath leaking the developer's real
+//! `~/.config/doiget/access.jsonl`.
+
+// Tests panic on failure by design; the workspace deny-lints for
+// `expect`/`unwrap`/`panic` are scoped to production code.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::fs;
+
+use assert_cmd::Command;
+use camino::Utf8PathBuf;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
+
+/// Convert a `TempDir`'s path to a `Utf8PathBuf`. CI temp dirs are ASCII;
+/// panic if not (acceptable for an integration test).
+fn utf8_path(dir: &TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir path must be UTF-8")
+}
+
+/// Seed a temp provenance log with `n` valid rows. Returns
+/// `(TempDir guard, log path)`. The guard MUST be kept alive for the
+/// duration of the test — dropping it deletes the tempdir.
+fn seed_log(n: usize) -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = utf8_path(&dir).join("access.jsonl");
+
+    let log = ProvenanceLog::open(path.clone(), "01JCKZ7Q0000000000000000AB".to_string())
+        .expect("open provenance log");
+    for _ in 0..n {
+        log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: None,
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        })
+        .expect("append seed row");
+    }
+    drop(log);
+
+    (dir, path)
+}
+
+/// Build an `assert_cmd::Command` for the freshly-built `doiget` binary,
+/// scoping `DOIGET_LOG_PATH` and the home-dir fallbacks to `dir_root`. Env
+/// mutation happens ONLY on the child process.
+fn doiget(log_path: &Utf8PathBuf, dir_root: &Utf8PathBuf) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("DOIGET_LOG_PATH", log_path.as_str())
+        // Belt-and-suspenders: clobber the home-dir resolution so a
+        // resolver bug can't accidentally point at the developer's real
+        // `~/.config/doiget/access.jsonl`.
+        .env("HOME", dir_root.as_str())
+        .env("USERPROFILE", dir_root.as_str());
+    cmd
+}
+
+#[test]
+fn audit_log_verify_clean_chain_succeeds() {
+    let (dir_guard, log_path) = seed_log(3);
+    let dir_root = utf8_path(&dir_guard);
+
+    let assert = doiget(&log_path, &dir_root)
+        .args(["audit-log", "--verify"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())
+        .expect("doiget audit-log stdout was not UTF-8");
+
+    // Header line includes the row count we seeded.
+    assert!(
+        stdout.contains("audit-log verify: 3 rows"),
+        "expected header with row count, got:\n{stdout}"
+    );
+    // All three rows accounted for as ok, zero issues.
+    assert!(
+        stdout.contains("ok:     3"),
+        "expected ok count of 3, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("issues: 0"),
+        "expected zero issues on a clean log, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn audit_log_verify_missing_log_succeeds() {
+    // No log file at all — spec: missing file is a clean log.
+    let dir = TempDir::new().expect("tempdir");
+    let dir_root = utf8_path(&dir);
+    let log_path = dir_root.join("never-created.jsonl");
+    assert!(!log_path.exists(), "precondition: log must not exist");
+
+    doiget(&log_path, &dir_root)
+        .args(["audit-log", "--verify"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("audit-log verify: 0 rows"))
+        .stdout(predicate::str::contains("issues: 0"));
+}
+
+#[test]
+fn audit_log_without_verify_flag_errors() {
+    // Phase 1: --verify is required.
+    let dir = TempDir::new().expect("tempdir");
+    let dir_root = utf8_path(&dir);
+    let log_path = dir_root.join("access.jsonl");
+
+    doiget(&log_path, &dir_root)
+        .args(["audit-log"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--verify is required"));
+}
+
+#[test]
+fn audit_log_verify_detects_tampered_this_hash() {
+    // Build a 2-row log, then corrupt the second row's `this_hash` to a
+    // syntactically-valid (64 hex chars) but wrong value. The subcommand
+    // must exit non-zero and print a `this-hash` issue line.
+    let (dir_guard, log_path) = seed_log(2);
+    let dir_root = utf8_path(&dir_guard);
+
+    let raw = fs::read_to_string(&log_path).expect("read log");
+    let mut lines: Vec<String> = raw.lines().map(str::to_string).collect();
+    assert_eq!(lines.len(), 2, "seed_log should produce exactly 2 rows");
+
+    // Locate `"this_hash":"<64 hex>"` on row 2 and overwrite the value.
+    let needle = "\"this_hash\":\"";
+    let target = &lines[1];
+    let start = target
+        .find(needle)
+        .expect("this_hash field present in row 2")
+        + needle.len();
+    let end_rel = target[start..]
+        .find('"')
+        .expect("closing quote for this_hash present");
+    let end = start + end_rel;
+    let bogus = "0000000000000000000000000000000000000000000000000000000000000000";
+    let mut new_line = String::with_capacity(target.len());
+    new_line.push_str(&target[..start]);
+    new_line.push_str(bogus);
+    new_line.push_str(&target[end..]);
+    lines[1] = new_line;
+    let mut tampered = lines.join("\n");
+    tampered.push('\n');
+    fs::write(&log_path, tampered).expect("write tampered log");
+
+    let assert = doiget(&log_path, &dir_root)
+        .args(["audit-log", "--verify"])
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())
+        .expect("doiget audit-log stdout was not UTF-8");
+
+    // Header line still names the total row count.
+    assert!(
+        stdout.contains("audit-log verify: 2 rows"),
+        "expected header with row count, got stdout:\n{stdout}"
+    );
+    // The tampered row surfaces as a `this-hash` issue on line 2.
+    assert!(
+        stdout.contains("this-hash"),
+        "expected 'this-hash' issue marker in stdout, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("line 2"),
+        "expected issue to be reported on line 2, got stdout:\n{stdout}"
+    );
+}

--- a/crates/doiget-core/src/provenance.rs
+++ b/crates/doiget-core/src/provenance.rs
@@ -504,6 +504,251 @@ fn recover_state(path: &Utf8Path) -> Result<(u64, String), LogError> {
 }
 
 // ---------------------------------------------------------------------------
+// Verification (`doiget audit-log --verify`)
+//
+// The provenance log is a JSON Lines file with a SHA-256 hash chain
+// (PROVENANCE_LOG.md §4). Tampering is detected by recomputing every row's
+// `this_hash` and validating the chain. This module provides the offline
+// verifier; the CLI wrapper lives in `doiget-cli::commands::audit_log`.
+//
+// Failure model: returning `Err` is reserved for I/O failures opening / reading
+// the file. Per-row issues (parse failures, hash/chain mismatches, sequence
+// regressions) are accumulated into [`VerifyReport::errors`] so callers can
+// report them all in one pass — this is the contract Phase 1 ships.
+// ---------------------------------------------------------------------------
+
+/// Outcome of [`verify`]: per-row chain status across the entire log.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct VerifyReport {
+    /// Total non-empty lines processed (1-based count).
+    pub total_rows: usize,
+    /// Rows whose hash, chain link, and `ts_seq` all validated.
+    pub ok_rows: usize,
+    /// Issues encountered, in encounter order. Line numbers are 1-based.
+    pub errors: Vec<VerifyIssue>,
+}
+
+impl VerifyReport {
+    /// An empty, all-clear report — used when the log file is absent.
+    fn empty() -> Self {
+        Self {
+            total_rows: 0,
+            ok_rows: 0,
+            errors: Vec::new(),
+        }
+    }
+}
+
+/// A single issue discovered by [`verify`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct VerifyIssue {
+    /// 1-based line number where the issue was detected.
+    pub line: usize,
+    /// Classification of the issue (see [`VerifyIssueKind`]).
+    pub kind: VerifyIssueKind,
+    /// Human-readable description (caller may format for stderr/stdout).
+    pub message: String,
+}
+
+/// Classification of a [`VerifyIssue`]. `non_exhaustive` for forward
+/// compatibility — future kinds may include `SessionIdChange`, etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum VerifyIssueKind {
+    /// Row failed to parse as [`LogRow`] (corrupted JSON or unknown field).
+    ParseError,
+    /// `prev_hash` did not match the previous row's `this_hash` (or the
+    /// genesis sentinel on row 1).
+    PrevHashMismatch,
+    /// Row's stored `this_hash` did not match the recomputed canonical-JSON
+    /// SHA-256.
+    ThisHashMismatch,
+    /// `ts_seq` did not increase strictly monotonically (within a session;
+    /// see PROVENANCE_LOG.md §3 + §6 — chain restarts after rotation are
+    /// permitted to reset `ts_seq` and are detected via the genesis sentinel).
+    SequenceJump,
+}
+
+/// Verify the entire log file at `path`.
+///
+/// Returns `Ok(VerifyReport)` regardless of whether the chain validates;
+/// callers inspect `report.errors.is_empty()` to determine pass/fail.
+/// Returns `Err` only when the file itself cannot be opened or read at the
+/// I/O level.
+///
+/// Behavior:
+///
+/// - A missing file is treated as a clean, empty log (no tampering possible
+///   on bytes that don't exist) and returns an empty report after a `warn!`.
+/// - Empty / blank lines are skipped — they are not data per the writer's
+///   on-disk format (PROVENANCE_LOG.md §2).
+/// - On a row that fails to parse as [`LogRow`], a `ParseError` is recorded
+///   and verification continues on the next line. The chain anchor does NOT
+///   advance through an unparseable row, so the next valid row's `prev_hash`
+///   is checked against the last successfully parsed row (or against
+///   `"GENESIS"` if no valid row has been seen yet).
+/// - A `prev_hash == "GENESIS"` sentinel marks a chain restart (first row of
+///   a fresh / rotated log per §6) and resets the `ts_seq` monotonicity
+///   anchor — `ts_seq` is NOT compared to the prior row across a restart.
+pub fn verify(path: &Utf8Path) -> Result<VerifyReport, LogError> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::warn!(
+                path = %path,
+                "audit-log verify: log file does not exist; reporting empty"
+            );
+            return Ok(VerifyReport::empty());
+        }
+        Err(e) => return Err(LogError::Io(e)),
+    };
+
+    let reader = BufReader::new(file);
+    let mut report = VerifyReport::empty();
+
+    // Anchor for the chain check: the LAST SUCCESSFULLY PARSED row. The chain
+    // is anchored to the bytes on disk, not to a hypothetical "should have
+    // been". This matches the spec — tampering at row N must surface both as
+    // a hash mismatch on N and as a chain break on N+1.
+    let mut prev_row: Option<LogRow> = None;
+
+    for (idx, line_res) in reader.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = line_res?;
+        if line.is_empty() {
+            continue;
+        }
+
+        report.total_rows += 1;
+
+        let row: LogRow = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                report.errors.push(VerifyIssue {
+                    line: line_no,
+                    kind: VerifyIssueKind::ParseError,
+                    message: format!("failed to parse row as LogRow: {e}"),
+                });
+                // Chain anchor cannot advance through an unparseable row;
+                // leave `prev_row` untouched so the next valid row's
+                // `prev_hash` is checked against the last-known anchor (or
+                // GENESIS if we never had one).
+                continue;
+            }
+        };
+
+        let mut row_ok = true;
+
+        // 1. Recompute `this_hash` from canonical JSON (row \ {this_hash}).
+        let rfh = RowForHash {
+            ts: row.ts,
+            ts_seq: row.ts_seq,
+            event: row.event,
+            ref_: row.ref_.as_deref(),
+            source: row.source.as_deref(),
+            result: row.result,
+            license: row.license.as_deref(),
+            size_bytes: row.size_bytes,
+            store_path: row.store_path.as_deref(),
+            capability: row.capability,
+            session_id: &row.session_id,
+            error_code: row.error_code.as_deref(),
+            prev_hash: &row.prev_hash,
+        };
+        match compute_this_hash(&rfh) {
+            Ok(recomputed) => {
+                if recomputed != row.this_hash {
+                    report.errors.push(VerifyIssue {
+                        line: line_no,
+                        kind: VerifyIssueKind::ThisHashMismatch,
+                        message: format!(
+                            "this_hash mismatch: stored={}, recomputed={}",
+                            row.this_hash, recomputed
+                        ),
+                    });
+                    row_ok = false;
+                }
+            }
+            Err(e) => {
+                // Canonicalization itself failed — surface as a hash
+                // mismatch with the underlying error in the message.
+                report.errors.push(VerifyIssue {
+                    line: line_no,
+                    kind: VerifyIssueKind::ThisHashMismatch,
+                    message: format!("failed to recompute this_hash: {e}"),
+                });
+                row_ok = false;
+            }
+        }
+
+        // 2. Chain link: `prev_hash` matches anchor (GENESIS on row 1 / after
+        //    a chain restart, prior row's `this_hash` otherwise).
+        let is_genesis = row.prev_hash == GENESIS_HASH;
+        match &prev_row {
+            None => {
+                // First non-empty row in the file: must declare GENESIS.
+                if !is_genesis {
+                    report.errors.push(VerifyIssue {
+                        line: line_no,
+                        kind: VerifyIssueKind::PrevHashMismatch,
+                        message: format!(
+                            "first row must have prev_hash=\"GENESIS\", got {:?}",
+                            row.prev_hash
+                        ),
+                    });
+                    row_ok = false;
+                }
+            }
+            Some(prev) => {
+                if is_genesis {
+                    // Chain restart (rotation per §6) — accepted, no link
+                    // check, and the `ts_seq` monotonicity anchor resets
+                    // (handled below via `is_genesis`).
+                } else if row.prev_hash != prev.this_hash {
+                    report.errors.push(VerifyIssue {
+                        line: line_no,
+                        kind: VerifyIssueKind::PrevHashMismatch,
+                        message: format!(
+                            "prev_hash mismatch: row stores {}, previous row's this_hash is {}",
+                            row.prev_hash, prev.this_hash
+                        ),
+                    });
+                    row_ok = false;
+                }
+            }
+        }
+
+        // 3. ts_seq monotonicity — strictly greater than the previous row's
+        //    `ts_seq`, EXCEPT across a chain restart (where `ts_seq` resets).
+        if let Some(prev) = &prev_row {
+            if !is_genesis && row.ts_seq <= prev.ts_seq {
+                report.errors.push(VerifyIssue {
+                    line: line_no,
+                    kind: VerifyIssueKind::SequenceJump,
+                    message: format!(
+                        "ts_seq did not increase strictly: previous={}, current={}",
+                        prev.ts_seq, row.ts_seq
+                    ),
+                });
+                row_ok = false;
+            }
+        }
+
+        if row_ok {
+            report.ok_rows += 1;
+        }
+
+        // Advance the anchor to the just-parsed row (whether or not it had
+        // issues — the on-disk bytes ARE the chain).
+        prev_row = Some(row);
+    }
+
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -799,6 +1044,191 @@ mod tests {
         let ts_idx = s.find("\"ts\":").expect("ts key present");
         let tsseq_idx = s.find("\"ts_seq\":").expect("ts_seq key present");
         assert!(ts_idx < tsseq_idx, "ts must precede ts_seq");
+    }
+
+    // -----------------------------------------------------------------
+    // verify() tests — Phase 1 surface for `doiget audit-log --verify`.
+    // -----------------------------------------------------------------
+
+    /// Rewrite a single field's quoted-string value on a specific 1-based
+    /// line of `path`. Used to simulate tampering. Panics on malformed input
+    /// — only valid inputs are produced by the test harness.
+    ///
+    /// `field_key` is matched as `"field_key":"...old..."` (quoted string
+    /// JSON value). The new value is the literal string `new_value` (no
+    /// JSON escaping needed for the test fixtures we use).
+    fn tamper_string_field(
+        path: &Utf8Path,
+        line_no_1based: usize,
+        field_key: &str,
+        new_value: &str,
+    ) {
+        let raw = fs::read_to_string(path).expect("read log");
+        let mut lines: Vec<String> = raw.lines().map(str::to_string).collect();
+        let target = &lines[line_no_1based - 1];
+        let needle = format!("\"{field_key}\":\"");
+        let start = target
+            .find(&needle)
+            .unwrap_or_else(|| panic!("field {field_key} not found on line {line_no_1based}"))
+            + needle.len();
+        let end_rel = target[start..]
+            .find('"')
+            .unwrap_or_else(|| panic!("unterminated string for field {field_key}"));
+        let end = start + end_rel;
+        let mut new_line = String::with_capacity(target.len());
+        new_line.push_str(&target[..start]);
+        new_line.push_str(new_value);
+        new_line.push_str(&target[end..]);
+        lines[line_no_1based - 1] = new_line;
+        let mut out = lines.join("\n");
+        out.push('\n');
+        fs::write(path, out).expect("write tampered log");
+    }
+
+    #[test]
+    fn verify_empty_log_is_ok() {
+        // Missing file is a clean log — no tampering possible on bytes that
+        // don't exist. `verify` returns an empty report, not an error.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("nonexistent.jsonl");
+        assert!(!path.exists(), "precondition: file must not exist");
+
+        let report = verify(&path).expect("verify must not error on missing file");
+        assert_eq!(report.total_rows, 0);
+        assert_eq!(report.ok_rows, 0);
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+    }
+
+    #[test]
+    fn verify_well_formed_chain_passes() {
+        // Three rows written via the real writer must verify clean.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("log.jsonl");
+        let log = open_log(&path);
+        for _ in 0..3 {
+            log.append(empty_input()).expect("append");
+        }
+
+        let report = verify(&path).expect("verify must succeed");
+        assert_eq!(report.total_rows, 3);
+        assert_eq!(report.ok_rows, 3);
+        assert!(
+            report.errors.is_empty(),
+            "expected no issues on a well-formed log; got: {:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn verify_detects_tampered_row_hash() {
+        // Mutate the SECOND row's `this_hash` to a syntactically-valid but
+        // wrong hash. The recomputed canonical-JSON SHA-256 will not match.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("log.jsonl");
+        let log = open_log(&path);
+        log.append(empty_input()).expect("append 1");
+        log.append(empty_input()).expect("append 2");
+        drop(log);
+
+        // 64 lowercase hex chars, all zeros — passes `LogRow` parse, fails hash check.
+        tamper_string_field(
+            &path,
+            2,
+            "this_hash",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        );
+
+        let report = verify(&path).expect("verify must succeed");
+        assert_eq!(report.total_rows, 2);
+        // Row 2's hash mismatch breaks both the hash check on row 2 AND the
+        // chain link from row 2's stored `prev_hash` (still correct) into the
+        // forward direction. There's no row 3 to fail forward, so we expect
+        // exactly one issue: the this-hash mismatch on line 2.
+        let hash_issues: Vec<_> = report
+            .errors
+            .iter()
+            .filter(|e| e.kind == VerifyIssueKind::ThisHashMismatch)
+            .collect();
+        assert_eq!(
+            hash_issues.len(),
+            1,
+            "expected exactly one ThisHashMismatch, got {:?}",
+            report.errors
+        );
+        assert_eq!(hash_issues[0].line, 2);
+    }
+
+    #[test]
+    fn verify_detects_tampered_prev_hash() {
+        // Mutate the SECOND row's `prev_hash` to a wrong value. This
+        // invalidates the chain link but the row's own `this_hash` was
+        // computed with the original `prev_hash`, so the this-hash check
+        // ALSO fails (hash input changed). We assert at least the prev-hash
+        // issue is reported on line 2.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("log.jsonl");
+        let log = open_log(&path);
+        log.append(empty_input()).expect("append 1");
+        log.append(empty_input()).expect("append 2");
+        drop(log);
+
+        tamper_string_field(
+            &path,
+            2,
+            "prev_hash",
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        );
+
+        let report = verify(&path).expect("verify must succeed");
+        assert_eq!(report.total_rows, 2);
+        let prev_issues: Vec<_> = report
+            .errors
+            .iter()
+            .filter(|e| e.kind == VerifyIssueKind::PrevHashMismatch)
+            .collect();
+        assert_eq!(
+            prev_issues.len(),
+            1,
+            "expected exactly one PrevHashMismatch, got {:?}",
+            report.errors
+        );
+        assert_eq!(prev_issues[0].line, 2);
+    }
+
+    #[test]
+    fn verify_detects_corrupted_json() {
+        // One valid row plus a literal `{"garbage":true}` line. The garbage
+        // line fails `serde_json::from_str::<LogRow>` (missing fields +
+        // `deny_unknown_fields`) and surfaces as a `ParseError` on line 2.
+        let dir = TempDir::new().expect("tmp");
+        let path = tmp_dir_utf8(&dir).join("log.jsonl");
+        let log = open_log(&path);
+        log.append(empty_input()).expect("append 1");
+        drop(log);
+
+        // Append a garbage line directly.
+        let mut existing = fs::read_to_string(&path).expect("read");
+        if !existing.ends_with('\n') {
+            existing.push('\n');
+        }
+        existing.push_str("{\"garbage\":true}\n");
+        fs::write(&path, existing).expect("write");
+
+        let report = verify(&path).expect("verify must succeed");
+        // total_rows counts non-empty lines, so both lines are counted.
+        assert_eq!(report.total_rows, 2);
+        let parse_issues: Vec<_> = report
+            .errors
+            .iter()
+            .filter(|e| e.kind == VerifyIssueKind::ParseError)
+            .collect();
+        assert_eq!(
+            parse_issues.len(),
+            1,
+            "expected exactly one ParseError, got {:?}",
+            report.errors
+        );
+        assert_eq!(parse_issues[0].line, 2);
     }
 
     #[test]

--- a/crates/doiget-core/src/provenance.rs
+++ b/crates/doiget-core/src/provenance.rs
@@ -586,7 +586,7 @@ pub enum VerifyIssueKind {
 ///   on-disk format (PROVENANCE_LOG.md §2).
 /// - On a row that fails to parse as [`LogRow`], a `ParseError` is recorded
 ///   and verification continues on the next line. The chain anchor does NOT
-///   advance through an unparseable row, so the next valid row's `prev_hash`
+///   advance through an unparsable row, so the next valid row's `prev_hash`
 ///   is checked against the last successfully parsed row (or against
 ///   `"GENESIS"` if no valid row has been seen yet).
 /// - A `prev_hash == "GENESIS"` sentinel marks a chain restart (first row of
@@ -631,7 +631,7 @@ pub fn verify(path: &Utf8Path) -> Result<VerifyReport, LogError> {
                     kind: VerifyIssueKind::ParseError,
                     message: format!("failed to parse row as LogRow: {e}"),
                 });
-                // Chain anchor cannot advance through an unparseable row;
+                // Chain anchor cannot advance through an unparsable row;
                 // leave `prev_row` untouched so the next valid row's
                 // `prev_hash` is checked against the last-known anchor (or
                 // GENESIS if we never had one).


### PR DESCRIPTION
## Summary

Adds the spec-mandated provenance-log integrity tool. `doiget audit-log --verify` recomputes the SHA-256 hash chain over `~/.config/doiget/access.jsonl` (per `docs/PROVENANCE_LOG.md` §4) and surfaces tampering as line-numbered issues on stdout with a non-zero exit. It is the only tool that detects log tampering — the writer is fail-closed but the chain is best-effort tamper-evident, not enforcing.

- `doiget_core::provenance::verify` — public verifier that walks the JSON Lines log, recomputes `this_hash` from the canonical-JSON-of-row-minus-this_hash rule, and validates the chain link plus `ts_seq` monotonicity. Per-row issues are accumulated into a structured `VerifyReport`; `Err` is reserved for I/O failures so partial-corruption reports are never swallowed.
- Missing log is treated as clean (the bytes that don't exist cannot be tampered).
- Genesis-sentinel rows (chain restart per §6 rotation) are honored as `ts_seq` reset points.
- New types `VerifyReport` / `VerifyIssue` / `VerifyIssueKind` are `#[non_exhaustive]` for forward compat.
- `doiget audit-log --verify` (`crates/doiget-cli/src/commands/audit_log.rs`) wraps `verify`, prints a 3-line header plus per-issue lines, and bails non-zero on issues. Path resolution honors `DOIGET_LOG_PATH` per `docs/PROVENANCE_LOG.md` §1, falling back to `<config_dir>/doiget/access.jsonl`. Phase 1 ships only `--verify`; `--since` / `--source` / `--session` land later.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test --workspace --no-default-features --features oa-only` (all suites green; new tests: 4 unit in `provenance::tests::verify_*`, 3 unit in `audit_log::tests`, 4 e2e in `tests/audit_log_e2e.rs`)
- [x] `cargo clippy --workspace --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check`

## Files

- `crates/doiget-core/src/provenance.rs` — add `verify` + `VerifyReport`/`VerifyIssue`/`VerifyIssueKind` + 4 verify tests
- `crates/doiget-cli/src/commands/audit_log.rs` — NEW; `run(verify_flag)` + path resolver + 3 unit tests
- `crates/doiget-cli/src/commands/mod.rs` — `pub mod audit_log;` (alphabetical-first)
- `crates/doiget-cli/src/main.rs` — match arm wiring `Command::AuditLog`
- `crates/doiget-cli/tests/audit_log_e2e.rs` — NEW; 4 assert_cmd-driven end-to-end tests

## Notes for the chain merge

Trivial conflicts expected with the parallel `feat/cli-batch` and `feat/cli-search` PRs at the 1-line `pub mod` add in `commands/mod.rs` and the 1-line match arm in `main.rs`.