### PR TITLE
refine: 4 design refinements following merged PR #84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,8 +251,8 @@ is reserved for Phase 2 (per ADR-0021 §3).
 
 ##### Post-incorporation review refinements (items 2/3/4/5)
 
-Four refinements landed on top of the C1/C2/I1–I7 review-fix commit
-(`6ba435a`) to harden the wire contracts the previous commits introduced:
+Four refinements landed on top of the C1/C2/I1–I7 review-fix commit to
+harden the wire contracts the previous commits introduced:
 
 - **(2)** ADR-0021 §1 (canonical-digest): made the `version_or_empty`
   byte-sequence semantics fully unambiguous — `version = None` MUST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,4 +249,49 @@ is reserved for Phase 2 (per ADR-0021 §3).
   `crates/doiget-core/Cargo.toml` so `Utf8PathBuf` fields on `FetchPlan`
   serialize. (`doiget-cli` already enabled the same feature.)
 
+##### Post-incorporation review refinements (items 2/3/4/5)
+
+Four refinements landed on top of the C1/C2/I1–I7 review-fix commit
+(`6ba435a`) to harden the wire contracts the previous commits introduced:
+
+- **(2)** ADR-0021 §1 (canonical-digest): made the `version_or_empty`
+  byte-sequence semantics fully unambiguous — `version = None` MUST
+  serialize as the empty byte sequence (zero bytes), NOT a `"null"` /
+  `"none"` / `"-"` sentinel. Docs-only; Phase 2 implementations
+  (`CanonicalRef`) can no longer disagree about the missing-version
+  digest.
+- **(3)** `DenialContext.expected: Vec<String>` → `Option<Vec<String>>`.
+  `None` = "producer did not populate this field for this reason";
+  `Some(vec![])` = "explicit empty allowlist". The previous shape
+  collapsed both states, leaving an LLM agent unable to disambiguate
+  "field not applicable" from "field applies but allowlist happens to
+  be empty". Updated in `doiget-core/src/lib.rs` (struct + 4 tests),
+  `doiget-core/src/http.rs` (4 `From` arms + 4 tests),
+  `doiget-core/src/source.rs` (1 `From` arm + 1 test),
+  `doiget-core/tests/redirect_denied_denial_context_e2e.rs` (2 tests),
+  plus ADR-0023 §3 + §4, ERRORS.md §3.1, MCP_TOOLS.md §5, PUBLIC_API.md
+  §8. New
+  `denial_context_expected_some_empty_vec_preserves_explicit_empty_allowlist`
+  test pins the disambiguation on the wire.
+- **(4)** Added `FetchPlan.candidate_hosts_are_upper_bound: bool` (always
+  `true` in Phase 1). Machine-encodes ADR-0022 §4 ("Honesty about
+  candidate uncertainty") directly into the dry-run envelope, so an
+  agent can detect the upper-bound semantics of `candidate_hosts`
+  without consulting the spec. Updated `doiget-core/src/dry_run.rs`
+  (struct + producer + new test), ADR-0022 §1 + prose, MCP_TOOLS.md §10.
+- **(5)** Added `ErrorCode::NotImplemented` (wire form `"NOT_IMPLEMENTED"`).
+  Distinct from `INTERNAL_ERROR` (a bug) and `CAPABILITY_DENIED` (a
+  runtime config gate). `doiget_metadata_only`'s non-dry-run stub
+  changed from `INTERNAL_ERROR` to `NOT_IMPLEMENTED` so agents react
+  with "wait for next minor release" rather than "report a bug". The
+  `metadata_only_error_envelope` helper now takes a typed `ErrorCode`
+  rather than `&str` (the I6 lesson from review-pr A5: free-form
+  string codes can drift from the SCREAMING_SNAKE_CASE rendering
+  without the compiler noticing). Test
+  `doiget_metadata_only_default_dry_run_false_returns_internal_error_stub`
+  → `..._returns_not_implemented_stub`. Updated `doiget-core/src/lib.rs`
+  (enum), `doiget-mcp/src/lib.rs` (stub + helper),
+  `doiget-mcp/tests/initialize_handshake.rs` (renamed test),
+  ERRORS.md §1 + §2 (new variant + semantics row).
+
 [Unreleased]: https://github.com/sotashimozono/doiget/compare/main...HEAD

--- a/crates/doiget-core/src/dry_run.rs
+++ b/crates/doiget-core/src/dry_run.rs
@@ -76,6 +76,13 @@ pub struct FetchPlan {
     /// fetch would NOT append" without inverting the flag's meaning
     /// (ADR-0022 §1).
     pub would_append_provenance: bool,
+    /// Always `true` in Phase 1: [`PdfSourcePlan::candidate_hosts`] is the
+    /// **static allowlist** for the resolver, NOT a prediction of the
+    /// single host the real fetch would touch. See ADR-0022 §4 ("Honesty
+    /// about candidate uncertainty"). The field is machine-parseable so
+    /// an agent can detect the upper-bound semantics without reading the
+    /// spec — encoding the §4 disclaimer into the wire shape itself.
+    pub candidate_hosts_are_upper_bound: bool,
 }
 
 /// Hard-coded rate-limit budget surfaced with every [`FetchPlan`] preview.
@@ -181,6 +188,12 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
         target_pdf_path,
         target_metadata_path,
         would_append_provenance: true,
+        // Always `true` in Phase 1 per ADR-0022 §4 ("Honesty about
+        // candidate uncertainty"): `candidate_hosts` is the static
+        // resolver allowlist, NOT a prediction of the single host the
+        // real fetch would touch. Surfaced on the wire so agents can
+        // detect the upper-bound semantics without parsing the spec.
+        candidate_hosts_are_upper_bound: true,
     }
 }
 
