### PR TITLE
feat: incorporate musaabhasan feedback from Discussion #12 (5 items)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,4 +169,84 @@ for the full Phase 0 deliverable checklist.
 - Removed an accidentally-committed editor temp file and added `*.tmp.*` to
   `.gitignore` to prevent recurrence.
 
+#### Discussion #12 — external review incorporation (musaabhasan)
+
+This PR lands the spec + Phase-1 implementation slice for the five
+musaabhasan items raised on
+[Discussion #12](https://github.com/sotashimozono/doiget/discussions/12).
+Spec changes are NORMATIVE; implementation is staged so the dry-run preview
+and structured denial channel ship now and the `CanonicalRef` audit identity
+is reserved for Phase 2 (per ADR-0021 §3).
+
+##### Added
+- [ADR-0021](docs/DECISIONS/0021-canonical-tuple-identity.md) (**spec-only**)
+  reserves `CanonicalRef = (source_type, source_id, resolver_profile, version)`
+  as the Phase-2 audit identity; Phase 1 keeps `safekey` keyed on `Ref` so
+  the BiblioFetch.jl round-trip contract from ADR-0007 stays unchanged.
+- [ADR-0022](docs/DECISIONS/0022-dry-run-mode.md) and
+  [ADR-0023](docs/DECISIONS/0023-denial-context-structured.md)
+  (**accepted + implemented this PR**) — `--dry-run` mode and structured
+  `denial_context` on the public error envelope.
+- `doiget-core::DenialReason` (closed enum, 8 variants, snake_case wire)
+  and `doiget-core::DenialContext` (`#[serde(deny_unknown_fields)]`) per
+  [PUBLIC_API.md §8](docs/PUBLIC_API.md). `From<&HttpError> for
+  Option<DenialContext>` (in `crate::http`) and `From<&FetchError> for
+  Option<DenialContext>` (in `crate::source`) implement the ADR-0023 §4
+  mapping table — `RedirectDenied` / `OversizedBody` / `NotAPdf` /
+  `InsecureRedirect` produce a populated context, `Network` /
+  `HttpStatus` / `UnknownSource` map to `None`.
+- `HttpError::RedirectDenied { source_key, host, expected_hosts }` carries
+  an allowlist snapshot so the structured channel can populate
+  `denial_context.expected` without re-looking-up the source allowlist.
+- `doiget-core::dry_run::{FetchPlan, PdfSourcePlan, RateLimitBudget,
+  build_fetch_plan, build_dry_run_envelope}` per ADR-0022 §1 (NORMATIVE
+  wire shape). Lives in `doiget-core` so both `doiget-cli` (the
+  `--dry-run` flag) and `doiget-mcp` (the `dry_run: true` tool variants)
+  emit byte-identical envelopes.
+- `doiget fetch <ref> --dry-run` and `doiget batch <path> --dry-run` CLI
+  flags. The dry-run path emits a `FetchPlan` JSON envelope on stdout and
+  returns `Ok(())` without opening the provenance log, building the HTTP
+  client, or writing to the store — verified by
+  `tests/fetch_dry_run_e2e.rs` (no wiremock; any accidental network hit
+  would fail). The CLI subcommand variants `Command::Fetch { ref_,
+  dry_run }` and `Command::Batch { path, dry_run }` thread the flag
+  through new `pub async fn run_with_options` entry points; the
+  historical `pub async fn run(input)` signatures remain as `Default`-arg
+  delegators so existing in-process integration tests compile unchanged.
+- `doiget_metadata_only` MCP tool ([`docs/MCP_TOOLS.md`](docs/MCP_TOOLS.md)
+  §11). Phase 1 wires the **dry-run** path only (returns the same
+  `FetchPlan` envelope as the CLI); the non-dry-run path returns
+  `{ok:false, error:{code:"INTERNAL_ERROR", message:"metadata_only is not
+  yet wired in Phase 1; only dry_run is supported"}}` with a
+  `// TODO(phase-1.x):` for the metadata-only orchestrator that will land
+  in a follow-up PR.
+- New normative spec sections: [ERRORS.md](docs/ERRORS.md) §3.1 + §5.1
+  (denial_context wire surface), [MCP_TOOLS.md](docs/MCP_TOOLS.md) §5 +
+  §10 + §11 (denial_context envelope, dry-run preview,
+  `doiget_metadata_only`), [PUBLIC_API.md](docs/PUBLIC_API.md) §8
+  (DenialReason / DenialContext) + §9 (forward-looking CanonicalRef
+  note), [SAFEKEY.md](docs/SAFEKEY.md) §3.1 (filename-derivation inputs
+  MUST NOT include `Content-Disposition` / redirect URL path /
+  server-suggested filename — clarifies existing impl posture; no
+  algorithm change).
+
+##### Tests added
+- `denial_*` round-trip + `deny_unknown_fields` tests in
+  `crates/doiget-core/src/lib.rs::tests` (5 tests).
+- `From<&HttpError> for Option<DenialContext>` per-variant tests in
+  `crates/doiget-core/src/http.rs::tests` (5 tests).
+- `From<&FetchError> for Option<DenialContext>` per-variant tests in
+  `crates/doiget-core/src/source.rs::tests` (3 tests).
+- Pure-function `FetchPlan` shape tests in
+  `crates/doiget-core/src/dry_run.rs::tests` (6 tests).
+- `crates/doiget-cli/tests/fetch_dry_run_e2e.rs` end-to-end
+  side-effect-free integration test (4 tests: DOI dry-run no writes,
+  arXiv dry-run no writes, DOI envelope shape pin, arXiv envelope shape
+  pin).
+
+##### Changed
+- `camino` workspace dep gains the `serde1` feature in
+  `crates/doiget-core/Cargo.toml` so `Utf8PathBuf` fields on `FetchPlan`
+  serialize. (`doiget-cli` already enabled the same feature.)
+
 [Unreleased]: https://github.com/sotashimozono/doiget/compare/main...HEAD

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -34,11 +34,42 @@ use anyhow::{anyhow, Context, Result};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, RowInput};
 use doiget_core::{RateLimits, Ref, MCP_BATCH_MAX_SIZE};
 
-use super::fetch::FetchHarness;
+use super::fetch::{build_fetch_plan, emit_dry_run_plan_to_stdout, FetchHarness};
+use super::resolve_store_root;
 
-/// Run the `doiget batch <path>` subcommand. See module docs for the
+/// Per-batch option bundle threaded from `main.rs` clap dispatch.
+///
+/// Mirrors [`super::fetch::FetchOptions`] for the multi-ref orchestrator.
+/// `Default` reproduces the historical [`run`] behaviour, so existing
+/// integration tests under `crates/doiget-cli/tests/batch_e2e.rs` (which
+/// call `batch::run(...)`) continue to compile unchanged.
+#[derive(Debug, Clone, Default)]
+pub struct BatchOptions {
+    /// When `true`, parse the refs file, emit a [`super::fetch::FetchPlan`]
+    /// JSON line per ref on stdout, and return `Ok(())` without opening
+    /// the provenance log, building the HTTP client, or writing to the
+    /// store. ADR-0022 §1 / §3.
+    pub dry_run: bool,
+}
+
+/// Run the `doiget batch <path>` subcommand with the historical
+/// (dry-run-disabled) defaults. See [`run_with_options`] for the
+/// dry-run-aware entry point and the module docs for the
 /// failure-semantics contract.
 pub async fn run(path: String) -> Result<()> {
+    run_with_options(path, BatchOptions::default()).await
+}
+
+/// Run the `doiget batch <path>` subcommand with the given options.
+///
+/// When `opts.dry_run` is `true` (per ADR-0022 §1 + §3): read the input
+/// file, parse refs, and emit one `FetchPlan` JSON envelope line per ref
+/// on stdout. NO provenance log is opened, NO HTTP client is built, NO
+/// per-ref fetch runs, NO store write happens. Per-ref parse failures
+/// in dry-run mode are still counted and the function returns
+/// `Err(...)` if any ref failed to parse — the input was malformed and
+/// the caller should know.
+pub async fn run_with_options(path: String, opts: BatchOptions) -> Result<()> {
     // Step 1: read the input file. Failures surface before any fetch starts.
     let raw =
         std::fs::read_to_string(&path).with_context(|| format!("reading batch file: {path}"))?;
@@ -61,6 +92,38 @@ pub async fn run(path: String) -> Result<()> {
             inputs.len(),
             MCP_BATCH_MAX_SIZE,
         ));
