### PR TITLE
feat(cli): doiget csl <ref> CSL JSON export (Phase 2 starter)

### DIFF
--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -1,0 +1,171 @@
+//! `doiget csl <ref>` — emit a CSL JSON 1.0 array for a stored Metadata.
+//!
+//! Phase 1 emits a single-entry array with the binding fields from
+//! [`docs/STORE.md`](../../../../docs/STORE.md) §2 (title, authors, year,
+//! doi, venue, publisher, issn). Richer shapes (abstract, keywords,
+//! container-IDs, page ranges) follow in Phase 2.
+//!
+//! The output is human-readable pretty-printed JSON, deliberately a JSON
+//! ARRAY (not a bare object) so it is a drop-in for citeproc-js / pandoc
+//! `--csl-json` consumers that expect an array of items.
+//!
+//! Reads go through [`Store::read`] per [`docs/PUBLIC_API.md`](../../../../docs/PUBLIC_API.md)
+//! §2. Network access is never required.
+
+use std::io::Write;
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+
+use doiget_core::store::{FsStore, Metadata, Store};
+use doiget_core::Ref;
+
+use super::resolve_store_root;
+
+/// Run the `csl` subcommand against the configured store.
+///
+/// `input` is the user-supplied ref string (e.g. `"10.1234/example"` or
+/// `"arxiv:2401.12345"` — anything accepted by [`Ref::parse`]).
+///
+/// On success, a single-element CSL JSON 1.0 array is written to stdout.
+/// On a missing entry, the function returns an error so the CLI exits
+/// non-zero — pipelines can distinguish "not in store" from "empty entry".
+pub fn run(input: String) -> Result<()> {
+    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let safekey = ref_.safekey();
+
+    let store_root = resolve_store_root()?;
+    let store = FsStore::new(store_root)?;
+
+    let metadata = store
+        .read(&safekey)
+        .with_context(|| format!("failed to read store entry for {input}"))?;
+
+    let metadata = match metadata {
+        Some(m) => m,
+        None => bail!("no entry for {input}"),
+    };
+
+    let item = build_csl_item(safekey.as_str(), &metadata);
+    let array = vec![item];
+    let json =
+        serde_json::to_string_pretty(&array).context("failed to serialize CSL JSON for stdout")?;
+
+    // Workspace lints deny `print_stdout` (`println!`/`print!`) so the
+    // sanctioned escape hatch is `writeln!(stdout().lock(), ...)`.
+    // See `docs/SECURITY.md` §3 / ADR-0001 — this guarantees JSON-RPC
+    // frames never collide with diagnostics.
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    writeln!(out, "{json}").context("failed to write CSL JSON to stdout")?;
+    Ok(())
+}
+
+/// One CSL JSON 1.0 item, scoped to the binding fields the local
+/// `Metadata` schema can populate.
+///
+/// Field order is the citeproc-js conventional order (id, type, title,
+/// author, issued, identifiers, container, publisher) so a human
+/// diffing two outputs sees a stable column layout.
+#[derive(Debug, Serialize)]
+struct CslItem<'a> {
+    id: &'a str,
+    #[serde(rename = "type")]
+    type_: &'static str,
+    title: &'a str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    author: Vec<CslName>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issued: Option<CslIssued>,
+    #[serde(rename = "DOI", skip_serializing_if = "Option::is_none")]
+    doi: Option<&'a str>,
+    #[serde(rename = "container-title", skip_serializing_if = "Option::is_none")]
+    container_title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    publisher: Option<&'a str>,
+    #[serde(rename = "ISSN", skip_serializing_if = "Option::is_none")]
+    issn: Option<&'a str>,
+}
+
+/// CSL name-variable shape: `{ "family": "...", "given": "..." }`.
+///
+/// Empty halves are omitted so a single-token name like `"Plato"` lands
+/// as `{"family": "Plato"}` rather than `{"family": "Plato", "given": ""}`,
+/// which citeproc-js renders with a stray comma.
+#[derive(Debug, Serialize)]
+struct CslName {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    family: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    given: String,
+}
+
+/// CSL date-variable shape, year-only for Phase 1.
+///
+/// `date-parts` is a list-of-lists: outer list holds 1 or 2 entries
+/// (single date or range), inner list is `[year, month?, day?]`. We only
+/// know the year, so the inner list is `[<year>]`.
+#[derive(Debug, Serialize)]
+struct CslIssued {
+    #[serde(rename = "date-parts")]
+    date_parts: Vec<Vec<i32>>,
+}
+
+/// Build a [`CslItem`] from a stored [`Metadata`].
+///
+/// Type mapping is intentionally narrow: Crossref's `journal-article`
+/// becomes CSL's `article-journal`. Everything else falls back to
+/// `manuscript`, which citeproc-js renders sensibly without forcing
+/// a container. Phase 2 will expand the table to cover `book-chapter`,
+/// `proceedings-article`, etc.
+fn build_csl_item<'a>(citation_key: &'a str, m: &'a Metadata) -> CslItem<'a> {
+    CslItem {
+        id: citation_key,
+        type_: match m.type_.as_deref() {
+            Some("journal-article") => "article-journal",
+            _ => "manuscript",
+        },
+        title: &m.title,
+        author: m.authors.iter().map(|s| parse_author(s)).collect(),
+        issued: m.year.map(|y| CslIssued {
+            date_parts: vec![vec![y]],
+        }),
+        doi: m.doi.as_ref().map(|d| d.as_str()),
+        container_title: m.venue.as_deref(),
+        publisher: m.publisher.as_deref(),
+        issn: m.issn.as_deref(),
+    }
+}
+
+/// Split a free-form name string into CSL `family` / `given` halves.
+///
+/// Heuristic, Phase 1:
+///
+/// - If the name contains a comma, it is `Family, Given` form: split on
+///   the first comma; left side is family, right side is given.
+/// - Otherwise, split on the LAST whitespace: left is given, right is
+///   family. (`"Alice Researcher"` → family `"Researcher"`,
+///   given `"Alice"`.) This is the convention citeproc-js itself uses
+///   for unparsed string names.
+/// - If neither rule applies (single token), the whole string is the
+///   family name and `given` is empty.
+fn parse_author(name: &str) -> CslName {
+    let trimmed = name.trim();
+    if let Some((family, given)) = trimmed.split_once(',') {
+        CslName {
+            family: family.trim().to_string(),
+            given: given.trim().to_string(),
+        }
+    } else if let Some(idx) = trimmed.rfind(char::is_whitespace) {
+        let (given, family) = trimmed.split_at(idx);
+        CslName {
+            family: family.trim().to_string(),
+            given: given.trim().to_string(),
+        }
+    } else {
+        CslName {
+            family: trimmed.to_string(),
+            given: String::new(),
+        }
+    }
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -12,17 +12,19 @@
 //! - [`batch`] — `doiget batch <path>` multi-ref orchestrator (rate-bounded).
 //! - [`bib`] — `doiget bib <ref>` BibTeX exporter (Phase 2 starter).
 //! - [`config`] — `doiget config show/path/doctor`.
+//! - [`csl`] — `doiget csl <ref>` exports a stored entry as CSL JSON 1.0.
 //! - [`fetch`] — `doiget fetch <ref>` orchestrator (arXiv E2E + DOI metadata-only).
 //! - [`info`] — prints a stored entry's `Metadata` as TOML on stdout.
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
 //! - [`search`] — case-insensitive substring search over stored metadata.
 //!
-//! Other subcommands (`csl`, `serve`) land in separate PRs.
+//! Other subcommands (`serve`) land in separate PRs.
 
 pub mod audit_log;
 pub mod batch;
 pub mod bib;
 pub mod config;
+pub mod csl;
 pub mod fetch;
 pub mod info;
 pub mod list_recent;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -5,8 +5,7 @@
 //!
 //! Phase 1 progressively replaces the Phase-0 bail-out per subcommand. The
 //! `config`, `info`, `list-recent`, `search`, `fetch`, `audit-log`, `batch`,
-//! and `bib` (Phase 2 starter) subcommands have landed; the remaining
-//! `serve` and `csl` paths follow in subsequent PRs.
+//! `bib`, and `csl` subcommands have landed; only `serve` remains.
 
 use clap::{Parser, Subcommand};
 
@@ -102,6 +101,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Fetch { ref_ }) => doiget_cli::commands::fetch::run(ref_).await,
         Some(Command::Batch { path }) => doiget_cli::commands::batch::run(path).await,
         Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_),
