### PR TITLE
refactor(slice-5): 7 advisory refactors from PR #84 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,60 @@ Phase 0 (design + scaffolding). No version tag is published in this phase; the
 workspace stays at `0.0.0` until Phase 6. See [docs/PHASES.md](docs/PHASES.md)
 for the full Phase 0 deliverable checklist.
 
+### Slice 5 — PR #84 review advisory refactors (code simplification)
+
+This slice addresses the seven Advisory-tier findings (A2 - A8) from
+the PR #84 multi-agent review. Every change is behavior-preserving and
+internal-only — the public Rust API, the CLI wire surface, the MCP
+tool envelopes, and the provenance-log shape are bit-identical before
+and after this slice. (Advisory item A1 — `expected: Option<Vec<String>>`
+— had already landed in PR #85 refinement #3 and required no further
+work here.)
+
+- **(A2 / A3)** Collapsed the single-field `FetchOptions { dry_run: bool }`
+  / `BatchOptions { dry_run: bool }` option bundles and their
+  back-compat `run(input) -> run_with_options(input, default)`
+  wrappers into bare `dry_run: bool` parameters on
+  `doiget_cli::commands::fetch::run_with_options` and
+  `doiget_cli::commands::batch::run_with_options`. The struct shape
+  was YAGNI and the wrappers only existed to spare tests a
+  `..::default()` literal. Call sites (CLI `main.rs` clap dispatch,
+  four `tests/*_e2e.rs` integration tests) updated in the same slice.
+
+- **(A4)** Replaced the duplicate `build_test_client_for_http` helper
+  inside `doiget_core::http::tests` with a one-line delegation to the
+  public `HttpClient::new_for_tests_allow_http` constructor. The two
+  paths had drifted into byte-identical re-implementations; the
+  delegation keeps the security-load-bearing redirect-policy + builder
+  in one place.
+
+- **(A5)** Extracted the `struct EnvGuard` test fixture into the shared
+  `crates/doiget-cli/tests/common/env_guard.rs` module (with
+  `tests/common/mod.rs` declaring `pub mod env_guard;`). Four
+  integration-test binaries (`fetch_arxiv_e2e`, `fetch_dry_run_e2e`,
+  `fetch_doi_oa_pdf_e2e`, `batch_e2e`) had each defined a private
+  `EnvGuard` with subtly different snapshot-and-restore behavior;
+  consolidated on the strictly-safer snapshot-and-restore variant.
+
+- **(A6)** Derived `FetchPlan::redirect_allowlists_loaded` from
+  `tier_1_allowlist() + oa_publisher_allowlist()` instead of a
+  hardcoded `vec!["crossref","unpaywall","arxiv","oa-publisher"]`.
+  Wire output is bit-identical today; the change prevents future drift
+  if a new allowlist source is added to the production HTTP client.
+
+- **(A7)** Fixed a docstring section reference in
+  `crates/doiget-mcp/src/lib.rs` — `metadata_only_error_envelope` now
+  cites ADR-0023 §1 (the top-level optionality of `denial_context`)
+  instead of §3 (which covers per-subfield optionality and applies
+  only when `denial_context` is present).
+
+- **(A8)** Tightened the doc comments on reserved
+  `DenialReason::SchemaDrift`, `HostInBlockList`, `RateLimitWindow`,
+  and `SsrfPrivateAddress` variants — each now states `Reserved — no
+  producer wired yet. Will be emitted by <future component> once that
+  component lands.` so the "unused variant" status is explicit on the
+  public API surface.
+
 ### Slice 4 — CanonicalRef impl + provenance log v1→v2 migration (BREAKING)
 
 This slice ships the audit-identity layer that [ADR-0021](docs/DECISIONS/0021-canonical-tuple-identity.md)

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -37,39 +37,28 @@ use doiget_core::{RateLimits, Ref, MCP_BATCH_MAX_SIZE};
 use super::fetch::{build_fetch_plan, emit_dry_run_plan_to_stdout, FetchHarness};
 use super::resolve_store_root;
 