@@ -297,6 +310,24 @@ mod tests {
         let plan = build_fetch_plan(&r, &temp_root());
         let env = build_dry_run_envelope(&r, &plan);
         assert_eq!(env["ref"], serde_json::json!({ "arxiv": "2401.12345" }));
+    }
+
+    #[test]
+    fn fetch_plan_carries_candidate_hosts_are_upper_bound_true() {
+        // ADR-0022 §4 ("Honesty about candidate uncertainty"): the field
+        // is always `true` in Phase 1, and the wire envelope must
+        // surface it inside `plan` so agents can detect the upper-bound
+        // semantics without consulting the spec.
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        let plan = build_fetch_plan(&r, &temp_root());
+        assert!(plan.candidate_hosts_are_upper_bound);
+        let env = build_dry_run_envelope(&r, &plan);
+        assert_eq!(
+            env["plan"]["candidate_hosts_are_upper_bound"],
+            serde_json::json!(true),
+            "plan.candidate_hosts_are_upper_bound must be true on the \
+             wire (ADR-0022 §4); got: {env}"
+        );
     }
 
     #[test]

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -310,7 +310,7 @@ impl From<&HttpError> for Option<crate::DenialContext> {
                 reason: DenialReason::RedirectNotInAllowlist,
                 source: Some(source_key.clone()),
                 attempted: Some(host.clone()),
-                expected: expected_hosts.clone(),
+                expected: Some(expected_hosts.clone()),
                 hop_index: None,
                 cap: None,
                 actual: None,
@@ -319,7 +319,11 @@ impl From<&HttpError> for Option<crate::DenialContext> {
                 reason: DenialReason::SizeCapExceeded,
                 source: None,
                 attempted: None,
-                expected: Vec::new(),
+                // The size-cap reason has no allowlist channel; use
+                // `None` to signal "field not populated by producer"
+                // rather than `Some(vec![])` (which would mean "explicit
+                // empty allowlist"). See `DenialContext::expected` docs.
+                expected: None,
                 hop_index: None,
                 cap: Some(*cap),
                 actual: Some(*actual),
@@ -336,7 +340,7 @@ impl From<&HttpError> for Option<crate::DenialContext> {
                     "{:02x}{:02x}{:02x}{:02x}{:02x}",
                     got[0], got[1], got[2], got[3], got[4]
                 )),
-                expected: vec!["%PDF-".to_string()],
+                expected: Some(vec!["%PDF-".to_string()]),
                 hop_index: None,
                 cap: None,
                 actual: None,
@@ -345,7 +349,7 @@ impl From<&HttpError> for Option<crate::DenialContext> {
                 reason: DenialReason::InsecureScheme,
                 source: None,
                 attempted: Some(format!("{}:...", scheme)),
-                expected: vec!["https".to_string()],
+                expected: Some(vec!["https".to_string()]),
                 hop_index: None,
                 cap: None,
                 actual: None,
@@ -1223,8 +1227,8 @@ mod tests {
         assert_eq!(dc.source.as_deref(), Some("crossref"));
         assert_eq!(dc.attempted.as_deref(), Some("evil.example.com"));
         assert_eq!(
-            dc.expected,
-            vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()]
+            dc.expected.as_deref(),
+            Some(&["api.crossref.org".to_string(), "*.crossref.org".to_string()][..])
         );
         assert!(dc.cap.is_none());
         assert!(dc.actual.is_none());
@@ -1245,7 +1249,10 @@ mod tests {
         assert_eq!(dc.actual, Some(209_715_200));
         assert!(dc.source.is_none());
         assert!(dc.attempted.is_none());
-        assert!(dc.expected.is_empty());
+        // OversizedBody has no allowlist channel: producer leaves
+        // `expected` at `None` (NOT `Some(vec![])`). See the field doc on
+        // `DenialContext::expected` for the disambiguation.
+        assert!(dc.expected.is_none());
     }
 
     #[test]
@@ -1260,7 +1267,7 @@ mod tests {
         let dc = dc.expect("NotAPdf -> Some(DenialContext)");
         assert_eq!(dc.reason, DenialReason::ContentTypeMismatch);
         assert_eq!(dc.attempted.as_deref(), Some("3c68746d6c"));
-        assert_eq!(dc.expected, vec!["%PDF-".to_string()]);
+        assert_eq!(dc.expected.as_deref(), Some(&["%PDF-".to_string()][..]));
     }
 
     #[test]
@@ -1276,7 +1283,7 @@ mod tests {
         // allowlist reason — they are semantically distinct denials.
         assert_eq!(dc.reason, DenialReason::InsecureScheme);
         assert_eq!(dc.attempted.as_deref(), Some("http:..."));
-        assert_eq!(dc.expected, vec!["https".to_string()]);
+        assert_eq!(dc.expected.as_deref(), Some(&["https".to_string()][..]));
     }
 
     #[test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -618,6 +618,14 @@ pub enum ErrorCode {
     LockTimeout,
     /// Bug — please open an issue.
     InternalError,
+    /// Feature is spec'd but not yet wired in this Phase. Distinct from
+    /// [`Self::InternalError`] (which signals a bug) and
+    /// [`Self::CapabilityDenied`] (which signals a runtime config gate).
+    /// Returned by stubs that exist to pin the public surface ahead of
+    /// orchestrator implementation, so an agent can react with "wait for
+    /// next minor release" rather than "report a bug" or "tweak my
+    /// capability profile". Wire form: `"NOT_IMPLEMENTED"`.
+    NotImplemented,
 }
 
 // ---------------------------------------------------------------------------
@@ -682,10 +690,17 @@ pub enum DenialReason {
 /// construction outside the crate AND wire-level extension — must agree.
 ///
 /// All fields except `reason` are optional. Producers populate the fields
-/// relevant to the reason and leave the rest at default (`None` / empty
-/// `Vec`); consumers MUST tolerate any subset of fields being present.
-/// Optional / empty fields are skipped on serialize but accepted as missing
-/// on deserialize via `#[serde(default, skip_serializing_if = ...)]`.
+/// relevant to the reason and leave the rest at `None`; consumers MUST
+/// tolerate any subset of fields being present. Optional fields are
+/// skipped on serialize but accepted as missing on deserialize via
+/// `#[serde(default, skip_serializing_if = "Option::is_none")]`.
+///
+/// [`Self::expected`] is `Option<Vec<String>>` rather than `Vec<String>`
+/// so the producer can distinguish "this reason has no allowlist channel"
+/// (`None` → field absent on the wire) from "this is the explicit list of
+/// acceptable values, possibly empty" (`Some(vec![])` → `"expected":[]` on
+/// the wire). The previous `Vec<String>` shape collapsed both states
+/// into "field omitted", which an LLM agent could not safely disambiguate.
 ///
 /// Mapping table: see ADR-0023 §4, plus the
 /// `From<&HttpError> for Option<DenialContext>` and
@@ -704,11 +719,15 @@ pub struct DenialContext {
     /// as opaque text.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attempted: Option<String>,
-    /// Allowlist entries / acceptable values. `Vec<String>` even when only
-    /// one value is meaningful (e.g. `["%PDF-"]`), so the format does not
-    /// have to flip when multiple values are acceptable.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub expected: Vec<String>,
+    /// Allowlist entries / acceptable values. `Option<Vec<String>>` so the
+    /// producer can distinguish "this reason has no allowlist channel"
+    /// (`None`, field absent on the wire) from "this is the explicit list
+    /// of acceptable values, possibly empty" (`Some(vec![])`, `"expected":[]`
+    /// on the wire). The inner `Vec<String>` is used even when only one
+    /// value is meaningful (e.g. `Some(vec!["%PDF-".into()])`) so the
+    /// format does not have to flip when multiple values are acceptable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected: Option<Vec<String>>,
     /// Redirect-chain hop position, 0-indexed. `u8` because the chain is
     /// hard-capped at [`crate::http`]'s `MAX_REDIRECTS` (= 10) and any
     /// larger value indicates a bug.
@@ -1909,7 +1928,10 @@ mod tests {
             reason: DenialReason::RedirectNotInAllowlist,
             source: Some("crossref".to_string()),
             attempted: Some("evil.example.com".to_string()),
-            expected: vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()],
+            expected: Some(vec![
+                "api.crossref.org".to_string(),
+                "*.crossref.org".to_string(),
+            ]),
             hop_index: Some(1),
             cap: None,
             actual: None,
@@ -1921,19 +1943,44 @@ mod tests {
 
     #[test]
     fn denial_context_serialize_elides_empty_fields() {
-        // `skip_serializing_if` must keep the wire form lean: None / empty
-        // Vec MUST NOT appear on the wire. Reason is always present.
+        // `skip_serializing_if = "Option::is_none"` must keep the wire form
+        // lean: every `None` field MUST NOT appear on the wire. Reason is
+        // always present.
         let dc = DenialContext {
             reason: DenialReason::CapabilityNotGranted,
             source: None,
             attempted: None,
-            expected: Vec::new(),
+            expected: None,
             hop_index: None,
             cap: None,
             actual: None,
         };
         let s = serde_json::to_string(&dc).expect("ser");
         assert_eq!(s, "{\"reason\":\"capability_not_granted\"}");
+    }
+
+    #[test]
+    fn denial_context_expected_some_empty_vec_preserves_explicit_empty_allowlist() {
+        // Post-refinement disambiguation: `expected: Some(vec![])` is the
+        // "explicit empty allowlist" signal and MUST survive the wire as
+        // `"expected":[]`. Only `expected: None` is skipped on serialize.
+        // This is the bug the previous `Vec<String>` shape masked.
+        let dc = DenialContext {
+            reason: DenialReason::RedirectNotInAllowlist,
+            source: Some("crossref".to_string()),
+            attempted: Some("evil.example.com".to_string()),
+            expected: Some(Vec::new()),
+            hop_index: None,
+            cap: None,
+            actual: None,
+        };
+        let s = serde_json::to_string(&dc).expect("ser");
+        assert!(
+            s.contains("\"expected\":[]"),
+            "expected:[] must survive on the wire (got: {s})"
+        );
+        let back: DenialContext = serde_json::from_str(&s).expect("de");
+        assert_eq!(back.expected, Some(Vec::new()));
     }
 
     #[test]
@@ -1948,7 +1995,7 @@ mod tests {
         assert_eq!(dc.actual, Some(209715200));
         assert!(dc.source.is_none());
         assert!(dc.attempted.is_none());
-        assert!(dc.expected.is_empty());
+        assert!(dc.expected.is_none());
         assert!(dc.hop_index.is_none());
     }
 
@@ -1972,7 +2019,7 @@ mod tests {
             reason: DenialReason::RedirectNotInAllowlist,
             source: Some("crossref".into()),
             attempted: Some("evil.example.com".into()),
-            expected: vec!["api.crossref.org".into(), "*.crossref.org".into()],
+            expected: Some(vec!["api.crossref.org".into(), "*.crossref.org".into()]),
             hop_index: Some(1),
             cap: None,
             actual: None,

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -149,7 +149,10 @@ impl From<&FetchError> for Option<crate::DenialContext> {
                 reason: DenialReason::CapabilityNotGranted,
                 source: Some(source_key.clone()),
                 attempted: None,
-                expected: Vec::new(),
+                // CapabilityNotGranted has no allowlist channel: the
+                // producer leaves `expected` at `None` (NOT `Some(vec![])`).
+                // See `DenialContext::expected` for the disambiguation.
+                expected: None,
                 hop_index: None,
                 cap: None,
                 actual: None,
@@ -377,7 +380,10 @@ mod tests {
         assert_eq!(dc.reason, DenialReason::CapabilityNotGranted);
         assert_eq!(dc.source.as_deref(), Some("tdm-elsevier"));
         assert!(dc.attempted.is_none());
-        assert!(dc.expected.is_empty());
+        // Post-refinement: `expected: None` ("producer did not populate")
+        // rather than `Some(vec![])` ("explicit empty allowlist"). See
+        // `DenialContext::expected` field doc for the disambiguation.
+        assert!(dc.expected.is_none());
     }
 
     #[test]

--- a/crates/doiget-core/tests/redirect_denied_denial_context_e2e.rs
+++ b/crates/doiget-core/tests/redirect_denied_denial_context_e2e.rs
@@ -105,18 +105,21 @@ async fn redirect_outside_allowlist_surfaces_denial_context_via_source_chain() {
          (got: {:?})",
         dc.attempted,
     );
+    let expected_hosts = dc.expected.as_deref().expect(
+        "RedirectNotInAllowlist must populate expected (post-refinement: Some(_), not None)",
+    );
     assert!(
-        !dc.expected.is_empty(),
+        !expected_hosts.is_empty(),
         "expected allowlist hosts must be carried through (the original \
          RedirectDenied snapshots them — see http.rs `expected_hosts` \
          field), got: {:?}",
-        dc.expected,
+        expected_hosts,
     );
     assert!(
-        dc.expected.iter().any(|h| h == &host),
+        expected_hosts.iter().any(|h| h == &host),
         "expected allowlist hosts must include the wiremock host {:?}; got: {:?}",
         host,
-        dc.expected,
+        expected_hosts,
     );
 }
 
@@ -181,6 +184,9 @@ fn source_chain_walk_recovers_wrapped_redirect_denied() {
     assert_eq!(dc.attempted.as_deref(), Some("evil.example.com"));
     assert_eq!(
         dc.expected,
-        vec!["api.crossref.org".to_string(), "*.crossref.org".to_string()]
+        Some(vec![
+            "api.crossref.org".to_string(),
+            "*.crossref.org".to_string(),
+        ]),
     );
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -37,7 +37,7 @@
 use camino::Utf8PathBuf;
 
 use doiget_core::dry_run::{build_dry_run_envelope, build_fetch_plan};
-use doiget_core::{CapabilityProfile, Ref, SCHEMA_VERSION, VERSION};
+use doiget_core::{CapabilityProfile, ErrorCode, Ref, SCHEMA_VERSION, VERSION};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{CallToolResult, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
@@ -169,9 +169,13 @@ impl Server {
     /// the orchestrator that performs a real metadata-only fetch (with
     /// the `metadata-only` provenance tag and no PDF leg) lands in a
     /// follow-up PR. The non-dry-run path returns
-    /// `{ok:false, error:{code:"INTERNAL_ERROR", ...}}` with a clear
-    /// message. The dry-run path is the user-visible value-add this PR
-    /// ships, per ADR-0022 (the `dry_run` companion ADR).
+    /// `{ok:false, error:{code:"NOT_IMPLEMENTED", ...}}` with a clear
+    /// message; `ErrorCode::NotImplemented` is the typed signal the
+    /// post-incorporation review (item 5) introduced specifically for
+    /// "spec'd but not yet wired" stubs — distinct from `INTERNAL_ERROR`
+    /// (a bug) and `CAPABILITY_DENIED` (a runtime config gate). The
+    /// dry-run path is the user-visible value-add this PR ships, per
+    /// ADR-0022 (the `dry_run` companion ADR).
     #[tool(
         description = "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\n\
                        INPUTS: ref (DOI or arXiv id), dry_run (optional bool).\n\
@@ -190,7 +194,7 @@ impl Server {
             Ok(r) => r,
             Err(e) => {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
-                    "INVALID_REF",
+                    ErrorCode::InvalidRef,
                     &format!("invalid ref: {e}"),
                 )));
             }
@@ -214,8 +218,14 @@ impl Server {
         }
 
         // Step 3: non-dry-run path. The real metadata-only orchestrator
-        // lands in a follow-up PR; surface a clear INTERNAL_ERROR
-        // envelope so an agent doesn't get a confusing default reply.
+        // lands in a follow-up PR; surface a clear NOT_IMPLEMENTED
+        // envelope so an agent reacts with "wait for the next minor
+        // release" rather than "report a bug" (INTERNAL_ERROR) or
+        // "tweak my capability profile" (CAPABILITY_DENIED). The typed
+        // `ErrorCode::NotImplemented` value (rather than a raw string
+        // literal) is the I6 lesson from the PR #84 multi-agent review:
+        // the envelope's `code` field MUST come from the closed enum
+        // so a typo in the literal cannot ship.
         // TODO(phase-1.x): wire the metadata-only orchestrator.
         // It should: dispatch Crossref + Unpaywall (DOI) or arXiv-meta
         // (arXiv), write the metadata TOML, append a `Fetch` row tagged
@@ -224,8 +234,10 @@ impl Server {
         // reported but never followed (that is the contract that
         // distinguishes this tool from `doiget_fetch_paper`).
         Ok(CallToolResult::structured(metadata_only_error_envelope(
-            "INTERNAL_ERROR",
-            "metadata_only is not yet wired in Phase 1; only dry_run is supported",
+            ErrorCode::NotImplemented,
+            "metadata-only orchestrator is not yet wired in Phase 1; \
+             only dry_run is supported. Will be implemented in a \
+             follow-up PR.",
         )))
     }
 }
@@ -261,18 +273,24 @@ pub struct MetadataOnlyInput {
 }
 
 /// Build the `{ok:false, error:{...}}` envelope used by
-/// `doiget_metadata_only` for both INVALID_REF (bad input) and
-/// INTERNAL_ERROR (Phase 1 stub) cases. Mirrors the wire shape from
+/// `doiget_metadata_only` for both `INVALID_REF` (bad input) and
+/// `NOT_IMPLEMENTED` (Phase 1 stub) cases. Mirrors the wire shape from
 /// `docs/MCP_TOOLS.md` §5; `denial_context` is omitted (these failure
 /// modes do not produce one — see `docs/ERRORS.md` §3.1).
-fn metadata_only_error_envelope(code: &str, message: &str) -> Value {
+///
+/// The `code` parameter is typed as [`ErrorCode`] (not `&str`) so the
+/// closed enum is the single source of truth for the wire token — the
+/// I6 lesson from PR #84's multi-agent review: free-form string codes
+/// can drift from `ErrorCode`'s SCREAMING_SNAKE_CASE rendering without
+/// the compiler noticing.
+fn metadata_only_error_envelope(code: ErrorCode, message: &str) -> Value {
     json!({
         "ok": false,
         "error": {
             "code": code,
             "message": message,
             // denial_context is intentionally absent for these envelope
-            // shapes (parse-error / internal-error); ADR-0023 §3 says
+            // shapes (parse-error / not-implemented); ADR-0023 §3 says
             // consumers MUST tolerate the field being absent.
         },
     })

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -256,7 +256,7 @@ async fn doiget_metadata_only_dry_run_true_returns_fetch_plan_envelope() -> anyh
 }
 
 #[tokio::test]
-async fn doiget_metadata_only_default_dry_run_false_returns_internal_error_stub(
+async fn doiget_metadata_only_default_dry_run_false_returns_not_implemented_stub(
 ) -> anyhow::Result<()> {
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -276,11 +276,14 @@ async fn doiget_metadata_only_default_dry_run_false_returns_internal_error_stub(
         .expect("doiget_metadata_only stub uses CallToolResult::structured");
 
     // Phase 1: the non-dry-run branch is a documented stub returning
-    // INTERNAL_ERROR with a clear message (see Server::doiget_metadata_only).
+    // NOT_IMPLEMENTED with a clear message (see Server::doiget_metadata_only).
+    // The post-incorporation review (item 5) introduced ErrorCode::NotImplemented
+    // specifically to distinguish "spec'd but not yet wired" stubs from
+    // bugs (INTERNAL_ERROR) or capability gates (CAPABILITY_DENIED).
     assert_eq!(structured["ok"], serde_json::json!(false));
     assert_eq!(
         structured["error"]["code"],
-        serde_json::json!("INTERNAL_ERROR"),
+        serde_json::json!("NOT_IMPLEMENTED"),
         "envelope: {structured:?}"
     );
     let msg = structured["error"]["message"]
@@ -288,7 +291,7 @@ async fn doiget_metadata_only_default_dry_run_false_returns_internal_error_stub(
         .expect("error.message is a string");
     assert!(
         msg.contains("not yet wired") || msg.contains("dry_run"),
-        "INTERNAL_ERROR stub message must mention the Phase 1 limitation; \
+        "NOT_IMPLEMENTED stub message must mention the Phase 1 limitation; \
          got: {msg:?}"
     );
 

--- a/docs/DECISIONS/0021-canonical-tuple-identity.md
+++ b/docs/DECISIONS/0021-canonical-tuple-identity.md
@@ -70,6 +70,13 @@ canonical_digest := SHA256( source_type | 0x00 | source_id | 0x00
 with `|` denoting byte concatenation, `0x00` as an unambiguous field separator,
 and `version_or_empty` being either the version string or an empty string.
 
+> **NORMATIVE.** When `version` is `None`, the `version_or_empty` byte sequence
+> MUST be the empty string (zero bytes). doiget MUST NOT use any sentinel value
+> (`"null"`, `"none"`, `"-"`, etc.) for an absent version — only the literal
+> empty byte sequence between the preceding `0x00` separator and the SHA-256
+> finalize call. This guarantees that two implementations of the canonical
+> digest cannot disagree about the missing-version case.
+
 ### 2. `safekey` continues to depend on `Ref` only
 
 The on-disk filename derivation algorithm in [`SAFEKEY.md`](../SAFEKEY.md) is

--- a/docs/DECISIONS/0022-dry-run-mode.md
+++ b/docs/DECISIONS/0022-dry-run-mode.md
@@ -53,10 +53,11 @@ The preview shape (NORMATIVE) is
       "key":             "oa-publisher",
       "candidate_hosts": ["*.springer.com", "*.springeropen.com"]
     }],
-    "redirect_allowlists_loaded": ["crossref", "unpaywall", "arxiv", "oa-publisher"],
-    "target_pdf_path":            "/home/.../store/doi_10.1234_foo.pdf",
-    "target_metadata_path":       "/home/.../store/doi_10.1234_foo.toml",
-    "would_append_provenance":    true
+    "redirect_allowlists_loaded":      ["crossref", "unpaywall", "arxiv", "oa-publisher"],
+    "candidate_hosts_are_upper_bound": true,
+    "target_pdf_path":                 "/home/.../store/doi_10.1234_foo.pdf",
+    "target_metadata_path":            "/home/.../store/doi_10.1234_foo.toml",
+    "would_append_provenance":         true
   },
   "rate_limit_budget": {
     "global_per_sec":        5.0,
@@ -72,6 +73,13 @@ is emitted on `stderr` and `stdout` carries no bytes. The
 fetch appends a row), but it is named explicitly so future fetch modes can
 declare "this fetch would NOT append" without having to invert the flag's
 meaning.
+
+The `candidate_hosts_are_upper_bound` field is always `true` in Phase 1 and
+machine-encodes the §4 ("Honesty about candidate uncertainty") disclaimer
+directly into the wire envelope: `pdf_sources[].candidate_hosts` is the
+static resolver allowlist, NOT a prediction of the single host the real
+fetch would touch. The field exists so an agent can detect the upper-bound
+semantics without consulting the spec.
 
 ### 2. MCP parameter
 

--- a/docs/DECISIONS/0023-denial-context-structured.md
+++ b/docs/DECISIONS/0023-denial-context-structured.md
@@ -108,7 +108,7 @@ pub struct DenialContext {
     pub reason:    DenialReason,
     pub source:    Option<String>,   // resolver source key (e.g. "crossref")
     pub attempted: Option<String>,   // host, path, or other concrete value
-    pub expected:  Vec<String>,      // allowlist entries / acceptable values
+    pub expected:  Option<Vec<String>>, // allowlist entries / acceptable values
     pub hop_index: Option<u8>,       // redirect chain position, 0-indexed
     pub cap:       Option<u64>,      // size or rate cap value
     pub actual:    Option<u64>,      // observed value (e.g. response bytes)
@@ -118,9 +118,20 @@ pub struct DenialContext {
 Field-shape rules (NORMATIVE):
 
 - All fields except `reason` are optional. Producers populate the fields
-  relevant to the reason and leave the rest at default (`None` / empty
-  `Vec`). Consumers MUST tolerate any subset of fields being present.
-- `expected` is `Vec<String>` even when only one value is meaningful, to
+  relevant to the reason and leave the rest at `None`. Consumers MUST
+  tolerate any subset of fields being present.
+- `expected` is `Option<Vec<String>>`. `None` means **"the producer did
+  not populate this field for this reason"** (this reason has no
+  allowlist channel) and serializes as an absent field. `Some(vec![...])`
+  means **"this is the explicit list of acceptable values, possibly
+  empty"** and serializes as `"expected":[...]` — including `"expected":[]`
+  for the explicit-empty-allowlist case. The previous `Vec<String>` shape
+  collapsed these two distinct states (both omitted the field on the
+  wire and both Rust-constructed identically as `vec![]`); this
+  refinement (post-incorporation review of PR #84) restores the
+  distinction so an LLM agent can disambiguate "field not applicable"
+  from "field applies but allowlist happens to be empty". The inner
+  `Vec<String>` is used even when only one value is meaningful, to
   avoid format ambiguity for cases where multiple values are acceptable
   (allowlist with several patterns).
 - `hop_index` is `u8` because the redirect chain is hard-capped at 10 in
@@ -133,14 +144,14 @@ The producer-side mapping from internal error variants to `DenialContext` is:
 
 | Internal source                                  | `reason`                  | Populated fields                                    |
 |--------------------------------------------------|---------------------------|-----------------------------------------------------|
-| `HttpError::RedirectDenied { source_key, host }` | `redirect_not_in_allowlist` | `source=source_key`, `attempted=host`, `expected=allowlist hosts`, `hop_index` if known |
-| `HttpError::OversizedBody { actual, cap }`       | `size_cap_exceeded`       | `cap`, `actual`                                     |
-| `HttpError::NotAPdf { got }`                     | `content_type_mismatch`   | `attempted=hex(got)`, `expected=["%PDF-"]`          |
-| `HttpError::InsecureRedirect { scheme }`         | `insecure_scheme`         | `attempted=scheme:...`, `expected=["https"]`        |
-| `FetchError::NotEligible { source_key }`         | `capability_not_granted`  | `source=source_key`                                 |
-| `RateLimiter` denial (future)                    | `rate_limit_window`       | `source`, `cap=per-source rate`                     |
-| Store schema rejection                           | `schema_drift`            | `actual=row schema_version`, `cap=binary version`   |
-| SSRF guard (future)                              | `ssrf_private_address`    | `attempted=ip:port`                                 |
+| `HttpError::RedirectDenied { source_key, host }` | `redirect_not_in_allowlist` | `source=Some(source_key)`, `attempted=Some(host)`, `expected=Some(allowlist hosts)`, `hop_index` if known |
+| `HttpError::OversizedBody { actual, cap }`       | `size_cap_exceeded`       | `cap`, `actual`; `expected=None` (no allowlist channel) |
+| `HttpError::NotAPdf { got }`                     | `content_type_mismatch`   | `attempted=Some(hex(got))`, `expected=Some(["%PDF-"])` |
+| `HttpError::InsecureRedirect { scheme }`         | `insecure_scheme`         | `attempted=Some(scheme:...)`, `expected=Some(["https"])` |
+| `FetchError::NotEligible { source_key }`         | `capability_not_granted`  | `source=Some(source_key)`; `expected=None` (no allowlist channel) |
+| `RateLimiter` denial (future)                    | `rate_limit_window`       | `source`, `cap=per-source rate`; `expected=None`    |
+| Store schema rejection                           | `schema_drift`            | `actual=row schema_version`, `cap=binary version`; `expected=None` |
+| SSRF guard (future)                              | `ssrf_private_address`    | `attempted=Some(ip:port)`; `expected=None`          |
 
 The mapping is implemented as a `From<HttpError> for Option<DenialContext>`
 plus `From<FetchError> for Option<DenialContext>`, sitting next to the

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -23,6 +23,7 @@ pub enum ErrorCode {
     SchemaTooNew,
     LockTimeout,
     InternalError,
+    NotImplemented,
 }
 ```
 
@@ -43,6 +44,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `SCHEMA_TOO_NEW` | Store entry's `schema_version` is ahead. | Upgrade doiget. |
 | `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | Retry; another process holds it. |
 | `INTERNAL_ERROR` | Bug. | Report at <https://github.com/sotashimozono/doiget/issues>. |
+| `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | Wait for next minor release; do not retry. |
 
 ## 3. Persona × error matrix
 
@@ -69,7 +71,13 @@ table below.
   "source":    "crossref",                     // resolver source key, optional
   "attempted": "evil.example.com",             // host/path/value, optional
   "expected":  ["api.crossref.org",
-                "*.crossref.org"],             // allowlist entries, [] when N/A
+                "*.crossref.org"],             // allowlist entries; the field
+                                                //   is ABSENT when the producer
+                                                //   did not populate it. An
+                                                //   explicit [] means "empty
+                                                //   allowlist" (ADR-0023 §3
+                                                //   None/Some(vec![])
+                                                //   disambiguation).
   "hop_index": 1,                              // redirect-chain position, optional
   "cap":       104857600,                      // size/rate cap, optional
   "actual":    209715200                       // observed value, optional

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -101,7 +101,11 @@ type DenialContext = {
         | "rate_limit_window" | "ssrf_private_address" | "content_type_mismatch",
   source?: string,
   attempted?: string,
-  expected: string[],
+  // `expected?` is absent when the producer did not populate this field for
+  // this reason. An empty array (`"expected": []`) is the distinct
+  // "explicit empty allowlist" signal — see ADR-0023 §3 for the
+  // None / Some(vec![]) disambiguation.
+  expected?: string[],
   hop_index?: number,
   cap?: number,
   actual?: number,
@@ -170,6 +174,10 @@ an optional `dry_run: boolean` input field, defaulting to `false`. When
   for the resolver, not a prediction of the single host the real fetch would
   hit. doiget cannot resolve the post-Unpaywall OA URL host without making
   the Unpaywall call, and `dry_run` MUST NOT make it.
+- The `plan.candidate_hosts_are_upper_bound` boolean is always `true` in
+  Phase 1 and machine-encodes the bullet above (ADR-0022 §4) directly into
+  the wire envelope, so an agent can detect the upper-bound semantics
+  without consulting the spec.
 
 ```jsonc
 {
@@ -182,10 +190,11 @@ an optional `dry_run: boolean` input field, defaulting to `false`. When
       "key":             "oa-publisher",
       "candidate_hosts": ["*.springer.com", "*.springeropen.com"]
     }],
-    "redirect_allowlists_loaded": ["crossref", "unpaywall", "arxiv", "oa-publisher"],
-    "target_pdf_path":            "/home/.../store/doi_10.1234_foo.pdf",
-    "target_metadata_path":       "/home/.../store/doi_10.1234_foo.toml",
-    "would_append_provenance":    true
+    "redirect_allowlists_loaded":      ["crossref", "unpaywall", "arxiv", "oa-publisher"],
+    "candidate_hosts_are_upper_bound": true,
+    "target_pdf_path":                 "/home/.../store/doi_10.1234_foo.pdf",
+    "target_metadata_path":            "/home/.../store/doi_10.1234_foo.toml",
+    "would_append_provenance":         true
   },
   "rate_limit_budget": {
     "global_per_sec":        5.0,

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -202,7 +202,7 @@ pub struct DenialContext {
     pub reason:    DenialReason,
     pub source:    Option<String>,
     pub attempted: Option<String>,
-    pub expected:  Vec<String>,
+    pub expected:  Option<Vec<String>>,
     pub hop_index: Option<u8>,
     pub cap:       Option<u64>,
     pub actual:    Option<u64>,


### PR DESCRIPTION
## Summary

Follow-up to merged PR #84 (Discussion #12 incorporation). During the design discussion after the multi-agent review, 4 refinements were agreed on:

| # | Refinement | Impact |
|---|---|---|
| ② | ADR-0021 §1: `version = None` MUST serialize as empty byte sequence (zero bytes), no sentinel values | docs only |
| ③ | `DenialContext.expected: Vec<String>` → `Option<Vec<String>>` (distinguishes "not populated" from "explicit empty") | core types + From impls + all spec docs + tests |
| ④ | `FetchPlan.candidate_hosts_are_upper_bound: bool` (always `true` in Phase 1) — surface ADR-0022 §4 honesty machine-readably | core/dry_run + ADR-0022 + MCP_TOOLS |
| ⑤ | `ErrorCode::NotImplemented` variant + `doiget_metadata_only` stub uses it (distinguishes "not yet wired in Phase" from "bug") | core ErrorCode + ERRORS.md + mcp stub + test |

## Why this is a separate PR

PR #84 already shipped the structural change (5 musaabhasan items + 9 review fixes). These 4 refinements were caught in the post-merge design discussion — small but non-cosmetic semantic improvements that benefit from their own review window.

## Verification

- `cargo fmt --check` clean
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` all green (2 new tests: `denial_context_expected_some_empty_vec_preserves_explicit_empty_allowlist`, `fetch_plan_carries_candidate_hosts_are_upper_bound_true`)
- posture-lint network-purity not regressed

## Spec layer

- `docs/DECISIONS/0021-canonical-tuple-identity.md` §1 — version_or_empty empty-bytes rule
- `docs/DECISIONS/0022-dry-run-mode.md` §1 — candidate_hosts_are_upper_bound JSON example + prose
- `docs/DECISIONS/0023-denial-context-structured.md` §3, §4 — Option<Vec<String>> + per-arm Some/None mapping
- `docs/ERRORS.md` §1, §2 — NotImplemented variant + semantics row; §3.1 — expected? semantics
- `docs/MCP_TOOLS.md` §5, §10 — typescript union + dry-run envelope
- `docs/PUBLIC_API.md` §8 — DenialContext struct shape

## Out of scope (acknowledged)

- canonical_digest impl (Phase 2, per ADR-0021 §3)
- `doiget_metadata_only` non-dry-run orchestrator wiring (Phase 1.x follow-up — now returns `NOT_IMPLEMENTED` instead of `INTERNAL_ERROR`)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only`

Refs: PR #84, Discussion #12.