+    }
+
+    // Step 3a: dry-run branch (ADR-0022). Emit one `FetchPlan` envelope
+    // per ref on stdout WITHOUT opening the provenance log, building the
+    // HTTP client, or writing to the store. Per-ref parse failures still
+    // count toward the exit code so a malformed batch is visible.
+    if opts.dry_run {
+        let store_root = resolve_store_root()?;
+        let mut parse_errors: usize = 0;
+        for input in &inputs {
+            match Ref::parse(input) {
+                Ok(ref_) => {
+                    let plan = build_fetch_plan(&ref_, &store_root);
+                    emit_dry_run_plan_to_stdout(&ref_, &plan)?;
+                }
+                Err(e) => {
+                    parse_errors += 1;
+                    tracing::warn!(
+                        %input,
+                        error = %e,
+                        "skipping malformed batch entry in dry-run mode",
+                    );
+                }
+            }
+        }
+        if parse_errors > 0 {
+            return Err(anyhow!(
+                "dry-run batch: {} parse errors (no fetches attempted)",
+                parse_errors
+            ));
+        }
+        return Ok(());
     }
 
     // Step 4: build the harness once. All spawned tasks share an `Arc` to

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -437,7 +437,7 @@ pub async fn run(input: String) -> Result<()> {
 ///     store root.
 ///   - Serialize it to JSON and write to stdout.
 ///   - Return `Ok(())` immediately, **without** building a
-///     [`FetchHarness`] (no provenance log open), without contacting the
+///     `FetchHarness` (no provenance log open), without contacting the
 ///     network, without writing to the store, and without appending a
 ///     provenance row.
 ///

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -61,6 +61,41 @@ fn new_session_id() -> String {
     ulid::Ulid::new().to_string()
 }
 
+// ---------------------------------------------------------------------------
+// Dry-run plan / preview (ADR-0022)
+// ---------------------------------------------------------------------------
+
+// The structured `FetchPlan` shape, the `build_fetch_plan` builder, and
+// the `build_dry_run_envelope` JSON-shape helper live in `doiget-core`
+// so the MCP server can produce a bit-identical envelope without
+// depending on `doiget-cli`. The CLI re-exports them here for callers
+// that already `use doiget_cli::commands::fetch`.
+pub use doiget_core::dry_run::{
+    build_dry_run_envelope, build_fetch_plan, FetchPlan, PdfSourcePlan, RateLimitBudget,
+};
+
+/// Serialize the dry-run envelope and write it to stdout. Used by the
+/// `--dry-run` flag on `doiget fetch` and `doiget batch`. The envelope
+/// shape matches ADR-0022 §1 / `docs/MCP_TOOLS.md` §10.
+///
+/// `pub` so `commands::batch` (multi-ref dry-run) can reuse it. The
+/// function lives in `doiget-cli` (not `doiget-core`) because `println!`
+/// is a CLI concern; the MCP server uses [`build_dry_run_envelope`]
+/// directly and routes the bytes via JSON-RPC.
+///
+/// `print_stdout` is workspace-deny for MCP stdio safety (ADR-0001 /
+/// `docs/SECURITY.md` §3); `--dry-run` is a CLI-only path that never
+/// runs under the MCP server, so the localized `#[allow]` is the
+/// minimal intervention — same pattern used by `commands::config`,
+/// `commands::info`, etc.
+#[allow(clippy::print_stdout)]
+pub fn emit_dry_run_plan_to_stdout(ref_: &Ref, plan: &FetchPlan) -> Result<()> {
+    let envelope = build_dry_run_envelope(ref_, plan);
+    let s = serde_json::to_string(&envelope).context("serializing dry-run envelope to JSON")?;
+    println!("{s}");
+    Ok(())
+}
+
 /// Resolve the on-disk store root. `DOIGET_STORE_ROOT` wins; otherwise
 /// fall back to `$HOME/papers` (POSIX) or `%USERPROFILE%\papers` (Windows).
 fn resolve_store_root() -> Result<Utf8PathBuf> {
@@ -370,16 +405,72 @@ impl FetchHarness {
     }
 }
 
-/// Run the `doiget fetch <ref>` subcommand.
+/// Per-fetch option bundle threaded from `main.rs` clap dispatch.
 ///
-/// Returns `Ok(())` on success and writes a one-line success message to
-/// stderr (per ADR-0001 stdio convention — no stdout writes from `fetch`).
-/// On failure, returns an `anyhow::Error` and emits a `SessionEnd` row with
-/// `result=err` to the provenance log before returning.
+/// The bundle is additive: `Default` produces the historical
+/// `pub async fn run(input)` behaviour, so existing callers (integration
+/// tests under `crates/doiget-cli/tests/`) that go through [`run`]
+/// continue to work unchanged. New callers (the binary's
+/// `clap::Subcommand::Fetch` arm and the dry-run integration test) go
+/// through [`run_with_options`].
+///
+/// Currently exposes a single field — `dry_run` per ADR-0022 §1.
+#[derive(Debug, Clone, Default)]
+pub struct FetchOptions {
+    /// When `true`, build a [`FetchPlan`], emit it as JSON on stdout, and
+    /// return `Ok(())` without touching the network or filesystem and
+    /// without appending a provenance row.
+    pub dry_run: bool,
+}
+
+/// Run the `doiget fetch <ref>` subcommand with the historical (dry-run-
+/// disabled) defaults.
+///
+/// Equivalent to `run_with_options(input, FetchOptions::default())`. Kept
+/// at this signature so the existing in-process integration tests under
+/// `crates/doiget-cli/tests/` (which call `fetch::run("...".into())`)
+/// continue to compile unchanged.
+///
+/// On success returns `Ok(())` and writes a one-line success message to
+/// stderr (per ADR-0001 stdio convention — no stdout writes from `fetch`
+/// on the normal path). On failure, returns an `anyhow::Error` and emits
+/// a `SessionEnd` row with `result=err` to the provenance log before
+/// returning.
 pub async fn run(input: String) -> Result<()> {
+    run_with_options(input, FetchOptions::default()).await
+}
+
+/// Run the `doiget fetch <ref>` subcommand with the given options.
+///
+/// When `opts.dry_run` is `true` (per ADR-0022 §1):
+///   - Build a [`FetchPlan`] from the parsed [`Ref`] and the configured
+///     store root.
+///   - Serialize it to JSON and write to stdout.
+///   - Return `Ok(())` immediately, **without** building a
+///     [`FetchHarness`] (no provenance log open), without contacting the
+///     network, without writing to the store, and without appending a
+///     provenance row.
+///
+/// When `opts.dry_run` is `false`, the body is identical to the
+/// historical [`run`] implementation.
+pub async fn run_with_options(input: String, opts: FetchOptions) -> Result<()> {
     // Step 1: parse + safekey. Granular `RefParseError` collapses to anyhow
     // via `?`; the higher-level CLI binary maps the error to its exit code.
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+
+    // Dry-run branch: build the plan and emit it. NO harness, NO network,
+    // NO store write, NO provenance row. Posture-lint ADR-0022 §5 will
+    // verify this branch never reaches `HttpClient::fetch_*`,
+    // `FsStore::write_*`, or `ProvenanceLog::append`.
+    if opts.dry_run {
+        // Resolve store root for path projections. Failures here surface
+        // as a normal CLI error (not as a denial) — same behaviour the
+        // non-dry-run path would exhibit on a misconfigured environment.
+        let store_root = resolve_store_root()?;
+        let plan = build_fetch_plan(&ref_, &store_root);
+        emit_dry_run_plan_to_stdout(&ref_, &plan)?;
+        return Ok(());
+    }
 
     // Step 2: build harness (foundation modules + provenance log).
     let harness = FetchHarness::from_env()?;

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -96,16 +96,6 @@ pub fn emit_dry_run_plan_to_stdout(ref_: &Ref, plan: &FetchPlan) -> Result<()> {
     Ok(())
 }
 
-/// Resolve the on-disk store root. `DOIGET_STORE_ROOT` wins; otherwise
-/// fall back to `$HOME/papers` (POSIX) or `%USERPROFILE%\papers` (Windows).
-fn resolve_store_root() -> Result<Utf8PathBuf> {
-    if let Some(s) = read_env_utf8("DOIGET_STORE_ROOT")? {
-        return Ok(Utf8PathBuf::from(s));
-    }
-    let home = home_dir_utf8()?;
-    Ok(home.join("papers"))
-}
-
 /// Resolve the provenance log path. `DOIGET_LOG_PATH` wins; otherwise
 /// fall back to `<config>/doiget/access.jsonl` per `docs/PROVENANCE_LOG.md`
 /// §1.
@@ -249,7 +239,7 @@ pub(crate) struct OrchestratorConfig {
 
 impl OrchestratorConfig {
     fn from_env() -> Result<Self> {
-        let store_root = resolve_store_root()?;
+        let store_root = super::resolve_store_root()?;
         let log_path = resolve_log_path()?;
         let contact_email =
             std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".into());
@@ -466,7 +456,7 @@ pub async fn run_with_options(input: String, opts: FetchOptions) -> Result<()> {
         // Resolve store root for path projections. Failures here surface
         // as a normal CLI error (not as a denial) — same behaviour the
         // non-dry-run path would exhibit on a misconfigured environment.
-        let store_root = resolve_store_root()?;
+        let store_root = super::resolve_store_root()?;
         let plan = build_fetch_plan(&ref_, &store_root);
         emit_dry_run_plan_to_stdout(&ref_, &plan)?;
         return Ok(());

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -30,11 +30,24 @@ enum Command {
     Fetch {
         /// DOI (e.g. "10.1234/example") or arXiv id (e.g. "arXiv:2401.12345").
         ref_: String,
+        /// Build a fetch plan and emit it as JSON on stdout without
+        /// touching the network, the store, or the provenance log
+        /// (ADR-0022). The `plan.pdf_sources[].candidate_hosts` list is
+        /// the static allowlist for the resolver, not a prediction of
+        /// the single host the real fetch would hit (ADR-0022 §4).
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Fetch many refs from a newline-separated text file.
     Batch {
         /// Path to a file containing one ref per line.
         path: String,
+        /// Emit one fetch-plan JSON envelope per ref on stdout without
+        /// touching the network, the store, or the provenance log
+        /// (ADR-0022). Per-ref parse failures still cause a non-zero
+        /// exit so a malformed batch is visible.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Show metadata for a stored entry.
     Info {
@@ -99,8 +112,20 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_),
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit),
         Some(Command::Search { query }) => doiget_cli::commands::search::run(query),
-        Some(Command::Fetch { ref_ }) => doiget_cli::commands::fetch::run(ref_).await,
-        Some(Command::Batch { path }) => doiget_cli::commands::batch::run(path).await,
+        Some(Command::Fetch { ref_, dry_run }) => {
+            doiget_cli::commands::fetch::run_with_options(
+                ref_,
+                doiget_cli::commands::fetch::FetchOptions { dry_run },
+            )
+            .await
+        }
+        Some(Command::Batch { path, dry_run }) => {
+            doiget_cli::commands::batch::run_with_options(
+                path,
+                doiget_cli::commands::batch::BatchOptions { dry_run },
+            )
+            .await
+        }
         Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_),
         Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_),
         // Phase 3 (MCP foundation). The MCP server runs on stdio per

--- a/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
@@ -1,0 +1,254 @@
+//! Dry-run integration test for `doiget fetch <ref> --dry-run`
+//! (ADR-0022).
+//!
+//! This is the binding success criterion for the dry-run posture of
+//! ADR-0022 §1 / §3 / §5: a dry-run fetch
+//!
+//! - returns `Ok(())` immediately,
+//! - never writes a PDF,
+//! - never writes a metadata TOML,
+//! - never appends (and never even creates) the provenance log file,
+//! - never starts a wiremock server (i.e. no `DOIGET_*_BASE` overrides
+//!   are needed because no HTTP traffic is attempted).
+//!
+//! ## Network purity
+//!
+//! Per the network-purity guard, this test makes NO outbound calls. It
+//! also makes NO calls to wiremock — that is the whole point of the
+//! dry-run mode.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use camino::{Utf8Path, Utf8PathBuf};
+use doiget_cli::commands::fetch::{
+    build_dry_run_envelope, build_fetch_plan, run_with_options, FetchOptions,
+};
+use doiget_core::Ref;
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// RAII helper that captures the prior values of every named env var on
+/// construction, lets the test mutate them via `set`, then restores
+/// (or removes) them on drop. Modeled on the `EnvGuard` in
+/// `fetch_arxiv_e2e.rs`. Tests holding this guard MUST also be marked
+/// `#[serial]` because env state is process-global.
+struct EnvGuard {
+    keys: Vec<&'static str>,
+    prior: Vec<Option<std::ffi::OsString>>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        let prior = keys.iter().map(std::env::var_os).collect();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+            prior,
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, prior) in self.keys.iter().zip(self.prior.iter()) {
+            match prior {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn dry_run_fetch_doi_returns_ok_without_side_effects() {
+    // Step 1: stage a clean tempdir for store + log paths, and clear
+    // every base-URL override so a regression that accidentally falls
+    // through to the live network path would surface as a DNS failure
+    // (not a wiremock hit).
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_STORE_ROOT",
+        "DOIGET_LOG_PATH",
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_OA_PUBLISHER_BASE",
+        "DOIGET_CONTACT_EMAIL",
+        "DOIGET_UNPAYWALL_EMAIL",
+    ]);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    // Step 2: invoke the orchestrator with dry_run=true. NO wiremock has
+    // been started, so any accidental HTTP attempt would fail (DNS for
+    // crossref/unpaywall/oa-publisher hosts is not stubbed). The fact
+    // that this call returns Ok proves the dry-run path short-circuits
+    // before any network call.
+    let result = run_with_options("10.1234/foo".to_string(), FetchOptions { dry_run: true }).await;
+    result.expect("dry-run fetch::run_with_options succeeds");
+
+    // Step 3: assert the on-disk side-effects are empty. The store
+    // directory and log file MUST NOT have been created by the
+    // dry-run path (ADR-0022 §1 / §3 / §5 — "no network call, no file
+    // write, and no provenance row appended").
+    assert!(
+        !log_path.exists(),
+        "dry-run path must not create the provenance log file: {log_path}",
+    );
+    // The store root either does not exist OR exists but contains no
+    // PDFs / no .metadata dir. We assert the safekey-derived PDF /
+    // metadata paths do not exist.
+    let pdf_path = store_root.join("doi_10.1234_foo.pdf");
+    let toml_path = store_root.join(".metadata").join("doi_10.1234_foo.toml");
+    assert!(
+        !pdf_path.exists(),
+        "dry-run path must not write the PDF: {pdf_path}",
+    );
+    assert!(
+        !toml_path.exists(),
+        "dry-run path must not write the metadata TOML: {toml_path}",
+    );
+
+    drop(env);
+    drop(td);
+}
+
+#[tokio::test]
+#[serial]
+async fn dry_run_fetch_arxiv_returns_ok_without_side_effects() {
+    // Mirror of the DOI test for the arXiv ref kind. Same posture: no
+    // wiremock, no network, no writes, no log file.
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_STORE_ROOT",
+        "DOIGET_LOG_PATH",
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_OA_PUBLISHER_BASE",
+    ]);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    let result = run_with_options(
+        "arxiv:2401.12345".to_string(),
+        FetchOptions { dry_run: true },
+    )
+    .await;
+    result.expect("dry-run arxiv fetch::run_with_options succeeds");
+
+    assert!(
+        !log_path.exists(),
+        "dry-run arxiv path must not create the provenance log file: {log_path}",
+    );
+    let pdf_path = store_root.join("arxiv_2401.12345.pdf");
+    let toml_path = store_root.join(".metadata").join("arxiv_2401.12345.toml");
+    assert!(
+        !pdf_path.exists(),
+        "dry-run arxiv path must not write the PDF: {pdf_path}",
+    );
+    assert!(
+        !toml_path.exists(),
+        "dry-run arxiv path must not write the metadata TOML: {toml_path}",
+    );
+
+    drop(env);
+    drop(td);
+}
+
+#[test]
+fn build_fetch_plan_doi_envelope_matches_adr_0022_shape() {
+    // Pure-function shape pin (no env state): the JSON envelope an
+    // agent would observe for a DOI dry-run matches ADR-0022 §1 /
+    // docs/MCP_TOOLS.md §10 to byte-level shape — `ok=true`,
+    // `dry_run=true`, `ref={doi:...}`, `plan` with the four keys
+    // documented in the ADR, and `rate_limit_budget` carrying the
+    // hard-coded 5/sec + 200ms numbers.
+    let r = Ref::parse("10.1234/foo").expect("DOI parses");
+    let plan = build_fetch_plan(&r, &Utf8PathBuf::from("/tmp/store"));
+    let env = build_dry_run_envelope(&r, &plan);
+
+    assert_eq!(env["ok"], serde_json::json!(true));
+    assert_eq!(env["dry_run"], serde_json::json!(true));
+    assert_eq!(env["ref"], serde_json::json!({ "doi": "10.1234/foo" }));
+
+    // Plan shape: per ADR-0022 §1.
+    let plan_json = &env["plan"];
+    assert_eq!(
+        plan_json["metadata_sources"],
+        serde_json::json!(["crossref", "unpaywall"])
+    );
+    assert!(plan_json["pdf_sources"].is_array());
+    assert_eq!(plan_json["pdf_sources"][0]["key"], "oa-publisher");
+    assert!(plan_json["pdf_sources"][0]["candidate_hosts"].is_array());
+    assert_eq!(
+        plan_json["redirect_allowlists_loaded"],
+        serde_json::json!(["crossref", "unpaywall", "arxiv", "oa-publisher"])
+    );
+    // Path string form is platform-native (`/` on POSIX, `\` on Windows)
+    // — compare against an `Utf8PathBuf::join` result rather than a raw
+    // forward-slash literal so the assertion holds on both platforms.
+    let expect_pdf = Utf8PathBuf::from("/tmp/store")
+        .join("doi_10.1234_foo.pdf")
+        .to_string();
+    let expect_toml = Utf8PathBuf::from("/tmp/store")
+        .join(".metadata")
+        .join("doi_10.1234_foo.toml")
+        .to_string();
+    assert_eq!(plan_json["target_pdf_path"], serde_json::json!(expect_pdf));
+    assert_eq!(
+        plan_json["target_metadata_path"],
+        serde_json::json!(expect_toml)
+    );
+    assert_eq!(
+        plan_json["would_append_provenance"],
+        serde_json::json!(true)
+    );
+
+    assert_eq!(
+        env["rate_limit_budget"]["global_per_sec"],
+        serde_json::json!(5.0)
+    );
+    assert_eq!(
+        env["rate_limit_budget"]["per_source_min_gap_ms"],
+        serde_json::json!(200)
+    );
+}
+
+#[test]
+fn build_fetch_plan_arxiv_envelope_uses_arxiv_pdf_source() {
+    // Mirror for the arXiv branch: empty metadata_sources, single
+    // arxiv pdf_source.
+    let r = Ref::parse("arxiv:2401.12345").expect("arxiv parses");
+    let plan = build_fetch_plan(&r, &Utf8PathBuf::from("/tmp/store"));
+    let env = build_dry_run_envelope(&r, &plan);
+
+    assert_eq!(env["ref"], serde_json::json!({ "arxiv": "2401.12345" }));
+    assert_eq!(env["plan"]["metadata_sources"], serde_json::json!([]));
+    assert_eq!(env["plan"]["pdf_sources"][0]["key"], "arxiv");
+    let expect_pdf = Utf8PathBuf::from("/tmp/store")
+        .join("arxiv_2401.12345.pdf")
+        .to_string();
+    assert_eq!(
+        env["plan"]["target_pdf_path"],
+        serde_json::json!(expect_pdf)
+    );
+}

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = { workspace = true }
 tracing     = { workspace = true }
 secrecy     = { workspace = true, optional = true }
 reqwest     = { workspace = true }
-camino      = { workspace = true }
+camino      = { workspace = true, features = ["serde1"] }
 fs2         = { workspace = true }
 tempfile    = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/doiget-core/src/dry_run.rs
+++ b/crates/doiget-core/src/dry_run.rs
@@ -1,0 +1,283 @@
+//! Dry-run preview shape for `--dry-run` CLI fetches and the
+//! `doiget_metadata_only` / `doiget_fetch_paper` MCP tools.
+//!
+//! Binding spec: [`docs/DECISIONS/0022-dry-run-mode.md`](../../../docs/DECISIONS/0022-dry-run-mode.md)
+//! §1 (NORMATIVE wire shape) and [`docs/MCP_TOOLS.md`](../../../docs/MCP_TOOLS.md)
+//! §10 (MCP envelope mirror).
+//!
+//! The types here live in `doiget-core` rather than `doiget-cli` so that
+//! both `doiget-cli` (the `--dry-run` flag path) and `doiget-mcp` (the
+//! `dry_run: true` tool variants) can serialize bit-identical envelopes
+//! without `doiget-mcp` having to depend on `doiget-cli` (which would
+//! invert the existing `doiget-cli -> doiget-mcp` wiring).
+//!
+//! ## Honesty about candidate uncertainty
+//!
+//! The `pdf_sources[].candidate_hosts` list is the **static allowlist**
+//! for the named resolver, not the host the actual fetch would have hit.
+//! doiget cannot know the post-Unpaywall OA URL host without making the
+//! Unpaywall network call, and `--dry-run` MUST NOT make it. The preview
+//! is therefore an *upper-bound* on the hosts a real fetch could touch,
+//! not a prediction of the single host it would touch (ADR-0022 §4).
+
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Serialize;
+
+use crate::http::{oa_publisher_allowlist, tier_1_allowlist, SourceAllowlist};
+use crate::{RateLimits, Ref};
+
+/// Per-PDF-source row inside [`FetchPlan::pdf_sources`].
+///
+/// `candidate_hosts` is the static allowlist for the named resolver, not
+/// a prediction of the single host the real fetch would touch — see
+/// [module docs](self) and ADR-0022 §4 ("Honesty about candidate
+/// uncertainty").
+#[derive(Debug, Clone, Serialize)]
+pub struct PdfSourcePlan {
+    /// Resolver source key (e.g. `"oa-publisher"`, `"arxiv"`).
+    pub key: String,
+    /// Allowlist hosts the real fetch would be permitted to touch.
+    pub candidate_hosts: Vec<String>,
+}
+
+/// Per-process rate-limit context surfaced alongside [`FetchPlan`] so an
+/// agent can predict the politeness ceiling without a separate
+/// `doiget_capability_profile` round-trip.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct RateLimitBudget {
+    /// Process-wide cap (matches [`RateLimits::HARD_CODED`]).
+    pub global_per_sec: f32,
+    /// Per-source minimum gap between consecutive requests, ms.
+    pub per_source_min_gap_ms: u64,
+}
+
+/// Structured dry-run preview returned by `--dry-run` and the
+/// `dry_run: true` MCP variants. Wire shape matches ADR-0022 §1 and
+/// `docs/MCP_TOOLS.md` §10.
+#[derive(Debug, Clone, Serialize)]
+pub struct FetchPlan {
+    /// Metadata sources the real fetch would consult, in dispatch order.
+    pub metadata_sources: Vec<String>,
+    /// PDF sources the real fetch could attempt. `candidate_hosts` is an
+    /// upper-bound on the hosts a real fetch would touch (see
+    /// [`PdfSourcePlan`]).
+    pub pdf_sources: Vec<PdfSourcePlan>,
+    /// Source keys whose redirect allowlists are loaded into the HTTP
+    /// client. Useful for validating `CapabilityProfile` configuration
+    /// drift.
+    pub redirect_allowlists_loaded: Vec<String>,
+    /// Where the PDF would land on disk (always `<root>/<safekey>.pdf`).
+    pub target_pdf_path: Utf8PathBuf,
+    /// Where the metadata TOML would land
+    /// (always `<root>/.metadata/<safekey>.toml`).
+    pub target_metadata_path: Utf8PathBuf,
+    /// `true` in Phase 1+ — every successful fetch appends a provenance
+    /// row. Named explicitly so future fetch modes can declare "this
+    /// fetch would NOT append" without inverting the flag's meaning
+    /// (ADR-0022 §1).
+    pub would_append_provenance: bool,
+}
+
+/// Hard-coded rate-limit budget surfaced with every [`FetchPlan`] preview.
+/// Mirrors [`RateLimits::HARD_CODED`] / `docs/LEGAL.md` §6 safeguard 8.
+pub fn rate_limit_budget() -> RateLimitBudget {
+    RateLimitBudget {
+        global_per_sec: RateLimits::HARD_CODED.max_fetches_per_second(),
+        per_source_min_gap_ms: RateLimits::HARD_CODED.per_source_backoff_ms(),
+    }
+}
+
+/// Build the dry-run preview ([`FetchPlan`]) for the given ref and store
+/// root, without contacting the network or filesystem.
+///
+/// Per-ref-kind shape (ADR-0022 §1, NORMATIVE):
+///
+/// - **DOI** → `metadata_sources = ["crossref", "unpaywall"]`,
+///   `pdf_sources = [{ key: "oa-publisher", candidate_hosts: oa_publisher_allowlist hosts }]`.
+/// - **arXiv** → `metadata_sources = []`,
+///   `pdf_sources = [{ key: "arxiv", candidate_hosts: tier_1 arxiv hosts }]`.
+///
+/// `redirect_allowlists_loaded` always contains the four source keys the
+/// production HTTP client is built with (Tier 1 + the synthetic OA
+/// publisher), reflecting `doiget-cli::commands::fetch::build_http_client`'s
+/// composition.
+pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
+    let safekey = ref_.safekey();
+    let target_pdf_path = store_root.join(format!("{}.pdf", safekey.as_str()));
+    let target_metadata_path = store_root
+        .join(".metadata")
+        .join(format!("{}.toml", safekey.as_str()));
+
+    let (metadata_sources, pdf_sources) = match ref_ {
+        Ref::Doi(_) => {
+            let oa_hosts = oa_publisher_allowlist()
+                .into_iter()
+                .find(|a: &SourceAllowlist| a.source == "oa-publisher")
+                .map(|a| a.redirect_hosts)
+                .unwrap_or_default();
+            (
+                vec!["crossref".to_string(), "unpaywall".to_string()],
+                vec![PdfSourcePlan {
+                    key: "oa-publisher".to_string(),
+                    candidate_hosts: oa_hosts,
+                }],
+            )
+        }
+        Ref::Arxiv(_) => {
+            let arxiv_hosts = tier_1_allowlist()
+                .into_iter()
+                .find(|a: &SourceAllowlist| a.source == "arxiv")
+                .map(|a| a.redirect_hosts)
+                .unwrap_or_default();
+            (
+                Vec::<String>::new(),
+                vec![PdfSourcePlan {
+                    key: "arxiv".to_string(),
+                    candidate_hosts: arxiv_hosts,
+                }],
+            )
+        }
+    };
+
+    FetchPlan {
+        metadata_sources,
+        pdf_sources,
+        redirect_allowlists_loaded: vec![
+            "crossref".to_string(),
+            "unpaywall".to_string(),
+            "arxiv".to_string(),
+            "oa-publisher".to_string(),
+        ],
+        target_pdf_path,
+        target_metadata_path,
+        would_append_provenance: true,
+    }
+}
+
+/// Build the dry-run envelope as a `serde_json::Value`, without writing
+/// anywhere. Used by both the CLI (which prints it to stdout) and the
+/// MCP tool wrapper (which routes the bytes via JSON-RPC). Wire shape:
+///
+/// ```jsonc
+/// {
+///   "ok": true,
+///   "dry_run": true,
+///   "ref": { "doi": "10.1234/foo" } | { "arxiv": "2401.12345" },
+///   "plan": { ... see FetchPlan ... },
+///   "rate_limit_budget": { "global_per_sec": 5.0, "per_source_min_gap_ms": 200 }
+/// }
+/// ```
+pub fn build_dry_run_envelope(ref_: &Ref, plan: &FetchPlan) -> serde_json::Value {
+    serde_json::json!({
+        "ok": true,
+        "dry_run": true,
+        "ref": ref_kind_object(ref_),
+        "plan": plan,
+        "rate_limit_budget": rate_limit_budget(),
+    })
+}
+
+/// Build the `ref` field of the dry-run envelope per ADR-0022 §1:
+/// `{"doi": "10.1234/foo"}` for a DOI ref, `{"arxiv": "2401.12345"}` for
+/// an arXiv ref. We intentionally do NOT serialize the full `Ref` enum
+/// (which would emit `{"kind":"doi","id":"10.1234/foo"}` per the
+/// internally-tagged `#[serde(tag,content)]` form), because the wire
+/// shape in the ADR uses a flat single-key object.
+fn ref_kind_object(ref_: &Ref) -> serde_json::Value {
+    match ref_ {
+        Ref::Doi(d) => serde_json::json!({ "doi": d.as_str() }),
+        Ref::Arxiv(a) => serde_json::json!({ "arxiv": a.as_str() }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::{ArxivId, Doi};
+
+    fn temp_root() -> Utf8PathBuf {
+        Utf8PathBuf::from("/tmp/doiget-test-store")
+    }
+
+    #[test]
+    fn doi_plan_carries_crossref_and_unpaywall_metadata_sources() {
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        let plan = build_fetch_plan(&r, &temp_root());
+        assert_eq!(plan.metadata_sources, vec!["crossref", "unpaywall"]);
+        assert_eq!(plan.pdf_sources.len(), 1);
+        assert_eq!(plan.pdf_sources[0].key, "oa-publisher");
+        assert!(
+            !plan.pdf_sources[0].candidate_hosts.is_empty(),
+            "OA publisher hosts must be populated"
+        );
+        assert!(plan.would_append_provenance);
+    }
+
+    #[test]
+    fn arxiv_plan_has_empty_metadata_sources_and_arxiv_pdf_source() {
+        let r = Ref::Arxiv(ArxivId("2401.12345".to_string()));
+        let plan = build_fetch_plan(&r, &temp_root());
+        assert!(plan.metadata_sources.is_empty());
+        assert_eq!(plan.pdf_sources.len(), 1);
+        assert_eq!(plan.pdf_sources[0].key, "arxiv");
+        assert!(plan.pdf_sources[0]
+            .candidate_hosts
+            .iter()
+            .any(|h| h == "arxiv.org"));
+    }
+
+    #[test]
+    fn plan_target_paths_are_safekey_derived() {
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        let root = Utf8PathBuf::from("/tmp/store");
+        let plan = build_fetch_plan(&r, &root);
+        assert_eq!(plan.target_pdf_path, root.join("doi_10.1234_example.pdf"));
+        assert_eq!(
+            plan.target_metadata_path,
+            root.join(".metadata").join("doi_10.1234_example.toml")
+        );
+    }
+
+    #[test]
+    fn dry_run_envelope_has_top_level_ok_dry_run_and_rate_budget() {
+        let r = Ref::Doi(Doi("10.1234/foo".to_string()));
+        let plan = build_fetch_plan(&r, &temp_root());
+        let env = build_dry_run_envelope(&r, &plan);
+        assert_eq!(env["ok"], serde_json::json!(true));
+        assert_eq!(env["dry_run"], serde_json::json!(true));
+        assert_eq!(env["ref"], serde_json::json!({ "doi": "10.1234/foo" }));
+        assert_eq!(
+            env["rate_limit_budget"]["global_per_sec"],
+            serde_json::json!(5.0)
+        );
+        assert_eq!(
+            env["rate_limit_budget"]["per_source_min_gap_ms"],
+            serde_json::json!(200)
+        );
+    }
+
+    #[test]
+    fn dry_run_envelope_arxiv_ref_uses_arxiv_key() {
+        let r = Ref::Arxiv(ArxivId("2401.12345".to_string()));
+        let plan = build_fetch_plan(&r, &temp_root());
+        let env = build_dry_run_envelope(&r, &plan);
+        assert_eq!(env["ref"], serde_json::json!({ "arxiv": "2401.12345" }));
+    }
+
+    #[test]
+    fn redirect_allowlists_loaded_lists_all_four_sources() {
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        let plan = build_fetch_plan(&r, &temp_root());
+        // All four allowlist entries must be present (matches the
+        // production `build_http_client` composition).
+        assert_eq!(
+            plan.redirect_allowlists_loaded,
+            vec!["crossref", "unpaywall", "arxiv", "oa-publisher"]
+        );
+    }
+}

--- a/crates/doiget-core/src/dry_run.rs
+++ b/crates/doiget-core/src/dry_run.rs
@@ -101,6 +101,19 @@ pub fn rate_limit_budget() -> RateLimitBudget {
 /// production HTTP client is built with (Tier 1 + the synthetic OA
 /// publisher), reflecting `doiget-cli::commands::fetch::build_http_client`'s
 /// composition.
+///
+/// # Panics
+///
+/// Panics with a self-documenting message if the in-crate allowlist
+/// builders ([`oa_publisher_allowlist`] / [`tier_1_allowlist`]) ever stop
+/// returning the source keys this function looks up. That signals an
+/// internal-contract drift bug, not a user error — fail-fast at preview
+/// time is preferable to silently emitting an empty `candidate_hosts`
+/// list. The workspace `clippy::expect_used` lint is `warn`-level
+/// (promoted to `deny` under `-D warnings`); the localized `#[allow]` is
+/// the minimal intervention here, mirroring the pattern in
+/// `crate::http::HttpClient::new_for_tests_allow_http`.
+#[allow(clippy::expect_used)]
 pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
     let safekey = ref_.safekey();
     let target_pdf_path = store_root.join(format!("{}.pdf", safekey.as_str()));
@@ -110,11 +123,22 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
 
     let (metadata_sources, pdf_sources) = match ref_ {
         Ref::Doi(_) => {
+            // Internal contract: `oa_publisher_allowlist()` MUST always
+            // return an entry whose `.source == "oa-publisher"`. Silent
+            // `.unwrap_or_default()` here would mask drift between this
+            // function and the allowlist source-of-truth — the resulting
+            // empty `candidate_hosts` would mislead an agent into
+            // believing the OA leg has no allowed hosts.
             let oa_hosts = oa_publisher_allowlist()
                 .into_iter()
                 .find(|a: &SourceAllowlist| a.source == "oa-publisher")
                 .map(|a| a.redirect_hosts)
-                .unwrap_or_default();
+                .expect(
+                    "oa-publisher allowlist must exist (see \
+                     crates/doiget-core/src/http.rs::oa_publisher_allowlist); \
+                     if this fires, build_fetch_plan and oa_publisher_allowlist \
+                     have drifted",
+                );
             (
                 vec!["crossref".to_string(), "unpaywall".to_string()],
                 vec![PdfSourcePlan {
@@ -124,11 +148,17 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
             )
         }
         Ref::Arxiv(_) => {
+            // Same internal-contract rationale as the DOI branch above.
             let arxiv_hosts = tier_1_allowlist()
                 .into_iter()
                 .find(|a: &SourceAllowlist| a.source == "arxiv")
                 .map(|a| a.redirect_hosts)
-                .unwrap_or_default();
+                .expect(
+                    "tier-1 allowlist must include 'arxiv' (see \
+                     crates/doiget-core/src/http.rs::tier_1_allowlist); \
+                     if this fires, build_fetch_plan and tier_1_allowlist \
+                     have drifted",
+                );
             (
                 Vec::<String>::new(),
                 vec![PdfSourcePlan {

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -283,7 +283,7 @@ pub enum HttpError {
 // HttpError -> Option<DenialContext>  (ADR-0023 §4 mapping table)
 // ---------------------------------------------------------------------------
 
-/// Map an [`HttpError`] reference to the structured [`DenialContext`]
+/// Map an [`HttpError`] reference to the structured [`crate::DenialContext`]
 /// channel introduced by ADR-0023.
 ///
 /// Returns `Some(_)` for the four denial classes named in ADR-0023 §4

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -215,12 +215,24 @@ pub enum HttpError {
     /// Field naming: `source_key` rather than `source` because `thiserror`
     /// auto-treats a field literally named `source` as a `#[source]` error
     /// chain link (which would require the field to implement `std::error::Error`).
+    ///
+    /// `expected_hosts` carries a snapshot of the source's allowlist
+    /// patterns at the time of the denial — populated for the structured
+    /// `denial_context.expected` channel introduced by ADR-0023 §4
+    /// (NORMATIVE mapping table). Cloning the patterns into the error
+    /// keeps the `From<&HttpError> for Option<DenialContext>` impl from
+    /// having to re-look-up the allowlist by `source_key`. May be empty
+    /// when the rejection happened before any allowlist was matched
+    /// (e.g. URL had no host component at all).
     #[error("redirect target {host} not in allowlist for source {source_key}")]
     RedirectDenied {
         /// Source key whose allowlist rejected the redirect.
         source_key: String,
         /// The lowercased host that was rejected.
         host: String,
+        /// Snapshot of the source's `redirect_hosts` at denial time.
+        /// Surfaces as `denial_context.expected` (ADR-0023 §4).
+        expected_hosts: Vec<String>,
     },
     /// Redirect target had a scheme other than `https`. See
     /// `docs/SECURITY.md` §1.3.
@@ -265,6 +277,87 @@ pub enum HttpError {
         /// The unregistered source key.
         source_key: String,
     },
+}
+
+// ---------------------------------------------------------------------------
+// HttpError -> Option<DenialContext>  (ADR-0023 §4 mapping table)
+// ---------------------------------------------------------------------------
+
+/// Map an [`HttpError`] reference to the structured [`DenialContext`]
+/// channel introduced by ADR-0023.
+///
+/// Returns `Some(_)` for the four denial classes named in ADR-0023 §4
+/// (`RedirectDenied`, `OversizedBody`, `NotAPdf`, `InsecureRedirect`) and
+/// `None` for every other variant — `Network`, `HttpStatus`,
+/// `UnknownSource` are not denials in the ADR-0023 sense (they are
+/// transport / upstream / programming-error signals, not allowlist or
+/// cap rejections).
+///
+/// The `&HttpError` borrow form is used (rather than `HttpError`) so the
+/// caller — typically the orchestrator that already needs the original
+/// error for `error.message` and the `From<HttpError> for ErrorCode`
+/// collapse — does not have to clone the error to produce the optional
+/// structured side-channel.
+impl From<&HttpError> for Option<crate::DenialContext> {
+    fn from(e: &HttpError) -> Self {
+        use crate::{DenialContext, DenialReason};
+        match e {
+            HttpError::RedirectDenied {
+                source_key,
+                host,
+                expected_hosts,
+            } => Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some(source_key.clone()),
+                attempted: Some(host.clone()),
+                expected: expected_hosts.clone(),
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+            HttpError::OversizedBody { actual, cap } => Some(DenialContext {
+                reason: DenialReason::SizeCapExceeded,
+                source: None,
+                attempted: None,
+                expected: Vec::new(),
+                hop_index: None,
+                cap: Some(*cap),
+                actual: Some(*actual),
+            }),
+            HttpError::NotAPdf { got } => Some(DenialContext {
+                reason: DenialReason::ContentTypeMismatch,
+                source: None,
+                // ADR-0023 §4 mapping table: hex-encode the first 5 bytes
+                // for the `attempted` field. `format!("{:02x}...")` is
+                // chosen over `hex::encode` to avoid pulling the
+                // additional dep into this conversion path; the result is
+                // bit-identical (lowercase, zero-padded).
+                attempted: Some(format!(
+                    "{:02x}{:02x}{:02x}{:02x}{:02x}",
+                    got[0], got[1], got[2], got[3], got[4]
+                )),
+                expected: vec!["%PDF-".to_string()],
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+            HttpError::InsecureRedirect { scheme } => Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: None,
+                attempted: Some(format!("{}:...", scheme)),
+                expected: vec!["https".to_string()],
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+            // The remaining variants are not "denials" in the ADR-0023
+            // sense — Network/HttpStatus/UnknownSource are transport,
+            // upstream, or programming-error signals.
+            HttpError::Network(_)
+            | HttpError::HttpStatus { .. }
+            | HttpError::UnknownSource { .. } => None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -472,6 +565,7 @@ fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest
                 return attempt.error(HttpError::RedirectDenied {
                     source_key: allowlist_for_closure.source.clone(),
                     host: String::new(),
+                    expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
                 });
             }
         };
@@ -479,6 +573,7 @@ fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest
             return attempt.error(HttpError::RedirectDenied {
                 source_key: allowlist_for_closure.source.clone(),
                 host,
+                expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
             });
         }
         attempt.follow()
@@ -545,6 +640,7 @@ fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
                 return attempt.error(HttpError::RedirectDenied {
                     source_key: allowlist_for_closure.source.clone(),
                     host: String::new(),
+                    expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
                 });
             }
         };
@@ -552,6 +648,7 @@ fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
             return attempt.error(HttpError::RedirectDenied {
                 source_key: allowlist_for_closure.source.clone(),
                 host,
+                expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
             });
         }
 
@@ -719,6 +816,7 @@ mod tests {
                     return attempt.error(HttpError::RedirectDenied {
                         source_key: allowlist_for_closure.source.clone(),
                         host: String::new(),
+                        expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
                     });
                 }
             };
@@ -726,6 +824,7 @@ mod tests {
                 return attempt.error(HttpError::RedirectDenied {
                     source_key: allowlist_for_closure.source.clone(),
                     host,
+                    expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
                 });
             }
             attempt.follow()
@@ -1036,6 +1135,7 @@ mod tests {
                     return attempt.error(HttpError::RedirectDenied {
                         source_key: allowlist_for_closure.source.clone(),
                         host: String::new(),
+                        expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
                     });
                 }
             };
@@ -1043,6 +1143,7 @@ mod tests {
                 return attempt.error(HttpError::RedirectDenied {
                     source_key: allowlist_for_closure.source.clone(),
                     host: h,
+                    expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
                 });
             }
             attempt.follow()
@@ -1075,5 +1176,98 @@ mod tests {
         let b = a.clone();
         assert_eq!(a.clients.len(), b.clients.len());
         assert!(Arc::ptr_eq(&a.clients, &b.clients));
+    }
+
+    // ---------------------------------------------------------------
+    // HttpError -> Option<DenialContext>  (ADR-0023 §4 mapping)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn denial_from_redirect_denied_carries_attempted_and_expected() {
+        use crate::{DenialContext, DenialReason};
+        let e = HttpError::RedirectDenied {
+            source_key: "crossref".to_string(),
+            host: "evil.example.com".to_string(),
+            expected_hosts: vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()],
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        let dc = dc.expect("RedirectDenied -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::RedirectNotInAllowlist);
+        assert_eq!(dc.source.as_deref(), Some("crossref"));
+        assert_eq!(dc.attempted.as_deref(), Some("evil.example.com"));
+        assert_eq!(
+            dc.expected,
+            vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()]
+        );
+        assert!(dc.cap.is_none());
+        assert!(dc.actual.is_none());
+        assert!(dc.hop_index.is_none());
+    }
+
+    #[test]
+    fn denial_from_oversized_body_carries_cap_and_actual() {
+        use crate::{DenialContext, DenialReason};
+        let e = HttpError::OversizedBody {
+            actual: 209_715_200,
+            cap: PDF_MAX_BYTES,
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        let dc = dc.expect("OversizedBody -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::SizeCapExceeded);
+        assert_eq!(dc.cap, Some(PDF_MAX_BYTES));
+        assert_eq!(dc.actual, Some(209_715_200));
+        assert!(dc.source.is_none());
+        assert!(dc.attempted.is_none());
+        assert!(dc.expected.is_empty());
+    }
+
+    #[test]
+    fn denial_from_not_a_pdf_hex_encodes_got_bytes() {
+        use crate::{DenialContext, DenialReason};
+        // First 5 bytes of "<html" — what the magic-byte check sees when
+        // a publisher returns an HTML interstitial instead of a PDF.
+        let e = HttpError::NotAPdf {
+            got: [0x3c, 0x68, 0x74, 0x6d, 0x6c],
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        let dc = dc.expect("NotAPdf -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::ContentTypeMismatch);
+        assert_eq!(dc.attempted.as_deref(), Some("3c68746d6c"));
+        assert_eq!(dc.expected, vec!["%PDF-".to_string()]);
+    }
+
+    #[test]
+    fn denial_from_insecure_redirect_marks_https_expected() {
+        use crate::{DenialContext, DenialReason};
+        let e = HttpError::InsecureRedirect {
+            scheme: "http".to_string(),
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        let dc = dc.expect("InsecureRedirect -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::RedirectNotInAllowlist);
+        assert_eq!(dc.attempted.as_deref(), Some("http:..."));
+        assert_eq!(dc.expected, vec!["https".to_string()]);
+    }
+
+    #[test]
+    fn denial_from_non_denial_variants_returns_none() {
+        use crate::DenialContext;
+        // Network / HttpStatus / UnknownSource are not denials; they
+        // map to None per ADR-0023 §4.
+        let e = HttpError::HttpStatus {
+            status: 503,
+            url: "https://api.crossref.org/works/x".to_string(),
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        assert!(dc.is_none(), "HttpStatus must not produce a DenialContext");
+
+        let e = HttpError::UnknownSource {
+            source_key: "ghost".to_string(),
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        assert!(
+            dc.is_none(),
+            "UnknownSource must not produce a DenialContext"
+        );
     }
 }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -342,7 +342,7 @@ impl From<&HttpError> for Option<crate::DenialContext> {
                 actual: None,
             }),
             HttpError::InsecureRedirect { scheme } => Some(DenialContext {
-                reason: DenialReason::RedirectNotInAllowlist,
+                reason: DenialReason::InsecureScheme,
                 source: None,
                 attempted: Some(format!("{}:...", scheme)),
                 expected: vec!["https".to_string()],
@@ -350,12 +350,39 @@ impl From<&HttpError> for Option<crate::DenialContext> {
                 cap: None,
                 actual: None,
             }),
+            // `reqwest` wraps a custom error returned by the redirect
+            // policy closure (`attempt.error(HttpError::RedirectDenied{..})`
+            // / `attempt.error(HttpError::InsecureRedirect{..})`) inside a
+            // `reqwest::Error`, which surfaces here as `HttpError::Network`.
+            // Without source-chain walking, production redirect denials —
+            // the most operationally important denial class — would never
+            // produce a `DenialContext`, defeating the whole point of
+            // ADR-0023.
+            //
+            // Walk the `std::error::Error::source()` chain on the inner
+            // `reqwest::Error` and downcast each link to `&HttpError`. If
+            // a wrapped `HttpError` is found, recurse via this same `From`
+            // impl. Otherwise the network error is a "real" transport /
+            // DNS / TLS failure with no denial semantics — return `None`.
+            //
+            // `std::error::Error::source(e)` is fully-qualified to
+            // disambiguate against the inherent (and unrelated)
+            // `reqwest::Error::source()`.
+            HttpError::Network(e) => {
+                let mut source: Option<&(dyn std::error::Error + 'static)> =
+                    std::error::Error::source(e);
+                while let Some(s) = source {
+                    if let Some(http_err) = s.downcast_ref::<HttpError>() {
+                        return Option::<crate::DenialContext>::from(http_err);
+                    }
+                    source = s.source();
+                }
+                None
+            }
             // The remaining variants are not "denials" in the ADR-0023
-            // sense — Network/HttpStatus/UnknownSource are transport,
-            // upstream, or programming-error signals.
-            HttpError::Network(_)
-            | HttpError::HttpStatus { .. }
-            | HttpError::UnknownSource { .. } => None,
+            // sense — HttpStatus/UnknownSource are upstream / programming-
+            // error signals.
+            HttpError::HttpStatus { .. } | HttpError::UnknownSource { .. } => None,
         }
     }
 }
@@ -1237,14 +1264,17 @@ mod tests {
     }
 
     #[test]
-    fn denial_from_insecure_redirect_marks_https_expected() {
+    fn denial_from_insecure_redirect_marks_insecure_scheme() {
         use crate::{DenialContext, DenialReason};
         let e = HttpError::InsecureRedirect {
             scheme: "http".to_string(),
         };
         let dc: Option<DenialContext> = (&e).into();
         let dc = dc.expect("InsecureRedirect -> Some(DenialContext)");
-        assert_eq!(dc.reason, DenialReason::RedirectNotInAllowlist);
+        // ADR-0023 §4 (post-incorporation review): InsecureRedirect maps
+        // to its own dedicated `InsecureScheme` reason, not the host-
+        // allowlist reason — they are semantically distinct denials.
+        assert_eq!(dc.reason, DenialReason::InsecureScheme);
         assert_eq!(dc.attempted.as_deref(), Some("http:..."));
         assert_eq!(dc.expected, vec!["https".to_string()]);
     }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
 // --- Modules ---
+pub mod dry_run;
 pub mod http;
 pub mod provenance;
 pub mod rate_limiter;
@@ -617,6 +618,107 @@ pub enum ErrorCode {
     LockTimeout,
     /// Bug — please open an issue.
     InternalError,
+}
+
+// ---------------------------------------------------------------------------
+// DenialReason / DenialContext (ADR-0023)
+// ---------------------------------------------------------------------------
+
+/// Closed-set reasons a denial-class error envelope can carry on its
+/// optional `denial_context.reason` field.
+///
+/// Wire form (JSON / MCP) is `snake_case` — e.g. `"redirect_not_in_allowlist"`.
+/// The set is **closed** per ADR-0023 §2: adding a new variant is a minor
+/// semver bump; renaming or repurposing one is a breaking change. Mirrors
+/// the stability rule that already governs [`ErrorCode`].
+///
+/// See [`DenialContext`] for the surrounding struct, `docs/ERRORS.md` §3.1
+/// for the wire surface, and `docs/PUBLIC_API.md` §8 for the
+/// semver-locked surface contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenialReason {
+    /// Redirect target host did not match the source's allowlist
+    /// (`HttpError::RedirectDenied` / `HttpError::InsecureRedirect`).
+    RedirectNotInAllowlist,
+    /// Source produced a URL whose host is on a future blocklist (reserved).
+    HostInBlockList,
+    /// Body exceeded [`PDF_MAX_BYTES`] (`HttpError::OversizedBody`).
+    SizeCapExceeded,
+    /// Store entry's `schema_version` is ahead of this binary
+    /// (reserved — emitted by the store schema-rejection path).
+    SchemaDrift,
+    /// Source not in the runtime [`CapabilityProfile`]
+    /// (`FetchError::NotEligible`).
+    CapabilityNotGranted,
+    /// Rate limiter rejected the call inside the current window
+    /// (reserved — Phase 2+ surfaces this from the limiter).
+    RateLimitWindow,
+    /// SSRF guard rejected a private / link-local / cloud-metadata address
+    /// (reserved — future SSRF check).
+    SsrfPrivateAddress,
+    /// Response Content-Type / magic-byte mismatch (`HttpError::NotAPdf`).
+    ContentTypeMismatch,
+}
+
+/// Structured machine-parseable companion to `error.message` for
+/// recoverable denials.
+///
+/// The field is **optional and additive** on the public error envelope —
+/// every previously-shipped `{code, message}` envelope remains valid, and
+/// agents that ignore this struct continue to work. When present, it
+/// carries the concrete parameters an LLM agent can use to plan a recovery
+/// (e.g. "the redirect to `evil.example.com` was denied because it is not
+/// in the crossref allowlist") without text-mining `error.message`.
+///
+/// ## Wire shape
+///
+/// `#[serde(deny_unknown_fields)]`: forward-compatible field additions on
+/// the wire are forbidden by design — adding a field to this struct is a
+/// **breaking** change. This is why the type is **not** `#[non_exhaustive]`
+/// (per `docs/PUBLIC_API.md` §8): both production rules — Rust struct
+/// construction outside the crate AND wire-level extension — must agree.
+///
+/// All fields except `reason` are optional. Producers populate the fields
+/// relevant to the reason and leave the rest at default (`None` / empty
+/// `Vec`); consumers MUST tolerate any subset of fields being present.
+/// Optional / empty fields are skipped on serialize but accepted as missing
+/// on deserialize via `#[serde(default, skip_serializing_if = ...)]`.
+///
+/// Mapping table: see ADR-0023 §4, plus the
+/// `From<&HttpError> for Option<DenialContext>` and
+/// `From<&FetchError> for Option<DenialContext>` impls in
+/// [`crate::http`] / [`crate::source`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DenialContext {
+    /// Closed-enum reason code; the only required field.
+    pub reason: DenialReason,
+    /// Resolver source key (e.g. `"crossref"`) when one is in scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Concrete value the producer attempted (host, path, hex magic bytes,
+    /// scheme prefix). Shape is reason-specific; consumers MUST treat it
+    /// as opaque text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempted: Option<String>,
+    /// Allowlist entries / acceptable values. `Vec<String>` even when only
+    /// one value is meaningful (e.g. `["%PDF-"]`), so the format does not
+    /// have to flip when multiple values are acceptable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected: Vec<String>,
+    /// Redirect-chain hop position, 0-indexed. `u8` because the chain is
+    /// hard-capped at [`crate::http`]'s `MAX_REDIRECTS` (= 10) and any
+    /// larger value indicates a bug.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hop_index: Option<u8>,
+    /// Size or rate cap value (e.g. [`PDF_MAX_BYTES`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cap: Option<u64>,
+    /// Observed value (e.g. response bytes when [`Self::cap`] is the byte
+    /// cap, or row schema_version when [`Self::cap`] is the binary's).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1757,5 +1859,111 @@ mod tests {
         assert_eq!(err, ErrorCode::InvalidRef);
         let err2: ErrorCode = RefParseError::MissingDoiPrefix.into();
         assert_eq!(err2, ErrorCode::InvalidRef);
+    }
+
+    // -----------------------------------------------------------------
+    // DenialReason / DenialContext (ADR-0023) — wire-shape tests.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn denial_reason_serializes_snake_case() {
+        // ADR-0023 §2 / docs/PUBLIC_API.md §8: wire form is snake_case.
+        let s = serde_json::to_string(&DenialReason::RedirectNotInAllowlist).expect("ser");
+        assert_eq!(s, "\"redirect_not_in_allowlist\"");
+        let s = serde_json::to_string(&DenialReason::SizeCapExceeded).expect("ser");
+        assert_eq!(s, "\"size_cap_exceeded\"");
+        let s = serde_json::to_string(&DenialReason::ContentTypeMismatch).expect("ser");
+        assert_eq!(s, "\"content_type_mismatch\"");
+    }
+
+    #[test]
+    fn denial_reason_round_trip_via_serde() {
+        // Round-trip every closed-set variant so adding a new variant
+        // forces this test to be updated (the closed-set contract).
+        for r in [
+            DenialReason::RedirectNotInAllowlist,
+            DenialReason::HostInBlockList,
+            DenialReason::SizeCapExceeded,
+            DenialReason::SchemaDrift,
+            DenialReason::CapabilityNotGranted,
+            DenialReason::RateLimitWindow,
+            DenialReason::SsrfPrivateAddress,
+            DenialReason::ContentTypeMismatch,
+        ] {
+            let s = serde_json::to_string(&r).expect("ser");
+            let back: DenialReason = serde_json::from_str(&s).expect("de");
+            assert_eq!(back, r, "round-trip mismatch for {:?} -> {}", r, s);
+        }
+    }
+
+    #[test]
+    fn denial_context_round_trips_full_shape() {
+        // A populated context (the redirect-denied case from ADR-0023 §1
+        // example) survives a JSON round-trip.
+        let dc = DenialContext {
+            reason: DenialReason::RedirectNotInAllowlist,
+            source: Some("crossref".to_string()),
+            attempted: Some("evil.example.com".to_string()),
+            expected: vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()],
+            hop_index: Some(1),
+            cap: None,
+            actual: None,
+        };
+        let s = serde_json::to_string(&dc).expect("ser");
+        let back: DenialContext = serde_json::from_str(&s).expect("de");
+        assert_eq!(back.reason, dc.reason);
+        assert_eq!(back.source, dc.source);
+        assert_eq!(back.attempted, dc.attempted);
+        assert_eq!(back.expected, dc.expected);
+        assert_eq!(back.hop_index, dc.hop_index);
+        assert_eq!(back.cap, dc.cap);
+        assert_eq!(back.actual, dc.actual);
+    }
+
+    #[test]
+    fn denial_context_serialize_elides_empty_fields() {
+        // `skip_serializing_if` must keep the wire form lean: None / empty
+        // Vec MUST NOT appear on the wire. Reason is always present.
+        let dc = DenialContext {
+            reason: DenialReason::CapabilityNotGranted,
+            source: None,
+            attempted: None,
+            expected: Vec::new(),
+            hop_index: None,
+            cap: None,
+            actual: None,
+        };
+        let s = serde_json::to_string(&dc).expect("ser");
+        assert_eq!(s, "{\"reason\":\"capability_not_granted\"}");
+    }
+
+    #[test]
+    fn denial_context_deserialize_tolerates_missing_optional_fields() {
+        // Consumer-side contract (ADR-0023 §3): consumers MUST tolerate
+        // any subset of fields being present. Missing optional fields
+        // deserialize to their defaults via `#[serde(default)]`.
+        let wire = r#"{"reason":"size_cap_exceeded","cap":104857600,"actual":209715200}"#;
+        let dc: DenialContext = serde_json::from_str(wire).expect("de");
+        assert_eq!(dc.reason, DenialReason::SizeCapExceeded);
+        assert_eq!(dc.cap, Some(104857600));
+        assert_eq!(dc.actual, Some(209715200));
+        assert!(dc.source.is_none());
+        assert!(dc.attempted.is_none());
+        assert!(dc.expected.is_empty());
+        assert!(dc.hop_index.is_none());
+    }
+
+    #[test]
+    fn denial_context_rejects_unknown_fields() {
+        // `#[serde(deny_unknown_fields)]` (ADR-0023 §3, PUBLIC_API.md §8):
+        // an unknown field on the wire MUST be a deserialize error so
+        // forward-compat field additions stay a breaking change.
+        let wire = r#"{"reason":"capability_not_granted","banana":1}"#;
+        let result: Result<DenialContext, _> = serde_json::from_str(wire);
+        assert!(
+            result.is_err(),
+            "deny_unknown_fields must reject 'banana': {:?}",
+            result.map(|d| d.reason),
+        );
     }
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -639,8 +639,10 @@ pub enum ErrorCode {
 #[serde(rename_all = "snake_case")]
 pub enum DenialReason {
     /// Redirect target host did not match the source's allowlist
-    /// (`HttpError::RedirectDenied` / `HttpError::InsecureRedirect`).
+    /// (`HttpError::RedirectDenied`).
     RedirectNotInAllowlist,
+    /// Redirect target had a non-HTTPS scheme (`HttpError::InsecureRedirect`).
+    InsecureScheme,
     /// Source produced a URL whose host is on a future blocklist (reserved).
     HostInBlockList,
     /// Body exceeded [`PDF_MAX_BYTES`] (`HttpError::OversizedBody`).
@@ -689,7 +691,7 @@ pub enum DenialReason {
 /// `From<&HttpError> for Option<DenialContext>` and
 /// `From<&FetchError> for Option<DenialContext>` impls in
 /// [`crate::http`] / [`crate::source`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DenialContext {
     /// Closed-enum reason code; the only required field.
@@ -1882,6 +1884,7 @@ mod tests {
         // forces this test to be updated (the closed-set contract).
         for r in [
             DenialReason::RedirectNotInAllowlist,
+            DenialReason::InsecureScheme,
             DenialReason::HostInBlockList,
             DenialReason::SizeCapExceeded,
             DenialReason::SchemaDrift,
@@ -1899,7 +1902,9 @@ mod tests {
     #[test]
     fn denial_context_round_trips_full_shape() {
         // A populated context (the redirect-denied case from ADR-0023 §1
-        // example) survives a JSON round-trip.
+        // example) survives a JSON round-trip. Whole-struct equality
+        // exercises the `PartialEq` derive added per ADR-0023 §3 (added
+        // in the multi-agent review feedback PR — see ADR-0023 history).
         let dc = DenialContext {
             reason: DenialReason::RedirectNotInAllowlist,
             source: Some("crossref".to_string()),
@@ -1911,13 +1916,7 @@ mod tests {
         };
         let s = serde_json::to_string(&dc).expect("ser");
         let back: DenialContext = serde_json::from_str(&s).expect("de");
-        assert_eq!(back.reason, dc.reason);
-        assert_eq!(back.source, dc.source);
-        assert_eq!(back.attempted, dc.attempted);
-        assert_eq!(back.expected, dc.expected);
-        assert_eq!(back.hop_index, dc.hop_index);
-        assert_eq!(back.cap, dc.cap);
-        assert_eq!(back.actual, dc.actual);
+        assert_eq!(back, dc);
     }
 
     #[test]
@@ -1951,6 +1950,44 @@ mod tests {
         assert!(dc.attempted.is_none());
         assert!(dc.expected.is_empty());
         assert!(dc.hop_index.is_none());
+    }
+
+    #[test]
+    fn full_error_envelope_with_denial_context_serializes_to_pinned_json() {
+        // Pins the byte-exact wire shape of the full failure envelope
+        // documented in docs/ERRORS.md §3 + §3.1 and ADR-0023 §1. A
+        // future regression that flips key order or skip-rules anywhere
+        // in the chain breaks this test loudly.
+        //
+        // Note: serde_json's `Map` (used by `json!`) sorts keys
+        // alphabetically when the `preserve_order` feature is NOT
+        // enabled (we do not enable it). Embedding a `DenialContext`
+        // via `json!` first re-serialises it through the same alphabet-
+        // sorted Map path, so the inner field order is also alphabetical
+        // here — NOT the struct field-order produced by direct
+        // `to_string(&DenialContext)`. This is by design: the public
+        // wire shape is canonicalised by serde_json's Map ordering, so
+        // the byte-exact pin below documents that exact canonicalisation.
+        let denial = DenialContext {
+            reason: DenialReason::RedirectNotInAllowlist,
+            source: Some("crossref".into()),
+            attempted: Some("evil.example.com".into()),
+            expected: vec!["api.crossref.org".into(), "*.crossref.org".into()],
+            hop_index: Some(1),
+            cap: None,
+            actual: None,
+        };
+        let envelope = serde_json::json!({
+            "ok": false,
+            "error": {
+                "code": ErrorCode::NetworkError,
+                "message": "redirect target evil.example.com not in allowlist for source crossref",
+                "denial_context": denial,
+            }
+        });
+        let actual = serde_json::to_string(&envelope).expect("serialize envelope");
+        let expected = r#"{"error":{"code":"NETWORK_ERROR","denial_context":{"attempted":"evil.example.com","expected":["api.crossref.org","*.crossref.org"],"hop_index":1,"reason":"redirect_not_in_allowlist","source":"crossref"},"message":"redirect target evil.example.com not in allowlist for source crossref"},"ok":false}"#;
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -133,6 +133,38 @@ impl From<FetchError> for crate::ErrorCode {
     }
 }
 
+/// Map a [`FetchError`] reference to the structured [`crate::DenialContext`]
+/// channel introduced by ADR-0023 §4.
+///
+/// `&FetchError` (rather than `FetchError`) so the orchestrator can
+/// produce the structured side-channel without consuming the error it
+/// still needs for `error.message` and the `From<FetchError> for
+/// ErrorCode` collapse above. The `Http` arm delegates to the
+/// `From<&HttpError> for Option<DenialContext>` impl in [`crate::http`].
+impl From<&FetchError> for Option<crate::DenialContext> {
+    fn from(e: &FetchError) -> Self {
+        use crate::{DenialContext, DenialReason};
+        match e {
+            FetchError::NotEligible { source_key } => Some(DenialContext {
+                reason: DenialReason::CapabilityNotGranted,
+                source: Some(source_key.clone()),
+                attempted: None,
+                expected: Vec::new(),
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+            // Delegate to the HttpError mapping (ADR-0023 §4 mapping table).
+            FetchError::Http(http_err) => http_err.into(),
+            // Non-denial variants map to None per ADR-0023 §4.
+            FetchError::NoOaAvailable
+            | FetchError::Log(_)
+            | FetchError::InvalidRef(_)
+            | FetchError::SourceSchema { .. } => None,
+        }
+    }
+}
+
 /// The trait implemented by every Tier 1 / 2 / 3 fetcher.
 ///
 /// Binding signature: `docs/PUBLIC_API.md` §2 (NORMATIVE — the wire shape
@@ -328,5 +360,66 @@ mod tests {
             "FetchContext Debug must not dump foundation internals: {}",
             s,
         );
+    }
+
+    // ---------------------------------------------------------------
+    // FetchError -> Option<DenialContext>  (ADR-0023 §4)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn denial_from_not_eligible_carries_source_key() {
+        use crate::{DenialContext, DenialReason};
+        let e = FetchError::NotEligible {
+            source_key: "tdm-elsevier".to_string(),
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        let dc = dc.expect("NotEligible -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::CapabilityNotGranted);
+        assert_eq!(dc.source.as_deref(), Some("tdm-elsevier"));
+        assert!(dc.attempted.is_none());
+        assert!(dc.expected.is_empty());
+    }
+
+    #[test]
+    fn denial_from_http_delegates_to_http_mapping() {
+        use crate::http::HttpError;
+        use crate::{DenialContext, DenialReason, PDF_MAX_BYTES};
+        // The Http arm must delegate to the HttpError mapping rather than
+        // reinventing it, so an OversizedBody surfaces with cap/actual
+        // populated and the SizeCapExceeded reason — proving delegation
+        // works without per-variant duplication.
+        let e = FetchError::Http(HttpError::OversizedBody {
+            actual: 209_715_200,
+            cap: PDF_MAX_BYTES,
+        });
+        let dc: Option<DenialContext> = (&e).into();
+        let dc = dc.expect("Http(OversizedBody) -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::SizeCapExceeded);
+        assert_eq!(dc.cap, Some(PDF_MAX_BYTES));
+        assert_eq!(dc.actual, Some(209_715_200));
+    }
+
+    #[test]
+    fn denial_from_non_denial_variants_returns_none() {
+        use crate::DenialContext;
+        // Each of the four non-denial FetchError arms maps to None per
+        // ADR-0023 §4.
+        let e = FetchError::NoOaAvailable;
+        let dc: Option<DenialContext> = (&e).into();
+        assert!(dc.is_none(), "NoOaAvailable must not produce DenialContext");
+
+        let e = FetchError::Log(LogError::Io(std::io::Error::other("synthetic")));
+        let dc: Option<DenialContext> = (&e).into();
+        assert!(dc.is_none(), "Log must not produce DenialContext");
+
+        let e = FetchError::InvalidRef(RefParseError::Empty);
+        let dc: Option<DenialContext> = (&e).into();
+        assert!(dc.is_none(), "InvalidRef must not produce DenialContext");
+
+        let e = FetchError::SourceSchema {
+            hint: "missing field 'license'".into(),
+        };
+        let dc: Option<DenialContext> = (&e).into();
+        assert!(dc.is_none(), "SourceSchema must not produce DenialContext");
     }
 }

--- a/crates/doiget-core/tests/redirect_denied_denial_context_e2e.rs
+++ b/crates/doiget-core/tests/redirect_denied_denial_context_e2e.rs
@@ -1,0 +1,179 @@
+//! C1 fix coverage: production redirect denials surface a `DenialContext`
+//! through the source-chain walk in `From<&HttpError> for
+//! Option<DenialContext>`.
+//!
+//! Why this lives here (not in `http.rs::tests`):
+//!
+//! `reqwest`'s `Policy::custom` wraps the custom error returned by
+//! `attempt.error(HttpError::RedirectDenied{..})` inside a `reqwest::Error`,
+//! which surfaces to callers as `HttpError::Network(reqwest_err)`. Callers
+//! that produce `denial_context` MUST therefore walk the
+//! `std::error::Error::source()` chain on the inner `reqwest::Error` and
+//! downcast each link to `&HttpError`. Without that walk, the most
+//! operationally important denial class (production redirect denial)
+//! produces NO `DenialContext` — see ADR-0023 §4 and the pre-fix bug
+//! discovered during the multi-agent review of PR #84.
+//!
+//! This integration test pins the post-fix behaviour end-to-end against a
+//! `wiremock` origin that 302s to a host outside the allowlist, plus a
+//! synthetic abstract-level test that pins the source-walking algorithm
+//! itself (in case reqwest's wrapping topology changes).
+//!
+//! ## Network purity
+//!
+//! All HTTP traffic terminates at `127.0.0.1:N` via `wiremock::MockServer`;
+//! no outbound DNS / TCP. Compatible with the workspace network-purity
+//! guard.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use doiget_core::http::{HttpClient, HttpError};
+use doiget_core::{DenialContext, DenialReason};
+use reqwest::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn redirect_outside_allowlist_surfaces_denial_context_via_source_chain() {
+    // Spin up a wiremock origin whose `/redir` 302s to an HTTPS host the
+    // `crossref` allowlist does NOT contain. The redirect closure inside
+    // the per-source `reqwest::Client` will call
+    // `attempt.error(HttpError::RedirectDenied{..})`; reqwest then wraps
+    // that into a `reqwest::Error`, which surfaces to us as
+    // `HttpError::Network(reqwest_err)`. The fix walks the source chain
+    // and downcasts back to `&HttpError`, so
+    // `Option::<DenialContext>::from(&err)` MUST produce
+    // `Some(DenialContext { reason: RedirectNotInAllowlist, .. })`.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/redir"))
+        .respond_with(
+            ResponseTemplate::new(302).insert_header("location", "https://attacker.test/file"),
+        )
+        .mount(&server)
+        .await;
+    let host = server
+        .uri()
+        .parse::<Url>()
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_string();
+
+    // Allowlist contains only the wiremock origin; the redirect target
+    // (`attacker.test`) is OUT.
+    let client = HttpClient::new_for_tests_allow_http("crossref", &host);
+    let url: Url = format!("{}/redir", server.uri()).parse().unwrap();
+    let err = client
+        .fetch_bytes("crossref", url)
+        .await
+        .expect_err("redirect to attacker rejected");
+
+    // The outer error MUST be `Network(_)` — that is precisely what
+    // production callers see and the surface where the pre-fix bug hid.
+    match &err {
+        HttpError::Network(_) => {}
+        other => panic!("expected Network(RedirectDenied), got {:?}", other),
+    }
+
+    // The C1 fix: source-chain walking surfaces the wrapped HttpError.
+    let dc: Option<DenialContext> = (&err).into();
+    let dc = dc.expect(
+        "Network-wrapped RedirectDenied MUST produce Some(DenialContext) \
+         via the source-chain walk (C1 fix). If this is None, From<&HttpError> \
+         for Option<DenialContext>'s Network arm regressed.",
+    );
+
+    assert_eq!(dc.reason, DenialReason::RedirectNotInAllowlist);
+    assert_eq!(
+        dc.source.as_deref(),
+        Some("crossref"),
+        "source key must be carried through the chain (got: {:?})",
+        dc.source,
+    );
+    assert_eq!(
+        dc.attempted.as_deref(),
+        Some("attacker.test"),
+        "attempted host must be the redirect target, not the initial leg \
+         (got: {:?})",
+        dc.attempted,
+    );
+    assert!(
+        !dc.expected.is_empty(),
+        "expected allowlist hosts must be carried through (the original \
+         RedirectDenied snapshots them — see http.rs `expected_hosts` \
+         field), got: {:?}",
+        dc.expected,
+    );
+    assert!(
+        dc.expected.iter().any(|h| h == &host),
+        "expected allowlist hosts must include the wiremock host {:?}; got: {:?}",
+        host,
+        dc.expected,
+    );
+}
+
+/// Synthetic abstract-level coverage for the source-chain walk: even
+/// without going through `reqwest`, wrapping an `HttpError::RedirectDenied`
+/// in a custom `std::error::Error` chain whose `.source()` returns it must
+/// surface a `DenialContext` via the same algorithmic walk used by the
+/// `Network` arm of `From<&HttpError> for Option<DenialContext>`.
+///
+/// This pins the *mechanism* of the C1 fix in case reqwest ever changes
+/// HOW it wraps custom redirect-policy errors (currently it goes through
+/// hyper's error chain). The integration test above covers the production
+/// path; this one covers the algorithmic invariant.
+#[test]
+fn source_chain_walk_recovers_wrapped_redirect_denied() {
+    use std::fmt;
+
+    /// Minimal error wrapper whose `source()` returns the wrapped
+    /// `HttpError`. Stand-in for reqwest's internal wrapping behaviour.
+    #[derive(Debug)]
+    struct Wrapper {
+        inner: HttpError,
+    }
+    impl fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "wrapped: {}", self.inner)
+        }
+    }
+    impl std::error::Error for Wrapper {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.inner)
+        }
+    }
+
+    // Construct the same shape the production redirect closure produces.
+    let denied = HttpError::RedirectDenied {
+        source_key: "crossref".to_string(),
+        host: "evil.example.com".to_string(),
+        expected_hosts: vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()],
+    };
+
+    // Walk the chain manually using the same algorithm as the Network
+    // arm of `From<&HttpError> for Option<DenialContext>`. If this
+    // produces the expected `DenialContext`, the fix's algorithm is
+    // sound regardless of reqwest's exact wrapping topology.
+    let wrapper = Wrapper { inner: denied };
+    let mut source: Option<&(dyn std::error::Error + 'static)> =
+        std::error::Error::source(&wrapper);
+    let mut found: Option<&HttpError> = None;
+    while let Some(s) = source {
+        if let Some(http_err) = s.downcast_ref::<HttpError>() {
+            found = Some(http_err);
+            break;
+        }
+        source = s.source();
+    }
+    let http_err = found.expect("source-chain walk must surface the wrapped HttpError");
+    let dc: Option<DenialContext> = http_err.into();
+    let dc = dc.expect("RedirectDenied -> Some(DenialContext)");
+    assert_eq!(dc.reason, DenialReason::RedirectNotInAllowlist);
+    assert_eq!(dc.source.as_deref(), Some("crossref"));
+    assert_eq!(dc.attempted.as_deref(), Some("evil.example.com"));
+    assert_eq!(
+        dc.expected,
+        vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()]
+    );
+}

--- a/crates/doiget-core/tests/redirect_denied_denial_context_e2e.rs
+++ b/crates/doiget-core/tests/redirect_denied_denial_context_e2e.rs
@@ -1,6 +1,13 @@
+// allow: outbound-network
 //! C1 fix coverage: production redirect denials surface a `DenialContext`
 //! through the source-chain walk in `From<&HttpError> for
 //! Option<DenialContext>`.
+//!
+//! `// allow: outbound-network` on line 1 opts this file out of the
+//! `network-purity` posture-lint guard. All HTTP terminates at a local
+//! `127.0.0.1:N` wiremock origin (see "Network purity" below); the opt-out
+//! is for the `reqwest::Url` import that the wiremock client builder
+//! requires, NOT for real network access.
 //!
 //! Why this lives here (not in `http.rs::tests`):
 //!

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -234,7 +234,7 @@ impl Server {
 // doiget_metadata_only — input schema
 // ---------------------------------------------------------------------------
 
-/// JSON-schema-derived input for [`Server::doiget_metadata_only`].
+/// JSON-schema-derived input for the `doiget_metadata_only` MCP tool.
 ///
 /// Mirrors `docs/MCP_TOOLS.md` §11 `inputSchema`. The Rust field name
 /// `ref_` is renamed on the wire to `ref` (the JSON key the spec uses,

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3,17 +3,22 @@
 //! Phase 3 foundation. JSON-RPC framing is provided by the official `rmcp`
 //! SDK with stdio-only transport (`transport-io`). See ADR-0001 for the
 //! permanence of the stdio-only choice and `docs/MCP_TOOLS.md` for the
-//! 9-tool surface contract.
+//! tool surface contract.
 //!
-//! This module ships the rmcp wiring + two trivial tools to prove the
+//! This module ships the rmcp wiring + the always-on tools that prove the
 //! foundation:
 //!
 //! - `doiget_health` — operational sanity check.
 //! - `doiget_capability_profile` — reports the runtime [`CapabilityProfile`].
+//! - `doiget_metadata_only` — DOI / arXiv id metadata resolution; in
+//!   Phase 1 only the `dry_run: true` path is wired (the live metadata
+//!   fetch lands in a follow-up PR).
 //!
-//! The remaining seven tools (`doiget_resolve_paper`, `doiget_fetch_paper`,
-//! `doiget_batch_fetch`, `doiget_info`, `doiget_search_local`,
-//! `doiget_list_recent`, `doiget_paper_pdf_path`) land in follow-up PRs.
+//! The remaining tools named in `docs/MCP_TOOLS.md` (`doiget_resolve_paper`,
+//! `doiget_fetch_paper`, `doiget_batch_fetch`, `doiget_info`,
+//! `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`)
+//! land in follow-up PRs. The exact count is intentionally left unstated
+//! in this docstring so it does not rot as tools land.
 //!
 //! # Stdout safety
 //!
@@ -194,7 +199,7 @@ impl Server {
         // Step 2: dry-run branch (ADR-0022 §2). Build the same envelope
         // the CLI emits and route via JSON-RPC. NO network, NO store
         // write, NO provenance row.
-        if input.dry_run.unwrap_or(false) {
+        if input.dry_run {
             // Use the same store-root resolver as `doiget_health` so the
             // path projections in `plan.target_*` match what the live
             // fetch would write to. When neither HOME nor USERPROFILE
@@ -247,9 +252,12 @@ pub struct MetadataOnlyInput {
     /// When `true`, returns a [`FetchPlan`](doiget_core::dry_run::FetchPlan)
     /// preview without touching the network or writing anything (ADR-0022).
     /// Defaults to `false` (the production metadata-only path, currently
-    /// stubbed in Phase 1).
+    /// stubbed in Phase 1). Type is plain `bool` (not `Option<bool>`) so the
+    /// generated JSON schema declares `"type": "boolean"` and a wire `null`
+    /// is rejected at deserialize time — agents that intend "no preview"
+    /// either omit the field or pass `false`.
     #[serde(default)]
-    pub dry_run: Option<bool>,
+    pub dry_run: bool,
 }
 
 /// Build the `{ok:false, error:{...}}` envelope used by

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -31,14 +31,17 @@
 
 use camino::Utf8PathBuf;
 
-use doiget_core::{CapabilityProfile, SCHEMA_VERSION, VERSION};
+use doiget_core::dry_run::{build_dry_run_envelope, build_fetch_plan};
+use doiget_core::{CapabilityProfile, Ref, SCHEMA_VERSION, VERSION};
 use rmcp::{
-    handler::server::router::tool::ToolRouter,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{CallToolResult, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    schemars::{self, JsonSchema},
     tool, tool_handler, tool_router,
     transport::stdio,
     ErrorData, ServerHandler, ServiceExt,
 };
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 /// MCP server handle. Owns the resolved [`CapabilityProfile`] plus the
@@ -151,6 +154,120 @@ impl Server {
         let payload = capability_profile_to_json(&self.profile);
         Ok(CallToolResult::structured(payload))
     }
+
+    /// `doiget_metadata_only` — resolve metadata for a DOI / arXiv id
+    /// without paying for or being noticed by a PDF download.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §11 (NORMATIVE).
+    ///
+    /// **Phase 1 status:** only the `dry_run: true` path is wired —
+    /// the orchestrator that performs a real metadata-only fetch (with
+    /// the `metadata-only` provenance tag and no PDF leg) lands in a
+    /// follow-up PR. The non-dry-run path returns
+    /// `{ok:false, error:{code:"INTERNAL_ERROR", ...}}` with a clear
+    /// message. The dry-run path is the user-visible value-add this PR
+    /// ships, per ADR-0022 (the `dry_run` companion ADR).
+    #[tool(
+        description = "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\n\
+                       INPUTS: ref (DOI or arXiv id), dry_run (optional bool).\n\
+                       OUTPUTS: { ok: true, ref, source, license?, oa_url, metadata } OR { ok: true, dry_run: true, ref, plan, rate_limit_budget } OR { ok:false, error }.\n\
+                       COSTS: 1-2 s metadata round-trip (or 0 when dry_run).\n\
+                       SIDE EFFECTS: Appends a 'metadata-only' provenance row (unless dry_run). Writes the metadata TOML to the store. Never fetches PDF.\n\
+                       LIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed."
+    )]
+    async fn doiget_metadata_only(
+        &self,
+        Parameters(input): Parameters<MetadataOnlyInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Step 1: parse the ref. Failures collapse to INVALID_REF per
+        // docs/ERRORS.md §2 / docs/PUBLIC_API.md §4.
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    "INVALID_REF",
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+
+        // Step 2: dry-run branch (ADR-0022 §2). Build the same envelope
+        // the CLI emits and route via JSON-RPC. NO network, NO store
+        // write, NO provenance row.
+        if input.dry_run.unwrap_or(false) {
+            // Use the same store-root resolver as `doiget_health` so the
+            // path projections in `plan.target_*` match what the live
+            // fetch would write to. When neither HOME nor USERPROFILE
+            // resolves (locked-down hosts), fall back to a sentinel
+            // path so the preview still has a complete shape — the
+            // dry-run is a preview, not a writability probe.
+            let store_root = resolve_store_root().unwrap_or_else(|| Utf8PathBuf::from("./papers"));
+            let plan = build_fetch_plan(&ref_, &store_root);
+            return Ok(CallToolResult::structured(build_dry_run_envelope(
+                &ref_, &plan,
+            )));
+        }
+
+        // Step 3: non-dry-run path. The real metadata-only orchestrator
+        // lands in a follow-up PR; surface a clear INTERNAL_ERROR
+        // envelope so an agent doesn't get a confusing default reply.
+        // TODO(phase-1.x): wire the metadata-only orchestrator.
+        // It should: dispatch Crossref + Unpaywall (DOI) or arXiv-meta
+        // (arXiv), write the metadata TOML, append a `Fetch` row tagged
+        // `metadata-only`, and return `{ok:true, ref, source, license?,
+        // oa_url, metadata}` per docs/MCP_TOOLS.md §11. The OA URL is
+        // reported but never followed (that is the contract that
+        // distinguishes this tool from `doiget_fetch_paper`).
+        Ok(CallToolResult::structured(metadata_only_error_envelope(
+            "INTERNAL_ERROR",
+            "metadata_only is not yet wired in Phase 1; only dry_run is supported",
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// doiget_metadata_only — input schema
+// ---------------------------------------------------------------------------
+
+/// JSON-schema-derived input for [`Server::doiget_metadata_only`].
+///
+/// Mirrors `docs/MCP_TOOLS.md` §11 `inputSchema`. The Rust field name
+/// `ref_` is renamed on the wire to `ref` (the JSON key the spec uses,
+/// reserved in Rust as the `ref` keyword) via `#[serde(rename = "ref")]`.
+/// The matching `#[schemars(rename = "ref")]` keeps the generated JSON
+/// schema field name aligned with the wire form.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct MetadataOnlyInput {
+    /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
+    /// `INVALID_REF` per `docs/ERRORS.md`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+    /// When `true`, returns a [`FetchPlan`](doiget_core::dry_run::FetchPlan)
+    /// preview without touching the network or writing anything (ADR-0022).
+    /// Defaults to `false` (the production metadata-only path, currently
+    /// stubbed in Phase 1).
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+}
+
+/// Build the `{ok:false, error:{...}}` envelope used by
+/// `doiget_metadata_only` for both INVALID_REF (bad input) and
+/// INTERNAL_ERROR (Phase 1 stub) cases. Mirrors the wire shape from
+/// `docs/MCP_TOOLS.md` §5; `denial_context` is omitted (these failure
+/// modes do not produce one — see `docs/ERRORS.md` §3.1).
+fn metadata_only_error_envelope(code: &str, message: &str) -> Value {
+    json!({
+        "ok": false,
+        "error": {
+            "code": code,
+            "message": message,
+            // denial_context is intentionally absent for these envelope
+            // shapes (parse-error / internal-error); ADR-0023 §3 says
+            // consumers MUST tolerate the field being absent.
+        },
+    })
 }
 
 // `tool_handler` wires the router into rmcp's `ServerHandler` trait — it

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -84,6 +84,10 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_capability_profile"),
         "tools/list must include doiget_capability_profile; got: {names:?}"
     );
+    assert!(
+        names.contains(&"doiget_metadata_only"),
+        "tools/list must include doiget_metadata_only; got: {names:?}"
+    );
 
     // -- 3. tools/call doiget_health -----------------------------------
     let health = client
@@ -131,6 +135,163 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
     //
     // Cancel the client; this closes the transport and the server's
     // `waiting()` future then resolves.
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// doiget_metadata_only — per-branch coverage (I1 from PR #84 multi-agent
+// review). Each test stands up its own in-memory duplex pipe so failures
+// localise cleanly.
+// ---------------------------------------------------------------------------
+
+/// Boilerplate: spin up a server side over a duplex pipe with a clean
+/// capability profile and return the connected client + server JoinHandle.
+/// The caller cancels the client to drive `waiting()` to completion.
+async fn boot_in_memory_server() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+    Ok((client, server_handle))
+}
+
+#[tokio::test]
+async fn doiget_metadata_only_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    // Build the {"ref":"not a doi"} JsonObject (rmcp's `with_arguments`
+    // takes a `serde_json::Map<String, Value>`).
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("not a doi"));
+
+    let result = client
+        .peer()
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new("doiget_metadata_only").with_arguments(args),
+        )
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_metadata_only uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF"),
+        "envelope: {structured:?}"
+    );
+    assert!(
+        structured["error"]["message"]
+            .as_str()
+            .map(|s| s.contains("invalid ref"))
+            .unwrap_or(false),
+        "INVALID_REF message must mention 'invalid ref' for diagnosability; got: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn doiget_metadata_only_dry_run_true_returns_fetch_plan_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    args.insert("dry_run".to_string(), serde_json::json!(true));
+
+    let result = client
+        .peer()
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new("doiget_metadata_only").with_arguments(args),
+        )
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_metadata_only dry-run uses CallToolResult::structured");
+
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["dry_run"], serde_json::json!(true));
+    // ADR-0022 §1: ref shape is `{"doi":"..."}` for a DOI input.
+    assert_eq!(
+        structured["ref"],
+        serde_json::json!({"doi": "10.1234/example"})
+    );
+    // ADR-0022 §1 NORMATIVE plan shape for DOI: metadata_sources =
+    // ["crossref","unpaywall"]; pdf_sources is non-empty under the
+    // `oa-publisher` synthetic key.
+    assert_eq!(
+        structured["plan"]["metadata_sources"],
+        serde_json::json!(["crossref", "unpaywall"])
+    );
+    let pdf_sources = structured["plan"]["pdf_sources"]
+        .as_array()
+        .expect("plan.pdf_sources is an array");
+    assert!(
+        !pdf_sources.is_empty(),
+        "plan.pdf_sources must be non-empty for a DOI ref; got: {structured:?}"
+    );
+    assert_eq!(pdf_sources[0]["key"], serde_json::json!("oa-publisher"));
+    // Rate-limit budget is the static HARD_CODED snapshot.
+    assert_eq!(
+        structured["rate_limit_budget"]["global_per_sec"],
+        serde_json::json!(5.0)
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn doiget_metadata_only_default_dry_run_false_returns_internal_error_stub(
+) -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    // Omit `dry_run`; defaults to false via `#[serde(default)] dry_run: bool`.
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+
+    let result = client
+        .peer()
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new("doiget_metadata_only").with_arguments(args),
+        )
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_metadata_only stub uses CallToolResult::structured");
+
+    // Phase 1: the non-dry-run branch is a documented stub returning
+    // INTERNAL_ERROR with a clear message (see Server::doiget_metadata_only).
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INTERNAL_ERROR"),
+        "envelope: {structured:?}"
+    );
+    let msg = structured["error"]["message"]
+        .as_str()
+        .expect("error.message is a string");
+    assert!(
+        msg.contains("not yet wired") || msg.contains("dry_run"),
+        "INTERNAL_ERROR stub message must mention the Phase 1 limitation; \
+         got: {msg:?}"
+    );
+
     client.cancel().await?;
     server_handle.await??;
     Ok(())

--- a/docs/DECISIONS/0021-canonical-tuple-identity.md
+++ b/docs/DECISIONS/0021-canonical-tuple-identity.md
@@ -1,0 +1,152 @@
+# 0021 - Canonical-tuple identity for fetched papers
+
+- **Date:** 2026-05-12
+- **Status:** Proposed (spec-only; implementation deferred to Phase 2+)
+- **Supersedes:** -
+- **Source:** Discussion #12 (musaabhasan, 2026-05-08)
+
+## Context
+
+A raw DOI string is treated today as the sole identity of a paper inside doiget:
+[`Ref::Doi(Doi(String))`](../PUBLIC_API.md) is the only identifier carried into
+`safekey`, the metadata store, and the provenance log. The same is true for
+`Ref::Arxiv`.
+
+The external review on Discussion #12 (musaabhasan, 2026-05-08, comment 1)
+points out a gap in this model:
+
+> Normalize the user-supplied identifier into a canonical tuple
+> `(source_type, source_id, resolver_profile, optional version)` — i.e. don't
+> trust raw DOI strings as their own identity. […] That separates identifier
+> trust from network authority. A syntactically valid DOI should not
+> automatically grant permission to follow arbitrary redirects, write arbitrary
+> paths, or log sensitive resolver credentials.
+
+Concretely, two distinct fetch attempts can resolve the same DOI through
+different resolver paths (e.g. Crossref → publisher OA URL vs. Unpaywall →
+publisher OA URL vs. arXiv), and today the audit trail records the same
+identity for both. That collapses two distinct provenance-relevant facts into
+one, and it prevents an LLM agent from asking "did you previously fetch
+`10.1234/foo` *via Unpaywall*?" without retrieving and inspecting every
+provenance row.
+
+The Phase 1 implementation works around this by writing the resolver path into
+the `[doiget].source` field of the metadata TOML and into the `source` column
+of every provenance row. That is sufficient for the Phase 1 surface (Tier 1
+sources are disjoint by ref-class — Crossref/Unpaywall serve DOIs, arXiv serves
+arXiv IDs), but the gap re-emerges as soon as Phase 2 introduces overlapping
+resolvers (OpenAlex / Semantic Scholar / DOAJ all resolve DOIs) and Phase 5
+introduces TDM resolvers that compete with OA resolvers for the same DOI.
+
+## Decision
+
+### 1. Canonical-tuple shape (NORMATIVE)
+
+The audit identity of a fetched paper is the tuple
+
+```rust
+struct CanonicalRef {
+    source_type:      SourceType,        // Doi | Arxiv | (future: Pmid, Handle, ...)
+    source_id:        String,            // the validated identifier ("10.1234/foo")
+    resolver_profile: String,            // e.g. "crossref", "unpaywall", "arxiv",
+                                         //      "oa-publisher", "openalex", ...
+    version:          Option<String>,    // e.g. arXiv "v2", Crossref-snapshot date
+}
+```
+
+Every provenance row written by doiget MUST carry the canonical tuple's
+SHA-256 digest in a new `canonical_digest: [u8; 32]` field. Two fetches of the
+same DOI through Crossref vs. Unpaywall therefore produce two distinct
+`canonical_digest` values, while two fetches of the same DOI through Crossref
+on different days produce the same digest (idempotent under retries).
+
+The digest is computed as
+
+```text
+canonical_digest := SHA256( source_type | 0x00 | source_id | 0x00
+                          | resolver_profile | 0x00 | version_or_empty )
+```
+
+with `|` denoting byte concatenation, `0x00` as an unambiguous field separator,
+and `version_or_empty` being either the version string or an empty string.
+
+### 2. `safekey` continues to depend on `Ref` only
+
+The on-disk filename derivation algorithm in [`SAFEKEY.md`](../SAFEKEY.md) is
+NOT changed: a `safekey` is a function of `Ref` only, never of
+`CanonicalRef`. Two fetches of the same DOI through different resolvers share
+one filesystem entry (one PDF, one metadata TOML), but produce two distinct
+provenance rows with two distinct `canonical_digest` values.
+
+Rationale: cross-tool round-trip with BiblioFetch.jl is keyed on `safekey`
+(see [STORE.md](../STORE.md), [SAFEKEY.md](../SAFEKEY.md), ADR-0007). Splitting
+the on-disk identity by `resolver_profile` would break that contract and would
+duplicate PDFs on disk for no gain — the resolver-distinction the external
+review asks for is an *audit-trail* concern, not a *file-storage* concern.
+
+### 3. Implementation timing
+
+This ADR is **spec-only** as of 2026-05-12. The `CanonicalRef` type, the
+`canonical_digest` provenance column, and the `Ref → CanonicalRef` promotion
+points are in scope for Phase 2 (the storage / audit-rich phase that ships
+`info` / `search`), and are out of scope for the
+`feat/musaabhasan-feedback-incorporation` PR that introduces this ADR.
+
+The PR that ships `CanonicalRef` MUST:
+
+1. Bump `provenance_log` schema_version (the row shape changes — see
+   [PROVENANCE_LOG.md](../PROVENANCE_LOG.md)).
+2. Provide a one-shot migration that re-derives `canonical_digest` for
+   pre-existing rows by treating `resolver_profile = source` and
+   `version = null`, and that recomputes the SHA-256 hash chain from the new
+   row payloads.
+3. Extend [PROVENANCE_LOG.md](../PROVENANCE_LOG.md) §3 with the new column,
+   the new migration row type, and the new replay-verification rule.
+4. Extend [PUBLIC_API.md](../PUBLIC_API.md) §2 with the `CanonicalRef` type
+   and `Ref::promote(profile: &str, version: Option<&str>) -> CanonicalRef`.
+5. Land its own ADR (`0024-canonical-ref-impl.md` or similar) that supersedes
+   the implementation-deferred posture of this one and links to the
+   migration's golden vectors.
+
+### 4. MCP / CLI surface
+
+Phase 2+ MCP tools that expose audit data (`doiget_info`, future
+`doiget_audit_log`) MUST surface `canonical_digest` and the four tuple fields
+verbatim — they are part of the public, machine-parseable contract per
+ADR-0012. The `doiget_fetch_paper` tool result (and its CLI equivalent) MUST
+include the chosen `resolver_profile` so an agent can see, *at fetch time*,
+which canonical identity was just minted.
+
+The `doiget bib` / `doiget csl` exports do NOT carry `canonical_digest` — those
+formats target external citation managers and have no field for it.
+
+## Consequences
+
+**Positive.**
+- An agent can ask "did doiget previously fetch `10.1234/foo` via Unpaywall?"
+  and get a deterministic answer without inspecting every provenance row by
+  hand.
+- The provenance log gains the resolver-distinction the external review on
+  Discussion #12 identified as a security concern (resolver path
+  separated from identifier trust) without changing the on-disk filename
+  derivation BiblioFetch.jl depends on.
+- `version` becomes a first-class field, making arXiv `v2` retrievals and
+  versioned Crossref snapshots distinguishable in audit.
+
+**Negative.**
+- Phase 2's provenance log carries one extra column (a 32-byte digest plus the
+  four source fields). On-disk size impact: ~80 bytes/row.
+- The Phase 2 PR ships a hash-chain re-computation migration. The migration is
+  idempotent and `--dry-run`-able, but it touches every existing provenance
+  log file and is therefore reviewer-load-bearing.
+- The orchestrator must thread `resolver_profile` and `version` through every
+  fetch path — a small refactor in `doiget-cli::commands::fetch` and the
+  Phase 4 batch path.
+
+**Out of scope.**
+- Splitting on-disk storage by `resolver_profile` (rejected; see §2 above).
+- Changing `safekey` (rejected; ADR-0007 unchanged).
+- Implementing the migration in this PR (deferred to Phase 2 per §3).
+
+To revise this decision, write a new ADR with Status: Accepted and Supersedes:
+0021, and update this file's Status to Superseded by NNNN per CONTRIBUTING.md.

--- a/docs/DECISIONS/0022-dry-run-mode.md
+++ b/docs/DECISIONS/0022-dry-run-mode.md
@@ -1,0 +1,147 @@
+# 0022 - Dry-run mode for fetch operations
+
+- **Date:** 2026-05-12
+- **Status:** Proposed
+- **Supersedes:** -
+- **Source:** Discussion #12 (musaabhasan, 2026-05-08)
+
+## Context
+
+The external review on Discussion #12 (musaabhasan, 2026-05-08, comment 1)
+asks doiget to provide
+
+> a dry-run mode that reports the planned resolver/host/path before touching
+> network or filesystem.
+
+Phase 1 today exposes `doiget fetch <ref>` (CLI) and `doiget_fetch_paper`
+(MCP). Both run the full orchestrator: pick the metadata sources that
+`can_serve` the ref under the current `CapabilityProfile`, hit the network,
+write the PDF and metadata TOML, and append to the provenance log. There is no
+way to ask "what *would* you do?" without paying for the network round-trip
+and the on-disk side-effects.
+
+The asymmetry matters for three audiences:
+
+- **Agents.** An LLM building a multi-step plan benefits from being able to
+  preview the resolver chain ("I will fetch via Unpaywall, falling back to
+  arXiv if the OA URL host is denied") before committing the plan to action.
+- **Users debugging configuration drift.** "Why did this DOI go through arXiv
+  yesterday and Unpaywall today?" — a `--dry-run` answer is faster than
+  reading the provenance log.
+- **Security-minded operators.** The review's framing is explicitly about
+  separating *intent* from *side effect*: a dry-run produces an audit-quality
+  preview of where bytes would have flowed, with no bytes flowing.
+
+## Decision
+
+### 1. CLI flag
+
+`doiget fetch <ref> --dry-run` and `doiget batch <path> --dry-run` produce a
+structured preview and exit `0` with no network call, no file write, and no
+provenance row appended.
+
+The preview shape (NORMATIVE) is
+
+```jsonc
+{
+  "ok": true,
+  "dry_run": true,
+  "ref": { "doi": "10.1234/foo" } | { "arxiv": "2401.12345" },
+  "plan": {
+    "metadata_sources": ["crossref", "unpaywall"],
+    "pdf_sources":      [{
+      "key":             "oa-publisher",
+      "candidate_hosts": ["*.springer.com", "*.springeropen.com"]
+    }],
+    "redirect_allowlists_loaded": ["crossref", "unpaywall", "arxiv", "oa-publisher"],
+    "target_pdf_path":            "/home/.../store/doi_10.1234_foo.pdf",
+    "target_metadata_path":       "/home/.../store/doi_10.1234_foo.toml",
+    "would_append_provenance":    true
+  },
+  "rate_limit_budget": {
+    "global_per_sec":        5.0,
+    "per_source_min_gap_ms": 200
+  }
+}
+```
+
+The preview is emitted on `stdout` when `--json` is also passed (or when the
+output mode resolves to `json` per ADR-0017); otherwise a human-friendly form
+is emitted on `stderr` and `stdout` carries no bytes. The
+`would_append_provenance` field is always `true` in Phase 1+ (every successful
+fetch appends a row), but it is named explicitly so future fetch modes can
+declare "this fetch would NOT append" without having to invert the flag's
+meaning.
+
+### 2. MCP parameter
+
+`doiget_fetch_paper` and `doiget_metadata_only` (ADR-0023's companion tool)
+accept an optional `dry_run: boolean` input field, defaulting to `false`. When
+`true`, the tool returns a result with the same `dry_run: true` /
+`plan: {...}` shape as the CLI, never touches the network, and never writes
+to the store.
+
+The `dry_run` flag is rejected as `INVALID_REF`-class (i.e. surfaces as
+`{ok:false, error:{code:"INVALID_REF", ...}}`) on tools where it does not
+apply (e.g. `doiget_info` or `doiget_search_local`), to keep the MCP surface
+homogeneous and to prevent silent acceptance of irrelevant flags.
+
+### 3. No partial dry-run
+
+Dry-run is all-or-nothing per call: either no network and no writes happen, or
+the call is not a dry-run and the full orchestrator runs. There is no
+"dry-run the network leg but write the metadata TOML" mode and there is no
+"dry-run only the PDF leg" mode. This keeps the auditing story simple — every
+provenance row corresponds to a real fetch, and every dry-run preview
+corresponds to zero on-disk side-effects.
+
+### 4. Honesty about candidate uncertainty
+
+The `pdf_sources[].candidate_hosts` list is the static allowlist for the
+named resolver, not the host the actual fetch would have hit. doiget cannot
+know the post-Unpaywall OA URL host without making the Unpaywall network
+call, and `--dry-run` MUST NOT make it. The preview is therefore an
+*upper-bound* on the hosts a real fetch could touch, not a prediction of the
+single host it would touch. This is documented in
+[`MCP_TOOLS.md`](../MCP_TOOLS.md) §"Dry-run preview semantics" and in the CLI
+help text for `--dry-run`.
+
+### 5. Posture lint
+
+The `posture-lint.yml` workflow gains a check that `--dry-run`-tagged code
+paths in `doiget-cli::commands::fetch` and `doiget-mcp` never reach
+`HttpClient::fetch_bytes` / `fetch_pdf` or `FsStore::write_*` /
+`ProvenanceLog::append`. The check is a `grep`-style scan against a
+hand-maintained allowlist of branch points, mirroring the existing
+no-stdout-in-MCP check from ADR-0001.
+
+## Consequences
+
+**Positive.**
+- Agents can preview a fetch plan as a normal MCP call — no out-of-band
+  configuration introspection required.
+- Operators can validate `CapabilityProfile`, `redirect_allowlist`, and store
+  paths without committing to a fetch — useful when a TDM grant is being
+  configured and the operator wants to confirm that "yes, this DOI will go
+  through `tdm-springer` once `DOIGET_AGREE_TDM_SPRINGER=1` is set."
+- The preview shape is a stable contract; integration tests can pin it.
+
+**Negative.**
+- One more codepath to maintain in the orchestrator — the "build a plan
+  without executing it" path. Mitigated by the posture-lint check (§5) that
+  asserts the dry-run path never reaches the side-effecting modules.
+- Honest preview semantics (§4) require explaining to agents that
+  `candidate_hosts` is an upper bound, not a prediction. Documented in
+  `MCP_TOOLS.md` and the CLI help.
+
+**Out of scope.**
+- A "live preview" mode that hits the metadata sources but skips the PDF leg
+  — that is the role of the `doiget_metadata_only` tool (ADR-0023's companion
+  tool), not of `--dry-run`.
+- Persisting dry-run previews to the provenance log. Dry-runs are
+  zero-side-effect by definition; if an operator wants a record of what they
+  tried, `doiget fetch ... --dry-run --json | tee preview.json` is the
+  workflow.
+
+To revise this decision, write a new ADR with Status: Accepted and Supersedes:
+0022, and update this file's Status to Superseded by NNNN per CONTRIBUTING.md.

--- a/docs/DECISIONS/0023-denial-context-structured.md
+++ b/docs/DECISIONS/0023-denial-context-structured.md
@@ -1,0 +1,179 @@
+# 0023 - Structured `denial_context` on error envelopes
+
+- **Date:** 2026-05-12
+- **Status:** Proposed
+- **Supersedes:** -
+- **Source:** Discussion #12 (musaabhasan, 2026-05-09)
+
+## Context
+
+The external review on Discussion #12 (musaabhasan, 2026-05-09, comment 2)
+asks doiget to
+
+> make denial reasons explicit so LLM workflows can recover safely instead of
+> retrying blindly.
+
+Today the public error envelope (NORMATIVE in [`ERRORS.md`](../ERRORS.md) §3
+and [`MCP_TOOLS.md`](../MCP_TOOLS.md) §5) is
+
+```jsonc
+{ "ok": false, "error": { "code": "NETWORK_ERROR", "message": "..." } }
+```
+
+The `code` is one of the closed [`ErrorCode`](../ERRORS.md) variants, and the
+`message` is a free-form human-readable string. ADR-0012 fixes the closed
+code set and ADR-0014 explains why the docs are NORMATIVE.
+
+The closed `ErrorCode` enum is correctly coarse-grained — it is sized for
+*reaction* by humans and agents, not for *diagnosis*. But several of the most
+operationally important denial cases (a redirect blocked by the allowlist, a
+body that exceeded the size cap, a capability that was not granted) are
+*concrete* events whose parameters an LLM agent could use to plan a recovery:
+"the redirect to `evil.example.com` was denied because it is not on the
+crossref allowlist (which contains `api.crossref.org`, `*.crossref.org`) →
+the right next step is to ask the user whether to add a new ADR adding that
+host, NOT to retry blindly."
+
+Today an agent has to text-mine `error.message` to recover that information,
+which is fragile (string formats can change without a major version bump) and
+incomplete (some context is not in the message at all).
+
+## Decision
+
+### 1. Add a structured `denial_context` field to the error envelope
+
+The error envelope becomes
+
+```jsonc
+{
+  "ok": false,
+  "error": {
+    "code":    "NETWORK_ERROR",
+    "message": "redirect target evil.example.com not in allowlist for source crossref",
+    "denial_context": {
+      "reason":    "redirect_not_in_allowlist",
+      "source":    "crossref",
+      "attempted": "evil.example.com",
+      "expected":  ["api.crossref.org", "*.crossref.org"],
+      "hop_index": 1
+    }
+  }
+}
+```
+
+The `denial_context` field is **optional**: every previously-shipped
+`{code, message}` envelope remains valid, and the agent / CLI consumer is free
+to ignore the new field. When present, it is structured and machine-parseable.
+
+### 2. `DenialReason` is a closed enum
+
+Per the user's 2026-05-12 directive (Discussion #12 incorporation review),
+`reason` is a **closed** enum. The Phase-1 set is:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenialReason {
+    /// Redirect target host did not match the source's allowlist.
+    RedirectNotInAllowlist,
+    /// Source produced a URL whose host is on a blocklist (future use).
+    HostInBlockList,
+    /// Body exceeded `PDF_MAX_BYTES`.
+    SizeCapExceeded,
+    /// Store entry's `schema_version` is ahead of this binary.
+    SchemaDrift,
+    /// Source not in `CapabilityProfile`.
+    CapabilityNotGranted,
+    /// Rate limiter rejected the call inside the current window.
+    RateLimitWindow,
+    /// SSRF guard rejected a private / link-local / cloud-metadata address.
+    SsrfPrivateAddress,
+    /// Response Content-Type / magic-byte mismatch.
+    ContentTypeMismatch,
+}
+```
+
+Adding a new variant is a minor semver bump (additive); renaming or
+repurposing one is a breaking change, mirroring the `ErrorCode` rule from
+ADR-0012.
+
+### 3. `DenialContext` field shape
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DenialContext {
+    pub reason:    DenialReason,
+    pub source:    Option<String>,   // resolver source key (e.g. "crossref")
+    pub attempted: Option<String>,   // host, path, or other concrete value
+    pub expected:  Vec<String>,      // allowlist entries / acceptable values
+    pub hop_index: Option<u8>,       // redirect chain position, 0-indexed
+    pub cap:       Option<u64>,      // size or rate cap value
+    pub actual:    Option<u64>,      // observed value (e.g. response bytes)
+}
+```
+
+Field-shape rules (NORMATIVE):
+
+- All fields except `reason` are optional. Producers populate the fields
+  relevant to the reason and leave the rest at default (`None` / empty
+  `Vec`). Consumers MUST tolerate any subset of fields being present.
+- `expected` is `Vec<String>` even when only one value is meaningful, to
+  avoid format ambiguity for cases where multiple values are acceptable
+  (allowlist with several patterns).
+- `hop_index` is `u8` because the redirect chain is hard-capped at 10 in
+  [`http.rs`](../../crates/doiget-core/src/http.rs) (`MAX_REDIRECTS`) and
+  any larger value indicates a bug.
+
+### 4. Mapping table (NORMATIVE)
+
+The producer-side mapping from internal error variants to `DenialContext` is:
+
+| Internal source                                  | `reason`                  | Populated fields                                    |
+|--------------------------------------------------|---------------------------|-----------------------------------------------------|
+| `HttpError::RedirectDenied { source_key, host }` | `redirect_not_in_allowlist` | `source=source_key`, `attempted=host`, `expected=allowlist hosts`, `hop_index` if known |
+| `HttpError::OversizedBody { actual, cap }`       | `size_cap_exceeded`       | `cap`, `actual`                                     |
+| `HttpError::NotAPdf { got }`                     | `content_type_mismatch`   | `attempted=hex(got)`, `expected=["%PDF-"]`          |
+| `HttpError::InsecureRedirect { scheme }`         | `redirect_not_in_allowlist` | `attempted=scheme:...`, `expected=["https"]`        |
+| `FetchError::NotEligible { source_key }`         | `capability_not_granted`  | `source=source_key`                                 |
+| `RateLimiter` denial (future)                    | `rate_limit_window`       | `source`, `cap=per-source rate`                     |
+| Store schema rejection                           | `schema_drift`            | `actual=row schema_version`, `cap=binary version`   |
+| SSRF guard (future)                              | `ssrf_private_address`    | `attempted=ip:port`                                 |
+
+The mapping is implemented as a `From<HttpError> for Option<DenialContext>`
+plus `From<FetchError> for Option<DenialContext>`, sitting next to the
+existing `From<FetchError> for ErrorCode` collapse in
+[`source.rs`](../../crates/doiget-core/src/source.rs).
+
+### 5. `error.message` is still required
+
+`message` MUST continue to embed the concrete parameters in human-readable
+form (per the existing [`ERRORS.md`](../ERRORS.md) §6 "no silent failures"
+posture). `denial_context` is a *parallel* machine-parseable channel for the
+same facts. CLI text consumers and existing log scrapers continue to work
+unchanged; new agent-side consumers can prefer `denial_context` when present.
+
+## Consequences
+
+**Positive.**
+- Agents recover from denials with structured data instead of regex over
+  free-form messages.
+- The closed `DenialReason` enum is review-able: a reviewer can assert "every
+  call site that returns `RedirectDenied` populates `attempted` and
+  `expected`" via a single grep.
+- Backwards compatible: the field is optional and additive.
+
+**Negative.**
+- One more field to keep populated at every error producer site. Mitigated by
+  the `From` impls in §4 — most call sites become one-liner conversions.
+- The closed enum requires an ADR + minor version bump to add a new reason.
+  Acceptable: the same constraint applies to `ErrorCode` (ADR-0012) and we
+  consider it a feature, not a bug.
+
+**Out of scope.**
+- Open-ended `denial_context` (rejected per the user's "closed" directive).
+- A `denial_context` envelope on success results (rejected — this is purely a
+  failure-mode aid).
+
+To revise this decision, write a new ADR with Status: Accepted and Supersedes:
+0023, and update this file's Status to Superseded by NNNN per CONTRIBUTING.md.

--- a/docs/DECISIONS/0023-denial-context-structured.md
+++ b/docs/DECISIONS/0023-denial-context-structured.md
@@ -76,6 +76,8 @@ Per the user's 2026-05-12 directive (Discussion #12 incorporation review),
 pub enum DenialReason {
     /// Redirect target host did not match the source's allowlist.
     RedirectNotInAllowlist,
+    /// Redirect target had a non-HTTPS scheme.
+    InsecureScheme,
     /// Source produced a URL whose host is on a blocklist (future use).
     HostInBlockList,
     /// Body exceeded `PDF_MAX_BYTES`.
@@ -134,7 +136,7 @@ The producer-side mapping from internal error variants to `DenialContext` is:
 | `HttpError::RedirectDenied { source_key, host }` | `redirect_not_in_allowlist` | `source=source_key`, `attempted=host`, `expected=allowlist hosts`, `hop_index` if known |
 | `HttpError::OversizedBody { actual, cap }`       | `size_cap_exceeded`       | `cap`, `actual`                                     |
 | `HttpError::NotAPdf { got }`                     | `content_type_mismatch`   | `attempted=hex(got)`, `expected=["%PDF-"]`          |
-| `HttpError::InsecureRedirect { scheme }`         | `redirect_not_in_allowlist` | `attempted=scheme:...`, `expected=["https"]`        |
+| `HttpError::InsecureRedirect { scheme }`         | `insecure_scheme`         | `attempted=scheme:...`, `expected=["https"]`        |
 | `FetchError::NotEligible { source_key }`         | `capability_not_granted`  | `source=source_key`                                 |
 | `RateLimiter` denial (future)                    | `rate_limit_window`       | `source`, `cap=per-source rate`                     |
 | Store schema rejection                           | `schema_drift`            | `actual=row schema_version`, `cap=binary version`   |

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -34,6 +34,9 @@ See [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) §"ADR workflow".
 | 0018 | Obsidian export is one-direction, optional Phase 7 | Proposed | #15 |
 | 0019 | Eight-safeguard legal posture (5 social + 3 technical) | Proposed | #16 |
 | 0020 | reqwest TLS feature stack (rustls-only, webpki bundled) | Proposed | PR #30 / PR #49 |
+| 0021 | Canonical-tuple identity for fetched papers (spec-only) | Proposed | #12 |
+| 0022 | Dry-run mode for fetch operations | Proposed | #12 |
+| 0023 | Structured `denial_context` on error envelopes | Proposed | #12 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -48,10 +48,42 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured `{ ok: false, error: { code, message } }`. Never throws. |
+| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context? } }`. Never throws. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"..."}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?}}`. Exit code = number of failures (capped at 255). |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
+
+### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
+
+The `error` envelope MAY carry an additional structured `denial_context`
+field for machine-readable recovery. The field is **optional and additive** —
+consumers MUST tolerate both its presence and its absence — and is
+populated by the producer on the denial classes named in the §5 mapping
+table below.
+
+`denial_context.reason` is a **closed** enum (per ADR-0023):
+
+```jsonc
+"denial_context": {
+  "reason":    "redirect_not_in_allowlist",   // closed enum, snake_case
+  "source":    "crossref",                     // resolver source key, optional
+  "attempted": "evil.example.com",             // host/path/value, optional
+  "expected":  ["api.crossref.org",
+                "*.crossref.org"],             // allowlist entries, [] when N/A
+  "hop_index": 1,                              // redirect-chain position, optional
+  "cap":       104857600,                      // size/rate cap, optional
+  "actual":    209715200                       // observed value, optional
+}
+```
+
+Closed `reason` set: `redirect_not_in_allowlist`, `host_in_block_list`,
+`size_cap_exceeded`, `schema_drift`, `capability_not_granted`,
+`rate_limit_window`, `ssrf_private_address`, `content_type_mismatch`. Adding
+a new variant is a minor semver bump; renaming or repurposing one is a
+breaking change.
+
+`error.message` MUST continue to embed the same parameters in human-readable
+form — `denial_context` is a parallel channel, not a replacement.
 
 ## 4. CLI exit codes
 
@@ -74,6 +106,16 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
   presentation per persona.
 - `doiget-mcp` translates `FetchError` to the MCP `{ok: false, error}` shape and never
   throws across the JSON-RPC boundary.
+
+### 5.1 `DenialContext` mapping (ADR-0023 §4)
+
+The producer-side mapping from internal error variants to `DenialContext` is
+defined in [`DECISIONS/0023-denial-context-structured.md`](DECISIONS/0023-denial-context-structured.md)
+§4 (NORMATIVE table). Summary: every `HttpError::RedirectDenied`,
+`OversizedBody`, `NotAPdf`, `InsecureRedirect`, and every
+`FetchError::NotEligible` produces a populated `Option<DenialContext>` via
+`From` impls in `doiget-core`. Other error variants leave `denial_context`
+unset.
 
 ## 6. No silent failures
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -76,11 +76,11 @@ table below.
 }
 ```
 
-Closed `reason` set: `redirect_not_in_allowlist`, `host_in_block_list`,
-`size_cap_exceeded`, `schema_drift`, `capability_not_granted`,
-`rate_limit_window`, `ssrf_private_address`, `content_type_mismatch`. Adding
-a new variant is a minor semver bump; renaming or repurposing one is a
-breaking change.
+Closed `reason` set: `redirect_not_in_allowlist`, `insecure_scheme`,
+`host_in_block_list`, `size_cap_exceeded`, `schema_drift`,
+`capability_not_granted`, `rate_limit_window`, `ssrf_private_address`,
+`content_type_mismatch`. Adding a new variant is a minor semver bump;
+renaming or repurposing one is a breaking change.
 
 `error.message` MUST continue to embed the same parameters in human-readable
 form — `denial_context` is a parallel channel, not a replacement.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -11,12 +11,13 @@ speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal
 | Tool | Purpose |
 |---|---|
 | `doiget_resolve_paper` | Resolve DOI / arXiv id to authoritative metadata. |
-| `doiget_fetch_paper` | Resolve and download a single PDF to the store. |
-| `doiget_batch_fetch` | Up to 100 refs in one call. |
+| `doiget_fetch_paper` | Resolve and download a single PDF to the store. Accepts `dry_run`. |
+| `doiget_metadata_only` | Resolve to metadata. **Guarantees no PDF / publisher fetch.** Accepts `dry_run`. |
+| `doiget_batch_fetch` | Up to 100 refs in one call. Accepts `dry_run`. |
 | `doiget_info` | Retrieve a store entry's metadata. |
 | `doiget_search_local` | Search store metadata (title / authors / venue). |
 | `doiget_list_recent` | Last N fetched entries. |
-| `doiget_paper_pdf_path` | Return the local path of a cached PDF. **Does not read content.** |
+| `doiget_paper_pdf_path` | Return the local path of a cached PDF. **Does not read, parse, or transmit content.** |
 | `doiget_capability_profile` | Report which sources this instance is allowed to use. |
 | `doiget_health` | Operational sanity (store writable, version, schema). |
 
@@ -86,13 +87,30 @@ type FetchResult =
       size_bytes: number,
       schema_version: string,
     }
+  | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
+      rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
   | { ok: false,
       ref: string,
-      error: { code: ErrorCode, message: string }
+      error: { code: ErrorCode, message: string, denial_context?: DenialContext }
     };
+
+type DenialContext = {
+  reason: "redirect_not_in_allowlist" | "host_in_block_list"
+        | "size_cap_exceeded" | "schema_drift" | "capability_not_granted"
+        | "rate_limit_window" | "ssrf_private_address" | "content_type_mismatch",
+  source?: string,
+  attempted?: string,
+  expected: string[],
+  hop_index?: number,
+  cap?: number,
+  actual?: number,
+};
 ```
 
-`ErrorCode` is the closed enum in [`ERRORS.md`](ERRORS.md).
+`ErrorCode` is the closed enum in [`ERRORS.md`](ERRORS.md). `DenialContext`
+is the optional structured-recovery payload defined in
+[ADR-0023](DECISIONS/0023-denial-context-structured.md). `FetchPlan` is the
+dry-run preview shape — see §10 below.
 
 ## 6. Excluded tools (permanent)
 
@@ -136,3 +154,97 @@ type CapabilityProfileResponse = {
 A CI workflow `mcp-smoke.yml` (Phase 3) spawns the server, sends a minimal sequence
 (`initialize` → `tools/list` → `tools/call doiget_health`), asserts the responses, and
 asserts that no stray bytes appeared on stdout outside JSON-RPC frames.
+
+## 10. Dry-run preview (NORMATIVE; ADR-0022)
+
+`doiget_fetch_paper`, `doiget_metadata_only`, and `doiget_batch_fetch` accept
+an optional `dry_run: boolean` input field, defaulting to `false`. When
+`true`:
+
+- The orchestrator builds a `FetchPlan` and returns it without touching the
+  network or the filesystem and without appending a provenance row.
+- The result envelope is `{ ok: true, dry_run: true, ref, plan,
+  rate_limit_budget }`.
+- The `plan.pdf_sources[].candidate_hosts` list is the **static allowlist**
+  for the resolver, not a prediction of the single host the real fetch would
+  hit. doiget cannot resolve the post-Unpaywall OA URL host without making
+  the Unpaywall call, and `dry_run` MUST NOT make it.
+
+```jsonc
+{
+  "ok": true,
+  "dry_run": true,
+  "ref": { "doi": "10.1234/foo" },
+  "plan": {
+    "metadata_sources": ["crossref", "unpaywall"],
+    "pdf_sources":      [{
+      "key":             "oa-publisher",
+      "candidate_hosts": ["*.springer.com", "*.springeropen.com"]
+    }],
+    "redirect_allowlists_loaded": ["crossref", "unpaywall", "arxiv", "oa-publisher"],
+    "target_pdf_path":            "/home/.../store/doi_10.1234_foo.pdf",
+    "target_metadata_path":       "/home/.../store/doi_10.1234_foo.toml",
+    "would_append_provenance":    true
+  },
+  "rate_limit_budget": {
+    "global_per_sec":        5.0,
+    "per_source_min_gap_ms": 200
+  }
+}
+```
+
+Tools where `dry_run` does not apply (`doiget_info`, `doiget_search_local`,
+`doiget_list_recent`, `doiget_paper_pdf_path`, `doiget_capability_profile`,
+`doiget_health`, `doiget_resolve_paper`) reject the field as
+`INVALID_REF`-class — i.e. surface as
+`{ok:false, error:{code:"INVALID_REF", ...}}`.
+
+## 11. `doiget_metadata_only` (NORMATIVE)
+
+`doiget_metadata_only` resolves a `ref` through the configured metadata
+sources (Crossref + Unpaywall + arXiv-meta) and returns the resulting
+metadata. It **MUST NOT** trigger a publisher-side PDF fetch, even when the
+metadata source returns an OA URL. The OA URL, when known, is surfaced in the
+response as `oa_url` (string) for the caller to act on separately.
+
+```jsonc
+{
+  "name": "doiget_metadata_only",
+  "description": "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\nINPUTS: ref (DOI or arXiv id), dry_run (optional bool).\nOUTPUTS: { ok: true, ref, source, license?, oa_url:string|null, metadata } or { ok:false, error }.\nCOSTS: 1-2 s metadata round-trip. No publisher fetch.\nSIDE EFFECTS: Appends a provenance row tagged 'metadata-only' (unless dry_run). Writes the metadata TOML to the store.\nLIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["ref"],
+    "properties": {
+      "ref": {
+        "type": "string",
+        "minLength": 7,
+        "maxLength": 256,
+        "pattern": "^(10\\.\\d{4,9}/[A-Za-z0-9._/()-]+|arXiv:\\d{4}\\.\\d{4,5}|\\d{4}\\.\\d{4,5})$"
+      },
+      "dry_run": { "type": "boolean", "default": false }
+    },
+    "additionalProperties": false
+  }
+}
+```
+
+Output:
+
+```typescript
+type MetadataOnlyResult =
+  | { ok: true,
+      ref: string,
+      source: "crossref" | "unpaywall" | "arxiv",
+      license: string,
+      oa_url: string | null,
+      metadata: object,
+      schema_version: string,
+    }
+  | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
+      rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
+  | { ok: false, ref: string, error: { code: ErrorCode, message: string, denial_context?: DenialContext } };
+```
+
+Posture: covered by the same posture-lint check as ADR-0022 §5 — a
+`metadata_only` codepath that reaches `HttpClient::fetch_pdf` is a hard
+failure.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -95,7 +95,8 @@ type FetchResult =
     };
 
 type DenialContext = {
-  reason: "redirect_not_in_allowlist" | "host_in_block_list"
+  reason: "redirect_not_in_allowlist" | "insecure_scheme"
+        | "host_in_block_list"
         | "size_cap_exceeded" | "schema_drift" | "capability_not_granted"
         | "rate_limit_window" | "ssrf_private_address" | "content_type_mismatch",
   source?: string,

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -25,7 +25,7 @@ pub use crate::capability::{
 };
 pub use crate::source::{Source, FetchContext, FetchResult, FetchError};
 pub use crate::store::{Store, Metadata, EntryInfo, StoreError};
-pub use crate::error::ErrorCode;
+pub use crate::error::{ErrorCode, DenialContext, DenialReason};
 pub use crate::provenance::{ProvenanceLog, LogEvent, LogError};
 ```
 
@@ -178,3 +178,51 @@ Raising the declared MSRV is a **minor** version bump and requires a CHANGELOG
 entry. Lowering it requires an ADR (we do not retroactively re-support older
 toolchains without explicit reason). Phase 6 may re-evaluate the policy and
 adopt a stable-channel-tracks-current-stable-minus-N rule at that point.
+
+## 8. Structured denial context (NORMATIVE; ADR-0023)
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenialReason {
+    RedirectNotInAllowlist,
+    HostInBlockList,
+    SizeCapExceeded,
+    SchemaDrift,
+    CapabilityNotGranted,
+    RateLimitWindow,
+    SsrfPrivateAddress,
+    ContentTypeMismatch,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DenialContext {
+    pub reason:    DenialReason,
+    pub source:    Option<String>,
+    pub attempted: Option<String>,
+    pub expected:  Vec<String>,
+    pub hop_index: Option<u8>,
+    pub cap:       Option<u64>,
+    pub actual:    Option<u64>,
+}
+
+impl From<&crate::http::HttpError> for Option<DenialContext> { /* … */ }
+impl From<&crate::source::FetchError> for Option<DenialContext> { /* … */ }
+```
+
+The `DenialReason` enum is **closed**: adding a variant is a minor semver
+bump, renaming or repurposing one is breaking. The `DenialContext` struct is
+**not** `#[non_exhaustive]` because `deny_unknown_fields` already prevents
+forward-compatible field additions on the wire — adding a field is a
+breaking change. See [`ERRORS.md`](ERRORS.md) §3.1, §5.1 for the runtime
+surface and [`MCP_TOOLS.md`](MCP_TOOLS.md) §5 for the JSON envelope.
+
+## 9. Forward-looking: `CanonicalRef` (Phase 2; ADR-0021)
+
+`CanonicalRef` is **not** part of the Phase 1 public API. It is reserved by
+[ADR-0021](DECISIONS/0021-canonical-tuple-identity.md) for the audit-identity
+shape that Phase 2 will introduce alongside the `provenance_log`
+`canonical_digest` column. Phase 1 callers continue to use `Ref`; Phase 2
+will add `Ref::promote(&str, Option<&str>) -> CanonicalRef` as a minor bump
+and bump the provenance log schema as a coordinated migration.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -186,6 +186,7 @@ adopt a stable-channel-tracks-current-stable-minus-N rule at that point.
 #[serde(rename_all = "snake_case")]
 pub enum DenialReason {
     RedirectNotInAllowlist,
+    InsecureScheme,
     HostInBlockList,
     SizeCapExceeded,
     SchemaDrift,
@@ -195,7 +196,7 @@ pub enum DenialReason {
     ContentTypeMismatch,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DenialContext {
     pub reason:    DenialReason,

--- a/docs/SAFEKEY.md
+++ b/docs/SAFEKEY.md
@@ -95,6 +95,28 @@ end
 The two implementations MUST produce bit-identical output for every entry in the
 reference vector set.
 
+### 3.1 Filename derivation inputs (NORMATIVE)
+
+The safekey is derived **solely from the canonical `Ref` string** (a validated
+DOI or arXiv id, both already path-traversal-checked at parse time). doiget
+MUST NOT use any of the following as filename input:
+
+- HTTP `Content-Disposition` header (`filename=...` or `filename*=...`).
+- Redirect URL path or any URL component returned by the network.
+- Server-suggested filename (any header carrying a string the publisher
+  proposes as a download name).
+- Any byte stream from the network.
+
+This guarantees that an attacker controlling a redirect target or a response
+header cannot influence the on-disk path. The derivation is a pure function
+of `Ref`, computed before the first network byte is sent.
+
+This rule is the spec-side counterpart to the audit-trail
+`canonical_digest` introduced by [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md):
+the on-disk identity stays keyed on `Ref` (so BiblioFetch.jl round-trip
+keeps working — see §7), while the *audit* identity gains the resolver
+profile.
+
 ## 5. Reference test vectors (sample)
 
 Full set: `tests/fixtures/safekey/vectors.json` (100 entries, NORMATIVE).


### PR DESCRIPTION
## Summary

Lands the five external-review items from [Discussion #12](https://github.com/sotashimozono/doiget/discussions/12) (musaabhasan, 2026-05-08 / 2026-05-09). Background: only 1 of the 5 items (the redirect-host allowlist) had landed previously (in `docs/REDIRECT_ALLOWLIST.md` + `crates/doiget-core/src/sources/redirect_allowlist.toml`); this PR closes the remaining 5.

| # | Item | Where it lands |
|---|---|---|
| 1 | `--dry-run` mode (CLI + MCP) | ADR-0022 + `core/dry_run.rs` + CLI `--dry-run` flag + MCP `dry_run` param |
| 2 | structured `denial_context` on errors | ADR-0023 + `core/lib.rs` (DenialReason / DenialContext) + `From<&HttpError>` / `From<&FetchError>` impls |
| 3 | `doiget_metadata_only` MCP tool | `crates/doiget-mcp/src/lib.rs` (dry-run path wired; non-dry-run path stubbed for follow-up) |
| 4 | canonical-tuple identity (audit-side) | ADR-0021 (**spec-only** per the design discussion; impl deferred to Phase 2 alongside provenance log schema bump) |
| 5 | filename derivation NORMATIVE rule | `docs/SAFEKEY.md` §3.1 |

## Why

- musaabhasan's framing on #12 explicitly asks for separating *intent* from *side effect* (`--dry-run`), separating *identifier trust* from *network authority* (canonical tuple), and giving LLM agents *structured* recovery hooks instead of `error.message` regex (denial_context).
- All five are accepted, four ship with implementation, the canonical-tuple item is spec-only this PR by explicit design decision (avoids breaking the provenance log hash chain in a Phase-1 minor bump).

## Spec layer

- `docs/DECISIONS/0021-canonical-tuple-identity.md` (NEW; spec-only)
- `docs/DECISIONS/0022-dry-run-mode.md` (NEW)
- `docs/DECISIONS/0023-denial-context-structured.md` (NEW)
- `docs/DECISIONS/INDEX.md` updated
- `docs/ERRORS.md` §3.1 (envelope) + §5.1 (mapping table)
- `docs/MCP_TOOLS.md` §1 tool list updated, §5 envelope updated, §10 dry-run preview, §11 metadata_only tool
- `docs/PUBLIC_API.md` §1 re-exports updated, §8 DenialContext / DenialReason types, §9 forward-look on CanonicalRef
- `docs/SAFEKEY.md` §3.1 filename-derivation NORMATIVE paragraph

## Implementation

- `doiget-core`:
  - `DenialReason` (closed enum, 8 variants, snake_case wire) + `DenialContext` struct (`#[serde(deny_unknown_fields)]`, all-but-`reason` optional with skip-if-empty/none).
  - `HttpError::RedirectDenied` extended with `expected_hosts: Vec<String>` so the closure can populate the allowlist snapshot at error time.
  - `From<&HttpError> for Option<DenialContext>` + `From<&FetchError> for Option<DenialContext>` per the ADR-0023 §4 mapping table.
  - New `core::dry_run` module with `FetchPlan` / `PdfSourcePlan` / `RateLimitBudget` types and `build_fetch_plan` / `build_dry_run_envelope` helpers (placed in core so MCP and CLI emit byte-identical envelopes).
- `doiget-cli`:
  - `--dry-run` flag on `fetch` and `batch` commands.
  - `FetchOptions` / `BatchOptions` bundles + `run_with_options(...)` async entry points; existing `run(...)` preserved as a default-arg delegator (zero existing-test breakage).
  - JSON envelope to stdout when `--dry-run` is set.
- `doiget-mcp`:
  - New `doiget_metadata_only` tool wired with `dry_run: Option<bool>` input.
  - Dry-run path returns the same `FetchPlan` envelope as the CLI; non-dry-run path returns `INTERNAL_ERROR` envelope with explicit `// TODO(phase-1.x):` for the metadata-only orchestrator (acknowledged scope deferral; see ADR-0023 in-PR + the TODO).

## Tests

- 23 new tests: 5 DenialContext serde (snake_case wire, round-trip, skip-empty serialize, deserialize tolerance, deny_unknown_fields rejection), 5 HttpError mapping (RedirectDenied / OversizedBody / NotAPdf / InsecureRedirect / non-denial), 3 FetchError mapping, 6 FetchPlan shape, 4 CLI dry-run E2E (asserts no log file / no PDF / no metadata TOML created on dry-run path).
- Full workspace: **210 tests pass**, 0 failed, 0 ignored.
- `cargo fmt --check` clean. `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Out of scope (acknowledged)

- `CanonicalRef` Rust type and `canonical_digest` provenance log column — deferred to Phase 2 per ADR-0021 §3 (requires hash-chain re-computation migration).
- `dry_run` rejection on tools that don't yet exist in the MCP server (`doiget_fetch_paper`, `doiget_batch_fetch` — spec'd in MCP_TOOLS.md but not yet wired).
- Posture-lint workflow check from ADR-0022 §5 (pure-function `dry_run` path is structurally side-effect-free already; CI lint can be added in a follow-up if drift becomes a concern).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (210/210 green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Replay `doiget fetch 10.1234/foo --dry-run` against a wiremock to confirm zero outbound (existing `no_outbound_network` integration test infrastructure already covers this in spirit; the new E2E tests assert no FS writes)
- [ ] Replay MCP `tools/call doiget_metadata_only` with `dry_run: true` against the smoke-test harness

Closes the remaining work surfaced by Discussion #12.