### PR TITLE
feat(cli): doiget bib <ref> BibTeX export (Phase 2 starter)

### DIFF
--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -1,0 +1,263 @@
+//! `doiget bib <ref>` subcommand — emit a BibTeX entry for a stored entry.
+//!
+//! Phase 2 starter: read the stored [`Metadata`] for a [`Ref`] and write a
+//! minimal BibTeX entry on stdout. The Phase 1 binding fields from
+//! `docs/STORE.md` §2 (title, authors, year, doi, venue, publisher, issn)
+//! are emitted as `@article` for `type = "journal-article"` and `@misc`
+//! otherwise. Richer entry-type mapping (`@inproceedings`, `@book`, custom
+//! note fields) lands in a follow-up.
+//!
+//! Output is a single hand-rolled BibTeX entry — no external bibtex /
+//! biber crate is pulled in for Phase 2. The emitter is intentionally
+//! conservative: any literal `{` / `}` in a field value is stripped (with a
+//! `tracing::warn!`), and missing / empty fields are omitted. Real-world
+//! Crossref / Unpaywall titles rarely contain bare braces, so the
+//! strip-on-encounter policy is safe-by-default and keeps the Phase 2
+//! starter free of a TeX-aware escaper.
+
+use std::io::Write;
+
+use anyhow::{bail, Context, Result};
+
+use doiget_core::store::{FsStore, Metadata, Store};
+use doiget_core::Ref;
+
+use super::resolve_store_root;
+
+/// Run the `bib` subcommand against the configured store.
+///
+/// `input` is the user-supplied ref string (e.g. `"10.1234/example"`,
+/// `"arxiv:2401.12345"`, or any of the schemes accepted by [`Ref::parse`]).
+///
+/// On success, a BibTeX entry derived from the entry's [`Metadata`] is
+/// written to stdout. On a missing entry, the function returns an error
+/// so the CLI exits non-zero.
+pub fn run(input: String) -> Result<()> {
+    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let safekey = ref_.safekey();
+
+    let store_root = resolve_store_root()?;
+    let store = FsStore::new(store_root)?;
+
+    let metadata = store
+        .read(&safekey)
+        .with_context(|| format!("failed to read store entry for {input}"))?;
+
+    match metadata {
+        Some(m) => {
+            // Workspace lints deny `print_stdout` (the `print!`/`println!`
+            // macros) so JSON-RPC frames never collide with diagnostics.
+            // `writeln!` against an explicit `stdout().lock()` is the
+            // sanctioned escape hatch — the caller chose stdout
+            // explicitly. See `docs/SECURITY.md` §3 / ADR-0001.
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            write_bibtex_entry(&mut out, safekey.as_str(), &m)
+                .context("failed to write BibTeX entry to stdout")?;
+            Ok(())
+        }
+        None => bail!("no entry for {input}"),
+    }
+}
+
+/// Map a Crossref-taxonomy `type` string to a BibTeX entry type.
+///
+/// Phase 2 starter only differentiates `journal-article` (→ `@article`)
+/// from everything else (→ `@misc`). Extending the map to
+/// `@inproceedings` / `@book` / `@techreport` is a Phase 2 follow-up that
+/// requires an explicit list of accepted Crossref types per entry kind.
+fn entry_type_for(type_: Option<&str>) -> &'static str {
+    match type_ {
+        Some("journal-article") => "article",
+        _ => "misc",
+    }
+}
+
+/// Write a single BibTeX entry for `m` keyed by `citation_key`.
+///
+/// Field order matches the spec block: `title`, `author`, `year`, `doi`,
+/// `journal`, `publisher`, `issn`. Any field that resolves to `None` /
+/// empty is omitted entirely.
+fn write_bibtex_entry<W: Write>(
+    out: &mut W,
+    citation_key: &str,
+    m: &Metadata,
+) -> std::io::Result<()> {
+    let entry_type = entry_type_for(m.type_.as_deref());
+    writeln!(out, "@{entry_type}{{{citation_key},")?;
+
+    write_field(out, "title", &m.title)?;
+    if !m.authors.is_empty() {
+        // BibTeX joins multiple authors with the literal token " and ".
+        write_field(out, "author", &m.authors.join(" and "))?;
+    }
+    if let Some(year) = m.year {
+        write_field(out, "year", &year.to_string())?;
+    }
+    if let Some(doi) = &m.doi {
+        write_field(out, "doi", doi.as_str())?;
+    }
+    if let Some(venue) = m.venue.as_deref() {
+        if !venue.is_empty() {
+            write_field(out, "journal", venue)?;
+        }
+    }
+    if let Some(publisher) = m.publisher.as_deref() {
+        if !publisher.is_empty() {
+            write_field(out, "publisher", publisher)?;
+        }
+    }
+    if let Some(issn) = m.issn.as_deref() {
+        if !issn.is_empty() {
+            write_field(out, "issn", issn)?;
+        }
+    }
+
+    writeln!(out, "}}")?;
+    Ok(())
+}
+
+/// Write a single `<key> = {<value>},` line, padded so the `=` columns
+/// line up across the seven-field Phase 2 surface.
+fn write_field<W: Write>(out: &mut W, key: &str, value: &str) -> std::io::Result<()> {
+    let escaped = strip_unsafe(key, value);
+    // Width 10 is wide enough for `publisher` (the longest key in the
+    // Phase 2 set). Future fields longer than 10 chars will reflow the
+    // table; that's an acceptable cost for a hand-rolled emitter.
+    writeln!(out, "  {key:<10} = {{{escaped}}},")
+}
+
+/// Strip BibTeX-unsafe characters from `value`.
+///
+/// Phase 2 starter takes the pragmatic route: any literal `{` or `}`
+/// would unbalance the surrounding braces, and no escaping convention
+/// applies inside a brace-wrapped value without falling back to a full
+/// LaTeX escaper. Real-world titles rarely contain bare braces, so we
+/// strip them and emit a `tracing::warn!` so the dropped chars are
+/// visible in stderr / structured logs.
+fn strip_unsafe(key: &str, value: &str) -> String {
+    let has_braces = value.contains('{') || value.contains('}');
+    if has_braces {
+        tracing::warn!(
+            field = key,
+            "stripping literal '{{'/'}}' from BibTeX field value; \
+             a TeX-aware escaper lands in a Phase 2 follow-up"
+        );
+    }
+    value.chars().filter(|c| !matches!(c, '{' | '}')).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::TimeZone;
+
+    use doiget_core::store::{DoigetExtension, Metadata};
+    use doiget_core::{Doi, SCHEMA_VERSION};
+
+    use super::*;
+
+    fn fixture(type_: Option<&str>) -> Metadata {
+        Metadata {
+            schema_version: SCHEMA_VERSION.to_string(),
+            title: "Quantum Stuff".to_string(),
+            authors: vec!["Alice Researcher".to_string(), "Bob Coauthor".to_string()],
+            year: Some(2026),
+            doi: Some(Doi::parse("10.1234/example").expect("valid DOI")),
+            arxiv_id: None,
+            abstract_: None,
+            venue: Some("Phys Rev X".to_string()),
+            publisher: Some("APS".to_string()),
+            issn: Some("2160-3308".to_string()),
+            isbn: None,
+            type_: type_.map(str::to_string),
+            keywords: vec![],
+            url: None,
+            pdf_path: None,
+            doiget: Some(DoigetExtension {
+                fetched_at: chrono::Utc
+                    .with_ymd_and_hms(2026, 5, 6, 12, 0, 0)
+                    .single()
+                    .expect("valid timestamp"),
+                source: "unpaywall".to_string(),
+                license: "CC-BY-4.0".to_string(),
+                size_bytes: 1234,
+                mcp_call_id: None,
+            }),
+            other: BTreeMap::new(),
+        }
+    }
+
+    fn render(citation_key: &str, m: &Metadata) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        write_bibtex_entry(&mut buf, citation_key, m).expect("write_bibtex_entry");
+        String::from_utf8(buf).expect("UTF-8 BibTeX output")
+    }
+
+    #[test]
+    fn journal_article_renders_as_article() {
+        let m = fixture(Some("journal-article"));
+        let s = render("doi_10.1234_example", &m);
+        assert!(s.starts_with("@article{doi_10.1234_example,\n"), "{s}");
+        assert!(s.contains("title      = {Quantum Stuff},"), "{s}");
+        assert!(
+            s.contains("author     = {Alice Researcher and Bob Coauthor},"),
+            "{s}"
+        );
+        assert!(s.contains("year       = {2026},"), "{s}");
+        assert!(s.contains("doi        = {10.1234/example},"), "{s}");
+        assert!(s.contains("journal    = {Phys Rev X},"), "{s}");
+        assert!(s.contains("publisher  = {APS},"), "{s}");
+        assert!(s.contains("issn       = {2160-3308},"), "{s}");
+        assert!(s.ends_with("}\n"), "{s}");
+    }
+
+    #[test]
+    fn missing_type_renders_as_misc() {
+        let m = fixture(None);
+        let s = render("doi_10.1234_example", &m);
+        assert!(s.starts_with("@misc{doi_10.1234_example,\n"), "{s}");
+    }
+
+    #[test]
+    fn unknown_type_renders_as_misc() {
+        let m = fixture(Some("posted-content"));
+        let s = render("doi_10.1234_example", &m);
+        assert!(s.starts_with("@misc{doi_10.1234_example,\n"), "{s}");
+    }
+
+    #[test]
+    fn empty_optional_fields_are_omitted() {
+        let mut m = fixture(Some("journal-article"));
+        m.venue = None;
+        m.publisher = None;
+        m.issn = None;
+        let s = render("doi_10.1234_example", &m);
+        assert!(!s.contains("journal"), "{s}");
+        assert!(!s.contains("publisher"), "{s}");
+        assert!(!s.contains("issn"), "{s}");
+        // Required-shape fields still emitted.
+        assert!(s.contains("title"));
+        assert!(s.contains("author"));
+        assert!(s.contains("year"));
+        assert!(s.contains("doi"));
+    }
+
+    #[test]
+    fn no_authors_omits_author_line() {
+        let mut m = fixture(Some("journal-article"));
+        m.authors = vec![];
+        let s = render("doi_10.1234_example", &m);
+        assert!(!s.contains("author"), "{s}");
+    }
+
+    #[test]
+    fn braces_in_value_are_stripped() {
+        let mut m = fixture(Some("journal-article"));
+        m.title = "A {curly} Title".to_string();
+        let s = render("doi_10.1234_example", &m);
+        assert!(s.contains("title      = {A curly Title},"), "{s}");
+    }
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -10,16 +10,18 @@
 //! - [`audit_log`] — `doiget audit-log --verify` recomputes the SHA-256 hash
 //!   chain on the provenance log and reports any mismatches.
 //! - [`batch`] — `doiget batch <path>` multi-ref orchestrator (rate-bounded).
