### PR TITLE
feat(slice-1): metadata_only orchestrator + arxiv Atom feed parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,51 @@ Phase 0 (design + scaffolding). No version tag is published in this phase; the
 workspace stays at `0.0.0` until Phase 6. See [docs/PHASES.md](docs/PHASES.md)
 for the full Phase 0 deliverable checklist.
 
+### Slice 1 — metadata_only orchestrator + arXiv Atom feed
+
+- **(A)** `doiget_metadata_only` non-dry-run path wired through the new
+  `doiget_core::orchestrator::metadata_only` function. Replaces the
+  Phase 1 `NOT_IMPLEMENTED` stub. The MCP envelope follows
+  [`docs/MCP_TOOLS.md`](docs/MCP_TOOLS.md) §11 NORMATIVE shape
+  (`{ok:true, ref, source, license, oa_url, metadata, schema_version}`).
+  Failure envelopes carry a structured `denial_context` channel for
+  denial-class errors per
+  [ADR-0023](docs/DECISIONS/0023-denial-context-structured.md);
+  transport-level (`NETWORK_ERROR`) failures omit it. DOI dispatch is
+  Crossref-first with Unpaywall as a fallback; the Crossref OA URL
+  (`message.link[].URL`) is surfaced in `oa_url` but never followed
+  (the spec contract that distinguishes this tool from
+  `doiget_fetch_paper`). The orchestrator honors the same
+  `DOIGET_*_BASE` test-override surface the CLI already accepts so a
+  single wiremock fixture drives both crates. Existing `dry_run: true`
+  preview behavior (ADR-0022) is unchanged.
+- **(B)** `doiget_core::sources::arxiv::ArxivSource` now produces
+  `FetchResult::metadata_json` populated from the arXiv Atom feed
+  (`https://export.arxiv.org/api/query?id_list=<id>`). XML parsing
+  uses [`quick-xml`](https://crates.io/crates/quick-xml) as a
+  streaming event walker — no DOM allocation, no `serde-xml-rs`
+  (deprecated). The Atom call is best-effort during a full fetch: a
+  failure logs `tracing::warn!` and falls back to a PDF-only result
+  (`metadata_json = None`) so existing end-to-end tests are unchanged.
+  A new public helper `ArxivSource::fetch_metadata_only` is the entry
+  point for the orchestrator's arXiv branch; it MUST NOT touch the
+  PDF endpoint and emits its provenance row under
+  `Capability::Metadata` to distinguish metadata-only from full
+  fetches without breaking
+  [`docs/PROVENANCE_LOG.md`](docs/PROVENANCE_LOG.md) §3.
+- Test surface added: 3 `parse_atom_feed` unit tests, 3 new arXiv
+  `Source::fetch` / `fetch_metadata_only` wiremock-driven unit tests,
+  6 `orchestrator` helper unit tests, a new
+  `crates/doiget-core/tests/arxiv_metadata_e2e.rs` integration suite,
+  and 3 new `doiget_metadata_only` MCP integration tests (arXiv happy
+  path, DOI Crossref happy path, simulated network failure). The
+  pre-existing `doiget_metadata_only_default_dry_run_false_returns_not_implemented_stub`
+  test was deleted (the stub is gone). All `cargo fmt --check`,
+  `cargo build --workspace`, `cargo test --workspace`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, and
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+  --no-default-features --features oa-only` are green locally.
+
 ### Added
 
 #### Workspace skeleton

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -525,7 +525,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -579,6 +579,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "proptest",
+ "quick-xml",
  "reqwest",
  "secrecy",
  "serde",
@@ -608,10 +609,15 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serial_test",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ulid",
+ "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -639,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1352,7 +1358,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1530,6 +1536,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -1829,7 +1844,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1886,7 +1901,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2195,7 +2210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2257,7 +2272,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2851,7 +2866,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,16 @@ ulid = { version = "1", features = ["serde"] }
 # URL parsing — required, see docs/SECURITY.md §1.4
 url = "2"
 
+# XML parsing for arXiv Atom feed
+# (`https://export.arxiv.org/api/query?id_list=...`). `quick-xml` is the
+# de-facto standard streaming XML parser in the Rust ecosystem (push-style
+# pull-parser, no DOM allocation). We deliberately avoid `serde-xml-rs`
+# (deprecated) and `roxmltree` (DOM-style; heavier for the small Atom
+# response). Default features (no `serde`, no `encoding`) are sufficient
+# — we hand-roll a small event walker in `sources::arxiv`. Not on
+# `deny.toml`'s banned list.
+quick-xml = { version = "0.36", default-features = false }
+
 # Byte buffer + async stream combinators for streaming-with-cap body reads
 # (see crates/doiget-core/src/http.rs, docs/SECURITY.md §1.2 oversized PDF).
 bytes        = "1"

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -50,6 +50,9 @@ ulid        = { workspace = true }
 url         = { workspace = true }
 bytes        = { workspace = true }
 futures-util = { workspace = true }
+# Streaming XML parser for the arXiv Atom feed. See B.1 in
+# `crates/doiget-core/src/sources/arxiv.rs::parse_atom_feed`.
+quick-xml    = { workspace = true }
 
 [dev-dependencies]
 wiremock     = { workspace = true }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -17,6 +17,7 @@ use sha2::Digest;
 // --- Modules ---
 pub mod dry_run;
 pub mod http;
+pub mod orchestrator;
 pub mod provenance;
 pub mod rate_limiter;
 pub mod source;

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1,0 +1,327 @@
+//! Cross-source orchestrators that compose multiple [`Source`] impls into
+//! a single user-facing operation.
+//!
+//! Phase 1 ships [`metadata_only`] only; the live PDF orchestrator lives
+//! in `doiget-cli::commands::fetch` because it owns the on-disk store
+//! (and `doiget-core` does not, by design). This module is the natural
+//! home for orchestrators that the MCP server needs to call directly
+//! without going through the CLI.
+//!
+//! [`Source`]: crate::source::Source
+
+use serde_json::Value;
+
+use crate::source::{FetchContext, FetchError, Source};
+use crate::sources::arxiv::ArxivSource;
+use crate::sources::crossref::CrossrefSource;
+use crate::sources::unpaywall::UnpaywallSource;
+use crate::{CapabilityProfile, Doi, Ref};
+
+/// Outcome of a successful [`metadata_only`] call.
+///
+/// Mirrors the wire shape documented in `docs/MCP_TOOLS.md` §11: the
+/// `source` identifies which resolver produced the metadata, `license`
+/// is the OA license string when known (Unpaywall channel), `oa_url` is
+/// the discovered OA URL **(never followed by this orchestrator)**, and
+/// `metadata` is the source's native JSON payload (Crossref `message`,
+/// Unpaywall work record, or the parsed arXiv Atom-feed object).
+///
+/// `metadata` is serialized as-is by the MCP envelope builder
+/// (`crates/doiget-mcp/src/lib.rs`); we deliberately do NOT normalize
+/// here so the agent can see exactly what the source returned.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct MetadataOnlyOutcome {
+    /// Resolver key that produced the metadata payload. One of
+    /// `"crossref"`, `"unpaywall"`, `"arxiv"` (the closed set named in
+    /// `docs/MCP_TOOLS.md` §11 type alias).
+    pub source: String,
+    /// OA license string when the resolver could supply one (today only
+    /// the Unpaywall fallback path populates this). `None` when the
+    /// primary source did not surface a license.
+    pub license: Option<String>,
+    /// Discovered OA URL — surfaced to the caller for separate action,
+    /// **never followed by this orchestrator**. The Crossref response's
+    /// `message.link[]` array is mined first; the Unpaywall fallback
+    /// path uses `best_oa_location.url_for_pdf` (or `url`).
+    pub oa_url: Option<String>,
+    /// Source's native metadata payload. For Crossref this is the
+    /// `message` object; for Unpaywall the work record; for arXiv the
+    /// parsed Atom-feed JSON (see
+    /// `crate::sources::arxiv::parse_atom_feed`).
+    pub metadata: Value,
+}
+
+/// Resolve a [`Ref`] to metadata WITHOUT triggering a publisher PDF
+/// fetch.
+///
+/// Binding spec: `docs/MCP_TOOLS.md` §11 (NORMATIVE — this function
+/// MUST NOT call [`crate::http::HttpClient::fetch_pdf`] under any code
+/// path). The posture-lint workflow greps for that pattern; the test
+/// suite additionally exercises the DOI and arXiv branches end-to-end
+/// against wiremock to assert the OA URL is reported, not followed.
+///
+/// # Dispatch
+///
+/// - `Ref::Doi(_)` → Crossref first (bibliographic metadata + OA URL
+///   via `message.link[]`). If Crossref returns a usable payload the
+///   call returns immediately; Unpaywall is consulted only as a fallback
+///   when Crossref fails. The Unpaywall fallback surfaces a license
+///   string and may overwrite `oa_url` with the `best_oa_location`
+///   channel.
+/// - `Ref::Arxiv(_)` → [`ArxivSource::fetch_metadata_only`]: ONLY the
+///   Atom feed (`https://export.arxiv.org/api/query?id_list=<id>`) is
+///   consulted; the PDF endpoint is NOT touched. `license` is set to
+///   the platform-wide `"arxiv-default"` token, `oa_url` is `None`
+///   (the arXiv abstract page is not a PDF URL).
+///
+/// # Side effects
+///
+/// Each consulted source appends ONE `LogEvent::Fetch` row to
+/// `ctx.log` (arXiv emits its row under `Capability::Metadata`; the
+/// DOI sources emit under `Capability::Oa` — they pre-date this
+/// distinction and a follow-up slice may unify them). The orchestrator
+/// itself does NOT bracket the call with `SessionStart` / `SessionEnd`
+/// rows — that is the MCP server's responsibility (it owns the
+/// per-tool-call session boundary).
+///
+/// TODO Phase 2.x: write the metadata TOML to the store after the
+/// orchestrator path is proven; the spec entry in `docs/MCP_TOOLS.md`
+/// §11 lists this as a SIDE EFFECT but Phase 2 store invariants
+/// (which directory, schema_version handling) are out of scope for
+/// Slice 1.
+///
+/// # Errors
+///
+/// Returns [`FetchError`] from the underlying [`Source`] dispatch. The
+/// MCP boundary converts these to the closed [`crate::ErrorCode`] set
+/// via the existing `From<FetchError> for ErrorCode` impl.
+pub async fn metadata_only(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+) -> Result<MetadataOnlyOutcome, FetchError> {
+    match ref_ {
+        Ref::Doi(doi) => metadata_only_doi(doi, ref_, profile, ctx).await,
+        Ref::Arxiv(id) => {
+            let arxiv = arxiv_source_from_env();
+            let metadata = arxiv.fetch_metadata_only(id, ctx).await?;
+            // TODO Phase 2.x: write metadata TOML to store after
+            // orchestrator path is proven.
+            Ok(MetadataOnlyOutcome {
+                source: arxiv.name().to_string(),
+                license: Some("arxiv-default".to_string()),
+                oa_url: None,
+                metadata,
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Env-aware source constructors (mirrors doiget-cli::commands::fetch::build_*)
+//
+// These let MCP integration tests redirect the orchestrator at a
+// wiremock origin via `DOIGET_*_BASE` env vars, without inverting the
+// `doiget-mcp -> doiget-core` wiring by depending on `doiget-cli`. The
+// override surface is identical to the CLI's `fetch.rs::build_*_source`
+// helpers so a single test fixture can drive both crates.
+// ---------------------------------------------------------------------------
+
+/// `DOIGET_CONTACT_EMAIL`, defaulting to the same `doiget@localhost`
+/// the CLI uses (`crates/doiget-cli/src/commands/fetch.rs::OrchestratorConfig`).
+const FALLBACK_CONTACT_EMAIL: &str = "doiget@localhost";
+
+fn contact_email_from_env() -> String {
+    std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| FALLBACK_CONTACT_EMAIL.to_string())
+}
+
+fn arxiv_source_from_env() -> ArxivSource {
+    if let Ok(s) = std::env::var("DOIGET_ARXIV_BASE") {
+        if let Ok(url) = url::Url::parse(&s) {
+            return ArxivSource::with_base(url);
+        }
+    }
+    ArxivSource::new()
+}
+
+fn crossref_source_from_env(contact: &str) -> CrossrefSource {
+    if let Ok(s) = std::env::var("DOIGET_CROSSREF_BASE") {
+        if let Ok(url) = url::Url::parse(&s) {
+            return CrossrefSource::with_base(url, contact.to_string());
+        }
+    }
+    CrossrefSource::new(contact.to_string())
+}
+
+fn unpaywall_source_from_env(contact: &str) -> UnpaywallSource {
+    if let Ok(s) = std::env::var("DOIGET_UNPAYWALL_BASE") {
+        if let Ok(url) = url::Url::parse(&s) {
+            return UnpaywallSource::with_base(url, contact.to_string());
+        }
+    }
+    UnpaywallSource::new(contact.to_string())
+}
+
+/// DOI branch — Crossref first, with Unpaywall as a fallback when
+/// Crossref fails. Crossref's `message.link[]` array (when present)
+/// supplies the OA URL hint without making a publisher request.
+async fn metadata_only_doi(
+    _doi: &Doi,
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+) -> Result<MetadataOnlyOutcome, FetchError> {
+    let contact = contact_email_from_env();
+    let crossref = crossref_source_from_env(&contact);
+    match crossref.fetch(ref_, profile, ctx).await {
+        Ok(res) => {
+            let metadata = res.metadata_json.unwrap_or(Value::Null);
+            let oa_url = extract_crossref_oa_url(&metadata);
+            // TODO Phase 2.x: write metadata TOML to store after
+            // orchestrator path is proven.
+            Ok(MetadataOnlyOutcome {
+                source: crossref.name().to_string(),
+                // Crossref does not surface a license directly; the
+                // license channel for DOI metadata is Unpaywall's
+                // `best_oa_location.license`. Leave `None` here; the
+                // agent can call `unpaywall` (or a follow-up slice's
+                // chained orchestrator) if it needs a license string.
+                license: None,
+                oa_url,
+                metadata,
+            })
+        }
+        Err(crossref_err) => {
+            // Crossref failed. Try Unpaywall as a fallback before
+            // surfacing the original error.
+            let unpaywall = unpaywall_source_from_env(&contact);
+            match unpaywall.fetch(ref_, profile, ctx).await {
+                Ok(res) => {
+                    let metadata = res.metadata_json.unwrap_or(Value::Null);
+                    let oa_url = extract_unpaywall_oa_url(&metadata);
+                    let license = if res.license == "unknown" {
+                        None
+                    } else {
+                        Some(res.license)
+                    };
+                    Ok(MetadataOnlyOutcome {
+                        source: unpaywall.name().to_string(),
+                        license,
+                        oa_url,
+                        metadata,
+                    })
+                }
+                Err(_unpaywall_err) => {
+                    // Both sources failed; surface the Crossref error
+                    // (the primary path) for diagnosability.
+                    Err(crossref_err)
+                }
+            }
+        }
+    }
+}
+
+/// Defensively pull a Crossref OA URL out of a `message.link[]` entry.
+///
+/// The Crossref `Link` model documents `link[].URL` as the OA URL string
+/// when the work has one (see
+/// `<https://api.crossref.org/swagger-ui/index.html>`). Multiple entries
+/// may be present; we return the first non-empty `URL` field
+/// encountered. Returns `None` if the array is missing, empty, or
+/// contains no usable URL string.
+fn extract_crossref_oa_url(msg: &Value) -> Option<String> {
+    let arr = msg.get("link")?.as_array()?;
+    arr.iter()
+        .filter_map(|entry| entry.get("URL").and_then(Value::as_str))
+        .find(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Defensively pull Unpaywall's preferred OA URL
+/// (`best_oa_location.url_for_pdf`, falling back to `.url`) out of a
+/// metadata payload.
+fn extract_unpaywall_oa_url(meta: &Value) -> Option<String> {
+    let loc = meta.get("best_oa_location")?;
+    loc.get("url_for_pdf")
+        .and_then(Value::as_str)
+        .or_else(|| loc.get("url").and_then(Value::as_str))
+        .map(|s| s.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_crossref_oa_url_finds_first_url() {
+        let msg = serde_json::json!({
+            "link": [
+                {"URL": "https://example.org/free.pdf"},
+                {"URL": "https://example.org/alt.pdf"}
+            ]
+        });
+        assert_eq!(
+            extract_crossref_oa_url(&msg),
+            Some("https://example.org/free.pdf".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_crossref_oa_url_returns_none_when_absent() {
+        let msg = serde_json::json!({});
+        assert!(extract_crossref_oa_url(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_crossref_oa_url_skips_empty_url_strings() {
+        let msg = serde_json::json!({
+            "link": [
+                {"URL": ""},
+                {"URL": "https://example.org/real.pdf"}
+            ]
+        });
+        assert_eq!(
+            extract_crossref_oa_url(&msg),
+            Some("https://example.org/real.pdf".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_unpaywall_oa_url_prefers_url_for_pdf() {
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/pdf",
+                "url": "https://example.org/landing"
+            }
+        });
+        assert_eq!(
+            extract_unpaywall_oa_url(&meta),
+            Some("https://example.org/pdf".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_unpaywall_oa_url_falls_back_to_url() {
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url": "https://example.org/landing"
+            }
+        });
+        assert_eq!(
+            extract_unpaywall_oa_url(&meta),
+            Some("https://example.org/landing".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_unpaywall_oa_url_returns_none_when_absent() {
+        let meta = serde_json::json!({});
+        assert!(extract_unpaywall_oa_url(&meta).is_none());
+    }
+}

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -1,33 +1,45 @@
-//! arXiv source — arXiv id → PDF (and minimal metadata fields).
+//! arXiv source — arXiv id → PDF + Atom-feed metadata.
 //!
 //! Spec: `docs/SOURCES.md` §4 arXiv. No auth; the API has a 3-second-per-request
 //! rate guideline that doiget's 5/sec global + 200ms per-source backoff
 //! comfortably respects (no extra source-specific tuning needed).
 //!
-//! # Fetch flow
+//! # Fetch flow (full)
 //!
 //! 1. `can_serve` returns `true` only for `Ref::Arxiv(_)`; `Ref::Doi(_)` is
 //!    rejected up front.
-//! 2. `fetch` acquires a permit from the shared `RateLimiter`, builds the
-//!    PDF URL `https://arxiv.org/pdf/<id>.pdf`, and dispatches via
+//! 2. `fetch` acquires a permit from the shared `RateLimiter`, then
+//!    best-effort fetches the Atom feed (`<base>/api/query?id_list=<id>`)
+//!    and parses it into a JSON metadata object via the private
+//!    `parse_atom_feed` helper. Atom failures degrade gracefully
+//!    (`metadata_json = None` + `tracing::warn!`) — the existing 1.0
+//!    PDF-leg semantics are preserved.
+//! 3. The PDF URL `<base>/pdf/<id>.pdf` is fetched via
 //!    [`crate::http::HttpClient::fetch_pdf`] which enforces the magic-byte
-//!    (`%PDF-`) check per `docs/SECURITY.md` §1.2 — non-PDF response is a
-//!    hard error.
-//! 3. One `LogEvent::Fetch` row is appended via `ctx.log.append`; per
-//!    `docs/PROVENANCE_LOG.md` §3 a write failure is fail-closed and aborts
-//!    the surrounding fetch (the `?` on `append` propagates as
-//!    `FetchError::Log`).
+//!    (`%PDF-`) check per `docs/SECURITY.md` §1.2.
+//! 4. ONE `LogEvent::Fetch` row is appended for the PDF leg. The Atom leg
+//!    does NOT emit its own row — the source-level audit unit is
+//!    "one fetch attempt = one row" and the Atom call is a supporting
+//!    leg of the same attempt.
 //!
-//! # Metadata (deferred)
+//! # Metadata-only path
 //!
-//! Phase 1 returns the PDF bytes only. The export.arxiv.org Atom feed
-//! (`https://export.arxiv.org/api/query?id_list=<id>`) is documented in the
-//! arXiv API guide but XML parsing is deferred to a follow-up PR — see the
-//! `metadata_json` field of [`FetchResult`] which is set to `None` here
-//! (TODO Phase 1+).
+//! [`ArxivSource::fetch_metadata_only`] performs ONLY the Atom feed fetch
+//! and is the entry point for the `metadata_only` orchestrator
+//! (`crate::orchestrator::metadata_only`). It MUST NOT call
+//! [`crate::http::HttpClient::fetch_pdf`] — doing so would violate the
+//! `doiget_metadata_only` contract (`docs/MCP_TOOLS.md` §11). It emits
+//! one `LogEvent::Fetch` row under `Capability::Metadata` so the audit
+//! trail distinguishes metadata-only fetches from full fetches without
+//! breaking the schema (the `capability` field is the structured channel
+//! for this distinction; spec §3 documents it as one of `oa` / `metadata`
+//! / `tdm-*`).
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use serde_json::{json, Value};
 use url::Url;
 
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
@@ -88,6 +100,75 @@ impl ArxivSource {
             hint: format!("arxiv URL construction failed: {e}"),
         })
     }
+
+    /// Build the Atom-feed metadata URL for a given arXiv id.
+    ///
+    /// Production: `https://export.arxiv.org/api/query?id_list=<id>`. In
+    /// tests the base is the wiremock origin; the path is the same
+    /// (`/api/query?id_list=<id>`). The `export.arxiv.org` host is on the
+    /// `arxiv` redirect allowlist (per
+    /// `crate::http::tier_1_allowlist`) so the redirect closure does not
+    /// reject this leg.
+    ///
+    /// Old-style ids (`cond-mat/9501001`) contain a `/` which we
+    /// URL-encode via `query_pairs_mut().append_pair` so the wire form is
+    /// `id_list=cond-mat%2F9501001`.
+    fn metadata_url(&self, id: &ArxivId) -> Result<Url, FetchError> {
+        let mut url = self
+            .base
+            .join("/api/query")
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("arxiv metadata URL construction failed: {e}"),
+            })?;
+        url.query_pairs_mut().append_pair("id_list", id.as_str());
+        Ok(url)
+    }
+
+    /// Fetch ONLY the Atom-feed metadata for the given arXiv id. Does NOT
+    /// touch the PDF endpoint — this is the entry point for the
+    /// `metadata_only` orchestrator (`docs/MCP_TOOLS.md` §11).
+    ///
+    /// Emits a single `LogEvent::Fetch` row under `Capability::Metadata`
+    /// so the audit trail distinguishes metadata-only attempts from full
+    /// (PDF) fetches.
+    ///
+    /// # Errors
+    ///
+    /// - [`FetchError::Http`] on transport / status / size-cap failures.
+    /// - [`FetchError::SourceSchema`] if the response body is not
+    ///   well-formed Atom XML.
+    /// - [`FetchError::Log`] if the provenance row write fails
+    ///   (fail-closed per `docs/PROVENANCE_LOG.md` §5).
+    pub async fn fetch_metadata_only(
+        &self,
+        id: &ArxivId,
+        ctx: &FetchContext,
+    ) -> Result<Value, FetchError> {
+        // Same politeness gate as the full fetch path.
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.metadata_url(id)?;
+        let (body, _final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+        let metadata = parse_atom_feed(&body)?;
+
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            // Distinguish metadata-only from full (PDF) fetches via the
+            // structured `capability` channel rather than mangling the
+            // `source` string — `docs/PROVENANCE_LOG.md` §3 lists
+            // `metadata` as a first-class capability value.
+            capability: Capability::Metadata,
+            ref_: Some(id.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some("arxiv-default"),
+            store_path: None,
+        })?;
+
+        Ok(metadata)
+    }
 }
 
 impl Default for ArxivSource {
@@ -124,10 +205,54 @@ impl Source for ArxivSource {
             }
         };
 
-        // Hold the rate-limiter permit for the duration of the HTTP fetch.
-        // Drop happens at end of scope after the log append below.
+        // Hold the rate-limiter permit for the duration of the HTTP
+        // fetch. Drop happens at end of scope after the log append below.
         let _permit = ctx.rate_limiter.acquire(self.name()).await;
 
+        // ----- Atom-feed metadata leg (best-effort) -------------------
+        //
+        // Fetched BEFORE the PDF so that `FetchResult::metadata_json` is
+        // populated for a single-pass fetch (the orchestrator does not
+        // need to re-issue a metadata-only call). Failures here degrade
+        // gracefully: we set `metadata_json = None`, emit a tracing
+        // warning, and proceed with the PDF leg unchanged. NO log row
+        // is emitted from this leg — the source-level audit unit is
+        // "one fetch attempt = one row" and the row comes from the PDF
+        // leg below. This is what preserves the 4-row sequence asserted
+        // by `crates/doiget-cli/tests/fetch_arxiv_e2e.rs`.
+        let metadata_json = match self.metadata_url(id) {
+            Ok(meta_url) => match ctx.http.fetch_bytes(self.name(), meta_url).await {
+                Ok((bytes, _final)) => match parse_atom_feed(&bytes) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        tracing::warn!(
+                            arxiv_id = %id.as_str(),
+                            error = %e,
+                            "arxiv Atom feed parse failed; continuing with PDF-only fetch"
+                        );
+                        None
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        arxiv_id = %id.as_str(),
+                        error = %e,
+                        "arxiv Atom feed fetch failed; continuing with PDF-only fetch"
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    arxiv_id = %id.as_str(),
+                    error = %e,
+                    "arxiv metadata URL construction failed; continuing with PDF-only fetch"
+                );
+                None
+            }
+        };
+
+        // ----- PDF leg -------------------------------------------------
         let url = self.pdf_url(id)?;
 
         // `fetch_pdf` enforces the magic-byte check (`%PDF-`) per
@@ -160,11 +285,252 @@ impl Source for ArxivSource {
             license: "arxiv-default".into(),
             pdf_bytes: Some(body),
             final_url: Some(final_url),
-            // TODO Phase 1+: parse export.arxiv.org Atom feed
-            // (`https://export.arxiv.org/api/query?id_list=<id>`) and
-            // populate this with title / authors / abstract / categories.
-            metadata_json: None,
+            metadata_json,
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Atom-feed parser (B.1)
+// ---------------------------------------------------------------------------
+
+/// Parse the arXiv Atom-feed response body into a structured JSON
+/// metadata object.
+///
+/// Endpoint: `https://export.arxiv.org/api/query?id_list=<id>` (see
+/// arXiv API user manual §3.1). The response is an `<feed>` document
+/// containing one `<entry>` per requested id. We extract the fields
+/// listed in `docs/SOURCES.md` §4 arXiv (title, summary/abstract,
+/// authors, published, updated, categories) into the synthetic JSON
+/// shape:
+///
+/// ```jsonc
+/// {
+///   "title": "...",
+///   "abstract": "...",
+///   "authors": ["Family, Given", ...],
+///   "published": "YYYY-MM-DDTHH:MM:SSZ",  // RFC3339 UTC, passed through verbatim
+///   "updated":   "YYYY-MM-DDTHH:MM:SSZ",
+///   "categories": ["cs.LG", "stat.ML"]
+/// }
+/// ```
+///
+/// All fields are best-effort: any missing element is omitted from the
+/// JSON output (NOT serialized as `null`). The parser is a small
+/// `quick-xml` event walker — no DOM allocation. Only the FIRST `<entry>`
+/// element is consumed (we always query a single id).
+///
+/// # Errors
+///
+/// Returns [`FetchError::SourceSchema`] if the XML is malformed (parser
+/// reports a syntax error) or if no `<entry>` element is present (arXiv
+/// returns an empty `<feed>` on an unknown id).
+pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
+    let mut reader = Reader::from_reader(xml);
+    let config = reader.config_mut();
+    config.trim_text(true);
+
+    // Top-level state. `in_entry` tracks whether we are inside the first
+    // (and only) `<entry>` element; once we exit, we stop collecting.
+    let mut in_entry = false;
+    let mut saw_entry = false;
+    let mut depth = 0_i32; // depth WITHIN the entry; 0 = at <entry> root
+
+    // Accumulators. Per-author state is kept on a stack so a nested
+    // `<author><name>...</name></author>` populates the right slot.
+    let mut title: Option<String> = None;
+    let mut abstract_: Option<String> = None;
+    let mut published: Option<String> = None;
+    let mut updated: Option<String> = None;
+    let mut authors: Vec<String> = Vec::new();
+    let mut categories: Vec<String> = Vec::new();
+
+    // Current text-collection target — None when we are not inside a
+    // leaf element whose text we want.
+    #[derive(Clone, Copy)]
+    enum Target {
+        Title,
+        Summary,
+        Published,
+        Updated,
+        AuthorName,
+    }
+    let mut target: Option<Target> = None;
+    let mut in_author = false;
+    let mut buf: Vec<u8> = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) => {
+                let name_bytes = e.name();
+                let local = local_name(name_bytes.as_ref());
+                if !in_entry {
+                    if local == b"entry" {
+                        in_entry = true;
+                        saw_entry = true;
+                        depth = 0;
+                    }
+                    buf.clear();
+                    continue;
+                }
+                depth += 1;
+                // Depth==1 means a direct child of `<entry>`.
+                if depth == 1 {
+                    match local {
+                        b"title" => target = Some(Target::Title),
+                        b"summary" => target = Some(Target::Summary),
+                        b"published" => target = Some(Target::Published),
+                        b"updated" => target = Some(Target::Updated),
+                        b"author" => {
+                            in_author = true;
+                            authors.push(String::new());
+                        }
+                        _ => {}
+                    }
+                } else if depth == 2 && in_author && local == b"name" {
+                    target = Some(Target::AuthorName);
+                }
+                buf.clear();
+            }
+            Ok(Event::Empty(e)) => {
+                let name_bytes = e.name();
+                let local = local_name(name_bytes.as_ref());
+                if in_entry && depth == 0 && local == b"category" {
+                    // <category term="cs.LG" scheme="..."/> — extract `term`.
+                    for attr in e.attributes().flatten() {
+                        if attr.key.as_ref() == b"term" {
+                            if let Ok(v) = attr.unescape_value() {
+                                categories.push(v.into_owned());
+                            }
+                        }
+                    }
+                }
+                buf.clear();
+            }
+            Ok(Event::Text(t)) => {
+                if let Some(tg) = target {
+                    if let Ok(s) = t.unescape() {
+                        let s = s.into_owned();
+                        match tg {
+                            Target::Title => title.get_or_insert_with(String::new).push_str(&s),
+                            Target::Summary => {
+                                abstract_.get_or_insert_with(String::new).push_str(&s)
+                            }
+                            Target::Published => {
+                                published.get_or_insert_with(String::new).push_str(&s)
+                            }
+                            Target::Updated => updated.get_or_insert_with(String::new).push_str(&s),
+                            Target::AuthorName => {
+                                if let Some(last) = authors.last_mut() {
+                                    last.push_str(&s);
+                                }
+                            }
+                        }
+                    }
+                }
+                buf.clear();
+            }
+            Ok(Event::End(e)) => {
+                if !in_entry {
+                    buf.clear();
+                    continue;
+                }
+                let name_bytes = e.name();
+                let local = local_name(name_bytes.as_ref());
+                if depth == 0 && local == b"entry" {
+                    // Done with the first entry — stop. We deliberately
+                    // ignore any subsequent entries since the orchestrator
+                    // always queries a single id.
+                    break;
+                }
+                depth -= 1;
+                if depth == 0 {
+                    if local == b"author" {
+                        in_author = false;
+                        // Drop empty author names (defensive).
+                        if let Some(last) = authors.last() {
+                            if last.is_empty() {
+                                authors.pop();
+                            }
+                        }
+                    }
+                    target = None;
+                } else if depth == 1 && in_author && local == b"name" {
+                    target = None;
+                }
+                buf.clear();
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(FetchError::SourceSchema {
+                    hint: format!("arxiv Atom XML parse error: {e}"),
+                });
+            }
+            // CDATA / Comment / Decl / PI / DocType — ignored.
+            _ => {
+                buf.clear();
+            }
+        }
+    }
+
+    if !saw_entry {
+        return Err(FetchError::SourceSchema {
+            hint: "arxiv Atom feed had no <entry> element (unknown id?)".into(),
+        });
+    }
+
+    // Build the JSON object, omitting empty optionals. `serde_json::Map`
+    // preserves insertion order so the output is stable.
+    let mut obj = serde_json::Map::new();
+    if let Some(t) = title {
+        let trimmed = t.trim().to_string();
+        if !trimmed.is_empty() {
+            obj.insert("title".into(), Value::String(trimmed));
+        }
+    }
+    if let Some(a) = abstract_ {
+        let trimmed = a.trim().to_string();
+        if !trimmed.is_empty() {
+            obj.insert("abstract".into(), Value::String(trimmed));
+        }
+    }
+    if !authors.is_empty() {
+        obj.insert(
+            "authors".into(),
+            Value::Array(authors.into_iter().map(Value::String).collect()),
+        );
+    }
+    if let Some(p) = published {
+        let trimmed = p.trim().to_string();
+        if !trimmed.is_empty() {
+            obj.insert("published".into(), Value::String(trimmed));
+        }
+    }
+    if let Some(u) = updated {
+        let trimmed = u.trim().to_string();
+        if !trimmed.is_empty() {
+            obj.insert("updated".into(), Value::String(trimmed));
+        }
+    }
+    if !categories.is_empty() {
+        obj.insert(
+            "categories".into(),
+            Value::Array(categories.into_iter().map(Value::String).collect()),
+        );
+    }
+    Ok(json!(obj))
+}
+
+/// Strip an XML namespace prefix from a qualified name, returning the
+/// local-part bytes. `b"atom:entry"` -> `b"entry"`. Atom uses the default
+/// namespace so most names arrive unprefixed; this helper makes the
+/// parser robust to either form without depending on quick-xml's
+/// namespace resolver (which would require us to thread a
+/// `NsReader` and explicit prefix bindings through every event).
+fn local_name(qname: &[u8]) -> &[u8] {
+    match qname.iter().rposition(|&b| b == b':') {
+        Some(idx) => &qname[idx + 1..],
+        None => qname,
     }
 }
 
@@ -452,5 +818,189 @@ mod tests {
             }
             other => panic!("expected FetchError::Http(HttpStatus), got {:?}", other),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // parse_atom_feed (B.1) — unit tests
+    // -----------------------------------------------------------------
+
+    /// Synthetic Atom payload from the Slice 1 spec (deliverable B.3). Do
+    /// not hit real arXiv from tests.
+    const SAMPLE_ATOM_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <updated>2024-02-01T00:00:00Z</updated>
+    <published>2024-01-15T00:00:00Z</published>
+    <title>Example arXiv Paper Title</title>
+    <summary>This is an example abstract.</summary>
+    <author>
+      <name>Jane Doe</name>
+    </author>
+    <author>
+      <name>John Roe</name>
+    </author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="stat.ML" scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"#;
+
+    #[test]
+    fn parse_atom_feed_extracts_all_fields() {
+        let v = parse_atom_feed(SAMPLE_ATOM_FEED.as_bytes()).expect("Atom parses");
+        assert_eq!(v["title"], serde_json::json!("Example arXiv Paper Title"));
+        assert_eq!(
+            v["abstract"],
+            serde_json::json!("This is an example abstract.")
+        );
+        assert_eq!(v["authors"], serde_json::json!(["Jane Doe", "John Roe"]));
+        assert_eq!(v["published"], serde_json::json!("2024-01-15T00:00:00Z"));
+        assert_eq!(v["updated"], serde_json::json!("2024-02-01T00:00:00Z"));
+        assert_eq!(v["categories"], serde_json::json!(["cs.LG", "stat.ML"]));
+    }
+
+    #[test]
+    fn parse_atom_feed_empty_feed_errors_source_schema() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>"#;
+        let err = parse_atom_feed(xml.as_bytes()).expect_err("empty feed must error");
+        match err {
+            FetchError::SourceSchema { hint } => {
+                assert!(
+                    hint.contains("entry"),
+                    "expected mention of <entry>; got {hint}"
+                );
+            }
+            other => panic!("expected SourceSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_atom_feed_omits_missing_optional_fields() {
+        // An entry with only an id and title — abstract/authors/categories
+        // absent. The output must omit those keys entirely (not emit
+        // `null`).
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.00001v1</id>
+    <title>Minimal Entry</title>
+  </entry>
+</feed>"#;
+        let v = parse_atom_feed(xml.as_bytes()).expect("parses");
+        let obj = v.as_object().expect("object");
+        assert_eq!(
+            obj.get("title").and_then(Value::as_str),
+            Some("Minimal Entry")
+        );
+        assert!(
+            !obj.contains_key("abstract"),
+            "abstract should be omitted: {obj:?}"
+        );
+        assert!(
+            !obj.contains_key("authors"),
+            "authors should be omitted: {obj:?}"
+        );
+        assert!(
+            !obj.contains_key("categories"),
+            "categories should be omitted: {obj:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // fetch_metadata_only — orchestrator entry point
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn arxiv_fetch_metadata_only_returns_atom_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+            .mount(&server)
+            .await;
+        let host = server
+            .uri()
+            .parse::<Url>()
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let (_td, ctx) = build_test_context(&host);
+        let s = ArxivSource::with_base(server.uri().parse().unwrap());
+        let id = ArxivId::parse("2401.12345").unwrap();
+
+        let meta = s
+            .fetch_metadata_only(&id, &ctx)
+            .await
+            .expect("metadata_only ok");
+        assert_eq!(
+            meta["title"],
+            serde_json::json!("Example arXiv Paper Title")
+        );
+        assert_eq!(meta["authors"], serde_json::json!(["Jane Doe", "John Roe"]));
+    }
+
+    #[tokio::test]
+    async fn arxiv_fetch_populates_metadata_json_when_atom_endpoint_mocked() {
+        // Full Source::fetch with BOTH Atom and PDF endpoints mocked must
+        // populate `metadata_json` from the Atom response.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/pdf/2401.12345.pdf"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.7\n%fix\n".to_vec()))
+            .mount(&server)
+            .await;
+        let host = server
+            .uri()
+            .parse::<Url>()
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let (_td, ctx) = build_test_context(&host);
+        let s = ArxivSource::with_base(server.uri().parse().unwrap());
+        let id = ArxivId::parse("2401.12345").unwrap();
+        let r = Ref::Arxiv(id);
+
+        let res = s.fetch(&r, &profile(), &ctx).await.expect("fetch ok");
+        let meta = res.metadata_json.expect("metadata_json populated");
+        assert_eq!(
+            meta["title"],
+            serde_json::json!("Example arXiv Paper Title")
+        );
+    }
+
+    #[tokio::test]
+    async fn arxiv_fetch_atom_failure_falls_back_to_pdf_only() {
+        // PDF endpoint mocked; Atom endpoint deliberately unmocked
+        // (will 404). The fetch must still succeed with
+        // `metadata_json = None` — the best-effort contract.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pdf/2401.12345.pdf"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.7\nx".to_vec()))
+            .mount(&server)
+            .await;
+        let host = server
+            .uri()
+            .parse::<Url>()
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let (_td, ctx) = build_test_context(&host);
+        let s = ArxivSource::with_base(server.uri().parse().unwrap());
+        let id = ArxivId::parse("2401.12345").unwrap();
+        let r = Ref::Arxiv(id);
+
+        let res = s.fetch(&r, &profile(), &ctx).await.expect("fetch ok");
+        assert!(res.metadata_json.is_none());
+        assert!(res.pdf_bytes.is_some());
     }
 }

--- a/crates/doiget-core/tests/arxiv_metadata_e2e.rs
+++ b/crates/doiget-core/tests/arxiv_metadata_e2e.rs
@@ -1,0 +1,149 @@
+// allow: outbound-network
+//! End-to-end wiremock-driven test for the arXiv Atom-feed metadata
+//! parsing (Slice 1 deliverable B.2).
+//!
+//! The `allow: outbound-network` escape hatch is set because this file
+//! imports `wiremock` (which transitively touches the same crates the
+//! posture-lint job greps for in unit-test sources). All HTTP traffic
+//! terminates at a `wiremock::MockServer` on `127.0.0.1:N` — there is
+//! NO real network call, mirroring the
+//! `crates/doiget-cli/tests/fetch_arxiv_e2e.rs` convention.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::sync::Arc;
+
+use camino::Utf8PathBuf;
+use doiget_core::http::HttpClient;
+use doiget_core::provenance::ProvenanceLog;
+use doiget_core::rate_limiter::RateLimiter;
+use doiget_core::source::{FetchContext, Source};
+use doiget_core::sources::arxiv::ArxivSource;
+use doiget_core::{ArxivId, CapabilityProfile, RateLimits, Ref};
+use tempfile::TempDir;
+use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Synthetic Atom payload from Slice 1 spec §B.3.
+const SAMPLE_ATOM_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <updated>2024-02-01T00:00:00Z</updated>
+    <published>2024-01-15T00:00:00Z</published>
+    <title>Example arXiv Paper Title</title>
+    <summary>This is an example abstract.</summary>
+    <author><name>Jane Doe</name></author>
+    <author><name>John Roe</name></author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="stat.ML" scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"#;
+
+const TEST_SESSION_ID: &str = "01J0000000000000000000TEST";
+
+/// Build a `FetchContext` against a wiremock origin under the `arxiv`
+/// source key. Mirrors the per-source helpers in the in-crate unit
+/// tests.
+fn build_ctx(host: &str) -> (TempDir, FetchContext) {
+    let td = TempDir::new().expect("tempdir");
+    let log_dir =
+        Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+    let log_path = log_dir.join("arxiv-meta.jsonl");
+    let http = Arc::new(HttpClient::new_for_tests_allow_http("arxiv", host));
+    let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+    let session_id = TEST_SESSION_ID.to_string();
+    let log =
+        Arc::new(ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"));
+    (
+        td,
+        FetchContext {
+            http,
+            rate_limiter,
+            log,
+            session_id,
+        },
+    )
+}
+
+#[tokio::test]
+async fn arxiv_source_fetch_populates_atom_metadata_via_wiremock() {
+    // Both the Atom and PDF endpoints are mocked on the same wiremock
+    // origin. After Slice 1, `Source::fetch` makes a best-effort Atom
+    // call before the PDF, populating `FetchResult::metadata_json`.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.7\n%fix\n".to_vec()))
+        .mount(&server)
+        .await;
+
+    let host = server
+        .uri()
+        .parse::<Url>()
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_string();
+    let (_td, ctx) = build_ctx(&host);
+    let s = ArxivSource::with_base(server.uri().parse().unwrap());
+    let id = ArxivId::parse("2401.12345").unwrap();
+    let r = Ref::Arxiv(id);
+    let profile = CapabilityProfile::from_env().expect("clean env");
+
+    let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
+    let meta = res
+        .metadata_json
+        .expect("metadata_json populated from Atom feed");
+    assert_eq!(
+        meta["title"],
+        serde_json::json!("Example arXiv Paper Title")
+    );
+    assert_eq!(
+        meta["abstract"],
+        serde_json::json!("This is an example abstract.")
+    );
+    assert_eq!(meta["authors"], serde_json::json!(["Jane Doe", "John Roe"]));
+    assert_eq!(meta["published"], serde_json::json!("2024-01-15T00:00:00Z"));
+    assert_eq!(meta["updated"], serde_json::json!("2024-02-01T00:00:00Z"));
+    assert_eq!(meta["categories"], serde_json::json!(["cs.LG", "stat.ML"]));
+}
+
+#[tokio::test]
+async fn arxiv_source_fetch_metadata_only_via_wiremock() {
+    // Atom endpoint only — `fetch_metadata_only` MUST NOT touch the
+    // PDF endpoint (no mount for `/pdf/...`).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+        .mount(&server)
+        .await;
+
+    let host = server
+        .uri()
+        .parse::<Url>()
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_string();
+    let (_td, ctx) = build_ctx(&host);
+    let s = ArxivSource::with_base(server.uri().parse().unwrap());
+    let id = ArxivId::parse("2401.12345").unwrap();
+
+    let meta = s
+        .fetch_metadata_only(&id, &ctx)
+        .await
+        .expect("metadata_only ok");
+    assert_eq!(
+        meta["title"],
+        serde_json::json!("Example arXiv Paper Title")
+    );
+    assert_eq!(meta["authors"], serde_json::json!(["Jane Doe", "John Roe"]));
+}

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -27,6 +27,15 @@ serde_json         = { workspace = true }
 # `camino::Utf8PathBuf` for the store-root probe — the workspace `clippy.toml`
 # bans `std::path::PathBuf` for user-facing paths.
 camino             = { workspace = true }
+# 26-char ULID per tool-call session_id (Slice 1: the non-dry-run
+# `doiget_metadata_only` path opens a per-call provenance log session;
+# the CLI uses `ulid` for the same purpose in
+# `crates/doiget-cli/src/commands/fetch.rs::new_session_id`).
+ulid               = { workspace = true }
+# URL parsing for the test-mode `DOIGET_*_BASE` overrides in
+# `build_metadata_only_http_client` (mirrors the CLI's
+# `build_http_client`).
+url                = { workspace = true }
 # Official Rust MCP SDK. Feature set is locked at the workspace root —
 # stdio-only (`transport-io`), no HTTP server, no oauth, no `__reqwest`.
 # See ADR-0001 / docs/SECURITY.md §3.
@@ -42,3 +51,9 @@ rmcp        = { workspace = true, features = ["client"] }
 # Match the test's `tokio::io::duplex` + `AsyncReadExt` use.
 tokio       = { workspace = true, features = ["io-util"] }
 serde_json  = { workspace = true }
+# Serializes env-var-mutating MCP integration tests (the Slice 1
+# `doiget_metadata_only` e2e tests stage `DOIGET_*_BASE` to redirect at
+# wiremock origins). Mirrors `doiget-cli/Cargo.toml`'s usage.
+serial_test = "3"
+wiremock    = { workspace = true }
+tempfile    = { workspace = true }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -10,9 +10,12 @@
 //!
 //! - `doiget_health` — operational sanity check.
 //! - `doiget_capability_profile` — reports the runtime [`CapabilityProfile`].
-//! - `doiget_metadata_only` — DOI / arXiv id metadata resolution; in
-//!   Phase 1 only the `dry_run: true` path is wired (the live metadata
-//!   fetch lands in a follow-up PR).
+//! - `doiget_metadata_only` — DOI / arXiv id metadata resolution. Both
+//!   the `dry_run: true` preview path (ADR-0022) and the live
+//!   non-dry-run path (Slice 1: dispatches through
+//!   [`doiget_core::orchestrator::metadata_only`]) are wired. The
+//!   tool MUST NOT call `HttpClient::fetch_pdf` — that contract is
+//!   enforced by the orchestrator and the posture-lint workflow.
 //!
 //! The remaining tools named in `docs/MCP_TOOLS.md` (`doiget_resolve_paper`,
 //! `doiget_fetch_paper`, `doiget_batch_fetch`, `doiget_info`,
@@ -34,10 +37,19 @@
 // outside JSON-RPC frames. See docs/SECURITY.md §3.
 #![deny(clippy::print_stdout)]
 
+use std::sync::Arc;
+
 use camino::Utf8PathBuf;
 
 use doiget_core::dry_run::{build_dry_run_envelope, build_fetch_plan};
-use doiget_core::{CapabilityProfile, ErrorCode, Ref, SCHEMA_VERSION, VERSION};
+use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
+use doiget_core::orchestrator::{metadata_only, MetadataOnlyOutcome};
+use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
+use doiget_core::rate_limiter::RateLimiter;
+use doiget_core::source::{FetchContext, FetchError};
+use doiget_core::{
+    CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref, SCHEMA_VERSION, VERSION,
+};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{CallToolResult, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
@@ -165,17 +177,26 @@ impl Server {
     ///
     /// Per `docs/MCP_TOOLS.md` §11 (NORMATIVE).
     ///
-    /// **Phase 1 status:** only the `dry_run: true` path is wired —
-    /// the orchestrator that performs a real metadata-only fetch (with
-    /// the `metadata-only` provenance tag and no PDF leg) lands in a
-    /// follow-up PR. The non-dry-run path returns
-    /// `{ok:false, error:{code:"NOT_IMPLEMENTED", ...}}` with a clear
-    /// message; `ErrorCode::NotImplemented` is the typed signal the
-    /// post-incorporation review (item 5) introduced specifically for
-    /// "spec'd but not yet wired" stubs — distinct from `INTERNAL_ERROR`
-    /// (a bug) and `CAPABILITY_DENIED` (a runtime config gate). The
-    /// dry-run path is the user-visible value-add this PR ships, per
-    /// ADR-0022 (the `dry_run` companion ADR).
+    /// Slice 1 wired both branches:
+    ///
+    /// - `dry_run: true` → builds a [`FetchPlan`] preview and returns
+    ///   it without touching the network, store, or provenance log
+    ///   (ADR-0022 §2).
+    /// - `dry_run: false` (default) → dispatches through
+    ///   [`doiget_core::orchestrator::metadata_only`]:
+    ///   - DOI → Crossref (`message` metadata + OA URL via
+    ///     `message.link[]`), with Unpaywall as a fallback when
+    ///     Crossref fails.
+    ///   - arXiv → Atom feed at
+    ///     `https://export.arxiv.org/api/query?id_list=<id>` via
+    ///     [`doiget_core::sources::arxiv::ArxivSource::fetch_metadata_only`].
+    ///
+    /// In neither branch does this tool call
+    /// `HttpClient::fetch_pdf` — the spec contract for
+    /// `doiget_metadata_only` (`docs/MCP_TOOLS.md` §11) is
+    /// posture-lint-enforced.
+    ///
+    /// [`FetchPlan`]: doiget_core::dry_run::FetchPlan
     #[tool(
         description = "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\n\
                        INPUTS: ref (DOI or arXiv id), dry_run (optional bool).\n\
@@ -217,28 +238,73 @@ impl Server {
             )));
         }
 
-        // Step 3: non-dry-run path. The real metadata-only orchestrator
-        // lands in a follow-up PR; surface a clear NOT_IMPLEMENTED
-        // envelope so an agent reacts with "wait for the next minor
-        // release" rather than "report a bug" (INTERNAL_ERROR) or
-        // "tweak my capability profile" (CAPABILITY_DENIED). The typed
-        // `ErrorCode::NotImplemented` value (rather than a raw string
-        // literal) is the I6 lesson from the PR #84 multi-agent review:
-        // the envelope's `code` field MUST come from the closed enum
-        // so a typo in the literal cannot ship.
-        // TODO(phase-1.x): wire the metadata-only orchestrator.
-        // It should: dispatch Crossref + Unpaywall (DOI) or arXiv-meta
-        // (arXiv), write the metadata TOML, append a `Fetch` row tagged
-        // `metadata-only`, and return `{ok:true, ref, source, license?,
-        // oa_url, metadata}` per docs/MCP_TOOLS.md §11. The OA URL is
-        // reported but never followed (that is the contract that
-        // distinguishes this tool from `doiget_fetch_paper`).
-        Ok(CallToolResult::structured(metadata_only_error_envelope(
-            ErrorCode::NotImplemented,
-            "metadata-only orchestrator is not yet wired in Phase 1; \
-             only dry_run is supported. Will be implemented in a \
-             follow-up PR.",
-        )))
+        // Step 3: non-dry-run path. Dispatch through the
+        // `metadata_only` orchestrator (Slice 1). The orchestrator owns
+        // source selection and per-leg politeness; we own the per-call
+        // session boundary (SessionStart / SessionEnd bookend rows) and
+        // the wire envelope shape (`docs/MCP_TOOLS.md` §11).
+        let ctx = match build_metadata_only_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    ErrorCode::InternalError,
+                    &format!("metadata-only context initialization failed: {e}"),
+                )));
+            }
+        };
+
+        // SessionStart bookend (mirrors the CLI orchestrator pattern in
+        // `crates/doiget-cli/src/commands/fetch.rs::FetchHarness::log_session_start`).
+        // A log-append failure here is fail-closed per
+        // `docs/PROVENANCE_LOG.md` §5 — abort the call.
+        if let Err(e) = ctx.log.append(RowInput {
+            event: LogEvent::SessionStart,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(input.ref_.as_str()),
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        }) {
+            return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                ErrorCode::LogError,
+                &format!("SessionStart append failed: {e}"),
+            )));
+        }
+
+        let outcome = metadata_only(&ref_, &self.profile, &ctx).await;
+
+        // SessionEnd bookend. Best-effort: if this append fails we still
+        // surface the orchestrator's outcome (a fresh log error here
+        // would mask the more informative orchestrator error).
+        let session_ok = outcome.is_ok();
+        let _ = ctx.log.append(RowInput {
+            event: LogEvent::SessionEnd,
+            result: if session_ok {
+                LogResult::Ok
+            } else {
+                LogResult::Err
+            },
+            capability: Capability::Metadata,
+            ref_: Some(input.ref_.as_str()),
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        });
+
+        match outcome {
+            Ok(o) => Ok(CallToolResult::structured(metadata_only_success_envelope(
+                &o,
+                &input.ref_,
+            ))),
+            Err(e) => Ok(CallToolResult::structured(
+                metadata_only_fetch_error_envelope(&e, &input.ref_),
+            )),
+        }
     }
 }
 
