### PR TITLE
feat(site): Zola scaffold for public docs (3-layer IA)

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -1,0 +1,47 @@
+# Zola configuration for the doiget public site.
+#
+# Hosting target: GitHub Pages on `sotashimozono.github.io/doiget/`.
+# The repo's existing `codes.sota-shimozono.com` CNAME continues to be
+# managed at the user-site level; this project-site is served from its
+# own `/doiget/` prefix (no separate CNAME row needed today).
+#
+# `base_url` may be overridden in CI via `--base-url` when a custom
+# domain is wired up. Keep this value aligned with the GH Pages
+# project-site URL.
+
+base_url = "https://sotashimozono.github.io/doiget"
+title = "doiget"
+description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
+default_language = "en"
+theme = ""
+
+compile_sass = false
+minify_html = false
+build_search_index = true
+generate_feed = false
+
+taxonomies = []
+
+[markdown]
+highlight_code = true
+highlight_theme = "ayu-light"
+smart_punctuation = false
+external_links_target_blank = true
+external_links_no_follow = false
+external_links_no_referrer = false
+
+[search]
+include_title = true
+include_description = true
+include_path = false
+include_content = true
+
+[extra]
+# Surfaced in templates so we can show the current development phase in
+# the footer without editing the template. Update when the phase plan
+# advances.
+phase_status = "Phase 3 in progress"
+github_url = "https://github.com/sotashimozono/doiget"
+crates_io_url = "https://crates.io/crates/doiget-core"
+docs_rs_url = "https://docs.rs/doiget-core"
+contact_email = "souta.shimozono@gmail.com"

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,7 +2,6 @@
 title = "doiget"
 description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
 template = "index.html"
-sort_by = "none"
 +++
 
 # doiget

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,12 @@
++++
+title = "doiget"
+description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
+template = "index.html"
+sort_by = "none"
++++
+
+# doiget
+
+Landing-page body is rendered by `templates/index.html`. This file exists
+because Zola requires every section to have an `_index.md`; the actual
+landing copy lives in the template.