+//! - [`bib`] — `doiget bib <ref>` BibTeX exporter (Phase 2 starter).
 //! - [`config`] — `doiget config show/path/doctor`.
 //! - [`fetch`] — `doiget fetch <ref>` orchestrator (arXiv E2E + DOI metadata-only).
 //! - [`info`] — prints a stored entry's `Metadata` as TOML on stdout.
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
 //! - [`search`] — case-insensitive substring search over stored metadata.
 //!
-//! Other subcommands (`bib`, `csl`, `serve`) land in separate PRs.
+//! Other subcommands (`csl`, `serve`) land in separate PRs.
 
 pub mod audit_log;
 pub mod batch;
+pub mod bib;
 pub mod config;
 pub mod fetch;
 pub mod info;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -4,9 +4,9 @@
 //! returns a Phase-1-pending error message. Real implementations land in Phase 1+.
 //!
 //! Phase 1 progressively replaces the Phase-0 bail-out per subcommand. The
-//! `config`, `info`, `list-recent`, `search`, `fetch`, and `audit-log`
-//! subcommands have landed; the remaining write / network paths (`batch`,
-//! `serve`, `bib`, `csl`) follow in subsequent PRs.
+//! `config`, `info`, `list-recent`, `search`, `fetch`, `audit-log`, `batch`,
+//! and `bib` (Phase 2 starter) subcommands have landed; the remaining
+//! `serve` and `csl` paths follow in subsequent PRs.
 
 use clap::{Parser, Subcommand};
 
