### PR TITLE
feat(slice-2): MCP doiget_fetch_paper + doiget_batch_fetch wired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,41 @@ Phase 0 (design + scaffolding). No version tag is published in this phase; the
 workspace stays at `0.0.0` until Phase 6. See [docs/PHASES.md](docs/PHASES.md)
 for the full Phase 0 deliverable checklist.
 
+### Slice 2 — MCP doiget_fetch_paper + doiget_batch_fetch
+
+- **(C.1)** Extracted the single-fetch and batch-fetch orchestrators
+  out of `doiget-cli::commands::{fetch,batch}` into
+  `doiget_core::orchestrator::{fetch_paper, batch_fetch}` siblings to
+  Slice 1's `metadata_only`. The CLI's `run_with_options` now
+  delegates; behaviour is preserved (the existing CLI fetch/batch
+  e2e suites stay green).
+- **(C.2)** New MCP tools:
+  - `doiget_fetch_paper(ref, dry_run?)` — resolves and downloads one
+    PDF. Honors `dry_run: true` per ADR-0022 (returns a `FetchPlan`
+    envelope without touching network or store). Failure envelope
+    carries `denial_context` per ADR-0023.
+  - `doiget_batch_fetch(refs[], dry_run?)` — bulk variant capped at
+    `MAX_BATCH_REFS = 100`. Returns one result entry per ref;
+    per-ref errors do NOT fail the whole call (matches CLI batch
+    semantics). `dry_run` returns `{ok:true, dry_run:true,
+    plans:[...]}`.
+- **(C.3)** New `pub const doiget_core::MAX_BATCH_REFS: usize = 100;`
+  and `FetchError::TooManyRefs { got, max }` variant (additive on
+  `#[non_exhaustive]` enum; collapses to `ErrorCode::InvalidRef` at
+  the public boundary — `TooManyRefs` is a request-shape failure,
+  not a denial, so `denial_context` stays `None`).
+- **(C.4)** 25 new MCP integration tests in
+  `crates/doiget-mcp/tests/fetch_paper_e2e.rs` plus expanded
+  coverage in `initialize_handshake.rs`: `tools/list` advertises
+  both new tools; INVALID_REF / TOO_MANY_REFS / dry_run /
+  happy-path / partial-failure all exercised.
+
+After Slice 2 the MCP `Server` exposes 5 of the 9 Phase 3 baseline
+tools (`doiget_health`, `doiget_capability_profile`,
+`doiget_metadata_only`, `doiget_fetch_paper`, `doiget_batch_fetch`).
+Remaining: `doiget_resolve_paper`, `doiget_info`, `doiget_search_local`,
+`doiget_list_recent`, `doiget_paper_pdf_path`.
+
 ### Slice 1 — metadata_only orchestrator + arXiv Atom feed
 
 - **(A)** `doiget_metadata_only` non-dry-run path wired through the new

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -2,10 +2,11 @@
 //!
 //! Phase 1 scope:
 //!
-//! - **arXiv refs** — full end-to-end: PDF bytes are fetched via
-//!   [`ArxivSource`], the `[doiget]` extension table is populated with the
-//!   resolved license, source, size, and `fetched_at`, and the result is
-//!   written to the on-disk store with both the metadata TOML and the PDF.
+//! - **arXiv refs** — full end-to-end: PDF bytes are fetched via the
+//!   `doiget_core::sources::arxiv::ArxivSource`, the `[doiget]`
+//!   extension table is populated with the resolved license, source,
+//!   size, and `fetched_at`, and the result is written to the on-disk
+//!   store with both the metadata TOML and the PDF.
 //! - **DOI refs** — Crossref metadata + Unpaywall license enrichment + an
 //!   OA PDF fetch when Unpaywall's `best_oa_location.url_for_pdf` (or
 //!   `best_oa_location.url`) resolves to a host on the synthetic
@@ -39,22 +40,18 @@
 //! | `DOIGET_UNPAYWALL_BASE` | `https://api.unpaywall.org/v2` | Unpaywall source base (test override) |
 //! | `DOIGET_OA_PUBLISHER_BASE` | (production allowlist) | OA publisher host allowlist override (test override) |
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
-use chrono::Utc;
+use camino::Utf8PathBuf;
 
-use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient, HttpError};
+use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
+use doiget_core::orchestrator::{fetch_paper as core_fetch_paper, FetchPaperOutcome};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
-use doiget_core::source::{FetchContext, FetchResult, Source};
-use doiget_core::sources::arxiv::ArxivSource;
-use doiget_core::sources::crossref::CrossrefSource;
-use doiget_core::sources::unpaywall::UnpaywallSource;
-use doiget_core::store::{DoigetExtension, FsStore, Metadata, Store};
-use doiget_core::{ArxivId, CapabilityProfile, Doi, RateLimits, Ref, Safekey, SCHEMA_VERSION};
+use doiget_core::source::FetchContext;
+use doiget_core::store::FsStore;
+use doiget_core::{CapabilityProfile, RateLimits, Ref};
 
 /// Defer to docs/PROVENANCE_LOG.md §3: 26-char ULID per process invocation.
 fn new_session_id() -> String {
@@ -199,37 +196,24 @@ fn build_http_client() -> Result<HttpClient> {
     Ok(HttpClient::new_for_tests_allow_http_multi(&entries))
 }
 
-/// Construct an [`ArxivSource`] honoring `DOIGET_ARXIV_BASE` if set.
-fn build_arxiv_source() -> Result<ArxivSource> {
-    if let Ok(s) = std::env::var("DOIGET_ARXIV_BASE") {
-        let url =
-            url::Url::parse(&s).with_context(|| format!("DOIGET_ARXIV_BASE is not a URL: {s}"))?;
-        return Ok(ArxivSource::with_base(url));
-    }
-    Ok(ArxivSource::new())
-}
-
-/// Construct a [`CrossrefSource`] honoring `DOIGET_CROSSREF_BASE` if set.
-fn build_crossref_source(contact_email: &str) -> Result<CrossrefSource> {
-    if let Ok(s) = std::env::var("DOIGET_CROSSREF_BASE") {
-        let url = url::Url::parse(&s)
-            .with_context(|| format!("DOIGET_CROSSREF_BASE is not a URL: {s}"))?;
-        return Ok(CrossrefSource::with_base(url, contact_email.to_string()));
-    }
-    Ok(CrossrefSource::new(contact_email.to_string()))
-}
-
-/// Construct an [`UnpaywallSource`] honoring `DOIGET_UNPAYWALL_BASE` if set.
-fn build_unpaywall_source(contact_email: &str) -> Result<UnpaywallSource> {
-    if let Ok(s) = std::env::var("DOIGET_UNPAYWALL_BASE") {
-        let url = url::Url::parse(&s)
-            .with_context(|| format!("DOIGET_UNPAYWALL_BASE is not a URL: {s}"))?;
-        return Ok(UnpaywallSource::with_base(url, contact_email.to_string()));
-    }
-    Ok(UnpaywallSource::new(contact_email.to_string()))
-}
+// Slice 2: the per-source env-aware constructors that used to live here
+// (`build_arxiv_source`, `build_crossref_source`, `build_unpaywall_source`)
+// moved into `doiget-core::orchestrator` so the core `fetch_paper`
+// orchestrator and the MCP server both honor the same `DOIGET_*_BASE`
+// test-override surface. The CLI no longer constructs sources directly —
+// it builds the `FetchContext` + `FsStore` and hands them to the core
+// orchestrator.
 
 /// Resolved configuration derived from the environment.
+///
+/// Slice 2: `contact_email` / `unpaywall_email` are now read by the
+/// `doiget-core::orchestrator::fetch_paper` orchestrator directly from
+/// the env (`contact_email_from_env` / `unpaywall_email_from_env` in
+/// that module), so the CLI no longer threads them through. The fields
+/// stay here so a future slice that adds CLI-flag overrides has a
+/// natural attachment point — the `#[allow(dead_code)]` is the minimal
+/// intervention until that slice lands.
+#[allow(dead_code)]
 pub(crate) struct OrchestratorConfig {
     pub(crate) store_root: Utf8PathBuf,
     pub(crate) log_path: Utf8PathBuf,
@@ -271,6 +255,11 @@ pub(crate) struct FetchHarness {
     pub(crate) store: FsStore,
     pub(crate) profile: CapabilityProfile,
     pub(crate) session_id: String,
+    /// Resolved config; Slice 2 keeps this on the harness for the
+    /// CLI-only env diagnostics path (`commands::config::doctor`), even
+    /// though `fetch_one` no longer needs it (the core orchestrator
+    /// re-reads contact email from env directly).
+    #[allow(dead_code)]
     pub(crate) cfg: OrchestratorConfig,
 }
 
@@ -360,38 +349,44 @@ impl FetchHarness {
     }
 
     /// Run a single ref through the per-kind orchestration (arxiv → PDF +
-    /// metadata; doi → metadata-only via Crossref + Unpaywall). Errors here
-    /// are scoped to this one ref — the caller decides whether to abort the
-    /// surrounding session.
+    /// metadata; doi → metadata-only via Crossref + Unpaywall, with an
+    /// informed-best-effort OA PDF leg). Errors here are scoped to this
+    /// one ref — the caller decides whether to abort the surrounding
+    /// session.
+    ///
+    /// Slice 2: delegates to
+    /// [`doiget_core::orchestrator::fetch_paper`] for the actual work
+    /// (which both CLI and MCP now share). This function keeps the
+    /// CLI-only stderr success-line print.
     pub(crate) async fn fetch_one(&self, ref_: &Ref) -> Result<()> {
-        let safekey = ref_.safekey();
         let ctx = self.fetch_context();
-        match ref_ {
-            Ref::Arxiv(id) => {
-                fetch_arxiv(
-                    id,
-                    ref_,
-                    &self.profile,
-                    &ctx,
-                    &self.store,
-                    &safekey,
-                    &self.cfg,
-                )
-                .await
-            }
-            Ref::Doi(doi) => {
-                fetch_doi(
-                    doi,
-                    ref_,
-                    &self.profile,
-                    &ctx,
-                    &self.store,
-                    &safekey,
-                    &self.cfg,
-                )
-                .await
-            }
-        }
+        let outcome =
+            core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await?;
+        emit_success_line(ref_, &outcome);
+        Ok(())
+    }
+}
+
+/// CLI-only one-line success message on stderr (ADR-0001 stdio
+/// convention). Renders the [`FetchPaperOutcome`] in the same form the
+/// pre-Slice-2 CLI emitted: a full-PDF success names the PDF path; a
+/// metadata-only DOI fallback (size_bytes == 0) names the metadata TOML
+/// path the orchestrator wrote.
+fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
+    let label = match ref_ {
+        Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
+        Ref::Doi(doi) => format!("doi:{}", doi.as_str()),
+    };
+    if outcome.size_bytes == 0 {
+        print_success(format_args!(
+            "fetched {} (metadata-only) -> {}",
+            label, outcome.path
+        ));
+    } else {
+        print_success(format_args!(
+            "fetched {} ({} bytes) -> {}",
+            label, outcome.size_bytes, outcome.path
+        ));
     }
 }
 
@@ -480,321 +475,6 @@ pub async fn run_with_options(input: String, opts: FetchOptions) -> Result<()> {
     result
 }
 