@@ -273,10 +339,12 @@ pub struct MetadataOnlyInput {
 }
 
 /// Build the `{ok:false, error:{...}}` envelope used by
-/// `doiget_metadata_only` for both `INVALID_REF` (bad input) and
-/// `NOT_IMPLEMENTED` (Phase 1 stub) cases. Mirrors the wire shape from
-/// `docs/MCP_TOOLS.md` §5; `denial_context` is omitted (these failure
-/// modes do not produce one — see `docs/ERRORS.md` §3.1).
+/// `doiget_metadata_only` for input-shape failures (e.g. `INVALID_REF`
+/// from `Ref::parse`) and internal initialization failures (e.g.
+/// `INTERNAL_ERROR` when the foundation modules cannot be constructed).
+/// Mirrors the wire shape from `docs/MCP_TOOLS.md` §5; `denial_context`
+/// is omitted (these failure modes do not produce one — see
+/// `docs/ERRORS.md` §3.1).
 ///
 /// The `code` parameter is typed as [`ErrorCode`] (not `&str`) so the
 /// closed enum is the single source of truth for the wire token — the
@@ -294,6 +362,181 @@ fn metadata_only_error_envelope(code: ErrorCode, message: &str) -> Value {
             // consumers MUST tolerate the field being absent.
         },
     })