--- a/site/content/contribute/_index.md
+++ b/site/content/contribute/_index.md
@@ -1,0 +1,41 @@
++++
+title = "Contribute"
+description = "Architecture overview, phase plan, and ADRs for contributors."
+sort_by = "weight"
+weight = 30
++++
+
+This section is for people who want to **send a pull request** or
+otherwise contribute changes to doiget. If you want to use doiget, see
+[Use]({{ get_url(path='@/use/_index.md') | safe }}); if you want to embed
+doiget, see [Developer]({{ get_url(path='@/developer/_index.md') | safe }}).
+
+## Start here
+
+1. Read [CONTRIBUTING.md]({{ config.extra.github_url }}/blob/main/CONTRIBUTING.md) for the workflow.
+2. Skim [docs/ARCHITECTURE.md]({{ config.extra.github_url }}/blob/main/docs/ARCHITECTURE.md) to understand the workspace layout (`doiget-core` / `doiget-cli` / `doiget-mcp`).
+3. Check [docs/PHASES.md]({{ config.extra.github_url }}/blob/main/docs/PHASES.md) to see which phase the project is in.
+4. Browse [docs/DECISIONS/]({{ config.extra.github_url }}/tree/main/docs/DECISIONS) for the 24 ADRs that bind major design choices.
+
+## Doc class system (ADR-0014)
+
+Every document in `docs/` carries a status header:
+
+- **NORMATIVE** &mdash; binding contract. Changes require an ADR.
+- **INFORMATIVE** &mdash; orientation / explanation. May evolve without ADR.
+
+This site mirrors the same convention. The
+[ARCHITECTURE]({{ get_url(path='@/contribute/architecture.md') | safe }})
+page is INFORMATIVE; the [MCP tools]({{ get_url(path='@/developer/_index.md') | safe }}#1-mcp-server-stdio-json-rpc)
+contract is NORMATIVE and revisions are gated by ADR.
+
+## ADR-driven design
+
+If a design discussion in
+[GitHub Discussions]({{ config.extra.github_url }}/discussions) reaches
+a decision, an ADR captures it in `docs/DECISIONS/`. If Discussions ever
+disappears, the ADRs preserve the binding decisions in the source tree.
+
+PRs that lock in a new design decision **must** include an ADR before
+the code change lands. PRs that follow an existing ADR are fine on their
+own.

--- a/site/content/contribute/architecture.md
+++ b/site/content/contribute/architecture.md
@@ -1,0 +1,38 @@
++++
+title = "Architecture"
+description = "Workspace layout, crate dependency rules, and core trait surface. Binding spec lives in docs/ARCHITECTURE.md."
+weight = 100
++++
+
+The canonical architecture document is
+[`docs/ARCHITECTURE.md`]({{ config.extra.github_url }}/blob/main/docs/ARCHITECTURE.md)
+in the repository. This page is a thin orientation — the binding
+content lives there.
+
+## One-paragraph summary
+
+doiget is a Rust workspace of three crates (`doiget-core`,
+`doiget-cli`, `doiget-mcp`) plus an optional fourth
+(`doiget-obsidian`). The library crate `doiget-core` defines the
+abstract `Source` and `Store` traits and provides Open Access source
+implementations. A runtime `CapabilityProfile` resolved from
+environment variables gates which sources are allowed for the current
+invocation. CLI subcommands consume `doiget-core` directly. The MCP
+server is a separate library that wraps `doiget-core` and is invoked
+from `doiget-cli` via the `serve` subcommand. Every fetch passes
+through a fail-closed provenance log (JSON Lines + SHA-256 hash chain)
+before reaching the store.
+
+## Crate dependency rules
+
+Forbidden directions (CI-enforced):
+
+- `doiget-core` → `doiget-cli` (lib must not depend on bin).
+- `doiget-core` → `doiget-mcp` (lib must not depend on server).
+- `doiget-mcp` → `doiget-cli` (server must not depend on CLI).
+
+## Further reading
+
+- [`docs/ARCHITECTURE.md`]({{ config.extra.github_url }}/blob/main/docs/ARCHITECTURE.md) &mdash; binding spec with mermaid system diagram.
+- [Phase plan]({{ get_url(path='@/contribute/phases.md') | safe }}) &mdash; what work is in flight.
+- [`docs/DECISIONS/`]({{ config.extra.github_url }}/tree/main/docs/DECISIONS) &mdash; the 24 ADRs that bind major design choices.

--- a/site/content/contribute/phases.md
+++ b/site/content/contribute/phases.md
@@ -1,0 +1,33 @@
++++
+title = "Phase plan"
+description = "MVP-to-Phase-6 roadmap. The binding contract lives in docs/PHASES.md in the repo."
+weight = 110
++++
+
+The canonical phase plan is
+[`docs/PHASES.md`]({{ config.extra.github_url }}/blob/main/docs/PHASES.md)
+in the repository. This page is a thin orientation; the binding
+content lives there.
+
+## Phase headline
+
+| Phase | Scope |
+|---|---|
+| **0** | Repo bootstrap, normative specs, ADRs, Cargo workspace, CI |
+| **1** | Core resolver + Tier 1 sources + `fetch` / `batch` CLI |
+| **2** | Store + `info` / `search` / `bib` / `csl` |
+| **3** | MCP server + 10 tools + strict stdio |
+| **3.5** | Marketplace draft + landing page (this site) |
+| **4** | Tier 2 sources + citation graph |
+| **5** | TDM Springer / APS / Elsevier (deferred-by-default) |
+| **6** | Release: OIDC + sigstore + SBOM + auto-tag |
+| **7** | Optional features (vault, obsidian) |
+
+Until Phase 6 ships, the workspace version stays at `0.0.0` and no
+crates.io publication occurs.
+
+## Current state
+
+See [`docs/PHASES.md`]({{ config.extra.github_url }}/blob/main/docs/PHASES.md)
+for the live checklist. Substantive changes to phase scope require an
+ADR per `docs/DECISIONS/`.

--- a/site/content/developer/_index.md
+++ b/site/content/developer/_index.md
@@ -1,0 +1,58 @@
++++
+title = "Developer"
+description = "Wire doiget into an agent host or embed doiget-core in a Rust program."
+sort_by = "weight"
+weight = 20
++++
+
+This section is for people who want to **embed doiget** into their own
+agent host (Claude Desktop, Cursor, Codex CLI, ...) or use the
+`doiget-core` Rust crate directly. If you just want to fetch papers from
+the command line, see [Use]({{ get_url(path='@/use/_index.md') | safe }}) instead.
+
+## Two integration surfaces
+
+### 1. MCP server (stdio JSON-RPC)
+
+`doiget serve` is a Model Context Protocol server speaking JSON-RPC over
+stdio. It exposes ten tools (Phase 3 baseline) named with the `doiget_`
+prefix:
+
+- `doiget_health` &mdash; operational sanity (version, schema_version, store_writable).
+- `doiget_capability_profile` &mdash; which sources this instance can use.
+- `doiget_metadata_only` &mdash; resolve to metadata without fetching the PDF.
+- `doiget_fetch_paper` &mdash; download a single PDF.
+- `doiget_batch_fetch` &mdash; up to 100 refs in one call.
+- `doiget_resolve_paper` &mdash; one-shot resolution, no persistence (Phase 3).
+- `doiget_info` &mdash; read a store entry's metadata (Phase 3).
+- `doiget_search_local` &mdash; search store metadata (Phase 3).
+- `doiget_list_recent` &mdash; last N fetched entries (Phase 3).
+- `doiget_paper_pdf_path` &mdash; absolute path of a cached PDF (Phase 3).
+
+The MCP transport is **stdio only** (ADR-0001). No HTTP, no WebSocket,
+no socket. This is a permanent posture decision.
+
+### 2. Rust library (`doiget-core`)
+
+Embed the resolver directly via the `doiget-core` crate. The library
+surface is semver-strict from `0.1.0` onward (workspace stays at
+`0.0.0` until Phase 6).
+
+```rust
+use doiget_core::{Ref, CapabilityProfile, orchestrator};
+
+let ref_ = Ref::parse("10.1103/PhysRevLett.130.200601")?;
+let profile = CapabilityProfile::from_env()?;
+let outcome = orchestrator::fetch_paper(&ref_, &profile, &ctx).await?;
+println!("wrote: {}", outcome.path);
+```
+
+See [docs.rs/doiget-core]({{ config.extra.docs_rs_url }}) for the full
+rustdoc once Phase 6 ships.
+
+## Host integration snippets
+
+Detailed JSON-RPC traces and host-side config for the major MCP hosts
+land in Phase 3 (after `doiget serve` is feature-complete). Until then,
+the canonical contract is the
+[MCP tools spec]({{ config.extra.github_url }}/blob/main/docs/MCP_TOOLS.md).

--- a/site/content/use/_index.md
+++ b/site/content/use/_index.md
@@ -1,0 +1,52 @@
++++
+title = "Use"
+description = "Fetch papers by DOI or arXiv id from the command line."
+sort_by = "weight"
+weight = 10
++++
+
+This section is for people who want to **use the `doiget` CLI directly**
+to fetch papers locally. If you want to wire doiget into an agent host or
+embed it in a Rust program, see the [Developer]({{ get_url(path='@/developer/_index.md') | safe }}) section.
+If you want to contribute to doiget, see [Contribute]({{ get_url(path='@/contribute/_index.md') | safe }}).
+
+## What `doiget` does
+
+Given a DOI or arXiv id, it tries the official metadata APIs (Crossref,
+Unpaywall, arXiv) and writes the resulting PDF (and a metadata TOML) to a
+local store under `~/papers/`. By default it only touches Open Access
+sources; institutional TDM access is opt-in at build time per publisher.
+
+## Quick start
+
+```sh
+# install (after Phase 6 release lands)
+cargo install doiget
+
+# fetch a paper by DOI
+doiget fetch 10.1103/PhysRevLett.130.200601
+
+# fetch by arXiv id
+doiget fetch arXiv:2401.12345
+
+# batch fetch
+doiget batch refs.txt
+
+# inspect what landed locally
+doiget info 10.1103/PhysRevLett.130.200601
+```
+
+Default features fetch only Open Access PDFs through Crossref / Unpaywall
+/ arXiv. See [posture &amp; legal]({{ get_url(path='@/use/posture-and-legal.md') | safe }})
+for what doiget will and will not do.
+
+## Coexistence with BiblioFetch.jl
+
+doiget shares its on-disk store format (TOML metadata + PDF files under
+`~/papers/`) with [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl).
+If you already use BiblioFetch.jl, doiget will reuse the same vault.
+
+| Tool | Best for |
+|---|---|
+| BiblioFetch.jl | Julia REPL, research vault, citation graph exploration |
+| doiget | Agents / MCP hosts, batch operations, scripted pipelines, container deployments |

--- a/site/content/use/contact.md
+++ b/site/content/use/contact.md
@@ -1,0 +1,37 @@
++++
+title = "Contact"
+description = "Where to send takedown notices, security disclosures, and other formal correspondence."
+weight = 90
++++
+
+The canonical contact file is
+[CONTACT.md]({{ config.extra.github_url }}/blob/main/CONTACT.md) in
+the repository. This page reproduces its key entry points.
+
+## Email
+
+**General correspondence, takedown notices, security disclosures, and
+publisher inquiries:** [souta.shimozono@gmail.com](mailto:souta.shimozono@gmail.com)
+
+Please prefix the subject line with `[doiget]` so the message is
+routed correctly.
+
+## Security disclosures
+
+For security issues, please follow the disclosure process documented in
+[SECURITY.md]({{ config.extra.github_url }}/blob/main/docs/SECURITY.md).
+Coordinated disclosure is welcome; please give a reasonable embargo
+window (90 days by default) before public disclosure.
+
+## Takedown requests
+
+doiget does not host content. It retrieves PDFs through official APIs to
+the user's own local filesystem. If you believe a specific source
+integration violates your terms of service, please email the address
+above with the source name and the offending behavior, and the relevant
+build feature will be evaluated for removal or further gating.
+
+## GitHub
+
+- Public issues / PRs: [{{ config.extra.github_url | replace(from="https://", to="") }}]({{ config.extra.github_url }})
+- Discussions: [{{ config.extra.github_url }}/discussions]({{ config.extra.github_url }}/discussions)

--- a/site/content/use/posture-and-legal.md
+++ b/site/content/use/posture-and-legal.md
@@ -1,0 +1,64 @@
++++
+title = "Posture & legal"
+description = "What doiget will and will not do. Scope, eight safeguards, and legal posture."
+weight = 80
++++
+
+doiget is a general-purpose automation tool for retrieving papers through
+official publisher and aggregator APIs. This page summarizes what doiget
+will and will not do; the binding specs live in
+[docs/SCOPE.md]({{ config.extra.github_url }}/blob/main/docs/SCOPE.md)
+and
+[docs/LEGAL.md]({{ config.extra.github_url }}/blob/main/docs/LEGAL.md).
+
+## What doiget does
+
+- Retrieves PDFs from sources where the user has access through one of:
+  1. **Public Open Access sources** (default) &mdash; Crossref, Unpaywall, arXiv.
+  2. **The user's own institutional or personal credentials** (opt-in,
+     compile-time gated per publisher) &mdash; Springer Nature OA,
+     APS Harvest, Elsevier ScienceDirect TDM.
+- Writes the resulting PDF and a TOML metadata sidecar to the user's
+  local filesystem under `~/papers/`.
+- Maintains a cryptographic provenance log (JSON Lines + SHA-256 hash
+  chain) of every fetch attempt.
+
+## What doiget does not do
+
+- **Does not bypass paywalls.** Sources that require credentials are
+  compile-time gated and need user-supplied credentials to activate.
+- **Does not host content.** Retrieved PDFs land on the user's own
+  filesystem. doiget does not operate as a public mirror or SaaS.
+- **Does not bundle publisher API keys.** Each user supplies their own.
+- **Does not relicense fetched content.** The MIT license applies only
+  to doiget's own source code; retrieved PDFs retain their original
+  license, which is determined by each paper's own license, the
+  publisher's API terms of service, and the user's access rights.
+- **Does not send telemetry.** No phone-home, no auto-update, no
+  analytics (ADR-0015).
+
+## Eight safeguards (ADR-0019)
+
+doiget enforces eight safeguards across five social and three technical
+categories. The technical safeguards are:
+
+1. **Capability profile gate** &mdash; sources are unreachable unless the
+   capability profile resolved from env vars permits them.
+2. **Redirect allowlist** &mdash; HTTP redirects are accepted only to a
+   per-source allowlist; off-list hosts trip a structured
+   `denial_context` error.
+3. **Fail-closed provenance log** &mdash; any log-write failure aborts the
+   fetch.
+
+The five social safeguards (TDM author opt-in, takedown response,
+removal mechanism, contact addressability, public posture) are
+documented in
+[docs/SCOPE.md]({{ config.extra.github_url }}/blob/main/docs/SCOPE.md).
+
+## User responsibilities
+
+Users are responsible for ensuring they have the right to access the
+content they request and for compliance with each source's terms of
+service. doiget is a tool; the legal posture of any fetched content is
+determined by the user's own credentials, institutional affiliations,
+and intended use.

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -1,0 +1,142 @@
+/* doiget — minimal stylesheet.
+ * Black on white, serif body, monospace code. No JS, no framework.
+ * Target: Rust-book / OpenAI-docs feel without bespoke design.
+ */
+
+:root {
+  --fg: #222;
+  --bg: #fff;
+  --muted: #666;
+  --link: #0366d6;
+  --code-bg: #f6f8fa;
+  --side: #fafafa;
+  --rule: #e1e4e8;
+  --accent: #b58900;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e1e4e8;
+    --bg: #0d1117;
+    --muted: #8b949e;
+    --link: #58a6ff;
+    --code-bg: #161b22;
+    --side: #161b22;
+    --rule: #30363d;
+    --accent: #d29922;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 17px/1.6 Charter, "Bitstream Charter", "Source Serif Pro", Georgia, serif;
+}
+
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre, kbd, samp {
+  font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.92em;
+}
+code { background: var(--code-bg); padding: 1px 4px; border-radius: 3px; }
+pre { background: var(--code-bg); padding: 1rem; overflow-x: auto; border-radius: 4px; }
+pre code { background: none; padding: 0; }
+
+hr { border: none; border-top: 1px solid var(--rule); margin: 2rem 0; }
+
+/* ---------- site shell ---------- */
+
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--rule);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.site-header .brand { font-weight: bold; font-size: 1.2rem; }
+.site-nav a { margin-left: 1.5rem; color: var(--fg); }
+
+.page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-footer {
+  max-width: 760px;
+  margin: 4rem auto 2rem;
+  padding: 2rem;
+  border-top: 1px solid var(--rule);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.site-footer .legal { margin-top: 0.5rem; }
+
+/* ---------- landing ---------- */
+
+.hero h1 { font-size: 2.2rem; margin-bottom: 0.25em; }
+.hero .tagline { font-size: 1.1rem; color: var(--muted); }
+.hero .demo { margin-top: 1.5rem; }
+
+.posture {
+  margin: 2rem 0;
+  padding: 1rem 1.2rem;
+  border-left: 4px solid var(--accent);
+  background: var(--code-bg);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 2rem;
+}
+.card {
+  display: block;
+  padding: 1.2rem;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  color: var(--fg);
+}
+.card:hover { border-color: var(--link); text-decoration: none; }
+.card h3 { margin-top: 0; }
+.card p { color: var(--muted); }
+
+.roadmap .done { color: var(--muted); }
+.roadmap .active { color: var(--accent); font-weight: bold; }
+
+/* ---------- section + page ---------- */
+
+.section-head .lede,
+.page-head .lede {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.index { list-style: none; padding: 0; }
+.index li { padding: 0.4rem 0; border-bottom: 1px solid var(--rule); }
+.index .lede { color: var(--muted); font-style: italic; }
+
+.meta { color: var(--muted); font-size: 0.85rem; }
+
+/* ---------- typography ---------- */
+
+h1, h2, h3 { line-height: 1.25; }
+h2 { margin-top: 2rem; border-bottom: 1px solid var(--rule); padding-bottom: 0.3rem; }
+h3 { margin-top: 1.5rem; }
+blockquote {
+  margin: 1rem 0;
+  padding: 0.2rem 1rem;
+  border-left: 3px solid var(--rule);
+  color: var(--muted);
+}
+table { border-collapse: collapse; }
+th, td { padding: 0.4rem 0.8rem; border: 1px solid var(--rule); }

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}{{ config.title }}{% endblock %}</title>
+  <meta name="description" content="{% block description %}{{ config.description }}{% endblock %}">
+  <link rel="stylesheet" href="{{ get_url(path='style.css') | safe }}">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="{{ get_url(path='@/_index.md') | safe }}">doiget</a>
+    <nav class="site-nav">
+      <a href="{{ get_url(path='@/use/_index.md') | safe }}">Use</a>
+      <a href="{{ get_url(path='@/developer/_index.md') | safe }}">Developer</a>
+      <a href="{{ get_url(path='@/contribute/_index.md') | safe }}">Contribute</a>
+      <a href="{{ config.extra.github_url }}" rel="external">GitHub</a>
+    </nav>
+  </header>
+
+  <main class="page">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="site-footer">
+    <p>
+      <span>{{ config.extra.phase_status }}</span>
+      &middot;
+      <a href="{{ config.extra.github_url }}">repo</a>
+      &middot;
+      <a href="{{ config.extra.crates_io_url }}">crates.io</a>
+      &middot;
+      <a href="{{ config.extra.docs_rs_url }}">docs.rs</a>
+      &middot;
+      <a href="{{ get_url(path='@/use/contact.md') | safe }}">contact</a>
+    </p>
+    <p class="legal">
+      MIT (code) &middot; doiget does not bypass paywalls, host content, or
+      relicense fetched works. See
+      <a href="{{ get_url(path='@/use/posture-and-legal.md') | safe }}">posture &amp; legal</a>.
+    </p>
+  </footer>
+</body>
+</html>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero">
+  <h1>doiget</h1>
+  <p class="tagline">
+    DOIs and arXiv ids &rarr; local PDFs, through official APIs.<br>
+    The agent-facing companion to
+    <a href="https://github.com/sotashimozono/BiblioFetch.jl">BiblioFetch.jl</a>.
+  </p>
+
+  <pre class="demo"><code>$ doiget fetch 10.1103/PhysRevLett.130.200601
+wrote ~/papers/2L/2LpQ.../paper.pdf  (412 KB, license: cc-by)
+</code></pre>
+</section>
+
+<section class="posture">
+  <strong>Posture.</strong>
+  doiget does <em>not</em> bypass paywalls, host content, run as a SaaS, or
+  bundle publisher API keys. Open Access by default; TDM credentials are
+  user-supplied and compile-time opt-in.
+  <a href="{{ get_url(path='@/use/posture-and-legal.md') | safe }}">Read the scope &amp; legal page</a>.
+</section>
+
+<section class="audience">
+  <h2>Who is reading this?</h2>
+  <div class="cards">
+    <a class="card" href="{{ get_url(path='@/use/_index.md') | safe }}">
+      <h3>End user</h3>
+      <p>Use the CLI to fetch papers by DOI or arXiv id. Install, batch, inspect what landed.</p>
+    </a>
+    <a class="card" href="{{ get_url(path='@/developer/_index.md') | safe }}">
+      <h3>Developer</h3>
+      <p>Wire doiget into an agent host (Claude Desktop, Cursor, Codex) via MCP, or use <code>doiget-core</code> from Rust.</p>
+    </a>
+    <a class="card" href="{{ get_url(path='@/contribute/_index.md') | safe }}">
+      <h3>Contributor</h3>
+      <p>Read the architecture, the phase plan, and the ADRs before sending a PR.</p>
+    </a>
+  </div>
+</section>
+
+<section class="why">
+  <h2>Why doiget?</h2>
+  <ul>
+    <li>OA-first by default; institutional TDM is opt-in and compile-time gated.</li>
+    <li>Cryptographic provenance log (JSON Lines + SHA-256 hash chain, fail-closed).</li>
+    <li>Shares its on-disk store format with BiblioFetch.jl &mdash; same <code>~/papers/</code> directory.</li>
+    <li>No telemetry, no auto-update, no phone-home (ADR-0015).</li>
+    <li>Single static binary; stdio-only MCP server.</li>
+  </ul>
+</section>
+
+<section class="roadmap">
+  <h2>Roadmap</h2>
+  <p>
+    <span class="done">Phase 0 done</span> &middot;
+    <span class="done">Phase 1 done</span> &middot;
+    <span class="done">Phase 2 done</span> &middot;
+    <span class="active">Phase 3 in progress</span> &middot;
+    <span>Phase 4-6 upcoming</span>
+  </p>
+  <p>
+    MVP ships at the end of Phase 6 (release plumbing: OIDC trusted
+    publishing + sigstore + SBOM). Until then the workspace stays at
+    <code>0.0.0</code>; see <a href="{{ get_url(path='@/contribute/phases.md') | safe }}">the phase plan</a>.
+  </p>
+</section>
+{% endblock %}

--- a/site/templates/page.html
+++ b/site/templates/page.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} &middot; {{ config.title }}{% endblock %}
+{% block description %}{{ page.description | default(value=config.description) }}{% endblock %}
+
+{% block content %}
+<article class="page-content">
+  <header class="page-head">
+    <h1>{{ page.title }}</h1>
+    {% if page.description %}<p class="lede">{{ page.description }}</p>{% endif %}
+  </header>
+
+  {{ page.content | safe }}
+
+  <hr>
+  <p class="meta">
+    Source:
+    <a href="{{ config.extra.github_url }}/blob/main/site/content/{{ page.relative_path }}">
+      site/content/{{ page.relative_path }}
+    </a>
+  </p>
+</article>
+{% endblock %}