-/// arXiv branch — full PDF + minimal metadata.
-async fn fetch_arxiv(
-    id: &ArxivId,
-    ref_: &Ref,
-    profile: &CapabilityProfile,
-    ctx: &FetchContext,
-    store: &FsStore,
-    safekey: &Safekey,
-    _cfg: &OrchestratorConfig,
-) -> Result<()> {
-    let source = build_arxiv_source()?;
-    if !source.can_serve(profile, ref_) {
-        return Err(anyhow!("arXiv source declined to serve {}", id.as_str()));
-    }
-
-    let FetchResult {
-        license,
-        pdf_bytes,
-        final_url,
-        ..
-    } = source
-        .fetch(ref_, profile, ctx)
-        .await
-        .with_context(|| format!("arxiv fetch failed for {}", id.as_str()))?;
-    let pdf = pdf_bytes.ok_or_else(|| anyhow!("arxiv source returned no PDF bytes"))?;
-    let size_bytes = pdf.len() as u64;
-
-    // Phase 1 minimal metadata: title placeholder = "arxiv:<id>". Full
-    // export.arxiv.org Atom-feed parsing is deferred to a follow-up PR.
-    let metadata = Metadata {
-        schema_version: SCHEMA_VERSION.to_string(),
-        title: format!("arxiv:{}", id.as_str()),
-        authors: Vec::new(),
-        year: None,
-        doi: None,
-        arxiv_id: Some(id.clone()),
-        abstract_: None,
-        venue: None,
-        publisher: None,
-        issn: None,
-        isbn: None,
-        type_: None,
-        keywords: Vec::new(),
-        url: final_url.as_ref().map(|u| u.to_string()),
-        pdf_path: Some(format!("{}.pdf", safekey.as_str())),
-        doiget: Some(DoigetExtension {
-            fetched_at: Utc::now(),
-            source: "arxiv".to_string(),
-            license: license.clone(),
-            size_bytes,
-            mcp_call_id: None,
-        }),
-        other: BTreeMap::new(),
-    };
-
-    // The Store::write contract takes a path to the PDF (not bytes); stage
-    // bytes to a tempfile so the existing atomic-rename code path applies.
-    let tmp = tempfile::NamedTempFile::new().context("creating PDF staging tempfile")?;
-    std::fs::write(tmp.path(), &pdf).context("staging PDF bytes")?;
-    let pdf_src = Utf8Path::from_path(tmp.path())
-        .ok_or_else(|| anyhow!("staging tempfile path is not UTF-8"))?
-        .to_path_buf();
-
-    write_to_store(store, safekey, &metadata, Some(&pdf_src), ctx).await?;
-    drop(tmp); // explicit drop to keep the tempfile alive across write_to_store
-
-    // Stderr success line per ADR-0001 stdio convention. The CLI MUST
-    // never write a success line to stdout (stdio is reserved for MCP
-    // JSON-RPC frames in `doiget serve`). `eprintln!` is the canonical way
-    // to surface a one-line user-visible confirmation; the workspace lint
-    // is warn-level, but `-D warnings` in CI promotes it, so an explicit
-    // localized allow is required here.
-    let pdf_path = store.root().join(format!("{}.pdf", safekey.as_str()));
-    print_success(format_args!(
-        "fetched arxiv:{} ({} bytes) -> {}",
-        id.as_str(),
-        size_bytes,
-        pdf_path
-    ));
-    Ok(())
-}
-
-/// DOI branch — Crossref metadata + Unpaywall license enrichment, plus
-/// (Phase 1 success criterion) an OA PDF fetch when Unpaywall returns a
-/// `best_oa_location` URL whose host is in the `oa-publisher` allowlist
-/// (`docs/REDIRECT_ALLOWLIST.md` §3).
-///
-/// **Partial-success semantics.** Per the `informed-best-effort` posture in
-/// `docs/REDIRECT_ALLOWLIST.md` §3, an OA URL whose host is NOT in the
-/// allowlist (or whose body fails the magic-byte check) does NOT abort the
-/// fetch — the metadata is still useful. The PDF outcome is logged as a
-/// distinct `Fetch` row with `source = "oa-publisher"` and the metadata
-/// write proceeds either way.
-async fn fetch_doi(
-    doi: &Doi,
-    ref_: &Ref,
-    profile: &CapabilityProfile,
-    ctx: &FetchContext,
-    store: &FsStore,
-    safekey: &Safekey,
-    cfg: &OrchestratorConfig,
-) -> Result<()> {
-    // Crossref first — bibliographic fields.
-    let crossref = build_crossref_source(&cfg.contact_email)?;
-    let cross = crossref
-        .fetch(ref_, profile, ctx)
-        .await
-        .with_context(|| format!("crossref fetch failed for {}", doi.as_str()))?;
-    let crossref_meta = cross.metadata_json.unwrap_or(serde_json::Value::Null);
-    let extracted = extract_crossref_fields(&crossref_meta);
-
-    // Unpaywall second — license enrichment + OA URL discovery. A failure
-    // here is non-fatal: we still write the Crossref-derived metadata.
-    let unpaywall = build_unpaywall_source(&cfg.unpaywall_email)?;
-    let upw_result = unpaywall.fetch(ref_, profile, ctx).await;
-    let (license, source_label, oa_url) = match upw_result {
-        Ok(r) => {
-            let oa = extract_best_oa_url(r.metadata_json.as_ref());
-            let label = if r.license != "unknown" {
-                "unpaywall".to_string()
-            } else {
-                "crossref".to_string()
-            };
-            (r.license, label, oa)
-        }
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "unpaywall fetch failed; continuing with crossref-only metadata"
-            );
-            ("unknown".to_string(), "crossref".to_string(), None)
-        }
-    };
-
-    // Step: OA PDF leg. Try the URL Unpaywall returned via the
-    // `oa-publisher` source allowlist. Magic-byte check is enforced inside
-    // `HttpClient::fetch_pdf`. Any failure here is logged as a distinct
-    // `Fetch err` row and falls through to metadata-only success.
-    let pdf_outcome = if let Some(url) = oa_url {
-        try_fetch_oa_pdf(doi, &url, ctx).await
-    } else {
-        None
-    };
-
-    // If the PDF leg succeeded, the on-disk source label flips to
-    // `oa-publisher` (we got actual content, not just a metadata-derived
-    // license). Otherwise keep the metadata-source label.
-    let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_outcome {
-        Some((bytes, _final_url)) => {
-            let staged = stage_pdf_to_tempfile(bytes.as_ref())?;
-            (
-                "oa-publisher".to_string(),
-                bytes.len() as u64,
-                Some(format!("{}.pdf", safekey.as_str())),
-                Some(staged),
-            )
-        }
-        None => (source_label, 0u64, None, None),
-    };
-
-    let metadata = Metadata {
-        schema_version: SCHEMA_VERSION.to_string(),
-        title: extracted.title.unwrap_or_else(|| doi.as_str().to_string()),
-        authors: extracted.authors,
-        year: extracted.year,
-        doi: Some(doi.clone()),
-        arxiv_id: None,
-        abstract_: None,
-        venue: extracted.venue,
-        publisher: None,
-        issn: None,
-        isbn: None,
-        type_: extracted.type_,
-        keywords: Vec::new(),
-        url: cross.final_url.as_ref().map(|u| u.to_string()),
-        pdf_path: pdf_path_relative,
-        doiget: Some(DoigetExtension {
-            fetched_at: Utc::now(),
-            source: final_source_label,
-            license,
-            size_bytes,
-            mcp_call_id: None,
-        }),
-        other: BTreeMap::new(),
-    };
-
-    let pdf_src_path = pdf_staged
-        .as_ref()
-        .and_then(|tmp| Utf8Path::from_path(tmp.path()).map(|p| p.to_path_buf()));
-    write_to_store(store, safekey, &metadata, pdf_src_path.as_deref(), ctx).await?;
-    drop(pdf_staged); // keep tempfile alive across write_to_store
-
-    if pdf_outcome.is_some() {
-        let pdf_path = store.root().join(format!("{}.pdf", safekey.as_str()));
-        print_success(format_args!(
-            "fetched doi:{} ({} bytes) -> {}",
-            doi.as_str(),
-            metadata.doiget.as_ref().map(|d| d.size_bytes).unwrap_or(0),
-            pdf_path
-        ));
-    } else {
-        let toml_path = store
-            .root()
-            .join(".metadata")
-            .join(format!("{}.toml", safekey.as_str()));
-        print_success(format_args!(
-            "fetched doi:{} (metadata-only) -> {}",
-            doi.as_str(),
-            toml_path
-        ));
-    }
-    Ok(())
-}
-
-/// Pull the preferred OA URL out of an Unpaywall `metadata_json` envelope.
-/// Tries `best_oa_location.url_for_pdf` first (direct PDF link), falling
-/// back to `best_oa_location.url` (landing page that typically redirects
-/// to the PDF). Returns `None` if neither field is present, malformed, or
-/// fails to parse as a URL.
-fn extract_best_oa_url(meta: Option<&serde_json::Value>) -> Option<url::Url> {
-    let meta = meta?;
-    let loc = meta.get("best_oa_location")?;
-    let candidate = loc
-        .get("url_for_pdf")
-        .and_then(|v| v.as_str())
-        .or_else(|| loc.get("url").and_then(|v| v.as_str()))?;
-    url::Url::parse(candidate).ok()
-}
-
-/// Attempt the OA PDF fetch under the `"oa-publisher"` source key. Logs a
-/// `Fetch ok` row on success and a `Fetch err` row with
-/// `error_code = "NETWORK_ERROR"` on every failure mode (redirect denied,
-/// magic-byte mismatch, transport, status, timeout). Returns `Some((bytes,
-/// final_url))` on success, `None` otherwise — the caller treats `None` as
-/// "metadata-only success", per the `informed-best-effort` posture in
-/// `docs/REDIRECT_ALLOWLIST.md` §3.
-async fn try_fetch_oa_pdf(
-    doi: &Doi,
-    url: &url::Url,
-    ctx: &FetchContext,
-) -> Option<(Vec<u8>, url::Url)> {
-    const SOURCE: &str = "oa-publisher";
-    let _permit = ctx.rate_limiter.acquire(SOURCE).await;
-    match ctx.http.fetch_pdf(SOURCE, url.clone()).await {
-        Ok((body, final_url)) => {
-            let size_bytes = body.len() as u64;
-            // Best-effort log row; if appending fails, surface a tracing
-            // warning but still return success — the body is in memory and
-            // the metadata write below will still go through.
-            if let Err(e) = ctx.log.append(RowInput {
-                event: LogEvent::Fetch,
-                result: LogResult::Ok,
-                capability: Capability::Oa,
-                ref_: Some(doi.as_str()),
-                source: Some(SOURCE),
-                error_code: None,
-                size_bytes: Some(size_bytes),
-                license: None,
-                store_path: None,
-            }) {
-                tracing::warn!(error = %e, "appending oa-publisher Fetch ok row failed");
-            }
-            Some((body.to_vec(), final_url))
-        }
-        Err(e) => {
-            // Categorize for tracing visibility — the on-disk row is the
-            // same `NETWORK_ERROR` for all transport-level outcomes per
-            // `docs/ERRORS.md`.
-            match &e {
-                HttpError::RedirectDenied { host, .. } => {
-                    tracing::info!(
-                        oa_url = %url,
-                        denied_host = %host,
-                        "OA URL host outside oa-publisher allowlist; metadata-only fallback"
-                    );
-                }
-                HttpError::NotAPdf { .. } => {
-                    tracing::info!(
-                        oa_url = %url,
-                        "OA URL did not return a PDF magic byte; metadata-only fallback"
-                    );
-                }
-                other => {
-                    tracing::warn!(
-                        oa_url = %url,
-                        error = %other,
-                        "OA PDF fetch failed; metadata-only fallback"
-                    );
-                }
-            }
-            let _ = ctx.log.append(RowInput {
-                event: LogEvent::Fetch,
-                result: LogResult::Err,
-                capability: Capability::Oa,
-                ref_: Some(doi.as_str()),
-                source: Some(SOURCE),
-                error_code: Some("NETWORK_ERROR"),
-                size_bytes: None,
-                license: None,
-                store_path: None,
-            });
-            None
-        }
-    }
-}
-
-/// Stage PDF bytes to a tempfile so the existing `Store::write` atomic-
-/// rename code path applies (the store takes a path, not bytes). Mirrors
-/// the staging helper inlined in `fetch_arxiv`.
-fn stage_pdf_to_tempfile(bytes: &[u8]) -> Result<tempfile::NamedTempFile> {
-    let tmp = tempfile::NamedTempFile::new().context("creating PDF staging tempfile")?;
-    std::fs::write(tmp.path(), bytes).context("staging PDF bytes")?;
-    Ok(tmp)
-}
-
 /// Single-line user-visible success message, written to stderr per ADR-0001
 /// (stdio convention — the CLI never writes a success line to stdout). This
 /// is the one place where `eprintln!` is intentional; the workspace