+}
+
+/// Build the `{ok:true, ...}` success envelope per `docs/MCP_TOOLS.md`
+/// §11 (the `MetadataOnlyResult` type alias). `oa_url` is always
+/// emitted (as `null` when the resolver did not surface one) so agents
+/// can pattern-match on the field without checking for absence.
+fn metadata_only_success_envelope(outcome: &MetadataOnlyOutcome, ref_str: &str) -> Value {
+    json!({
+        "ok": true,
+        "ref": ref_str,
+        "source": outcome.source,
+        "license": outcome.license,
+        "oa_url": outcome.oa_url,
+        "metadata": outcome.metadata,
+        "schema_version": SCHEMA_VERSION,
+    })
+}
+
+/// Build the `{ok:false, error:{code, message, denial_context?}}`
+/// envelope for orchestrator failures. Maps the [`FetchError`] to the
+/// closed [`ErrorCode`] set via the existing
+/// `From<FetchError> for ErrorCode` impl, and produces the optional
+/// structured `denial_context` channel via
+/// `From<&FetchError> for Option<DenialContext>` (ADR-0023 §4).
+fn metadata_only_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value {
+    // `FetchError` is not `Clone`; we can't move out of `&err`. Use
+    // the existing `From` boundary indirectly by re-mapping via a
+    // match on `&FetchError`. This duplicates a few lines of the
+    // `From<FetchError> for ErrorCode` impl but avoids cloning the
+    // underlying transport error.
+    let code: ErrorCode = match err {
+        FetchError::NotEligible { .. } => ErrorCode::CapabilityDenied,
+        FetchError::NoOaAvailable => ErrorCode::NoOaAvailable,
+        FetchError::Http(_) => ErrorCode::NetworkError,
+        FetchError::Log(_) => ErrorCode::LogError,
+        FetchError::InvalidRef(_) => ErrorCode::InvalidRef,
+        FetchError::SourceSchema { .. } => ErrorCode::InternalError,
+        // `FetchError` is `#[non_exhaustive]`; this wildcard pins
+        // future variants to `INTERNAL_ERROR` until they get an
+        // explicit mapping. Mirrors the conservative default in
+        // `doiget-core`'s `From<FetchError> for ErrorCode` impl.
+        _ => ErrorCode::InternalError,
+    };
+    let denial: Option<DenialContext> = err.into();
+    let message = err.to_string();
+
+    let mut error_obj = serde_json::Map::new();
+    error_obj.insert("code".into(), json!(code));
+    error_obj.insert("message".into(), json!(message));
+    if let Some(dc) = denial {
+        // `DenialContext` is `Serialize` (`#[serde(deny_unknown_fields)]`,
+        // optional fields). `serde_json::to_value` cannot fail on a
+        // typed struct; the `unwrap_or` defensively returns `null` if a
+        // future field becomes non-serializable (defensive only).
+        error_obj.insert(
+            "denial_context".into(),
+            serde_json::to_value(&dc).unwrap_or(Value::Null),
+        );
+    }
+    json!({
+        "ok": false,
+        "ref": ref_str,
+        "error": error_obj,
+    })
+}
+
+/// Build a [`FetchContext`] for the non-dry-run `doiget_metadata_only`
+/// path.
+///
+/// Mirrors `crates/doiget-cli/src/commands/fetch.rs::FetchHarness::from_env`
+/// minus the on-disk store (which the orchestrator does not touch in
+/// Slice 1 — see the `TODO Phase 2.x` in
+/// `crates/doiget-core/src/orchestrator.rs::metadata_only`):
+///
+/// - `HttpClient` — production allowlist (Tier 1 ∪ OA publisher), or
+///   the test-mode multi-source allowlist when any `DOIGET_*_BASE` env
+///   var is set.
+/// - `RateLimiter` — process-wide hard-coded politeness
+///   ([`RateLimits::HARD_CODED`]).
+/// - `ProvenanceLog` — opened at `$DOIGET_LOG_PATH` or
+///   `<config>/doiget/access.jsonl`; the parent directory is created
+///   if missing.
+/// - `session_id` — fresh 26-char ULID per call (one tool call = one
+///   logical session, per `docs/PROVENANCE_LOG.md` §3).
+fn build_metadata_only_context() -> anyhow::Result<FetchContext> {
+    let log_path = resolve_log_path()?;
+    if let Some(parent) = log_path.parent() {
+        if !parent.as_str().is_empty() {
+            std::fs::create_dir_all(parent.as_std_path())
+                .map_err(|e| anyhow::anyhow!("creating log dir {parent}: {e}"))?;
+        }
+    }
+    let session_id = ulid::Ulid::new().to_string();
+    let log = Arc::new(
+        ProvenanceLog::open(log_path, session_id.clone())
+            .map_err(|e| anyhow::anyhow!("opening provenance log: {e}"))?,
+    );
+    let http = Arc::new(build_metadata_only_http_client()?);
+    let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+    Ok(FetchContext {
+        http,
+        rate_limiter,
+        log,
+        session_id,
+    })
+}
+
+/// HTTP client construction with the same `DOIGET_*_BASE` test-override
+/// surface that `doiget-cli` honors (`build_http_client` in
+/// `crates/doiget-cli/src/commands/fetch.rs`). When no overrides are
+/// set, returns the production allowlist (Tier 1 ∪ OA publisher).
+fn build_metadata_only_http_client() -> anyhow::Result<HttpClient> {
+    let arxiv = std::env::var("DOIGET_ARXIV_BASE").ok();
+    let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
+    let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
+    let oa_publisher = std::env::var("DOIGET_OA_PUBLISHER_BASE").ok();
+
+    if arxiv.is_none() && crossref.is_none() && unpaywall.is_none() && oa_publisher.is_none() {
+        let mut allowlists = tier_1_allowlist();
+        allowlists.extend(oa_publisher_allowlist());
+        return HttpClient::new(allowlists)
+            .map_err(|e| anyhow::anyhow!("building production HTTP client: {e}"));
+    }
+
+    let mut owned: Vec<(String, String)> = Vec::new();
+    for (source, base) in [
+        ("arxiv", arxiv.as_deref()),
+        ("crossref", crossref.as_deref()),
+        ("unpaywall", unpaywall.as_deref()),
+        ("oa-publisher", oa_publisher.as_deref()),
+    ] {
+        if let Some(b) = base {
+            let url = url::Url::parse(b)
+                .map_err(|e| anyhow::anyhow!("DOIGET_*_BASE for {source} not a URL: {b}: {e}"))?;
+            let host = url
+                .host_str()
+                .ok_or_else(|| anyhow::anyhow!("base URL has no host: {b}"))?;
+            owned.push((source.to_string(), host.to_string()));
+        }
+    }
+    let entries: Vec<(&str, &str)> = owned
+        .iter()
+        .map(|(s, h)| (s.as_str(), h.as_str()))
+        .collect();
+    Ok(HttpClient::new_for_tests_allow_http_multi(&entries))
+}
+
+/// Resolve the provenance log path. Mirrors the CLI's precedence
+/// (`crates/doiget-cli/src/commands/fetch.rs::resolve_log_path`):
+/// 1. `DOIGET_LOG_PATH` env var.
+/// 2. `<config>/doiget/access.jsonl` where `<config>` is
+///    `XDG_CONFIG_HOME` / `APPDATA` / `$HOME/.config`.
+fn resolve_log_path() -> anyhow::Result<Utf8PathBuf> {
+    if let Ok(s) = std::env::var("DOIGET_LOG_PATH") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s));
+        }
+    }
+    if let Ok(s) = std::env::var("XDG_CONFIG_HOME") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s).join("doiget").join("access.jsonl"));
+        }
+    }
+    if let Ok(s) = std::env::var("APPDATA") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s).join("doiget").join("access.jsonl"));
+        }
+    }
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| anyhow::anyhow!("neither HOME nor USERPROFILE is set"))?;
+    Ok(Utf8PathBuf::from(home)
+        .join(".config")
+        .join("doiget")
+        .join("access.jsonl"))
 }
 
 // `tool_handler` wires the router into rmcp's `ServerHandler` trait — it

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -255,12 +255,165 @@ async fn doiget_metadata_only_dry_run_true_returns_fetch_plan_envelope() -> anyh
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// doiget_metadata_only — Slice 1 non-dry-run wiring (A.3)
+//
+// The stub-era `doiget_metadata_only_default_dry_run_false_returns_not_implemented_stub`
+// test was DELETED here: the NOT_IMPLEMENTED branch no longer exists.
+// The tests below exercise the live orchestrator end-to-end through
+// the MCP envelope (wiremock-driven; no real network).
+//
+// These tests mutate process-global env vars (`DOIGET_*_BASE`,
+// `DOIGET_LOG_PATH`) so they are serialized via `serial_test::serial`.
+// ---------------------------------------------------------------------------
+
+/// RAII helper to scope env-var mutations across a test. Mirrors the
+/// `EnvGuard` in `crates/doiget-cli/tests/fetch_arxiv_e2e.rs`.
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+/// Synthetic Atom payload (B.3 from the Slice 1 spec). Do not hit
+/// real arXiv.
+const SAMPLE_ATOM_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <updated>2024-02-01T00:00:00Z</updated>
+    <published>2024-01-15T00:00:00Z</published>
+    <title>Example arXiv Paper Title</title>
+    <summary>This is an example abstract.</summary>
+    <author><name>Jane Doe</name></author>
+    <author><name>John Roe</name></author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="stat.ML" scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"#;
+
 #[tokio::test]