-/// Per-batch option bundle threaded from `main.rs` clap dispatch.
+/// Run the `doiget batch <path>` subcommand.
 ///
-/// Mirrors [`super::fetch::FetchOptions`] for the multi-ref orchestrator.
-/// `Default` reproduces the historical [`run`] behaviour, so existing
-/// integration tests under `crates/doiget-cli/tests/batch_e2e.rs` (which
-/// call `batch::run(...)`) continue to compile unchanged.
-#[derive(Debug, Clone, Default)]
-pub struct BatchOptions {
-    /// When `true`, parse the refs file, emit a [`super::fetch::FetchPlan`]
-    /// JSON line per ref on stdout, and return `Ok(())` without opening
-    /// the provenance log, building the HTTP client, or writing to the
-    /// store. ADR-0022 §1 / §3.
-    pub dry_run: bool,
-}
-
-/// Run the `doiget batch <path>` subcommand with the historical
-/// (dry-run-disabled) defaults. See [`run_with_options`] for the
-/// dry-run-aware entry point and the module docs for the
-/// failure-semantics contract.
-pub async fn run(path: String) -> Result<()> {
-    run_with_options(path, BatchOptions::default()).await
-}
-
-/// Run the `doiget batch <path>` subcommand with the given options.
-///
-/// When `opts.dry_run` is `true` (per ADR-0022 §1 + §3): read the input
+/// When `dry_run` is `true` (per ADR-0022 §1 + §3): read the input
 /// file, parse refs, and emit one `FetchPlan` JSON envelope line per ref
 /// on stdout. NO provenance log is opened, NO HTTP client is built, NO
 /// per-ref fetch runs, NO store write happens. Per-ref parse failures
 /// in dry-run mode are still counted and the function returns
 /// `Err(...)` if any ref failed to parse — the input was malformed and
 /// the caller should know.