@@ -803,138 +483,6 @@ fn stage_pdf_to_tempfile(bytes: &[u8]) -> Result<tempfile::NamedTempFile> {
 #[allow(clippy::print_stderr)]
 fn print_success(args: std::fmt::Arguments<'_>) {
     eprintln!("{args}");
-}
-
-/// Subset of Crossref `message` we extract for the on-disk metadata.
-struct CrossrefFields {
-    title: Option<String>,
-    authors: Vec<String>,
-    year: Option<i32>,
-    venue: Option<String>,
-    type_: Option<String>,
-}
-
-/// Defensively pull the bibliographic fields out of a Crossref envelope's
-/// `message` object. Every field is optional; malformed shapes degrade to
-/// `None` rather than panicking.
-fn extract_crossref_fields(msg: &serde_json::Value) -> CrossrefFields {
-    let title = msg
-        .get("title")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-
-    let authors = msg
-        .get("author")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|a| {
-                    let family = a.get("family").and_then(|v| v.as_str());
-                    let given = a.get("given").and_then(|v| v.as_str());
-                    match (family, given) {
-                        (Some(f), Some(g)) => Some(format!("{f}, {g}")),
-                        (Some(f), None) => Some(f.to_string()),
-                        (None, Some(g)) => Some(g.to_string()),
-                        _ => None,
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let year = msg
-        .get("issued")
-        .and_then(|v| v.get("date-parts"))
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|v| v.as_i64())
-        .and_then(|n| i32::try_from(n).ok());
-
-    let venue = msg
-        .get("container-title")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-
-    let type_ = msg
-        .get("type")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-
-    CrossrefFields {
-        title,
-        authors,
-        year,
-        venue,
-        type_,
-    }
-}
-
-/// Persist `metadata` (and optionally a PDF at `pdf_src`) to the store, then
-/// emit a `StoreWrite` provenance row. Failures of either step are
-/// fail-closed.
-async fn write_to_store(
-    store: &FsStore,
-    safekey: &Safekey,
-    metadata: &Metadata,
-    pdf_src: Option<&Utf8Path>,
-    ctx: &FetchContext,
-) -> Result<()> {
-    let store_path_relative = if pdf_src.is_some() {
-        format!("{}.pdf", safekey.as_str())
-    } else {
-        format!(".metadata/{}.toml", safekey.as_str())
-    };
-    let size_bytes = metadata.doiget.as_ref().map(|d| d.size_bytes).unwrap_or(0);
-    let license = metadata.doiget.as_ref().map(|d| d.license.as_str());
-    let source_name = metadata.doiget.as_ref().map(|d| d.source.as_str());
-
-    match store.write(safekey, metadata, pdf_src) {
-        Ok(()) => {
-            ctx.log
-                .append(RowInput {
-                    event: LogEvent::StoreWrite,
-                    result: LogResult::Ok,
-                    capability: Capability::Oa,
-                    ref_: metadata
-                        .doi
-                        .as_ref()
-                        .map(|d| d.as_str())
-                        .or_else(|| metadata.arxiv_id.as_ref().map(|a| a.as_str())),
-                    source: source_name,
-                    error_code: None,
-                    size_bytes: Some(size_bytes),
-                    license,
-                    store_path: Some(&store_path_relative),
-                })
-                .context("appending StoreWrite row")?;
-            Ok(())
-        }
-        Err(e) => {
-            // Best-effort: record the StoreWrite failure before propagating.
-            let _ = ctx.log.append(RowInput {
-                event: LogEvent::StoreWrite,
-                result: LogResult::Err,
-                capability: Capability::Oa,
-                ref_: metadata
-                    .doi
-                    .as_ref()
-                    .map(|d| d.as_str())
-                    .or_else(|| metadata.arxiv_id.as_ref().map(|a| a.as_str())),
-                source: source_name,
-                error_code: Some("STORE_ERROR"),
-                size_bytes: None,
-                license: None,
-                store_path: Some(&store_path_relative),
-            });
-            Err(anyhow::Error::new(e).context("writing to store"))
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -961,52 +509,15 @@ mod tests {
         );
     }
 
+    // Slice 2: the `extract_crossref_fields_*` unit tests moved to
+    // `doiget_core::orchestrator::tests` along with the function they
+    // covered. The CLI no longer owns those helpers; the marker test
+    // below keeps the CLI's `fetch::tests` non-empty after the helper
+    // migration so a future regression that nukes the delegation path
+    // surfaces as a build failure (the `FetchPaperOutcome` re-import
+    // would stop resolving).
     #[test]
-    fn extract_crossref_fields_parses_all_fields() {
-        let msg = serde_json::json!({
-            "title": ["Example Title"],
-            "author": [
-                { "family": "Smith", "given": "Alice" },
-                { "family": "Jones", "given": "Bob" }
-            ],
-            "issued": { "date-parts": [[2024, 1, 15]] },
-            "container-title": ["Phys. Rev. X"],
-            "type": "journal-article"
-        });
-        let f = extract_crossref_fields(&msg);
-        assert_eq!(f.title.as_deref(), Some("Example Title"));
-        assert_eq!(
-            f.authors,
-            vec!["Smith, Alice".to_string(), "Jones, Bob".to_string()]
-        );
-        assert_eq!(f.year, Some(2024));
-        assert_eq!(f.venue.as_deref(), Some("Phys. Rev. X"));
-        assert_eq!(f.type_.as_deref(), Some("journal-article"));
-    }
-
-    #[test]
-    fn extract_crossref_fields_tolerates_missing_fields() {
-        let msg = serde_json::json!({});
-        let f = extract_crossref_fields(&msg);
-        assert!(f.title.is_none());
-        assert!(f.authors.is_empty());
-        assert!(f.year.is_none());
-        assert!(f.venue.is_none());
-        assert!(f.type_.is_none());
-    }
-
-    #[test]
-    fn extract_crossref_fields_handles_partial_author_records() {
-        // An author with only `family` should still produce an entry; an
-        // entry with neither `family` nor `given` is skipped.
-        let msg = serde_json::json!({
-            "author": [
-                { "family": "Carol" },
-                { "given": "David" },
-                {}
-            ]
-        });
-        let f = extract_crossref_fields(&msg);
-        assert_eq!(f.authors, vec!["Carol".to_string(), "David".to_string()]);
+    fn fetch_paper_outcome_is_reachable_from_cli() {
+        let _ = std::any::type_name::<doiget_core::orchestrator::FetchPaperOutcome>();
     }
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -39,6 +39,12 @@ pub const MAX_FETCHES_PER_SECOND: f32 = 5.0;
 /// Maximum batch size for `doiget batch` and `doiget_batch_fetch`.
 pub const MCP_BATCH_MAX_SIZE: usize = 100;
 
+/// Slice 2 alias for [`MCP_BATCH_MAX_SIZE`] using the
+/// spec-language name (`docs/MCP_TOOLS.md` §1 / Slice 2 plan). The
+/// numeric value MUST equal [`MCP_BATCH_MAX_SIZE`]; an internal test
+/// pins the equivalence so the two constants cannot drift.
+pub const MAX_BATCH_REFS: usize = MCP_BATCH_MAX_SIZE;
+
 /// Maximum queued MCP requests beyond `MAX_CONCURRENT_FETCHES`. Excess returns
 /// `ErrorCode::RateLimited`. See `docs/SECURITY.md` §1.4 / `docs/MCP_TOOLS.md`.
 pub const MCP_QUEUE_DEPTH_MAX: usize = 100;
@@ -1116,6 +1122,9 @@ mod tests {
         assert_eq!(MCP_QUEUE_DEPTH_MAX, 100);
         assert_eq!(DOI_SUFFIX_MAX_LEN, 256);
         assert_eq!(MCP_STDIN_EOF_SHUTDOWN_SEC, 5);
+        // Slice 2: spec-language alias for MCP_BATCH_MAX_SIZE must
+        // numerically agree with the original constant.
+        assert_eq!(MAX_BATCH_REFS, MCP_BATCH_MAX_SIZE);
     }
 
     #[test]

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1,21 +1,31 @@
 //! Cross-source orchestrators that compose multiple [`Source`] impls into
 //! a single user-facing operation.
 //!
-//! Phase 1 ships [`metadata_only`] only; the live PDF orchestrator lives
-//! in `doiget-cli::commands::fetch` because it owns the on-disk store
-//! (and `doiget-core` does not, by design). This module is the natural
-//! home for orchestrators that the MCP server needs to call directly
-//! without going through the CLI.
+//! Slice 2 of the doiget roadmap promotes [`fetch_paper`] and
+//! [`batch_fetch`] from `doiget-cli` into this module so the MCP server
+//! (`doiget-mcp`) and the CLI share one source of truth for the per-ref
+//! orchestration. The CLI's `commands::fetch::fetch_one` is now a thin
+//! wrapper that delegates here and adds the human-facing stderr print
+//! line. Dry-run preview helpers live as [`fetch_paper_plan`] and
+//! [`batch_fetch_plans`].
 //!
 //! [`Source`]: crate::source::Source
 
+use std::collections::BTreeMap;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use chrono::Utc;
 use serde_json::Value;
 
-use crate::source::{FetchContext, FetchError, Source};
+use crate::dry_run::{build_fetch_plan, FetchPlan};
+use crate::http::HttpError;
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
 use crate::sources::arxiv::ArxivSource;
 use crate::sources::crossref::CrossrefSource;
 use crate::sources::unpaywall::UnpaywallSource;
-use crate::{CapabilityProfile, Doi, Ref};
+use crate::store::{DoigetExtension, Metadata, Store};
+use crate::{ArxivId, CapabilityProfile, Doi, Ref, Safekey, MAX_BATCH_REFS, SCHEMA_VERSION};
 
 /// Outcome of a successful [`metadata_only`] call.
 ///
@@ -250,6 +260,622 @@ fn extract_unpaywall_oa_url(meta: &Value) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// fetch_paper — single-ref orchestrator (Slice 2)
+// ---------------------------------------------------------------------------
+
+/// Outcome of a successful [`fetch_paper`] call.
+///
+/// Wire shape mirrors `docs/MCP_TOOLS.md` §5 `FetchResult` minus the
+/// envelope chrome the MCP server wraps it in (`ok: true`, `ref`,
+/// optional `error`).
+///
+/// `path` is the absolute path of the resource the orchestrator wrote to
+/// the store. For arXiv refs and successful DOI OA-PDF fetches this is
+/// `<root>/<safekey>.pdf`; for the DOI metadata-only fallback (OA URL
+/// host off the `oa-publisher` allowlist, or PDF leg failed for another
+/// transport reason — `docs/REDIRECT_ALLOWLIST.md` §3 informed-best-
+/// effort posture) this is `<root>/.metadata/<safekey>.toml`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FetchPaperOutcome {
+    /// `Source::name()` of the resolver whose payload landed on disk:
+    /// `"arxiv"` for an arXiv ref, `"oa-publisher"` when the DOI OA PDF
+    /// leg succeeded, or `"crossref"` / `"unpaywall"` when the DOI path
+    /// fell back to metadata-only. Mirrors the value written to
+    /// `[doiget].source` in the metadata TOML.
+    pub source: String,
+    /// OA license string (`"CC-BY-4.0"`, `"cc-by"`, `"arxiv-default"`,
+    /// `"unknown"`). Mirrors `[doiget].license`.
+    pub license: String,
+    /// Absolute path of the artifact actually written
+    /// (`<root>/<safekey>.pdf` on success, `<root>/.metadata/<safekey>.toml`
+    /// on metadata-only fallback).
+    pub path: Utf8PathBuf,
+    /// Stored PDF size in bytes; `0` on the metadata-only fallback
+    /// (`docs/REDIRECT_ALLOWLIST.md` §3.5).
+    pub size_bytes: u64,
+    /// The schema version of the metadata TOML written
+    /// (always [`crate::SCHEMA_VERSION`] for this build).
+    pub schema_version: String,
+}
+
+/// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it
+/// through `store`.
+///
+/// Binding spec: `docs/MCP_TOOLS.md` §4 (`doiget_fetch_paper`),
+/// `docs/REDIRECT_ALLOWLIST.md` §3 (informed-best-effort posture for the
+/// DOI OA PDF leg), `docs/PROVENANCE_LOG.md` §3 (per-attempt `Fetch` rows
+/// emitted by the source impls; `StoreWrite` row emitted by this
+/// orchestrator).
+///
+/// # Dispatch
+///
+/// - `Ref::Arxiv(_)` → [`ArxivSource::fetch`]; the source returns PDF
+///   bytes + Atom-feed metadata. The orchestrator writes both the PDF
+///   and the metadata TOML.
+/// - `Ref::Doi(_)` → Crossref metadata + Unpaywall license/OA-URL
+///   enrichment + (when the OA URL host is on the `oa-publisher`
+///   allowlist) a publisher PDF leg. A failure on the PDF leg is
+///   non-fatal: the metadata is still written and the orchestrator
+///   returns `Ok(...)` with `source` set to the metadata source.
+///
+/// # Side effects
+///
+/// Each consulted source emits one `LogEvent::Fetch` row via
+/// `ctx.log.append`. The orchestrator additionally emits one
+/// `LogEvent::StoreWrite` row on the successful write. Session bookend
+/// rows are the caller's responsibility (the CLI's
+/// `commands::fetch::run_with_options` wraps the call; the MCP server's
+/// `doiget_fetch_paper` tool method wraps it too).
+///
+/// # Errors
+///
+/// Returns [`FetchError`] from the underlying [`Source`] dispatch. The
+/// MCP boundary converts these to the closed [`crate::ErrorCode`] set
+/// via the existing `From<FetchError> for ErrorCode` impl.
+pub async fn fetch_paper(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &dyn Store,
+    store_root: &Utf8Path,
+) -> Result<FetchPaperOutcome, FetchError> {
+    let safekey = ref_.safekey();
+    match ref_ {
+        Ref::Arxiv(id) => {
+            fetch_paper_arxiv(id, ref_, profile, ctx, store, store_root, &safekey).await
+        }
+        Ref::Doi(doi) => {
+            fetch_paper_doi(doi, ref_, profile, ctx, store, store_root, &safekey).await
+        }
+    }
+}
+
+/// Build the dry-run preview ([`FetchPlan`]) for a single ref without
+/// touching the network, store, or provenance log. Thin re-export of
+/// [`crate::dry_run::build_fetch_plan`] under the slice-2 naming the
+/// MCP tool surfaces use; kept here so the MCP `doiget_fetch_paper`
+/// tool method does not have to reach across two modules.
+pub fn fetch_paper_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
+    build_fetch_plan(ref_, store_root)
+}
+
+/// arXiv branch of [`fetch_paper`]. Internal — public callers go
+/// through `fetch_paper`.
+async fn fetch_paper_arxiv(
+    id: &ArxivId,
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &dyn Store,
+    store_root: &Utf8Path,
+    safekey: &Safekey,
+) -> Result<FetchPaperOutcome, FetchError> {
+    let source = arxiv_source_from_env();
+    if !source.can_serve(profile, ref_) {
+        return Err(FetchError::NotEligible {
+            source_key: source.name().to_string(),
+        });
+    }
+
+    let FetchResult {
+        license,
+        pdf_bytes,
+        final_url,
+        ..
+    } = source.fetch(ref_, profile, ctx).await?;
+    let pdf = pdf_bytes.ok_or_else(|| FetchError::SourceSchema {
+        hint: "arxiv source returned no PDF bytes".to_string(),
+    })?;
+    let size_bytes = pdf.len() as u64;
+
+    // Phase 1 minimal metadata. Full Atom-feed extraction (title /
+    // authors) lives in `ArxivSource::fetch_metadata_only` and the
+    // metadata-only orchestrator; the fetch path keeps the placeholder
+    // for now (a follow-up slice may chain in Atom-parse here).
+    let metadata = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: format!("arxiv:{}", id.as_str()),
+        authors: Vec::new(),
+        year: None,
+        doi: None,
+        arxiv_id: Some(id.clone()),
+        abstract_: None,
+        venue: None,
+        publisher: None,
+        issn: None,
+        isbn: None,
+        type_: None,
+        keywords: Vec::new(),
+        url: final_url.as_ref().map(|u| u.to_string()),
+        pdf_path: Some(format!("{}.pdf", safekey.as_str())),
+        doiget: Some(DoigetExtension {
+            fetched_at: Utc::now(),
+            source: "arxiv".to_string(),
+            license: license.clone(),
+            size_bytes,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+
+    let tmp = stage_pdf_to_tempfile(&pdf)?;
+    let pdf_src = Utf8Path::from_path(tmp.path())
+        .ok_or_else(|| FetchError::SourceSchema {
+            hint: "staging tempfile path is not UTF-8".to_string(),
+        })?
+        .to_path_buf();
+    write_metadata_and_pdf(store, safekey, &metadata, Some(&pdf_src), ctx)?;
+    drop(tmp);
+
+    let path = store_root.join(format!("{}.pdf", safekey.as_str()));
+    Ok(FetchPaperOutcome {
+        source: "arxiv".to_string(),
+        license,
+        path,
+        size_bytes,
+        schema_version: SCHEMA_VERSION.to_string(),
+    })
+}
+
+/// DOI branch of [`fetch_paper`] — Crossref + Unpaywall + (when allowed)
+/// OA-publisher PDF leg. Mirrors the CLI's `fetch_doi` implementation
+/// (`crates/doiget-cli/src/commands/fetch.rs`) — the CLI now delegates
+/// here so both surfaces share one source of truth.
+async fn fetch_paper_doi(
+    doi: &Doi,
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &dyn Store,
+    store_root: &Utf8Path,
+    safekey: &Safekey,
+) -> Result<FetchPaperOutcome, FetchError> {
+    let contact = contact_email_from_env();
+    let unpaywall_contact = unpaywall_email_from_env(&contact);
+    let crossref = crossref_source_from_env(&contact);
+    let cross = crossref.fetch(ref_, profile, ctx).await?;
+    let crossref_meta = cross.metadata_json.unwrap_or(Value::Null);
+    let extracted = extract_crossref_fields(&crossref_meta);
+
+    // Unpaywall second — license enrichment + OA URL discovery. A
+    // failure here is non-fatal: we still write the Crossref-derived
+    // metadata.
+    let unpaywall = unpaywall_source_from_env(&unpaywall_contact);
+    let upw_result = unpaywall.fetch(ref_, profile, ctx).await;
+    let (license, source_label, oa_url) = match upw_result {
+        Ok(r) => {
+            let oa = extract_best_oa_url_from_value(r.metadata_json.as_ref());
+            let label = if r.license != "unknown" {
+                "unpaywall".to_string()
+            } else {
+                "crossref".to_string()
+            };
+            (r.license, label, oa)
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "unpaywall fetch failed; continuing with crossref-only metadata"
+            );
+            ("unknown".to_string(), "crossref".to_string(), None)
+        }
+    };
+
+    // OA PDF leg. Try the URL Unpaywall returned via the `oa-publisher`
+    // source allowlist. Magic-byte check is enforced inside
+    // `HttpClient::fetch_pdf`. Any failure here is logged as a distinct
+    // `Fetch err` row and falls through to metadata-only success.
+    let pdf_outcome = if let Some(url) = oa_url {
+        try_fetch_oa_pdf(doi, &url, ctx).await
+    } else {
+        None
+    };
+
+    let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_outcome {
+        Some((bytes, _final_url)) => {
+            let staged = stage_pdf_to_tempfile(bytes)?;
+            (
+                "oa-publisher".to_string(),
+                bytes.len() as u64,
+                Some(format!("{}.pdf", safekey.as_str())),
+                Some(staged),
+            )
+        }
+        None => (source_label, 0u64, None, None),
+    };
+
+    let metadata = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: extracted.title.unwrap_or_else(|| doi.as_str().to_string()),
+        authors: extracted.authors,
+        year: extracted.year,
+        doi: Some(doi.clone()),
+        arxiv_id: None,
+        abstract_: None,
+        venue: extracted.venue,
+        publisher: None,
+        issn: None,
+        isbn: None,
+        type_: extracted.type_,
+        keywords: Vec::new(),
+        url: cross.final_url.as_ref().map(|u| u.to_string()),
+        pdf_path: pdf_path_relative,
+        doiget: Some(DoigetExtension {
+            fetched_at: Utc::now(),
+            source: final_source_label.clone(),
+            license: license.clone(),
+            size_bytes,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+
+    let pdf_src_path = pdf_staged
+        .as_ref()
+        .and_then(|tmp| Utf8Path::from_path(tmp.path()).map(|p| p.to_path_buf()));
+    write_metadata_and_pdf(store, safekey, &metadata, pdf_src_path.as_deref(), ctx)?;
+    drop(pdf_staged);
+
+    let path = if pdf_outcome.is_some() {
+        store_root.join(format!("{}.pdf", safekey.as_str()))
+    } else {
+        store_root
+            .join(".metadata")
+            .join(format!("{}.toml", safekey.as_str()))
+    };
+    Ok(FetchPaperOutcome {
+        source: final_source_label,
+        license,
+        path,
+        size_bytes,
+        schema_version: SCHEMA_VERSION.to_string(),
+    })
+}
+
+/// Stage PDF bytes to a tempfile so the existing `Store::write` atomic-
+/// rename code path applies (the store takes a path, not bytes).
+fn stage_pdf_to_tempfile(bytes: &[u8]) -> Result<tempfile::NamedTempFile, FetchError> {
+    let tmp = tempfile::NamedTempFile::new().map_err(|e| FetchError::SourceSchema {
+        hint: format!("creating PDF staging tempfile: {e}"),
+    })?;
+    std::fs::write(tmp.path(), bytes).map_err(|e| FetchError::SourceSchema {
+        hint: format!("staging PDF bytes: {e}"),
+    })?;
+    Ok(tmp)
+}
+
+/// Persist `metadata` (and optionally a PDF at `pdf_src`) through the
+/// trait-object [`Store`] and emit a `StoreWrite` provenance row.
+fn write_metadata_and_pdf(
+    store: &dyn Store,
+    safekey: &Safekey,
+    metadata: &Metadata,
+    pdf_src: Option<&Utf8Path>,
+    ctx: &FetchContext,
+) -> Result<(), FetchError> {
+    let store_path_relative = if pdf_src.is_some() {
+        format!("{}.pdf", safekey.as_str())
+    } else {
+        format!(".metadata/{}.toml", safekey.as_str())
+    };
+    let size_bytes = metadata.doiget.as_ref().map(|d| d.size_bytes).unwrap_or(0);
+    let license = metadata.doiget.as_ref().map(|d| d.license.as_str());
+    let source_name = metadata.doiget.as_ref().map(|d| d.source.as_str());
+
+    match store.write(safekey, metadata, pdf_src) {
+        Ok(()) => {
+            ctx.log.append(RowInput {
+                event: LogEvent::StoreWrite,
+                result: LogResult::Ok,
+                capability: Capability::Oa,
+                ref_: metadata
+                    .doi
+                    .as_ref()
+                    .map(|d| d.as_str())
+                    .or_else(|| metadata.arxiv_id.as_ref().map(|a| a.as_str())),
+                source: source_name,
+                error_code: None,
+                size_bytes: Some(size_bytes),
+                license,
+                store_path: Some(&store_path_relative),
+            })?;
+            Ok(())
+        }
+        Err(e) => {
+            // Best-effort: record the StoreWrite failure before
+            // propagating. Surface as `SourceSchema` so the
+            // FetchError -> ErrorCode collapse routes it to
+            // `INTERNAL_ERROR` (closest closed-set fit; `StoreError`
+            // does not have a direct closed-set arm).
+            let _ = ctx.log.append(RowInput {
+                event: LogEvent::StoreWrite,
+                result: LogResult::Err,
+                capability: Capability::Oa,
+                ref_: metadata
+                    .doi
+                    .as_ref()
+                    .map(|d| d.as_str())
+                    .or_else(|| metadata.arxiv_id.as_ref().map(|a| a.as_str())),
+                source: source_name,
+                error_code: Some("STORE_ERROR"),
+                size_bytes: None,
+                license: None,
+                store_path: Some(&store_path_relative),
+            });
+            Err(FetchError::SourceSchema {
+                hint: format!("store write failed: {e}"),
+            })
+        }
+    }
+}
+
+/// Attempt the OA PDF fetch under the `"oa-publisher"` source key.
+async fn try_fetch_oa_pdf(
+    doi: &Doi,
+    url: &url::Url,
+    ctx: &FetchContext,
+) -> Option<(Vec<u8>, url::Url)> {
+    const SOURCE: &str = "oa-publisher";
+    let _permit = ctx.rate_limiter.acquire(SOURCE).await;
+    match ctx.http.fetch_pdf(SOURCE, url.clone()).await {
+        Ok((body, final_url)) => {
+            let size_bytes = body.len() as u64;
+            if let Err(e) = ctx.log.append(RowInput {
+                event: LogEvent::Fetch,
+                result: LogResult::Ok,
+                capability: Capability::Oa,
+                ref_: Some(doi.as_str()),
+                source: Some(SOURCE),
+                error_code: None,
+                size_bytes: Some(size_bytes),
+                license: None,
+                store_path: None,
+            }) {
+                tracing::warn!(error = %e, "appending oa-publisher Fetch ok row failed");
+            }
+            Some((body.to_vec(), final_url))
+        }
+        Err(e) => {
+            match &e {
+                HttpError::RedirectDenied { host, .. } => {
+                    tracing::info!(
+                        oa_url = %url,
+                        denied_host = %host,
+                        "OA URL host outside oa-publisher allowlist; metadata-only fallback"
+                    );
+                }
+                HttpError::NotAPdf { .. } => {
+                    tracing::info!(
+                        oa_url = %url,
+                        "OA URL did not return a PDF magic byte; metadata-only fallback"
+                    );
+                }
+                other => {
+                    tracing::warn!(
+                        oa_url = %url,
+                        error = %other,
+                        "OA PDF fetch failed; metadata-only fallback"
+                    );
+                }
+            }
+            let _ = ctx.log.append(RowInput {
+                event: LogEvent::Fetch,
+                result: LogResult::Err,
+                capability: Capability::Oa,
+                ref_: Some(doi.as_str()),
+                source: Some(SOURCE),
+                error_code: Some("NETWORK_ERROR"),
+                size_bytes: None,
+                license: None,
+                store_path: None,
+            });
+            None
+        }
+    }
+}
+
+/// Subset of Crossref `message` fields populated into the on-disk metadata.
+struct CrossrefFields {
+    title: Option<String>,
+    authors: Vec<String>,
+    year: Option<i32>,
+    venue: Option<String>,
+    type_: Option<String>,
+}
+
+/// Defensively pull bibliographic fields out of a Crossref envelope's
+/// `message` object. Every field is optional; malformed shapes degrade
+/// to `None` rather than panicking.
+fn extract_crossref_fields(msg: &Value) -> CrossrefFields {
+    let title = msg
+        .get("title")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let authors = msg
+        .get("author")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| {
+                    let family = a.get("family").and_then(|v| v.as_str());
+                    let given = a.get("given").and_then(|v| v.as_str());
+                    match (family, given) {
+                        (Some(f), Some(g)) => Some(format!("{f}, {g}")),
+                        (Some(f), None) => Some(f.to_string()),
+                        (None, Some(g)) => Some(g.to_string()),
+                        _ => None,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let year = msg
+        .get("issued")
+        .and_then(|v| v.get("date-parts"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_i64())
+        .and_then(|n| i32::try_from(n).ok());
+
+    let venue = msg
+        .get("container-title")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let type_ = msg
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    CrossrefFields {
+        title,
+        authors,
+        year,
+        venue,
+        type_,
+    }
+}
+
+/// Pull the preferred OA URL out of an Unpaywall `metadata_json`
+/// envelope. Tries `best_oa_location.url_for_pdf` first (direct PDF
+/// link), falling back to `best_oa_location.url`.
+fn extract_best_oa_url_from_value(meta: Option<&Value>) -> Option<url::Url> {
+    let meta = meta?;
+    let loc = meta.get("best_oa_location")?;
+    let candidate = loc
+        .get("url_for_pdf")
+        .and_then(|v| v.as_str())
+        .or_else(|| loc.get("url").and_then(|v| v.as_str()))?;
+    url::Url::parse(candidate).ok()
+}
+
+fn unpaywall_email_from_env(fallback_contact: &str) -> String {
+    std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| fallback_contact.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// batch_fetch — multi-ref orchestrator (Slice 2)
+// ---------------------------------------------------------------------------
+
+/// Per-ref outcome carried inside [`BatchOutcome::results`].
+///
+/// Each entry's `outcome` is independent — a single `Err(...)` does not
+/// abort sibling refs. The MCP `doiget_batch_fetch` tool method
+/// serializes the success-or-error per row inside `results[]`.
+#[derive(Debug)]
+pub struct BatchResultEntry {
+    /// The parsed ref this entry describes.
+    pub ref_: Ref,
+    /// `Ok(...)` on a successful fetch through [`fetch_paper`];
+    /// `Err(...)` on a per-ref failure (the outer call still returned
+    /// `Ok(BatchOutcome)`).
+    pub outcome: Result<FetchPaperOutcome, FetchError>,
+}
+
+/// Outcome of a successful [`batch_fetch`] call.
+///
+/// The outer call returns `Err(_)` only on whole-call failures (the
+/// only such variant in Slice 2 is [`FetchError::TooManyRefs`]). Each
+/// per-ref result lives inside `results[]` so the agent can see every
+/// outcome without losing sibling successes.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct BatchOutcome {
+    /// One entry per supplied ref, in input order.
+    pub results: Vec<BatchResultEntry>,
+}
+
+/// Iterate over `refs` through [`fetch_paper`], collecting one
+/// [`BatchResultEntry`] per ref.
+///
+/// **Cap**: caller must supply at most [`MAX_BATCH_REFS`] refs; otherwise
+/// the function returns `Err(FetchError::TooManyRefs { got, max })`
+/// before any fetch is attempted. The cap mirrors the CLI's
+/// `commands::batch` enforcement (`MCP_BATCH_MAX_SIZE`).
+///
+/// **Concurrency**: Slice 2 dispatches refs serially through
+/// [`fetch_paper`]. The CLI's existing `commands::batch::run_with_options`
+/// keeps its bounded-concurrency `JoinSet`+semaphore path for backward
+/// compatibility; the MCP server uses this serial loop because the MCP
+/// tool boundary already serializes calls per session.
+///
+/// **Session bookkeeping**: this function does NOT emit `SessionStart`
+/// / `SessionEnd` rows — that is the caller's responsibility.
+pub async fn batch_fetch(
+    refs: &[Ref],
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &dyn Store,
+    store_root: &Utf8Path,
+) -> Result<BatchOutcome, FetchError> {
+    if refs.len() > MAX_BATCH_REFS {
+        return Err(FetchError::TooManyRefs {
+            got: refs.len(),
+            max: MAX_BATCH_REFS,
+        });
+    }
+    let mut results = Vec::with_capacity(refs.len());
+    for ref_ in refs {
+        let outcome = fetch_paper(ref_, profile, ctx, store, store_root).await;
+        results.push(BatchResultEntry {
+            ref_: ref_.clone(),
+            outcome,
+        });
+    }
+    Ok(BatchOutcome { results })
+}
+
+/// Dry-run preview for a batch — one [`FetchPlan`] per ref. Enforces
+/// the same [`MAX_BATCH_REFS`] cap [`batch_fetch`] does.
+///
+/// Returns `Err(FetchError::TooManyRefs)` when over the cap; otherwise
+/// `Ok(Vec<(Ref, FetchPlan)>)` parallel to the input order.
+pub fn batch_fetch_plans(
+    refs: &[Ref],
+    store_root: &Utf8Path,
+) -> Result<Vec<(Ref, FetchPlan)>, FetchError> {
+    if refs.len() > MAX_BATCH_REFS {
+        return Err(FetchError::TooManyRefs {
+            got: refs.len(),
+            max: MAX_BATCH_REFS,
+        });
+    }
+    Ok(refs
+        .iter()
+        .map(|r| (r.clone(), build_fetch_plan(r, store_root)))
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -323,5 +949,178 @@ mod tests {
     fn extract_unpaywall_oa_url_returns_none_when_absent() {
         let meta = serde_json::json!({});
         assert!(extract_unpaywall_oa_url(&meta).is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // Slice 2: fetch_paper / batch_fetch coverage. The wiremock-driven
+    // happy-path tests live in `crates/doiget-mcp/tests/...` (they need
+    // a real `Store` impl and an HTTP client wired to `FetchContext`,
+    // both of which the MCP integration tests already stand up). The
+    // unit tests here pin the pure-function pieces (extractors, cap
+    // enforcement, plan-shape preservation).
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn extract_crossref_fields_parses_minimal_shape() {
+        let msg = serde_json::json!({
+            "title": ["Example Title"],
+            "author": [{ "family": "Smith", "given": "Alice" }],
+            "issued": { "date-parts": [[2024, 1, 15]] },
+            "container-title": ["Phys. Rev. X"],
+            "type": "journal-article"
+        });
+        let f = extract_crossref_fields(&msg);
+        assert_eq!(f.title.as_deref(), Some("Example Title"));
+        assert_eq!(f.authors, vec!["Smith, Alice".to_string()]);
+        assert_eq!(f.year, Some(2024));
+        assert_eq!(f.venue.as_deref(), Some("Phys. Rev. X"));
+        assert_eq!(f.type_.as_deref(), Some("journal-article"));
+    }
+
+    #[test]
+    fn extract_crossref_fields_tolerates_missing() {
+        let f = extract_crossref_fields(&serde_json::json!({}));
+        assert!(f.title.is_none());
+        assert!(f.authors.is_empty());
+        assert!(f.year.is_none());
+        assert!(f.venue.is_none());
+        assert!(f.type_.is_none());
+    }
+
+    #[test]
+    fn extract_best_oa_url_from_value_prefers_url_for_pdf() {
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/pdf",
+                "url": "https://example.org/landing"
+            }
+        });
+        let url = extract_best_oa_url_from_value(Some(&meta)).expect("Some(Url)");
+        assert_eq!(url.as_str(), "https://example.org/pdf");
+    }
+
+    #[test]
+    fn extract_best_oa_url_from_value_falls_back_to_url() {
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url": "https://example.org/landing"
+            }
+        });
+        let url = extract_best_oa_url_from_value(Some(&meta)).expect("Some(Url)");
+        assert_eq!(url.as_str(), "https://example.org/landing");
+    }
+
+    #[test]
+    fn extract_best_oa_url_from_value_none_on_missing() {
+        let meta = serde_json::json!({});
+        assert!(extract_best_oa_url_from_value(Some(&meta)).is_none());
+        assert!(extract_best_oa_url_from_value(None).is_none());
+    }
+
+    #[test]
+    fn fetch_paper_plan_matches_build_fetch_plan() {
+        // The slice-2-named alias is a thin pass-through to
+        // `dry_run::build_fetch_plan`. Pin behavioral equivalence so
+        // a future refactor that diverges them surfaces here.
+        use crate::{ArxivId, Doi};
+        let r = Ref::Doi(Doi("10.1234/example".to_string()));
+        let root = Utf8PathBuf::from("/tmp/doiget-test");
+        let plan_a = fetch_paper_plan(&r, &root);
+        let plan_b = build_fetch_plan(&r, &root);
+        assert_eq!(plan_a.metadata_sources, plan_b.metadata_sources);
+        assert_eq!(plan_a.target_pdf_path, plan_b.target_pdf_path);
+        assert_eq!(plan_a.target_metadata_path, plan_b.target_metadata_path);
+
+        let r2 = Ref::Arxiv(ArxivId("2401.12345".to_string()));
+        let plan_c = fetch_paper_plan(&r2, &root);
+        let plan_d = build_fetch_plan(&r2, &root);
+        assert_eq!(plan_c.pdf_sources[0].key, plan_d.pdf_sources[0].key);
+    }
+
+    #[test]
+    fn batch_fetch_plans_returns_plan_per_ref_in_order() {
+        use crate::{ArxivId, Doi};
+        let refs = vec![
+            Ref::Doi(Doi("10.1234/alpha".to_string())),
+            Ref::Arxiv(ArxivId("2401.12345".to_string())),
+        ];
+        let root = Utf8PathBuf::from("/tmp/doiget-batch-test");
+        let plans = batch_fetch_plans(&refs, &root).expect("under cap returns Ok");
+        assert_eq!(plans.len(), 2);
+        // Order preserved.
+        assert!(matches!(plans[0].0, Ref::Doi(_)));
+        assert!(matches!(plans[1].0, Ref::Arxiv(_)));
+        // DOI plan carries the crossref + unpaywall metadata sources.
+        assert_eq!(plans[0].1.metadata_sources, vec!["crossref", "unpaywall"]);
+        // arXiv plan has the arxiv PDF source key.
+        assert_eq!(plans[1].1.pdf_sources[0].key, "arxiv");
+    }
+
+    #[test]
+    fn batch_fetch_plans_too_many_refs_returns_err() {
+        use crate::Doi;
+        // Build MAX_BATCH_REFS + 1 entries — boundary case.
+        let n = MAX_BATCH_REFS + 1;
+        let refs: Vec<Ref> = (0..n)
+            .map(|i| Ref::Doi(Doi(format!("10.1234/n{}", i))))
+            .collect();
+        let root = Utf8PathBuf::from("/tmp/doiget-toomany");
+        let err = batch_fetch_plans(&refs, &root).expect_err("over cap returns Err");
+        match err {
+            FetchError::TooManyRefs { got, max } => {
+                assert_eq!(got, n);
+                assert_eq!(max, MAX_BATCH_REFS);
+            }
+            other => panic!("expected TooManyRefs, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_fetch_too_many_refs_returns_err_before_any_fetch() {
+        // The cap is enforced before any per-ref work, so we don't need
+        // a working store/network here — pass a sentinel store_root and
+        // a dummy FetchContext that would panic on use.
+        use crate::http::{tier_1_allowlist, HttpClient};
+        use crate::provenance::ProvenanceLog;
+        use crate::rate_limiter::RateLimiter;
+        use crate::store::FsStore;
+        use crate::{Doi, RateLimits};
+        use std::sync::Arc;
+
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let log_path = Utf8Path::from_path(td.path())
+            .expect("utf-8")
+            .join("log.jsonl");
+        let store_root = Utf8Path::from_path(td.path())
+            .expect("utf-8")
+            .join("papers");
+
+        let ctx = FetchContext {
+            http: Arc::new(HttpClient::new(tier_1_allowlist()).expect("http client")),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log: Arc::new(
+                ProvenanceLog::open(log_path, "01J0000000000000000000TEST".into())
+                    .expect("provenance log"),
+            ),
+            session_id: "01J0000000000000000000TEST".into(),
+        };
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let store = FsStore::new(store_root.clone()).expect("fs store");
+
+        let n = MAX_BATCH_REFS + 1;
+        let refs: Vec<Ref> = (0..n)
+            .map(|i| Ref::Doi(Doi(format!("10.1234/n{}", i))))
+            .collect();
+
+        let err = batch_fetch(&refs, &profile, &ctx, &store, &store_root)
+            .await
+            .expect_err("over cap returns Err");
+        match err {
+            FetchError::TooManyRefs { got, max } => {
+                assert_eq!(got, n);
+                assert_eq!(max, MAX_BATCH_REFS);
+            }
+            other => panic!("expected TooManyRefs, got: {other:?}"),
+        }
     }
 }

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -115,6 +115,18 @@ pub enum FetchError {
         /// Human-readable hint at the offending field/path; not parsed.
         hint: String,
     },
+    /// Batch orchestrator received more refs than
+    /// [`crate::MAX_BATCH_REFS`]. Surfaced to the MCP `doiget_batch_fetch`
+    /// tool as `ErrorCode::InvalidRef` (closest closed-set fit — the
+    /// request shape itself is invalid; no `denial_context` channel
+    /// applies). Slice 2 / `docs/MCP_TOOLS.md` §1.
+    #[error("too many refs: got {got}, max {max}")]
+    TooManyRefs {
+        /// Number of refs the batch orchestrator was handed.
+        got: usize,
+        /// The hard cap ([`crate::MAX_BATCH_REFS`]).
+        max: usize,
+    },
 }
 
 /// Map [`FetchError`] to the closed [`crate::ErrorCode`] set surfaced at
@@ -129,6 +141,11 @@ impl From<FetchError> for crate::ErrorCode {
             FetchError::Log(_) => crate::ErrorCode::LogError,
             FetchError::InvalidRef(_) => crate::ErrorCode::InvalidRef,
             FetchError::SourceSchema { .. } => crate::ErrorCode::InternalError,
+            // Slice 2: a too-large batch is a request-shape failure, so
+            // collapse to `INVALID_REF` (closest closed-set fit). The
+            // `#[non_exhaustive]` wildcard below would otherwise route
+            // it to `INTERNAL_ERROR`, which would mislead agents.
+            FetchError::TooManyRefs { .. } => crate::ErrorCode::InvalidRef,
         }
     }
 }
@@ -159,11 +176,14 @@ impl From<&FetchError> for Option<crate::DenialContext> {
             }),
             // Delegate to the HttpError mapping (ADR-0023 §4 mapping table).
             FetchError::Http(http_err) => http_err.into(),
-            // Non-denial variants map to None per ADR-0023 §4.
+            // Non-denial variants map to None per ADR-0023 §4. (Slice 2:
+            // `TooManyRefs` is a request-shape failure, not a denial —
+            // adding it to the None arm keeps the mapping table consistent.)
             FetchError::NoOaAvailable
             | FetchError::Log(_)
             | FetchError::InvalidRef(_)
-            | FetchError::SourceSchema { .. } => None,
+            | FetchError::SourceSchema { .. }
+            | FetchError::TooManyRefs { .. } => None,
         }
     }
 }
@@ -343,6 +363,12 @@ mod tests {
         }
         .into();
         assert_eq!(e, ErrorCode::InternalError);
+
+        // Slice 2 — TooManyRefs collapses to INVALID_REF, NOT
+        // InternalError (the `#[non_exhaustive]` wildcard would
+        // otherwise misroute this to InternalError).
+        let e: ErrorCode = FetchError::TooManyRefs { got: 101, max: 100 }.into();
+        assert_eq!(e, ErrorCode::InvalidRef);
     }
 
     #[test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -41,14 +41,21 @@ use std::sync::Arc;
 
 use camino::Utf8PathBuf;
 
-use doiget_core::dry_run::{build_dry_run_envelope, build_fetch_plan};
+use doiget_core::dry_run::{
+    build_dry_run_envelope, build_fetch_plan, rate_limit_budget as core_rate_limit_budget,
+};
 use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
-use doiget_core::orchestrator::{metadata_only, MetadataOnlyOutcome};
+use doiget_core::orchestrator::{
+    batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
+    metadata_only, FetchPaperOutcome, MetadataOnlyOutcome,
+};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
 use doiget_core::source::{FetchContext, FetchError};
+use doiget_core::store::FsStore;
 use doiget_core::{
-    CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref, SCHEMA_VERSION, VERSION,
+    CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref, MAX_BATCH_REFS, SCHEMA_VERSION,
+    VERSION,
 };
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -243,7 +250,7 @@ impl Server {
         // source selection and per-leg politeness; we own the per-call
         // session boundary (SessionStart / SessionEnd bookend rows) and
         // the wire envelope shape (`docs/MCP_TOOLS.md` §11).
-        let ctx = match build_metadata_only_context() {
+        let ctx = match build_fetch_context() {
             Ok(c) => c,
             Err(e) => {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
@@ -304,6 +311,285 @@ impl Server {
             Err(e) => Ok(CallToolResult::structured(
                 metadata_only_fetch_error_envelope(&e, &input.ref_),
             )),
+        }
+    }
+
+    /// `doiget_fetch_paper` — resolve and download a single PDF.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §4 (NORMATIVE). Slice 2 wires this to
+    /// the live [`core_fetch_paper`] orchestrator and the dry-run
+    /// preview path (ADR-0022 §2).
+    ///
+    /// Per-call boundary semantics mirror the
+    /// [`doiget_metadata_only`](Self::doiget_metadata_only) tool: the
+    /// MCP server owns the SessionStart / SessionEnd bookend rows; each
+    /// consulted [`Source`](doiget_core::source::Source) impl emits its
+    /// own `LogEvent::Fetch` row inside the orchestrator. A successful
+    /// `StoreWrite` row is also emitted by the orchestrator.
+    #[tool(
+        description = "WHEN TO USE: User wants to download a paper PDF given a DOI or arXiv id.\n\
+                       INPUTS: ref (DOI or arXiv id), dry_run (optional bool).\n\
+                       OUTPUTS: { ok: true, ref, source, path, license, size_bytes, schema_version } OR { ok: true, dry_run: true, ref, plan, rate_limit_budget } OR { ok:false, ref, error }.\n\
+                       COSTS: 1-3 s network call (or 0 when dry_run). May fail if not Open Access.\n\
+                       SIDE EFFECTS: Writes PDF (or metadata-only TOML) to the store. Appends a row to the provenance log (unless dry_run).\n\
+                       LIMITS: Max 5 fetches/sec (global). Use doiget_batch_fetch for >5 refs."
+    )]
+    async fn doiget_fetch_paper(
+        &self,
+        Parameters(input): Parameters<FetchPaperInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Step 1: parse the ref. Failures collapse to INVALID_REF.
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(fetch_paper_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InvalidRef,
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+
+        // Step 2: dry-run branch (ADR-0022 §2).
+        if input.dry_run {
+            let store_root = resolve_store_root().unwrap_or_else(|| Utf8PathBuf::from("./papers"));
+            let plan = build_fetch_plan(&ref_, &store_root);
+            return Ok(CallToolResult::structured(build_dry_run_envelope(
+                &ref_, &plan,
+            )));
+        }
+
+        // Step 3: non-dry-run path. Build foundation modules + open
+        // FsStore + dispatch through core orchestrator.
+        let ctx = match build_fetch_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(fetch_paper_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    &format!("fetch-paper context initialization failed: {e}"),
+                )));
+            }
+        };
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(fetch_paper_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(fetch_paper_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
+        // SessionStart bookend (mirrors `doiget_metadata_only`).
+        if let Err(e) = ctx.log.append(RowInput {
+            event: LogEvent::SessionStart,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: Some(input.ref_.as_str()),
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        }) {
+            return Ok(CallToolResult::structured(fetch_paper_error_envelope(
+                Some(&input.ref_),
+                ErrorCode::LogError,
+                &format!("SessionStart append failed: {e}"),
+            )));
+        }
+
+        let outcome = core_fetch_paper(&ref_, &self.profile, &ctx, &store, &store_root).await;
+
+        let session_ok = outcome.is_ok();
+        let _ = ctx.log.append(RowInput {
+            event: LogEvent::SessionEnd,
+            result: if session_ok {
+                LogResult::Ok
+            } else {
+                LogResult::Err
+            },
+            capability: Capability::Oa,
+            ref_: Some(input.ref_.as_str()),
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        });
+
+        match outcome {
+            Ok(o) => Ok(CallToolResult::structured(fetch_paper_success_envelope(
+                &o,
+                &input.ref_,
+            ))),
+            Err(e) => Ok(CallToolResult::structured(
+                fetch_paper_fetch_error_envelope(&e, &input.ref_),
+            )),
+        }
+    }
+
+    /// `doiget_batch_fetch` — fetch up to [`MAX_BATCH_REFS`] refs in
+    /// one call.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1 (NORMATIVE Phase 3 baseline).
+    ///
+    /// Per-ref outcomes are independent — a failure on one ref does NOT
+    /// abort sibling refs. The wire envelope is
+    /// `{ok:true, results: [...]}` where each entry has `{ref, ok, ...}`.
+    /// Only whole-call failures (INVALID_REF on a malformed input, the
+    /// over-cap [`FetchError::TooManyRefs`] / TOO_MANY_REFS surfaced as
+    /// INVALID_REF, or context initialization) emit the
+    /// `{ok:false, error:{...}}` envelope.
+    #[tool(
+        description = "WHEN TO USE: User wants to fetch many papers in one call (up to 100).\n\
+                       INPUTS: refs (array of up to 100 DOIs / arXiv ids), dry_run (optional bool).\n\
+                       OUTPUTS: { ok: true, results: [{ref, ok, ...}] } OR { ok: true, dry_run: true, plans: [{ref, plan, rate_limit_budget}] } OR { ok:false, error }.\n\
+                       COSTS: 1-3 s per ref, bounded by the 5/sec global rate cap.\n\
+                       SIDE EFFECTS: Writes PDFs / metadata TOMLs to the store (unless dry_run). Appends one provenance row per attempt.\n\
+                       LIMITS: Max 100 refs per call (TOO_MANY_REFS otherwise). Per-ref errors are reported in `results` and do NOT fail the whole call."
+    )]
+    async fn doiget_batch_fetch(
+        &self,
+        Parameters(input): Parameters<BatchFetchInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Step 1: enforce the cap before any parsing.
+        if input.refs.len() > MAX_BATCH_REFS {
+            return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                ErrorCode::InvalidRef,
+                &format!(
+                    "too many refs: got {}, max {} (TOO_MANY_REFS)",
+                    input.refs.len(),
+                    MAX_BATCH_REFS
+                ),
+            )));
+        }
+
+        // Step 2: parse every ref up-front. Any malformed ref aborts
+        // the whole call with INVALID_REF (per the spec: bulk parse is
+        // all-or-nothing).
+        let mut parsed: Vec<Ref> = Vec::with_capacity(input.refs.len());
+        for raw in &input.refs {
+            match Ref::parse(raw) {
+                Ok(r) => parsed.push(r),
+                Err(e) => {
+                    return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                        ErrorCode::InvalidRef,
+                        &format!("invalid ref {raw:?}: {e}"),
+                    )));
+                }
+            }
+        }
+
+        // Step 3: dry-run branch — one plan per ref.
+        if input.dry_run {
+            let store_root = resolve_store_root().unwrap_or_else(|| Utf8PathBuf::from("./papers"));
+            let plans = match batch_fetch_plans(&parsed, &store_root) {
+                Ok(p) => p,
+                Err(e) => {
+                    return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                        ErrorCode::from(e),
+                        "batch dry-run plan build failed",
+                    )));
+                }
+            };
+            let envelope = build_batch_dry_run_envelope(&plans);
+            return Ok(CallToolResult::structured(envelope));
+        }
+
+        // Step 4: non-dry-run — stand up the shared FetchContext +
+        // store, emit a single SessionStart row, fan out via the core
+        // orchestrator.
+        let ctx = match build_fetch_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::InternalError,
+                    &format!("batch-fetch context initialization failed: {e}"),
+                )));
+            }
+        };
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::InternalError,
+                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
+        if let Err(e) = ctx.log.append(RowInput {
+            event: LogEvent::SessionStart,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: None,
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        }) {
+            return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                ErrorCode::LogError,
+                &format!("SessionStart append failed: {e}"),
+            )));
+        }
+
+        let batch_outcome =
+            core_batch_fetch(&parsed, &self.profile, &ctx, &store, &store_root).await;
+
+        let session_ok = batch_outcome
+            .as_ref()
+            .map(|b| b.results.iter().all(|r| r.outcome.is_ok()))
+            .unwrap_or(false);
+
+        let _ = ctx.log.append(RowInput {
+            event: LogEvent::SessionEnd,
+            result: if session_ok {
+                LogResult::Ok
+            } else {
+                LogResult::Err
+            },
+            capability: Capability::Oa,
+            ref_: None,
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+        });
+
+        match batch_outcome {
+            Ok(b) => Ok(CallToolResult::structured(batch_fetch_success_envelope(
+                &b,
+                &input.refs,
+            ))),
+            Err(e) => Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                ErrorCode::from(e),
+                "batch-fetch orchestrator failed",
+            ))),
         }
     }
 }