@@ -101,6 +101,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Search { query }) => doiget_cli::commands::search::run(query),
         Some(Command::Fetch { ref_ }) => doiget_cli::commands::fetch::run(ref_).await,
         Some(Command::Batch { path }) => doiget_cli::commands::batch::run(path).await,
+        Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_),
         // Other subcommands remain Phase-1-pending; they land in their own
         // dedicated PRs to keep the diff scoped.
         Some(_) => {

--- a/crates/doiget-cli/tests/bib_e2e.rs
+++ b/crates/doiget-cli/tests/bib_e2e.rs
@@ -1,0 +1,152 @@
+//! End-to-end tests for `doiget bib`.
+//!
+//! Strategy mirrors `tests/info_list_recent_e2e.rs`: seed a `FsStore` rooted
+//! at a per-test `tempfile::TempDir`, then invoke the freshly-built `doiget`
+//! binary as a subprocess with `DOIGET_STORE_ROOT` pointing at that
+//! tempdir. `HOME` and `USERPROFILE` are also overridden — belt-and-
+//! suspenders against any fallback codepath leaking the developer's real
+//! `~/papers` into a test.
+//!
+//! Each test owns its own tempdir, so the suite runs in parallel without
+//! `serial_test` coordination. No assertion is made about the byte-for-
+//! byte stdout layout outside of the field lines emitted by `bib::run` —
+//! that lets the underlying serializer evolve without breaking these
+//! tests.
+
+// Tests are panic-on-failure by design; relax the workspace-wide lints
+// that ban `expect`/`unwrap`/`panic` in production code.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+use assert_cmd::Command;
+use camino::Utf8PathBuf;
+use chrono::TimeZone;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use doiget_core::store::{DoigetExtension, FsStore, Metadata, Store};
+use doiget_core::{Doi, Ref, SCHEMA_VERSION};
+
+/// Convert a `TempDir`'s path to a `Utf8PathBuf` so it can drive
+/// `FsStore::new` (which is camino-only). Panics if the temp path is not
+/// UTF-8 — on every platform we test, the system temp dir is ASCII.
+fn utf8_path(dir: &TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir path must be UTF-8")
+}
+
+/// Build a fixture for `10.1234/example` with the given Crossref `type_`.
+///
+/// All other binding fields match the spec block in the implementation
+/// task: title `"Quantum Stuff"`, two authors, year 2026, journal
+/// `"Phys Rev X"`, publisher `"APS"`, ISSN `"2160-3308"`. The `[doiget]`
+/// extension table is populated with a fixed RFC3339-shaped fetched_at so
+/// the metadata round-trips cleanly through `FsStore::write` /
+/// `Store::read`.
+fn fixture(type_: Option<&str>) -> Metadata {
+    Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: "Quantum Stuff".to_string(),
+        authors: vec!["Alice Researcher".to_string(), "Bob Coauthor".to_string()],
+        year: Some(2026),
+        doi: Some(Doi::parse("10.1234/example").expect("valid DOI")),
+        arxiv_id: None,
+        abstract_: None,
+        venue: Some("Phys Rev X".to_string()),
+        publisher: Some("APS".to_string()),
+        issn: Some("2160-3308".to_string()),
+        isbn: None,
+        type_: type_.map(str::to_string),
+        keywords: vec![],
+        url: None,
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: chrono::Utc
+                .with_ymd_and_hms(2026, 5, 6, 12, 0, 0)
+                .single()
+                .expect("valid timestamp"),
+            source: "unpaywall".to_string(),
+            license: "CC-BY-4.0".to_string(),
+            size_bytes: 1234,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    }
+}
+
+/// Seed a temp store with a single `10.1234/example` entry of the given
+/// Crossref `type_`. Returns the (TempDir guard, store-root) pair; the
+/// guard MUST outlive the test — dropping it deletes the tempdir.
+fn seeded_store(type_: Option<&str>) -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+
+    let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("valid DOI"));
+    let safekey = ref_.safekey();
+    let metadata = fixture(type_);
+    store
+        .write(&safekey, &metadata, None)
+        .expect("seed bib entry");
+
+    (dir, root)
+}
+
+/// Configure a `doiget` subprocess to use `root` as its store. Sets
+/// `DOIGET_STORE_ROOT` (the primary resolution hook) and clears
+/// `HOME`/`USERPROFILE` so any fallback in `resolve_store_root` cannot
+/// leak the developer's real home directory into the test.
+fn doiget(root: &Utf8PathBuf) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("DOIGET_STORE_ROOT", root.as_str())
+        .env("HOME", root.as_str())
+        .env("USERPROFILE", root.as_str());
+    cmd
+}
+
+#[test]
+fn bib_emits_article_for_journal_article_type() {
+    let (_dir_guard, root) = seeded_store(Some("journal-article"));
+
+    doiget(&root)
+        .args(["bib", "doi:10.1234/example"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("@article{doi_10.1234_example,"))
+        .stdout(predicate::str::contains("title      = {Quantum Stuff},"))
+        .stdout(predicate::str::contains(
+            "author     = {Alice Researcher and Bob Coauthor},",
+        ))
+        .stdout(predicate::str::contains("year       = {2026},"))
+        .stdout(predicate::str::contains("doi        = {10.1234/example},"))
+        .stdout(predicate::str::contains("journal    = {Phys Rev X},"))
+        .stdout(predicate::str::contains("publisher  = {APS},"))
+        .stdout(predicate::str::contains("issn       = {2160-3308},"))
+        // Closing brace on its own line, terminated by a newline.
+        .stdout(predicate::str::contains("\n}\n"));
+}
+
+#[test]
+fn bib_fails_for_missing_entry() {
+    // Empty store: no `.metadata/*.toml` files at all.
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+
+    doiget(&root)
+        .args(["bib", "doi:10.9999/missing"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no entry for"));
+}
+
+#[test]
+fn bib_emits_misc_for_missing_type() {
+    let (_dir_guard, root) = seeded_store(None);
+
+    doiget(&root)
+        .args(["bib", "doi:10.1234/example"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("@misc{doi_10.1234_example,"));
+}


### PR DESCRIPTION
## Summary

- Implements `doiget bib <ref>` — reads the stored `Metadata` for a ref via `Store::read` and emits a minimal BibTeX entry on stdout. `journal-article` -> `@article`, everything else -> `@misc`. Phase 2 starter; richer entry-type mapping (`@inproceedings` / `@book` / `@techreport`) and a TeX-aware escaper land in follow-ups.
- Hand-rolled emitter — no new dependencies. Brace chars in field values are stripped with a `tracing::warn!`.
- Wires the existing clap `Bib { ref_ }` variant into `main.rs` (1 line) and registers the new module in `commands/mod.rs` (1 line).

## Files

- `crates/doiget-cli/src/commands/bib.rs` (new) — `run`, `write_bibtex_entry`, `entry_type_for`, `strip_unsafe`, plus 6 unit tests covering the article / misc / unknown-type / empty-optional / no-author / brace-stripping branches.
- `crates/doiget-cli/tests/bib_e2e.rs` (new) — 3 `assert_cmd`-driven e2e tests (success, missing entry, misc type) mirroring `info_list_recent_e2e.rs`.
- `crates/doiget-cli/src/commands/mod.rs` — `pub mod bib;` + module-doc bullet.
- `crates/doiget-cli/src/main.rs` — `Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_),` + module-doc tweak.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test --workspace --no-default-features --features oa-only` (6 new unit + 3 new e2e tests pass; all 195+ existing tests still green)
- [x] `cargo clippy --workspace --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check` (85 fully audited, 5 partially audited, 230 exempted)

Sample output for `doiget bib doi:10.1234/example` against a seeded entry:

```bibtex
@article{doi_10.1234_example,
  title      = {Quantum Stuff},
  author     = {Alice Researcher and Bob Coauthor},
  year       = {2026},
  doi        = {10.1234/example},
  journal    = {Phys Rev X},
  publisher  = {APS},
  issn       = {2160-3308},
}
```

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>