-async fn doiget_metadata_only_default_dry_run_false_returns_not_implemented_stub(
-) -> anyhow::Result<()> {
+#[serial_test::serial]
+async fn doiget_metadata_only_arxiv_happy_path_returns_metadata_envelope() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-meta.jsonl");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_LOG_PATH",
+    ]);
+    env.set("DOIGET_ARXIV_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
     let (client, server_handle) = boot_in_memory_server().await?;
 
-    // Omit `dry_run`; defaults to false via `#[serde(default)] dry_run: bool`.
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("2401.12345"));
+
+    let result = client
+        .peer()
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new("doiget_metadata_only").with_arguments(args),
+        )
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_metadata_only uses CallToolResult::structured");
+
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    assert_eq!(structured["source"], serde_json::json!("arxiv"));
+    assert_eq!(structured["ref"], serde_json::json!("2401.12345"));
+    assert_eq!(structured["license"], serde_json::json!("arxiv-default"));
+    // arXiv branch never surfaces an OA URL (the abstract page is not
+    // a PDF URL) — the field is emitted as `null`.
+    assert_eq!(structured["oa_url"], serde_json::Value::Null);
+    assert_eq!(
+        structured["metadata"]["title"],
+        serde_json::json!("Example arXiv Paper Title")
+    );
+    assert_eq!(
+        structured["metadata"]["authors"],
+        serde_json::json!(["Jane Doe", "John Roe"])
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_metadata_only_doi_crossref_happy_path_returns_metadata_envelope(
+) -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/example"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://example.org/oa.pdf"}]}}"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-meta.jsonl");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_LOG_PATH",
+    ]);
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
     let mut args = serde_json::Map::new();
     args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
 