+        Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_),
         // Other subcommands remain Phase-1-pending; they land in their own
         // dedicated PRs to keep the diff scoped.
         Some(_) => {

--- a/crates/doiget-cli/tests/csl_e2e.rs
+++ b/crates/doiget-cli/tests/csl_e2e.rs
@@ -1,0 +1,278 @@
+//! End-to-end tests for `doiget csl <ref>`.
+//!
+//! Strategy mirrors `info_list_recent_e2e.rs`: seed an `FsStore` rooted at
+//! a per-test `tempfile::TempDir`, then drive the freshly-built `doiget`
+//! binary as a subprocess with `DOIGET_STORE_ROOT` pointing at that
+//! tempdir. This keeps the real `~/papers/` untouched and lets the tests
+//! run in parallel without `serial_test` coordination.
+//!
+//! The assertions are SHAPE-LEVEL — we parse stdout as `serde_json::Value`
+//! and probe individual fields rather than doing a byte-for-byte string
+//! match. That insulates us from cosmetic changes (whitespace, key order)
+//! in `serde_json::to_string_pretty`.
+
+// Tests are panic-on-failure by design; relax the workspace-wide lints
+// that ban `expect`/`unwrap`/`panic` in production code.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+use assert_cmd::Command;
+use camino::Utf8PathBuf;
+use chrono::TimeZone;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use doiget_core::store::{DoigetExtension, FsStore, Metadata, Store};
+use doiget_core::{Doi, Safekey, SCHEMA_VERSION};
+
+/// Convert a `TempDir`'s path to a `Utf8PathBuf` so it can drive
+/// `FsStore::new` (which is camino-only). Panics if the temp path is not
+/// UTF-8 — on every platform we test, the system temp dir is ASCII.
+fn utf8_path(dir: &TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir path must be UTF-8")
+}
+
+/// Configure a `doiget` subprocess to use `root` as its store. Sets
+/// `DOIGET_STORE_ROOT` (the primary resolution hook) and clears
+/// `HOME` / `USERPROFILE` to belt-and-suspenders against any fallback
+/// codepath leaking the developer's real home directory into the test.
+fn doiget(root: &Utf8PathBuf) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("DOIGET_STORE_ROOT", root.as_str())
+        .env("HOME", root.as_str())
+        .env("USERPROFILE", root.as_str());
+    cmd
+}
+
+/// Build the journal-article fixture used by the happy-path test:
+/// two authors in `Given Family` form, full venue / publisher / issn.
+fn journal_article_fixture() -> (Safekey, Metadata) {
+    let doi = "10.1234/example";
+    let ref_ = doiget_core::Ref::Doi(Doi::parse(doi).expect("valid DOI"));
+    let safekey = ref_.safekey();
+    let m = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: "Quantum Stuff".to_string(),
+        authors: vec!["Alice Researcher".to_string(), "Bob Coauthor".to_string()],
+        year: Some(2026),
+        doi: Some(Doi::parse(doi).expect("valid DOI")),
+        arxiv_id: None,
+        abstract_: None,
+        venue: Some("Phys Rev X".to_string()),
+        publisher: Some("APS".to_string()),
+        issn: Some("2160-3308".to_string()),
+        isbn: None,
+        type_: Some("journal-article".to_string()),
+        keywords: vec![],
+        url: None,
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: chrono::Utc
+                .with_ymd_and_hms(2026, 5, 6, 12, 0, 0)
+                .single()
+                .expect("valid timestamp"),
+            source: "unpaywall".to_string(),
+            license: "CC-BY-4.0".to_string(),
+            size_bytes: 1234,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+    (safekey, m)
+}
+
+/// Build a fixture with `Family, Given` form authors and no Crossref
+/// type — exercises both the comma-form name parser branch and the
+/// `manuscript` type fallback.
+fn comma_form_fixture() -> (Safekey, Metadata) {
+    let doi = "10.5678/comma";
+    let ref_ = doiget_core::Ref::Doi(Doi::parse(doi).expect("valid DOI"));
+    let safekey = ref_.safekey();
+    let m = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: "Comma Title".to_string(),
+        authors: vec!["Smith, John".to_string()],
+        year: Some(2025),
+        doi: Some(Doi::parse(doi).expect("valid DOI")),
+        arxiv_id: None,
+        abstract_: None,
+        venue: None,
+        publisher: None,
+        issn: None,
+        isbn: None,
+        // No `type_` — expected CSL type falls back to "manuscript".
+        type_: None,
+        keywords: vec![],
+        url: None,
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: chrono::Utc
+                .with_ymd_and_hms(2025, 1, 1, 0, 0, 0)
+                .single()
+                .expect("valid timestamp"),
+            source: "unpaywall".to_string(),
+            license: "unknown".to_string(),
+            size_bytes: 0,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+    (safekey, m)
+}
+
+/// Seed a temp store with the journal-article fixture and return
+/// `(TempDir, store_root)`. The `TempDir` MUST stay in scope for the
+/// duration of the test — dropping it deletes the tempdir.
+fn seeded_store_journal() -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+    let (k, m) = journal_article_fixture();
+    store.write(&k, &m, None).expect("seed entry");
+    (dir, root)
+}
+
+/// Seed a temp store with the comma-form fixture.
+fn seeded_store_comma() -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+    let (k, m) = comma_form_fixture();
+    store.write(&k, &m, None).expect("seed entry");
+    (dir, root)
+}
+
+#[test]
+fn csl_emits_array_with_expected_fields_for_journal_article() {
+    let (_dir_guard, root) = seeded_store_journal();
+
+    let assert = doiget(&root)
+        .args(["csl", "doi:10.1234/example"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())
+        .expect("doiget csl stdout was not UTF-8");
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("doiget csl stdout was not valid JSON: {e}\nstdout:\n{stdout}"));
+
+    let array = value
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level JSON array, got: {value}"));
+    assert_eq!(array.len(), 1, "expected single-entry array, got: {value}");
+    let item = &array[0];
+
+    assert_eq!(item["id"], Value::String("doi_10.1234_example".into()));
+    assert_eq!(item["type"], Value::String("article-journal".into()));
+    assert_eq!(item["title"], Value::String("Quantum Stuff".into()));
+    assert_eq!(item["DOI"], Value::String("10.1234/example".into()));
+    assert_eq!(item["container-title"], Value::String("Phys Rev X".into()));
+    assert_eq!(item["publisher"], Value::String("APS".into()));
+    assert_eq!(item["ISSN"], Value::String("2160-3308".into()));
+
+    // `issued.date-parts == [[2026]]`.
+    let date_parts = &item["issued"]["date-parts"];
+    assert_eq!(
+        date_parts,
+        &serde_json::json!([[2026]]),
+        "issued.date-parts shape mismatch: {date_parts}"
+    );
+
+    // Authors: `Given Family` form splits on last whitespace.
+    let authors = item["author"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected author array, got: {}", item["author"]));
+    assert_eq!(authors.len(), 2, "expected 2 authors, got: {authors:?}");
+    assert_eq!(
+        authors[0],
+        serde_json::json!({"family": "Researcher", "given": "Alice"}),
+        "author[0] mismatch"
+    );
+    assert_eq!(
+        authors[1],
+        serde_json::json!({"family": "Coauthor", "given": "Bob"}),
+        "author[1] mismatch"
+    );
+}
+
+#[test]
+fn csl_parses_comma_form_author_and_falls_back_to_manuscript_type() {
+    let (_dir_guard, root) = seeded_store_comma();
+
+    let assert = doiget(&root)
+        .args(["csl", "doi:10.5678/comma"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())
+        .expect("doiget csl stdout was not UTF-8");
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("doiget csl stdout was not valid JSON: {e}\nstdout:\n{stdout}"));
+
+    let item = &value
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level JSON array, got: {value}"))[0];
+
+    // No `type_` on the metadata → CSL type falls back to "manuscript".
+    assert_eq!(item["type"], Value::String("manuscript".into()));
+
+    // Optional fields with `None` on the metadata side are omitted from
+    // the JSON object — `Value::get` returns None for missing keys.
+    assert!(
+        item.get("container-title").is_none(),
+        "container-title should be omitted when venue is None; got: {item}"
+    );
+    assert!(
+        item.get("publisher").is_none(),
+        "publisher should be omitted when publisher is None; got: {item}"
+    );
+    assert!(
+        item.get("ISSN").is_none(),
+        "ISSN should be omitted when issn is None; got: {item}"
+    );
+
+    // `Family, Given` form splits on the first comma.
+    let authors = item["author"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected author array, got: {}", item["author"]));
+    assert_eq!(authors.len(), 1);
+    assert_eq!(
+        authors[0],
+        serde_json::json!({"family": "Smith", "given": "John"}),
+        "author[0] mismatch for comma-form name"
+    );
+}
+
+#[test]
+fn csl_fails_for_missing_entry() {
+    // Empty store: `csl` for a ref that was never written must fail
+    // with a non-zero exit and a recognisable error on stderr, so shell
+    // pipelines can distinguish "not in store" from "empty entry".
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+
+    doiget(&root)
+        .args(["csl", "doi:10.9999/missing"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no entry for"));
+}
+
+#[test]
+fn csl_fails_for_invalid_ref_string() {
+    // Garbage input must short-circuit at `Ref::parse` and never touch
+    // the filesystem. We assert non-zero exit + a hint mentioning the
+    // bad input.
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+
+    doiget(&root)
+        .args(["csl", "not-a-ref"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid ref"));
+}


### PR DESCRIPTION
## Summary

- Implements `doiget csl <ref>`: reads a stored `Metadata` via `Store::read` and emits a single-element **CSL JSON 1.0** array on stdout, ready for citeproc-js / pandoc `--csl-json` consumption.
- Phase 1 shape covers the binding fields from `docs/STORE.md` §2: `id`, `type`, `title`, `author`, `issued.date-parts`, `DOI`, `container-title`, `publisher`, `ISSN`. Optional fields are omitted from the JSON object when the metadata side is `None`.
- Type mapping: Crossref `journal-article` -> CSL `article-journal`; everything else falls back to `manuscript`.
- Author parsing heuristic: split on the first `,` for `Family, Given` form, otherwise split on the last whitespace for `Given Family` form.
- Network-free read path; stdout writes go through the sanctioned `writeln!(stdout().lock(), ...)` escape hatch so the workspace `print_stdout` lint stays in force.

## Files

- NEW `crates/doiget-cli/src/commands/csl.rs` — orchestrator, `CslItem` / `CslName` / `CslIssued` serde shapes, `parse_author` heuristic.
- NEW `crates/doiget-cli/tests/csl_e2e.rs` — 4 `assert_cmd` integration tests (happy path, comma-form name + manuscript fallback, missing-entry exit code, invalid-ref short-circuit).
- `crates/doiget-cli/src/commands/mod.rs` — adds `pub mod csl;` (alphabetical) + doc-comment refresh.
- `crates/doiget-cli/src/main.rs` — adds the `Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_)` dispatch arm + doc-comment refresh.

## Test plan

- [x] `cargo build --workspace --no-default-features --features oa-only`
- [x] `cargo test --workspace --no-default-features --features oa-only` (csl_e2e: 4 passed)
- [x] `cargo clippy --workspace --tests --no-default-features --features oa-only -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only`
- [x] `cargo vet check`

## Notes

- No new dependencies; `serde`, `serde_json`, `assert_cmd`, `predicates`, `tempfile` were already present in the workspace.
- A parallel `feat/cli-bib` PR for the BibTeX equivalent is in flight; conflicts on `commands/mod.rs` + `main.rs` are trivial 1-line additions either side.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)