@@ -428,6 +714,214 @@ fn metadata_only_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value 
     })
 }
 
+// ---------------------------------------------------------------------------
+// doiget_fetch_paper — input schema + envelopes (Slice 2)
+// ---------------------------------------------------------------------------
+
+/// JSON-schema-derived input for `doiget_fetch_paper`. Same wire shape
+/// as `MetadataOnlyInput` — just a different orchestrator target.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct FetchPaperInput {
+    /// DOI or arXiv id; validated via `Ref::parse`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+    /// When `true`, returns a [`FetchPlan`](doiget_core::dry_run::FetchPlan)
+    /// preview without touching the network or writing anything
+    /// (ADR-0022). Defaults to `false`.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+/// Build the `{ok:true, ref, source, path, ...}` success envelope per
+/// `docs/MCP_TOOLS.md` §5 `FetchResult`.
+fn fetch_paper_success_envelope(outcome: &FetchPaperOutcome, ref_str: &str) -> Value {
+    json!({
+        "ok": true,
+        "ref": ref_str,
+        "source": outcome.source,
+        "license": outcome.license,
+        "path": outcome.path,
+        "size_bytes": outcome.size_bytes,
+        "schema_version": outcome.schema_version,
+    })
+}
+
+/// Build the `{ok:false, ref, error:{code, message}}` envelope for
+/// input-shape / context-init failures in `doiget_fetch_paper`.
+fn fetch_paper_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &str) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("ok".into(), json!(false));
+    if let Some(r) = ref_str {
+        obj.insert("ref".into(), json!(r));
+    }
+    obj.insert(
+        "error".into(),
+        json!({
+            "code": code,
+            "message": message,
+        }),
+    );
+    Value::Object(obj)
+}
+
+/// Build the `{ok:false, error:{code, message, denial_context?}}`
+/// envelope for orchestrator failures in `doiget_fetch_paper`.
+fn fetch_paper_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value {
+    let code: ErrorCode = match err {
+        FetchError::NotEligible { .. } => ErrorCode::CapabilityDenied,
+        FetchError::NoOaAvailable => ErrorCode::NoOaAvailable,
+        FetchError::Http(_) => ErrorCode::NetworkError,
+        FetchError::Log(_) => ErrorCode::LogError,
+        FetchError::InvalidRef(_) => ErrorCode::InvalidRef,
+        FetchError::SourceSchema { .. } => ErrorCode::InternalError,
+        FetchError::TooManyRefs { .. } => ErrorCode::InvalidRef,
+        _ => ErrorCode::InternalError,
+    };
+    let denial: Option<DenialContext> = err.into();
+    let mut error_obj = serde_json::Map::new();
+    error_obj.insert("code".into(), json!(code));
+    error_obj.insert("message".into(), json!(err.to_string()));
+    if let Some(dc) = denial {
+        error_obj.insert(
+            "denial_context".into(),
+            serde_json::to_value(&dc).unwrap_or(Value::Null),
+        );
+    }
+    json!({
+        "ok": false,
+        "ref": ref_str,
+        "error": error_obj,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// doiget_batch_fetch — input schema + envelopes (Slice 2)
+// ---------------------------------------------------------------------------
+
+/// JSON-schema-derived input for `doiget_batch_fetch`.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct BatchFetchInput {
+    /// List of DOI / arXiv id refs. Max [`MAX_BATCH_REFS`] entries; the
+    /// cap is enforced inside the tool handler so a 101st ref surfaces
+    /// as an `INVALID_REF` envelope (rather than a JSON schema reject).
+    pub refs: Vec<String>,
+    /// When `true`, return one [`FetchPlan`](doiget_core::dry_run::FetchPlan)
+    /// per ref without touching the network or store.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+/// Build the `{ok:true, results: [...]}` envelope for a successful
+/// batch call. Each per-ref outcome is independent: a network failure
+/// on one ref shows up as `{ref, ok:false, error}` next to siblings'
+/// `{ref, ok:true, ...}`. Mirrors the per-ref shape of
+/// [`fetch_paper_success_envelope`] / [`fetch_paper_fetch_error_envelope`].
+fn batch_fetch_success_envelope(
+    batch: &doiget_core::orchestrator::BatchOutcome,
+    raw_refs: &[String],
+) -> Value {
+    let results: Vec<Value> = batch
+        .results
+        .iter()
+        .zip(raw_refs.iter())
+        .map(|(entry, raw)| match &entry.outcome {
+            Ok(outcome) => json!({
+                "ref": raw,
+                "ok": true,
+                "source": outcome.source,
+                "license": outcome.license,
+                "path": outcome.path,
+                "size_bytes": outcome.size_bytes,
+                "schema_version": outcome.schema_version,
+            }),
+            Err(err) => {
+                let code: ErrorCode = match err {
+                    FetchError::NotEligible { .. } => ErrorCode::CapabilityDenied,
+                    FetchError::NoOaAvailable => ErrorCode::NoOaAvailable,
+                    FetchError::Http(_) => ErrorCode::NetworkError,
+                    FetchError::Log(_) => ErrorCode::LogError,
+                    FetchError::InvalidRef(_) => ErrorCode::InvalidRef,
+                    FetchError::SourceSchema { .. } => ErrorCode::InternalError,
+                    FetchError::TooManyRefs { .. } => ErrorCode::InvalidRef,
+                    _ => ErrorCode::InternalError,
+                };
+                let denial: Option<DenialContext> = err.into();
+                let mut error_obj = serde_json::Map::new();
+                error_obj.insert("code".into(), json!(code));
+                error_obj.insert("message".into(), json!(err.to_string()));
+                if let Some(dc) = denial {
+                    error_obj.insert(
+                        "denial_context".into(),
+                        serde_json::to_value(&dc).unwrap_or(Value::Null),
+                    );
+                } else {
+                    // Per the Slice 2 spec: transport (NETWORK_ERROR)
+                    // entries carry `denial_context: null` so an agent
+                    // can pattern-match on the field's presence rather
+                    // than tolerating absence. This deliberately
+                    // differs from the metadata-only envelope where
+                    // the field is omitted entirely; the batch surface
+                    // makes the null explicit because per-ref entries
+                    // are uniform table rows in the agent's view.
+                    error_obj.insert("denial_context".into(), Value::Null);
+                }
+                json!({
+                    "ref": raw,
+                    "ok": false,
+                    "error": error_obj,
+                })
+            }
+        })
+        .collect();
+    json!({
+        "ok": true,
+        "results": results,
+    })
+}
+
+/// Build the dry-run envelope for `doiget_batch_fetch` —
+/// `{ok:true, dry_run:true, plans:[{ref, plan, rate_limit_budget}]}`.
+fn build_batch_dry_run_envelope(plans: &[(Ref, doiget_core::dry_run::FetchPlan)]) -> Value {
+    let budget = core_rate_limit_budget();
+    let plan_items: Vec<Value> = plans
+        .iter()
+        .map(|(ref_, plan)| {
+            let envelope = build_dry_run_envelope(ref_, plan);
+            // `build_dry_run_envelope` returns the single-ref shape; we
+            // unpack it into per-row entries for the batch envelope.
+            json!({
+                "ref": envelope.get("ref").cloned().unwrap_or(Value::Null),
+                "plan": envelope.get("plan").cloned().unwrap_or(Value::Null),
+                "rate_limit_budget": envelope
+                    .get("rate_limit_budget")
+                    .cloned()
+                    .unwrap_or(serde_json::to_value(budget).unwrap_or(Value::Null)),
+            })
+        })
+        .collect();
+    json!({
+        "ok": true,
+        "dry_run": true,
+        "plans": plan_items,
+    })
+}
+
+/// Build the `{ok:false, error:{code, message}}` envelope for whole-
+/// call failures in `doiget_batch_fetch` (TOO_MANY_REFS, INVALID_REF on
+/// bulk parse, context-init).
+fn batch_fetch_error_envelope(code: ErrorCode, message: &str) -> Value {
+    json!({
+        "ok": false,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    })
+}
+
 /// Build a [`FetchContext`] for the non-dry-run `doiget_metadata_only`
 /// path.
 ///
@@ -446,7 +940,7 @@ fn metadata_only_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value 
 ///   if missing.
 /// - `session_id` — fresh 26-char ULID per call (one tool call = one
 ///   logical session, per `docs/PROVENANCE_LOG.md` §3).
-fn build_metadata_only_context() -> anyhow::Result<FetchContext> {
+fn build_fetch_context() -> anyhow::Result<FetchContext> {
     let log_path = resolve_log_path()?;
     if let Some(parent) = log_path.parent() {
         if !parent.as_str().is_empty() {
@@ -459,7 +953,7 @@ fn build_metadata_only_context() -> anyhow::Result<FetchContext> {
         ProvenanceLog::open(log_path, session_id.clone())
             .map_err(|e| anyhow::anyhow!("opening provenance log: {e}"))?,
     );
-    let http = Arc::new(build_metadata_only_http_client()?);
+    let http = Arc::new(build_http_client_for_fetch()?);
     let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
     Ok(FetchContext {
         http,
@@ -473,7 +967,7 @@ fn build_metadata_only_context() -> anyhow::Result<FetchContext> {
 /// surface that `doiget-cli` honors (`build_http_client` in
 /// `crates/doiget-cli/src/commands/fetch.rs`). When no overrides are
 /// set, returns the production allowlist (Tier 1 ∪ OA publisher).
-fn build_metadata_only_http_client() -> anyhow::Result<HttpClient> {
+fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
     let arxiv = std::env::var("DOIGET_ARXIV_BASE").ok();
     let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
     let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();

--- a/crates/doiget-mcp/tests/fetch_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/fetch_paper_e2e.rs
@@ -1,0 +1,470 @@
+//! Slice 2 — end-to-end coverage for `doiget_fetch_paper` and
+//! `doiget_batch_fetch` (wiremock-driven; NO outbound network).
+//!
+//! ## Network purity
+//!
+//! Per the workspace network-purity guard, this file imports `wiremock`
+//! to mount fake origins; no `reqwest::*` items are imported directly.
+//! All HTTP traffic terminates at a `wiremock::MockServer` on
+//! `127.0.0.1:N`. The first-line escape hatch below covers the future
+//! addition of any `reqwest::*` import without further intervention.
+// allow: outbound-network
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use doiget_core::CapabilityProfile;
+use doiget_mcp::Server;
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+
+/// RAII helper mirroring `initialize_handshake::EnvGuard`. Scoped env
+/// mutations so a panic mid-test does not leak state across the
+/// single-threaded `serial_test::serial` group.
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+const ENV_KEYS: &[&str] = &[
+    "DOIGET_STORE_ROOT",
+    "DOIGET_LOG_PATH",
+    "DOIGET_ARXIV_BASE",
+    "DOIGET_CROSSREF_BASE",
+    "DOIGET_UNPAYWALL_BASE",
+    "DOIGET_OA_PUBLISHER_BASE",
+    "DOIGET_CONTACT_EMAIL",
+    "DOIGET_UNPAYWALL_EMAIL",
+];
+
+async fn boot_in_memory_server() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+    Ok((client, server_handle))
+}
+
+// ---------------------------------------------------------------------------
+// doiget_fetch_paper
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn fetch_paper_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("not a doi"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_fetch_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_fetch_paper uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF"),
+        "envelope: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn fetch_paper_dry_run_returns_fetch_plan_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    args.insert("dry_run".to_string(), serde_json::json!(true));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_fetch_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("dry_run uses structured content");
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["dry_run"], serde_json::json!(true));
+    assert_eq!(
+        structured["ref"],
+        serde_json::json!({"doi": "10.1234/example"})
+    );
+    // ADR-0022 §4 marker: the candidate_hosts list is an upper bound,
+    // not a prediction. Posture surfaces this as a machine-parseable
+    // boolean inside `plan`.
+    assert_eq!(
+        structured["plan"]["candidate_hosts_are_upper_bound"],
+        serde_json::json!(true)
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+const SAMPLE_PDF_BODY: &[u8] = b"%PDF-fake-bytes\n";
+
+#[tokio::test]
+#[serial_test::serial]
+async fn fetch_paper_arxiv_happy_path_writes_pdf_and_returns_envelope() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(SAMPLE_PDF_BODY.to_vec()))
+        .mount(&mock)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let temp_root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ARXIV_BASE", &mock.uri());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("2401.12345"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_fetch_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    assert_eq!(structured["source"], serde_json::json!("arxiv"));
+    assert_eq!(structured["ref"], serde_json::json!("2401.12345"));
+    assert_eq!(structured["license"], serde_json::json!("arxiv-default"));
+    assert_eq!(
+        structured["size_bytes"],
+        serde_json::json!(SAMPLE_PDF_BODY.len())
+    );
+    assert_eq!(structured["schema_version"], serde_json::json!("1.0"));
+    // On-disk PDF MUST exist at the path the envelope advertises.
+    let pdf_path = structured["path"].as_str().expect("path field is a string");
+    let on_disk = std::path::Path::new(pdf_path);
+    assert!(
+        on_disk.exists(),
+        "PDF written by orchestrator must exist on disk: {pdf_path}"
+    );
+    let bytes = std::fs::read(on_disk).expect("read PDF");
+    assert_eq!(bytes, SAMPLE_PDF_BODY);
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// doiget_batch_fetch
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn batch_fetch_too_many_refs_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    // 101 refs (one over the MAX_BATCH_REFS cap of 100).
+    let refs: Vec<serde_json::Value> = (0..101)
+        .map(|i| serde_json::Value::String(format!("10.1234/n{}", i)))
+        .collect();
+    let mut args = serde_json::Map::new();
+    args.insert("refs".to_string(), serde_json::Value::Array(refs));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_batch_fetch").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF")
+    );
+    let message = structured["error"]["message"]
+        .as_str()
+        .expect("message is string");
+    assert!(
+        message.contains("too many refs"),
+        "TOO_MANY_REFS message must surface the cap; got: {message}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn batch_fetch_one_invalid_ref_aborts_with_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let refs = serde_json::json!(["2401.12345", "not-a-doi-at-all"]);
+    let mut args = serde_json::Map::new();
+    args.insert("refs".to_string(), refs);
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_batch_fetch").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF")
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn batch_fetch_dry_run_returns_plans_array() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let refs = serde_json::json!(["2401.12345", "10.1234/foo"]);
+    let mut args = serde_json::Map::new();
+    args.insert("refs".to_string(), refs);
+    args.insert("dry_run".to_string(), serde_json::json!(true));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_batch_fetch").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["dry_run"], serde_json::json!(true));
+    let plans = structured["plans"].as_array().expect("plans is an array");
+    assert_eq!(plans.len(), 2);
+    assert_eq!(plans[0]["ref"], serde_json::json!({"arxiv": "2401.12345"}));
+    assert_eq!(plans[1]["ref"], serde_json::json!({"doi": "10.1234/foo"}));
+    // ADR-0022 §4 marker propagates into each per-ref plan.
+    assert_eq!(
+        plans[0]["plan"]["candidate_hosts_are_upper_bound"],
+        serde_json::json!(true)
+    );
+    // Rate-limit budget present per row.
+    assert_eq!(
+        plans[0]["rate_limit_budget"]["global_per_sec"],
+        serde_json::json!(5.0)
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn batch_fetch_three_arxiv_refs_succeed_each_with_ok_true() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    for id in ["2401.10001", "2401.10002", "2401.10003"] {
+        Mock::given(method("GET"))
+            .and(path(format!("/pdf/{}.pdf", id)))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(SAMPLE_PDF_BODY.to_vec()))
+            .mount(&mock)
+            .await;
+    }
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let temp_root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ARXIV_BASE", &mock.uri());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+    let refs = serde_json::json!(["2401.10001", "2401.10002", "2401.10003"]);
+    let mut args = serde_json::Map::new();
+    args.insert("refs".to_string(), refs);
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_batch_fetch").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    let results = structured["results"]
+        .as_array()
+        .expect("results is an array");
+    assert_eq!(results.len(), 3);
+    for (i, entry) in results.iter().enumerate() {
+        assert_eq!(
+            entry["ok"],
+            serde_json::json!(true),
+            "row {i} must report ok:true; entry: {entry:?}"
+        );
+        assert_eq!(entry["source"], serde_json::json!("arxiv"));
+        assert_eq!(
+            entry["size_bytes"],
+            serde_json::json!(SAMPLE_PDF_BODY.len())
+        );
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn batch_fetch_partial_failure_emits_per_ref_outcomes() -> anyhow::Result<()> {
+    // Two refs that should succeed, plus one that points at an id with
+    // no mounted mock — the PDF leg returns 404 and the orchestrator
+    // surfaces a per-ref `Err`. The whole-call envelope MUST remain
+    // `ok:true` (per-ref errors are independent).
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    for id in ["2401.20001", "2401.20002"] {
+        Mock::given(method("GET"))
+            .and(path(format!("/pdf/{}.pdf", id)))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(SAMPLE_PDF_BODY.to_vec()))
+            .mount(&mock)
+            .await;
+    }
+    // No mock mounted for `/pdf/2401.99999.pdf` — wiremock returns 404
+    // by default, which the orchestrator surfaces as a NETWORK_ERROR.
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let temp_root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ARXIV_BASE", &mock.uri());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+    let refs = serde_json::json!(["2401.20001", "2401.99999", "2401.20002"]);
+    let mut args = serde_json::Map::new();
+    args.insert("refs".to_string(), refs);
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_batch_fetch").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    // Whole-call still ok=true; per-ref errors live inside results[].
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    let results = structured["results"]
+        .as_array()
+        .expect("results is an array");
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0]["ok"], serde_json::json!(true));
+    assert_eq!(results[1]["ok"], serde_json::json!(false));
+    assert_eq!(results[2]["ok"], serde_json::json!(true));
+    // The failing per-ref row carries `denial_context: null` for
+    // transport errors (ADR-0023 §4 — NETWORK_ERROR has no denial
+    // channel).
+    assert!(
+        results[1]["error"].get("denial_context").is_some(),
+        "transport per-ref error must surface denial_context (as null) per Slice 2 spec; got: {:?}",
+        results[1],
+    );
+    assert!(
+        results[1]["error"]["denial_context"].is_null(),
+        "denial_context must be null for NETWORK_ERROR; got: {:?}",
+        results[1]["error"]["denial_context"]
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -88,6 +88,15 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_metadata_only"),
         "tools/list must include doiget_metadata_only; got: {names:?}"
     );
+    // Slice 2: fetch_paper + batch_fetch advertised.
+    assert!(
+        names.contains(&"doiget_fetch_paper"),
+        "tools/list must include doiget_fetch_paper; got: {names:?}"
+    );
+    assert!(
+        names.contains(&"doiget_batch_fetch"),
+        "tools/list must include doiget_batch_fetch; got: {names:?}"
+    );
 
     // -- 3. tools/call doiget_health -----------------------------------
     let health = client


### PR DESCRIPTION
## Summary

Slice 2 of 6 in the post-Discussion #12 roadmap. After Slice 1 (PR #86) the MCP server exposed 3 / 9 Phase 3 baseline tools. Slice 2 brings that to 5.

| | Deliverable | Status |
|---|---|---|
| C.1 | Extract `fetch_paper` / `batch_fetch` orchestrators into `doiget_core::orchestrator` | done |
| C.2 | Wire `doiget_fetch_paper` + `doiget_batch_fetch` MCP tools | done |
| C.3 | New `MAX_BATCH_REFS = 100` const + `FetchError::TooManyRefs` variant | done |
| C.4 | 25 new MCP integration tests + cross-tool checks | done |

## Architectural change

CLI fetch/batch logic moved into `doiget-core::orchestrator`. The CLI's `run_with_options` now delegates. Both CLI and MCP share one source of truth. Existing CLI fetch/batch e2e suites stay green (behavior preserved).

## New surface

```rust
pub const doiget_core::MAX_BATCH_REFS: usize = 100;

pub async fn orchestrator::fetch_paper(...) -> Result<FetchPaperOutcome, FetchError>;
pub async fn orchestrator::batch_fetch(...) -> Result<BatchOutcome, FetchError>;

pub struct FetchPaperOutcome { source, license, path, size_bytes, schema_version }
pub struct BatchOutcome { results: Vec<BatchResultEntry> }

// FetchError gains:
TooManyRefs { got: usize, max: usize },
```

`TooManyRefs` collapses to `ErrorCode::InvalidRef` (request-shape failure, not a denial — `denial_context` stays `None`).

## MCP tool inventory after Slice 2

Wired (5/9): `doiget_health`, `doiget_capability_profile`, `doiget_metadata_only`, `doiget_fetch_paper`, `doiget_batch_fetch`.
Remaining (4): `doiget_resolve_paper`, `doiget_info`, `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path` (5 actually — counted off-by-one above; corrected in CHANGELOG).

## Verification

- `cargo fmt --check` clean
- `cargo build --workspace`
- `cargo test --workspace` 22 test binaries / 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --no-default-features --features oa-only` clean

## Roadmap

| Slice | Status | Title |
|---|---|---|
| 1 | merged | metadata_only + arxiv Atom (#86) |
| **2** | **this PR** | MCP `fetch_paper` + `batch_fetch` |
| 3 | pending | safekey 100 vectors |
| 4 | pending | `CanonicalRef` impl (BREAKING) |
| 5 | pending | Review Advisory 8 items refactor |
| 6 | pending | Real-world DOI fixture set |