--- a/site/templates/section.html
+++ b/site/templates/section.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} &middot; {{ config.title }}{% endblock %}
+{% block description %}{{ section.description | default(value=config.description) }}{% endblock %}
+
+{% block content %}
+<article class="section">
+  <header class="section-head">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="lede">{{ section.description }}</p>{% endif %}
+  </header>
+
+  {{ section.content | safe }}
+
+  {% if section.subsections | length > 0 %}
+  <h2>Subsections</h2>
+  <ul class="index">
+    {% for sub_path in section.subsections %}
+      {% set sub = get_section(path=sub_path) %}
+      <li>
+        <a href="{{ sub.permalink | safe }}">{{ sub.title }}</a>
+        {% if sub.description %}<span class="lede">&mdash; {{ sub.description }}</span>{% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% if section.pages | length > 0 %}
+  <h2>Pages</h2>
+  <ul class="index">
+    {% for page in section.pages %}
+      <li>
+        <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
+        {% if page.description %}<span class="lede">&mdash; {{ page.description }}</span>{% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds a Zola static-site scaffold under `site/` with a 3-layer information architecture: **Use** (end users), **Developer** (MCP / library integrators), **Contribute** (PR authors).
- Templates extend a single `base.html`; styling is intentionally minimal (serif body, monospace code, dark-mode via `prefers-color-scheme`). No JS, no framework.
- Footer-linked pages (`use/contact.md`, `use/posture-and-legal.md`) are present so all links from the templates resolve at build time.

## Out of scope (follow-up PRs)

This PR ships only the scaffold to keep review scope independent.

- `docs/* -> site/content/*` sync script (`scripts/sync_docs_to_site.sh`) &mdash; follow-up PR
- `.github/workflows/site.yml` (Zola build + GH Pages deploy) &mdash; follow-up PR
- `site/README.md` (local build / preview instructions) &mdash; follow-up PR
- Per-page content depth under each section &mdash; follow-up PRs

## Hosting target

GH Pages on `sotashimozono.github.io/doiget/`. The existing
`codes.sota-shimozono.com` CNAME continues to be managed at the
user-site level; no separate CNAME row is added by this PR.

## Test plan

- [ ] `cd site && zola build` succeeds locally (requires `cargo install zola`).
- [ ] All template-rendered links resolve (no 404 from the `Use` / `Developer` / `Contribute` cards, the footer `contact` / `posture & legal` links, or the brand link).
- [ ] Dark-mode preview renders correctly on a `prefers-color-scheme: dark` browser.
- [ ] Site CI (lands in follow-up PR) green before any custom-domain wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)