@@ -273,29 +426,108 @@ async fn doiget_metadata_only_default_dry_run_false_returns_not_implemented_stub
     let structured = result
         .structured_content
         .as_ref()
-        .expect("doiget_metadata_only stub uses CallToolResult::structured");
+        .expect("doiget_metadata_only uses CallToolResult::structured");
 
-    // Phase 1: the non-dry-run branch is a documented stub returning
-    // NOT_IMPLEMENTED with a clear message (see Server::doiget_metadata_only).
-    // The post-incorporation review (item 5) introduced ErrorCode::NotImplemented
-    // specifically to distinguish "spec'd but not yet wired" stubs from
-    // bugs (INTERNAL_ERROR) or capability gates (CAPABILITY_DENIED).
-    assert_eq!(structured["ok"], serde_json::json!(false));
     assert_eq!(
-        structured["error"]["code"],
-        serde_json::json!("NOT_IMPLEMENTED"),
+        structured["ok"],
+        serde_json::json!(true),
         "envelope: {structured:?}"
     );
-    let msg = structured["error"]["message"]
-        .as_str()
-        .expect("error.message is a string");
-    assert!(
-        msg.contains("not yet wired") || msg.contains("dry_run"),
-        "NOT_IMPLEMENTED stub message must mention the Phase 1 limitation; \
-         got: {msg:?}"
+    assert_eq!(structured["source"], serde_json::json!("crossref"));
+    assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
+    // Crossref does not surface a license directly (Phase 1; future
+    // slices will chain Unpaywall for license enrichment).
+    assert_eq!(structured["license"], serde_json::Value::Null);
+    // OA URL discovered via `message.link[]`. Surfaced but never
+    // followed — the test does not mount a mock for it.
+    assert_eq!(
+        structured["oa_url"],
+        serde_json::json!("https://example.org/oa.pdf")
+    );
+    assert_eq!(
+        structured["metadata"]["title"],
+        serde_json::json!(["Example Paper"])
     );
 
     client.cancel().await?;
     server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_metadata_only_network_failure_returns_network_error_envelope() -> anyhow::Result<()>
+{
+    // Point Crossref and Unpaywall at a wiremock that returns 500 on
+    // every call. The orchestrator will try Crossref first, then fall
+    // back to Unpaywall (also pointed at the same broken origin), and
+    // surface a NETWORK_ERROR envelope when both legs fail.
+    // `denial_context` is absent — transport errors are not denials
+    // per ADR-0023 §4.
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-meta.jsonl");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_LOG_PATH",
+    ]);
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_UNPAYWALL_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+
+    let result = client
+        .peer()
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new("doiget_metadata_only").with_arguments(args),
+        )
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_metadata_only uses CallToolResult::structured");
+
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(false),
+        "envelope: {structured:?}"
+    );
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("NETWORK_ERROR"),
+        "envelope: {structured:?}"
+    );
+    // Transport-level errors do NOT produce a denial_context (ADR-0023
+    // §4 mapping table: only RedirectDenied / InsecureRedirect /
+    // OversizedBody / NotAPdf map to denial reasons).
+    assert!(
+        structured["error"].get("denial_context").is_none()
+            || structured["error"]["denial_context"].is_null(),
+        "NETWORK_ERROR envelope must omit denial_context; got: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
     Ok(())
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -470,16 +470,16 @@ criteria = "safe-to-deploy"
 version = "1.11.0"
 criteria = "safe-to-run"
 
+[[exemptions.quick-xml]]
+version = "0.36.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.quinn]]
 version = "0.11.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.quinn-proto]]
 version = "0.11.14"
-criteria = "safe-to-deploy"
-
-[[exemptions.quick-xml]]
-version = "0.36.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.quote]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -478,6 +478,10 @@ criteria = "safe-to-deploy"
 version = "0.11.14"
 criteria = "safe-to-deploy"
 
+[[exemptions.quick-xml]]
+version = "0.36.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.quote]]
 version = "1.0.45"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

Slice 1 of 6 in the post-Discussion #12 incorporation roadmap. Closes the two coupled Phase 1.x TODOs surfaced by PR #84 + PR #85:

| | Deliverable | Where |
|---|---|---|
| **A** | `doiget_metadata_only` MCP tool non-dry-run path wired (was `NOT_IMPLEMENTED` stub) | new `core::orchestrator::metadata_only` + `mcp/lib.rs` |
| **B** | arXiv `Source::fetch` produces real `metadata_json` via Atom feed parsing | `core/sources/arxiv.rs` + new `quick-xml` dep |

## Why coupled

(A) needs (B): the orchestrator must produce metadata for arXiv refs without fetching the PDF, and the only path is the Atom feed.

## Surface

`MetadataOnlyOutcome { source, license, oa_url, metadata }` per `docs/MCP_TOOLS.md` §11. `oa_url` is reported but never followed — the contract is enforced structurally (no `HttpClient::fetch_pdf` call exists on this code path).

## Tests

- 6 orchestrator unit tests
- 3 MCP integration tests (wiremock: DOI happy / arXiv happy / network failure with `denial_context: null`)
- 3 + 3 unit tests for the new Atom parsing
- 2 e2e tests in new `tests/arxiv_metadata_e2e.rs`
- Deleted the obsolete `NOT_IMPLEMENTED` stub test

## Verification

- `cargo fmt --check` clean
- `cargo build --workspace`
- `cargo test --workspace` 21 test binaries / 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only` clean

## Deviations

- Provenance log tagging: uses existing `Capability::Metadata` channel rather than bumping schema_version or mangling the `source` field. Documented in commit message.
- Metadata TOML store write: deferred to Phase 2.x with explicit `// TODO` markers (needs Phase 2 store invariants).

## Roadmap context

| Slice | Status | Title |
|---|---|---|
| **1** | **this PR** | metadata_only + arxiv Atom |
| 2 | pending | MCP `doiget_fetch_paper` + `doiget_batch_fetch` |
| 3 | pending | safekey 100 vectors |
| 4 | pending | `CanonicalRef` impl (BREAKING) |
| 5 | pending | Review Advisory 8 items refactor |
| 6 | pending | Real-world DOI fixture set |

Refs: PR #84, PR #85, Discussion #12.