-pub async fn run_with_options(path: String, opts: BatchOptions) -> Result<()> {
+///
+/// When `dry_run` is `false`, runs the normal multi-ref orchestration —
+/// see the module-level docs for the failure-semantics contract.
+///
+/// # History
+///
+/// Slice 5 (PR #84 advisory item A2/A3 refactor): the previous
+/// `BatchOptions { dry_run: bool }` single-field option bundle plus the
+/// thin `run(path)` backwards-compat wrapper were collapsed into this
+/// single `dry_run: bool` parameter — the option bundle's single-bool
+/// shape was YAGNI, and the wrapper only existed to spare integration
+/// tests a `BatchOptions::default()` literal.
+pub async fn run_with_options(path: String, dry_run: bool) -> Result<()> {
     // Step 1: read the input file. Failures surface before any fetch starts.
     let raw =
         std::fs::read_to_string(&path).with_context(|| format!("reading batch file: {path}"))?;
@@ -98,7 +87,7 @@ pub async fn run_with_options(path: String, opts: BatchOptions) -> Result<()> {
     // per ref on stdout WITHOUT opening the provenance log, building the
     // HTTP client, or writing to the store. Per-ref parse failures still
     // count toward the exit code so a malformed batch is visible.
-    if opts.dry_run {
+    if dry_run {
         let store_root = resolve_store_root()?;
         let mut parse_errors: usize = 0;
         for input in &inputs {

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -394,55 +394,34 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
     }
 }
 
-/// Per-fetch option bundle threaded from `main.rs` clap dispatch.
+/// Run the `doiget fetch <ref>` subcommand.
 ///
-/// The bundle is additive: `Default` produces the historical
-/// `pub async fn run(input)` behaviour, so existing callers (integration
-/// tests under `crates/doiget-cli/tests/`) that go through [`run`]
-/// continue to work unchanged. New callers (the binary's
-/// `clap::Subcommand::Fetch` arm and the dry-run integration test) go
-/// through [`run_with_options`].
+/// `dry_run` (ADR-0022 §1): when `true`, build a [`FetchPlan`] from the
+/// parsed [`Ref`] and the configured store root, serialize it as JSON to
+/// stdout, and return `Ok(())` immediately, **without** building a
+/// `FetchHarness` (no provenance log open), without contacting the
+/// network, without writing to the store, and without appending a
+/// provenance row.
 ///
-/// Currently exposes a single field — `dry_run` per ADR-0022 §1.
-#[derive(Debug, Clone, Default)]
-pub struct FetchOptions {
-    /// When `true`, build a [`FetchPlan`], emit it as JSON on stdout, and
-    /// return `Ok(())` without touching the network or filesystem and
-    /// without appending a provenance row.
-    pub dry_run: bool,
-}
-
-/// Run the `doiget fetch <ref>` subcommand with the historical (dry-run-
-/// disabled) defaults.
-///
-/// Equivalent to `run_with_options(input, FetchOptions::default())`. Kept
-/// at this signature so the existing in-process integration tests under
-/// `crates/doiget-cli/tests/` (which call `fetch::run("...".into())`)
-/// continue to compile unchanged.
+/// When `dry_run` is `false`, the function runs the normal end-to-end
+/// orchestration path: open the provenance log, dispatch the per-kind
+/// orchestrator, emit a `SessionStart` / `SessionEnd` bookend pair.
 ///
 /// On success returns `Ok(())` and writes a one-line success message to
 /// stderr (per ADR-0001 stdio convention — no stdout writes from `fetch`
 /// on the normal path). On failure, returns an `anyhow::Error` and emits
 /// a `SessionEnd` row with `result=err` to the provenance log before
 /// returning.
-pub async fn run(input: String) -> Result<()> {
-    run_with_options(input, FetchOptions::default()).await
-}
-
-/// Run the `doiget fetch <ref>` subcommand with the given options.
 ///
-/// When `opts.dry_run` is `true` (per ADR-0022 §1):
-///   - Build a [`FetchPlan`] from the parsed [`Ref`] and the configured
-///     store root.
-///   - Serialize it to JSON and write to stdout.
-///   - Return `Ok(())` immediately, **without** building a
-///     `FetchHarness` (no provenance log open), without contacting the
-///     network, without writing to the store, and without appending a
-///     provenance row.
+/// # History
 ///
-/// When `opts.dry_run` is `false`, the body is identical to the
-/// historical [`run`] implementation.
-pub async fn run_with_options(input: String, opts: FetchOptions) -> Result<()> {
+/// Slice 5 (PR #84 advisory item A2/A3 refactor): the previous
+/// `FetchOptions { dry_run: bool }` single-field option bundle plus the
+/// thin `run(input)` backwards-compat wrapper were collapsed into this
+/// single `dry_run: bool` parameter — the option bundle's single-bool
+/// shape was YAGNI, and the wrapper only existed to spare integration
+/// tests a `FetchOptions::default()` literal.
+pub async fn run_with_options(input: String, dry_run: bool) -> Result<()> {
     // Step 1: parse + safekey. Granular `RefParseError` collapses to anyhow
     // via `?`; the higher-level CLI binary maps the error to its exit code.
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
@@ -451,7 +430,7 @@ pub async fn run_with_options(input: String, opts: FetchOptions) -> Result<()> {
     // NO store write, NO provenance row. Posture-lint ADR-0022 §5 will
     // verify this branch never reaches `HttpClient::fetch_*`,
     // `FsStore::write_*`, or `ProvenanceLog::append`.
-    if opts.dry_run {
+    if dry_run {
         // Resolve store root for path projections. Failures here surface
         // as a normal CLI error (not as a denial) — same behaviour the
         // non-dry-run path would exhibit on a misconfigured environment.

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -140,18 +140,10 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit),
         Some(Command::Search { query }) => doiget_cli::commands::search::run(query),
         Some(Command::Fetch { ref_, dry_run }) => {
-            doiget_cli::commands::fetch::run_with_options(
-                ref_,
-                doiget_cli::commands::fetch::FetchOptions { dry_run },
-            )
-            .await
+            doiget_cli::commands::fetch::run_with_options(ref_, dry_run).await
         }
         Some(Command::Batch { path, dry_run }) => {
-            doiget_cli::commands::batch::run_with_options(
-                path,
-                doiget_cli::commands::batch::BatchOptions { dry_run },
-            )
-            .await
+            doiget_cli::commands::batch::run_with_options(path, dry_run).await
         }
         Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_),
         Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_),

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -25,34 +25,8 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// RAII helper to scope env-var mutations so a panic mid-test does not leak
-/// state across the (single-threaded) `serial` group. Same shape as the one
-/// in `tests/fetch_arxiv_e2e.rs`.
-struct EnvGuard {
-    keys: Vec<&'static str>,
-}
-
-impl EnvGuard {
-    fn new(keys: &[&'static str]) -> Self {
-        for k in keys {
-            std::env::remove_var(k);
-        }
-        Self {
-            keys: keys.to_vec(),
-        }
-    }
-    fn set(&self, key: &str, val: &str) {
-        std::env::set_var(key, val);
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        for k in &self.keys {
-            std::env::remove_var(k);
-        }
-    }
-}
+mod common;
+use common::env_guard::EnvGuard;
 
 /// Read every JSONL row from the on-disk provenance log.
 fn read_log_rows(path: &Utf8PathBuf) -> Vec<LogRow> {
@@ -151,9 +125,9 @@ async fn batch_three_arxiv_refs_succeeds_end_to_end() {
     )
     .expect("write refs file");
 
-    batch::run(refs_path.as_str().to_string())
+    batch::run_with_options(refs_path.as_str().to_string(), false)
         .await
-        .expect("batch::run succeeds");
+        .expect("batch::run_with_options succeeds");
 
     // Step 4: assert all three PDFs landed in the store under the expected
     // safekey-derived names.
@@ -263,7 +237,7 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
     )
     .expect("write refs file");
 
-    let result = batch::run(refs_path.as_str().to_string()).await;
+    let result = batch::run_with_options(refs_path.as_str().to_string(), false).await;
     assert!(
         result.is_err(),
         "batch with a malformed ref must surface an error to the binary"

--- a/crates/doiget-cli/tests/common/env_guard.rs
+++ b/crates/doiget-cli/tests/common/env_guard.rs
@@ -1,0 +1,67 @@
+//! RAII helper that scopes env-var mutations within a single test.
+//!
+//! On construction, snapshots the current value of each named env var
+//! (or `None` if unset) and clears the variable. Tests then call
+//! [`EnvGuard::set`] to seed test-specific values. On drop, every prior
+//! value is restored — `Some(_)` is written back via `std::env::set_var`,
+//! `None` is written back as a `remove_var`.
+//!
+//! ## Threading
+//!
+//! Env state is process-global. Tests holding this guard MUST also be
+//! marked `#[serial]` (via the `serial_test` crate) so the (single-
+//! threaded) `serial` group is the only writer at a time. Concurrent
+//! tests outside the `serial` group will race with this guard's
+//! mutations.
+//!
+//! ## History
+//!
+//! Slice 5 (PR #84 advisory item A5 refactor): four
+//! `crates/doiget-cli/tests/*_e2e.rs` integration-test binaries each
+//! defined a private `struct EnvGuard` with subtly different
+//! capabilities (some snapshotted prior values, some only cleared).
+//! Consolidated here on the snapshot-and-restore variant so a test that
+//! runs after another test that exported a real `DOIGET_*` env var
+//! cannot leak that variable into the test under inspection.
+
+#![allow(dead_code)]
+
+/// RAII guard that saves + clears the named env vars on construction
+/// and restores them on drop.
+pub struct EnvGuard {
+    keys: Vec<&'static str>,
+    prior: Vec<Option<std::ffi::OsString>>,
+}
+
+impl EnvGuard {
+    /// Snapshot the current value of every name in `keys`, then clear
+    /// each so the test starts from a clean slate. Pre-existing values
+    /// are restored on drop.
+    pub fn new(keys: &[&'static str]) -> Self {
+        let prior: Vec<Option<std::ffi::OsString>> = keys.iter().map(std::env::var_os).collect();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+            prior,
+        }
+    }
+
+    /// Set a (test-scoped) env var. The value is reverted to its
+    /// pre-`new` state when this guard drops.
+    pub fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, prior) in self.keys.iter().zip(self.prior.iter()) {
+            match prior {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}

--- a/crates/doiget-cli/tests/common/mod.rs
+++ b/crates/doiget-cli/tests/common/mod.rs
@@ -1,0 +1,16 @@
+//! Shared helpers for the `doiget-cli` integration test binaries.
+//!
+//! Cargo treats `tests/common/mod.rs` as a non-test submodule — it is
+//! compiled into each `tests/<name>_e2e.rs` integration test binary that
+//! declares `mod common;`, but never compiled as its own test binary
+//! (so it never produces a "no tests found" warning). See
+//! <https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests>
+//! for the canonical pattern.
+//!
+//! Per-`tests/`-binary `unused`-warnings: each integration test binary
+//! is a separate crate, and each may use only a subset of this module's
+//! exports. The `#[allow(dead_code)]` attribute on
+//! [`env_guard::EnvGuard`] (and its members) keeps every binary's
+//! `-D warnings` build green regardless of which helpers it exercises.
+
+pub mod env_guard;

--- a/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
@@ -32,36 +32,8 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// RAII helper to scope env-var mutations so a panic mid-test does not leak
-/// state across the (single-threaded) `serial` group.
-struct EnvGuard {
-    keys: Vec<&'static str>,
-}
-
-impl EnvGuard {
-    fn new(keys: &[&'static str]) -> Self {
-        // Snapshot of any pre-existing values so they can be restored on
-        // drop. For simplicity in this test we just clear; serial_test
-        // ensures no concurrent test reads them.
-        for k in keys {
-            std::env::remove_var(k);
-        }
-        Self {
-            keys: keys.to_vec(),
-        }
-    }
-    fn set(&self, key: &str, val: &str) {
-        std::env::set_var(key, val);
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        for k in &self.keys {
-            std::env::remove_var(k);
-        }
-    }
-}
+mod common;
+use common::env_guard::EnvGuard;
 
 fn read_log_rows(path: &Utf8PathBuf) -> Vec<LogRow> {
     let raw = std::fs::read_to_string(path.as_std_path()).expect("read log");
@@ -108,9 +80,9 @@ async fn arxiv_2401_12345_end_to_end() {
 
     // Step 3: run the orchestrator end-to-end. No child binary; no real
     // network traffic.
-    fetch::run("arxiv:2401.12345".to_string())
+    fetch::run_with_options("arxiv:2401.12345".to_string(), false)
         .await
-        .expect("fetch::run succeeds");
+        .expect("fetch::run_with_options succeeds");
 
     // Step 4: assert the on-disk PDF.
     let pdf_path = store_root.join("arxiv_2401.12345.pdf");

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -5,7 +5,7 @@
 //!
 //! ## What is exercised
 //!
-//! - `doiget_cli::commands::fetch::run` end-to-end on a DOI input.
+//! - `doiget_cli::commands::fetch::run_with_options` end-to-end on a DOI input.
 //! - Crossref + Unpaywall fan-out to the wiremock origin.
 //! - The synthetic `oa-publisher` source key with its OA URL host check
 //!   pulled from `HttpClient::new_for_tests_allow_http_multi(...)` over
@@ -33,34 +33,8 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// RAII guard mirroring the one in `fetch_arxiv_e2e.rs`. Clears any
-/// pre-existing values on construction and on drop so the (single-
-/// threaded `serial`) tests cannot leak env state across each other.
-struct EnvGuard {
-    keys: Vec<&'static str>,
-}
-
-impl EnvGuard {
-    fn new(keys: &[&'static str]) -> Self {
-        for k in keys {
-            std::env::remove_var(k);
-        }
-        Self {
-            keys: keys.to_vec(),
-        }
-    }
-    fn set(&self, key: &str, val: &str) {
-        std::env::set_var(key, val);
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        for k in &self.keys {
-            std::env::remove_var(k);
-        }
-    }
-}
+mod common;
+use common::env_guard::EnvGuard;
 
 /// Env-var keys mutated by the tests in this file. Wired through the
 /// `EnvGuard` above so each test's setup is hermetic.
@@ -177,9 +151,9 @@ async fn fetch_doi_oa_pdf_happy_path() {
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
     // Step 3: run the orchestrator end-to-end. No real network traffic.
-    fetch::run(format!("doi:{}", TEST_DOI))
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
         .await
-        .expect("fetch::run succeeds");
+        .expect("fetch::run_with_options succeeds");
 
     // Step 4: assert the on-disk PDF exists and starts with `%PDF-`.
     let pdf_path = store_root.join("doi_10.1234_test.pdf");
@@ -316,9 +290,9 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
 
     // The orchestrator MUST still return Ok(()) — metadata is the
     // partial-success contract from REDIRECT_ALLOWLIST.md §3.
-    fetch::run(format!("doi:{}", TEST_DOI))
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
         .await
-        .expect("fetch::run succeeds (metadata-only fallback)");
+        .expect("fetch::run_with_options succeeds (metadata-only fallback)");
 
     // PDF MUST NOT be written.
     let pdf_path = store_root.join("doi_10.1234_test.pdf");

--- a/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
@@ -20,49 +20,13 @@
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
 use camino::{Utf8Path, Utf8PathBuf};
-use doiget_cli::commands::fetch::{
-    build_dry_run_envelope, build_fetch_plan, run_with_options, FetchOptions,
-};
+use doiget_cli::commands::fetch::{build_dry_run_envelope, build_fetch_plan, run_with_options};
 use doiget_core::Ref;
 use serial_test::serial;
 use tempfile::TempDir;
 
-/// RAII helper that captures the prior values of every named env var on
-/// construction, lets the test mutate them via `set`, then restores
-/// (or removes) them on drop. Modeled on the `EnvGuard` in
-/// `fetch_arxiv_e2e.rs`. Tests holding this guard MUST also be marked
-/// `#[serial]` because env state is process-global.
-struct EnvGuard {
-    keys: Vec<&'static str>,
-    prior: Vec<Option<std::ffi::OsString>>,
-}
-
-impl EnvGuard {
-    fn new(keys: &[&'static str]) -> Self {
-        let prior = keys.iter().map(std::env::var_os).collect();
-        for k in keys {
-            std::env::remove_var(k);
-        }
-        Self {
-            keys: keys.to_vec(),
-            prior,
-        }
-    }
-    fn set(&self, key: &str, val: &str) {
-        std::env::set_var(key, val);
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        for (k, prior) in self.keys.iter().zip(self.prior.iter()) {
-            match prior {
-                Some(v) => std::env::set_var(k, v),
-                None => std::env::remove_var(k),
-            }
-        }
-    }
-}
+mod common;
+use common::env_guard::EnvGuard;
 
 #[tokio::test]
 #[serial]
@@ -96,7 +60,7 @@ async fn dry_run_fetch_doi_returns_ok_without_side_effects() {
     // crossref/unpaywall/oa-publisher hosts is not stubbed). The fact
     // that this call returns Ok proves the dry-run path short-circuits
     // before any network call.
-    let result = run_with_options("10.1234/foo".to_string(), FetchOptions { dry_run: true }).await;
+    let result = run_with_options("10.1234/foo".to_string(), true).await;
     result.expect("dry-run fetch::run_with_options succeeds");
 
     // Step 3: assert the on-disk side-effects are empty. The store
@@ -148,11 +112,7 @@ async fn dry_run_fetch_arxiv_returns_ok_without_side_effects() {
     env.set("DOIGET_STORE_ROOT", store_root.as_str());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
 
-    let result = run_with_options(
-        "arxiv:2401.12345".to_string(),
-        FetchOptions { dry_run: true },
-    )
-    .await;
+    let result = run_with_options("arxiv:2401.12345".to_string(), true).await;
     result.expect("dry-run arxiv fetch::run_with_options succeeds");
 
     assert!(

--- a/crates/doiget-core/src/dry_run.rs
+++ b/crates/doiget-core/src/dry_run.rs
@@ -176,15 +176,22 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
         }
     };
 
+    // Slice 5 (PR #84 advisory item A6): derive the loaded-allowlist
+    // list from the same `tier_1_allowlist()` + `oa_publisher_allowlist()`
+    // functions the production `HttpClient` is composed from. A
+    // hardcoded `vec![...]` here would silently drift if a future slice
+    // adds a new allowlist source to the production client — the wire
+    // shape would still claim only the old four.
+    let redirect_allowlists_loaded: Vec<String> = tier_1_allowlist()
+        .iter()
+        .chain(oa_publisher_allowlist().iter())
+        .map(|a| a.source.clone())
+        .collect();
+
     FetchPlan {
         metadata_sources,
         pdf_sources,
-        redirect_allowlists_loaded: vec![
-            "crossref".to_string(),
-            "unpaywall".to_string(),
-            "arxiv".to_string(),
-            "oa-publisher".to_string(),
-        ],
+        redirect_allowlists_loaded,
         target_pdf_path,
         target_metadata_path,
         would_append_provenance: true,

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -823,63 +823,18 @@ mod tests {
     // ---------------------------------------------------------------
 
     /// Build a test-only `HttpClient` against an `http://` wiremock
-    /// origin. The redirect closure still rejects insecure schemes — we
-    /// only relax `https_only` at the connection level so wiremock can
-    /// serve. This is acceptable because the redirect closure (which is
-    /// the security-load-bearing path) is exercised separately by the
-    /// `redirect_to_http_is_rejected_by_closure` test.
+    /// origin.
+    ///
+    /// Slice 5 (PR #84 advisory item A4 refactor): this helper now
+    /// delegates to the public
+    /// [`HttpClient::new_for_tests_allow_http`] constructor (defined
+    /// just above the test module) instead of re-implementing the
+    /// redirect-policy + `https_only(false)` builder. The two
+    /// implementations had drifted into duplicates — keeping a private
+    /// re-implementation only meant a future security tweak to the
+    /// builder would silently leave the tests on a stale path.
     fn build_test_client_for_http(source: &str, allowlist_host: &str) -> HttpClient {
-        let allowlist = SourceAllowlist::new(source, vec![allowlist_host.to_string()]);
-        let allowlist_for_closure = allowlist.clone();
-        let redirect_policy = Policy::custom(move |attempt| {
-            let scheme = attempt.url().scheme().to_string();
-            let host_opt = attempt.url().host_str().map(|h| h.to_ascii_lowercase());
-            let prev_count = attempt.previous().len();
-            if scheme != "https" {
-                return attempt.error(HttpError::InsecureRedirect { scheme });
-            }
-            if prev_count >= MAX_REDIRECTS {
-                return attempt.stop();
-            }
-            let host = match host_opt {
-                Some(h) => h,
-                None => {
-                    return attempt.error(HttpError::RedirectDenied {
-                        source_key: allowlist_for_closure.source.clone(),
-                        host: String::new(),
-                        expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
-                    });
-                }
-            };
-            if !allowlist_for_closure.matches(&host) {
-                return attempt.error(HttpError::RedirectDenied {
-                    source_key: allowlist_for_closure.source.clone(),
-                    host,
-                    expected_hosts: allowlist_for_closure.redirect_hosts.clone(),
-                });
-            }
-            attempt.follow()
-        });
-        let client = ClientBuilder::new()
-            // `https_only(false)` only at this scope — production
-            // builders (the public `HttpClient::new`) keep it on.
-            .https_only(false)
-            .redirect(redirect_policy)
-            .connect_timeout(CONNECT_TIMEOUT)
-            .timeout(TOTAL_TIMEOUT)
-            .read_timeout(READ_TIMEOUT)
-            .user_agent(format!(
-                "doiget/{} (+https://github.com/sotashimozono/doiget)",
-                VERSION
-            ))
-            .tls_backend_rustls()
-            .build()
-            .expect("test client builds");
-        let mut map = HashMap::new();
-        map.insert(allowlist.source.clone(), client);
-        HttpClient {
-            clients: Arc::new(map),
-        }
+        HttpClient::new_for_tests_allow_http(source, allowlist_host)
     }
 
     #[tokio::test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -664,21 +664,37 @@ pub enum DenialReason {
     RedirectNotInAllowlist,
     /// Redirect target had a non-HTTPS scheme (`HttpError::InsecureRedirect`).
     InsecureScheme,
-    /// Source produced a URL whose host is on a future blocklist (reserved).
+    /// Source produced a URL whose host is on a future blocklist.
+    ///
+    /// Reserved — no producer wired yet. Will be emitted by the future
+    /// per-source URL host-blocklist guard once that component lands
+    /// (post-Phase-1 supply-chain hardening; see
+    /// `docs/REDIRECT_ALLOWLIST.md` §4 for the staging plan).
     HostInBlockList,
     /// Body exceeded [`PDF_MAX_BYTES`] (`HttpError::OversizedBody`).
     SizeCapExceeded,
-    /// Store entry's `schema_version` is ahead of this binary
-    /// (reserved — emitted by the store schema-rejection path).
+    /// Store entry's `schema_version` is ahead of this binary.
+    ///
+    /// Reserved — no producer wired yet. Will be emitted by the
+    /// `FsStore` schema-rejection path once the read-side bump check
+    /// lands (it currently only writes the current `SCHEMA_VERSION`).
     SchemaDrift,
     /// Source not in the runtime [`CapabilityProfile`]
     /// (`FetchError::NotEligible`).
     CapabilityNotGranted,
-    /// Rate limiter rejected the call inside the current window
-    /// (reserved — Phase 2+ surfaces this from the limiter).
+    /// Rate limiter rejected the call inside the current window.
+    ///
+    /// Reserved — no producer wired yet. Will be emitted by
+    /// [`RateLimiter`](crate::rate_limiter::RateLimiter) once the
+    /// limiter surfaces structured denials (Phase 2+; today the
+    /// limiter only sleeps to enforce the window).
     RateLimitWindow,
-    /// SSRF guard rejected a private / link-local / cloud-metadata address
-    /// (reserved — future SSRF check).
+    /// SSRF guard rejected a private / link-local / cloud-metadata address.
+    ///
+    /// Reserved — no producer wired yet. Will be emitted by the
+    /// future SSRF pre-flight check (post-Phase-1 supply-chain
+    /// hardening; the workspace currently relies on rustls + the
+    /// HTTPS-only redirect policy to keep the attack surface small).
     SsrfPrivateAddress,
     /// Response Content-Type / magic-byte mismatch (`HttpError::NotAPdf`).
     ContentTypeMismatch,

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -668,8 +668,10 @@ fn metadata_only_error_envelope(code: ErrorCode, message: &str) -> Value {
             "code": code,
             "message": message,
             // denial_context is intentionally absent for these envelope
-            // shapes (parse-error / not-implemented); ADR-0023 §3 says
-            // consumers MUST tolerate the field being absent.
+            // shapes (parse-error / not-implemented); ADR-0023 §1 says
+            // the field is optional and consumers MUST tolerate it
+            // being absent (§3 covers the per-subfield optionality
+            // rules that apply when denial_context IS present).
         },
     })
 }


### PR DESCRIPTION
Slice 5 of 6 in the post-Discussion #12 roadmap. 7 code-simplification refactors (A2-A8) from the original multi-agent review of PR #84. All behavior-preserving. A1 was already addressed in PR #85 refinement #3.

Highlights:
- A2/A3: collapsed single-field option structs + deleted run() wrappers
- A5: extracted shared EnvGuard test helper (4 files DRY'd up)
- A6: derive redirect_allowlists_loaded from allowlist functions instead of hardcoding
- A8: reserved DenialReason variants explicitly commented

Local: fmt + clippy + 23 tests all green.

Roadmap: #86 → #87 → #88 → #89 → **this** → Slice 6.