### PR TITLE
feat(slice-7): doiget_resolve_paper MCP tool + no-persistence orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ Slice 6: real-world fixture set). With this slice merged the
 roadmap is complete; subsequent work tracks back to the normal
 phase plan in [docs/PHASES.md](docs/PHASES.md).
 
-**Phase 3 close-out, read-path branch.** Slice 8 wires the four
-local-only MCP tools (`doiget_info`, `doiget_search_local`,
-`doiget_list_recent`, `doiget_paper_pdf_path`) that close out the
-Phase 3 baseline alongside `doiget_resolve_paper` (Slice 7,
-parallel PR).
+**Phase 3 close-out begins.** Post-roadmap, the MCP tool surface
+returns to the Phase 3 baseline (`docs/MCP_TOOLS.md` §1 — ten tools).
+Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
+`doiget_capability_profile`, `doiget_metadata_only`,
+`doiget_fetch_paper`, `doiget_batch_fetch`); Slice 7 onward closes
+out the remaining five (`doiget_resolve_paper`, `doiget_info`,
+`doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
 ### Slice 8 — Read-path MCP tools (4 tools)
 
@@ -96,8 +98,72 @@ JSON-RPC.
 
 ### Slice 7 — `doiget_resolve_paper` MCP tool
 
-(Parallel PR — see the dedicated CHANGELOG entry on
-`feat/slice-7-mcp-resolve-paper`.)
+This slice wires the **sixth** Phase-3 tool: `doiget_resolve_paper`,
+the audit-trail-preserving sibling of `doiget_metadata_only`. The new
+tool resolves a DOI / arXiv id to live metadata through Crossref /
+Unpaywall / arXiv (each consulted resolver still emits its own
+`LogEvent::Fetch` provenance row, preserving the audit chain), but the
+orchestrator MUST NOT write the metadata TOML to the store under any
+code path — present or future. This is the binding contract that
+distinguishes `resolve_paper` from `metadata_only`, codified directly
+in the doc-comment on the new orchestrator function and re-stated in
+the MCP tool description so an agent picking between the two tools
+sees the difference without consulting the spec.
+
+- **New core orchestrator**
+  `doiget_core::orchestrator::resolve_only`. Today this delegates to
+  `metadata_only` (which itself does not yet write to the store —
+  the Phase 2.x TODO). The function's doc-comment fixes the
+  future-divergence contract: when Phase 2.x lands the store-write
+  for `metadata_only`, `resolve_only` MUST be refactored to call the
+  inner dispatchers (`metadata_only_doi` + the arXiv-Atom path) with
+  the store-write step excluded, NOT continue delegating. Splitting
+  the function out as a named symbol now reserves the API slot so
+  that future refactor lands purely inside `doiget-core` without
+  touching the MCP tool wiring.
+
+- **New MCP tool** `doiget_resolve_paper`
+  (`crates/doiget-mcp/src/lib.rs`). Per-call semantics mirror
+  `doiget_metadata_only`: the MCP server emits the
+  `SessionStart` / `SessionEnd` bookend rows, each consulted
+  `Source` emits its own `LogEvent::Fetch` row, and the orchestrator
+  emits **no** `StoreWrite` row (no store mutation). `dry_run` is
+  not a supported input field per `docs/MCP_TOOLS.md` §10/§211 — the
+  new `ResolvePaperInput` struct uses `schemars(deny_unknown_fields)`
+  so an attempted `dry_run` is rejected at the rmcp transport
+  boundary before reaching the tool body. The tool description
+  explicitly redirects agents to `metadata_only` with `dry_run: true`
+  for preview use cases.
+
+- **New e2e coverage**
+  `crates/doiget-mcp/tests/resolve_paper_e2e.rs`:
+  - `doiget_resolve_paper_invalid_ref_returns_invalid_ref_envelope`
+    — a malformed `ref` collapses to the closed `INVALID_REF` error
+    code via the same `Ref::parse` shim used by other tools.
+  - `doiget_resolve_paper_arxiv_happy_path_returns_metadata_envelope`
+    — an arXiv id is resolved through a wiremocked Atom feed; the
+    success envelope carries `source = "arxiv"`,
+    `license = "arxiv-default"`, `oa_url = null`, and the parsed
+    metadata.
+  - `doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope`
+    — a DOI is resolved through a wiremocked Crossref response; the
+    OA URL is extracted from `message.link[]` and surfaced in
+    `oa_url`, `license` is `null` (Crossref does not carry a
+    license; that channel is Unpaywall's).
+  - All three tests carry the `// allow: outbound-network` posture
+    marker; no `reqwest::*` imports are introduced — all HTTP
+    terminates at `127.0.0.1` wiremock servers.
+
+- **tools/list assertion update**
+  `crates/doiget-mcp/tests/initialize_handshake.rs` now also asserts
+  that `doiget_resolve_paper` appears in the `tools/list` response,
+  matching the §1 table in `docs/MCP_TOOLS.md`.
+
+- **No spec drift.** `docs/MCP_TOOLS.md` §1 already lists
+  `doiget_resolve_paper` in the Phase-3 baseline table; this slice
+  ships the implementation, not a new spec section. A follow-up
+  documentation slice may add a §N normative subsection mirroring
+  the `metadata_only` §11 / `fetch_paper` §4 detail blocks.
 
 ### Slice 6 — Real-world DOI / arXiv fixture set
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -136,6 +136,63 @@ pub async fn metadata_only(
     }
 }
 
+/// Resolve a [`Ref`] to metadata with **no local persistence**.
+///
+/// This is the audit-trail-preserving sibling of [`metadata_only`]: each
+/// consulted [`Source`] still emits its own `LogEvent::Fetch` row
+/// through `ctx.log` (so the provenance hash chain remains continuous,
+/// per `docs/PROVENANCE_LOG.md`), but the orchestrator MUST NOT write
+/// the metadata TOML to the store under any code path — present or
+/// future.
+///
+/// Binding spec: `docs/MCP_TOOLS.md` §1 (the `doiget_resolve_paper`
+/// tool — Slice 7).
+///
+/// # Why this exists as a distinct orchestrator
+///
+/// Today [`metadata_only`] does not write to the store (the Phase 2.x
+/// TODO inside `metadata_only_doi` and the arXiv branch), so the two
+/// functions are functionally identical. When Phase 2.x lands the store
+/// write for `metadata_only`, [`resolve_only`] MUST NOT pick it up —
+/// the future divergence is the entire reason this function exists.
+///
+/// Concretely: when the Phase 2.x change happens, this function must be
+/// refactored to call the **inner** dispatchers (`metadata_only_doi` for
+/// DOI, the arXiv-Atom path for arXiv) directly with the store-write
+/// step **excluded**, rather than continuing to delegate to
+/// [`metadata_only`]. The audit-trail / provenance-row emission is
+/// retained either way.
+///
+/// # Dispatch
+///
+/// Identical to [`metadata_only`] (DOI → Crossref-first with Unpaywall
+/// fallback; arXiv → Atom feed only). The `oa_url` and `license`
+/// outputs follow the same rules.
+///
+/// # Side effects
+///
+/// One `LogEvent::Fetch` row per consulted resolver, written by the
+/// underlying [`Source`] impls. No metadata TOML write. No PDF fetch.
+/// No store mutation.
+///
+/// # Errors
+///
+/// Returns [`FetchError`] from the underlying [`Source`] dispatch,
+/// identical to [`metadata_only`].
+pub async fn resolve_only(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+) -> Result<MetadataOnlyOutcome, FetchError> {
+    // Slice 7: delegate to `metadata_only` because the latter does not
+    // yet write to the store. When Phase 2.x adds the store-write to
+    // `metadata_only`, this delegation MUST be replaced with a direct
+    // call to the inner dispatchers (`metadata_only_doi` + the arXiv
+    // Atom path) with the store-write step excluded. See the function
+    // doc-comment for the binding contract.
+    metadata_only(ref_, profile, ctx).await
+}
+
 // ---------------------------------------------------------------------------
 // Env-aware source constructors (mirrors doiget-cli::commands::fetch::build_*)
 //

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -47,7 +47,7 @@ use doiget_core::dry_run::{
 use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
 use doiget_core::orchestrator::{
     batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
-    metadata_only, FetchPaperOutcome, MetadataOnlyOutcome,
+    metadata_only, resolve_only as core_resolve_only, FetchPaperOutcome, MetadataOnlyOutcome,
 };
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
@@ -308,6 +308,122 @@ impl Server {
             // Session bookend rows carry no audit identity — they
             // bracket the call, they do not mint a CanonicalRef
             // (ADR-0021 §1; ADR-0024).
+            canonical_digest: None,
+        });
+
+        match outcome {
+            Ok(o) => Ok(CallToolResult::structured(metadata_only_success_envelope(
+                &o,
+                &input.ref_,
+            ))),
+            Err(e) => Ok(CallToolResult::structured(
+                metadata_only_fetch_error_envelope(&e, &input.ref_),
+            )),
+        }
+    }
+
+    /// `doiget_resolve_paper` — resolve a DOI / arXiv id to metadata with
+    /// **no local persistence**.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1 (Phase 3 baseline tool list — Slice 7).
+    ///
+    /// Delegates to [`core_resolve_only`], whose binding contract is that
+    /// no metadata TOML is ever written to the store — present or future
+    /// (when Phase 2.x adds the store-write to `metadata_only`, the
+    /// orchestrator-level divergence kicks in there, not here).
+    ///
+    /// Per-call boundary semantics mirror [`Self::doiget_metadata_only`]:
+    /// the MCP server emits `SessionStart` / `SessionEnd` bookend rows,
+    /// each consulted [`Source`](doiget_core::source::Source) emits its
+    /// own `LogEvent::Fetch` row inside the orchestrator. No `StoreWrite`
+    /// row is emitted (no store mutation).
+    ///
+    /// `dry_run` is **not** a supported input field per
+    /// `docs/MCP_TOOLS.md` §10/§211 (the spec lists `doiget_resolve_paper`
+    /// in the "dry_run does not apply" set). The schema's
+    /// `deny_unknown_fields` posture rejects an attempted `dry_run`
+    /// field at deserialize time, which surfaces as the rmcp transport's
+    /// own input-validation error rather than reaching the tool body.
+    /// Agents that intend "preview the resolve" must call
+    /// `doiget_metadata_only` with `dry_run: true` instead.
+    #[tool(
+        description = "WHEN TO USE: User wants metadata for a DOI / arXiv id with no local persistence (audit log row only).\n\
+                       INPUTS: ref (DOI or arXiv id).\n\
+                       OUTPUTS: { ok: true, ref, source, resolver_profile, license?, oa_url, metadata, schema_version } OR { ok:false, ref, error }.\n\
+                       COSTS: 1-2 s metadata round-trip.\n\
+                       SIDE EFFECTS: Appends one provenance row per consulted resolver. NEVER writes a metadata TOML to the store. NEVER fetches PDF.\n\
+                       LIMITS: Subject to the same rate cap as metadata_only (5/sec). The OA URL is reported but never followed. dry_run is not supported; use metadata_only with dry_run for a preview."
+    )]
+    async fn doiget_resolve_paper(
+        &self,
+        Parameters(input): Parameters<ResolvePaperInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Step 1: parse the ref. Failures collapse to INVALID_REF per
+        // docs/ERRORS.md §2 / docs/PUBLIC_API.md §4.
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    ErrorCode::InvalidRef,
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+
+        // Step 2: build the per-call context. Failures here surface as
+        // INTERNAL_ERROR per the metadata_only pattern.
+        let ctx = match build_fetch_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    ErrorCode::InternalError,
+                    &format!("resolve-paper context initialization failed: {e}"),
+                )));
+            }
+        };
+
+        // SessionStart bookend (mirrors doiget_metadata_only). A
+        // log-append failure here is fail-closed per
+        // `docs/PROVENANCE_LOG.md` §5 — abort the call.
+        if let Err(e) = ctx.log.append(RowInput {
+            event: LogEvent::SessionStart,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(input.ref_.as_str()),
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+            // Session bookend rows carry no audit identity — they
+            // bracket the call, they do not mint a CanonicalRef
+            // (ADR-0021 §1; ADR-0024).
+            canonical_digest: None,
+        }) {
+            return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                ErrorCode::LogError,
+                &format!("SessionStart append failed: {e}"),
+            )));
+        }
+
+        let outcome = core_resolve_only(&ref_, &self.profile, &ctx).await;
+
+        // SessionEnd bookend. Best-effort.
+        let session_ok = outcome.is_ok();
+        let _ = ctx.log.append(RowInput {
+            event: LogEvent::SessionEnd,
+            result: if session_ok {
+                LogResult::Ok
+            } else {
+                LogResult::Err
+            },
+            capability: Capability::Metadata,
+            ref_: Some(input.ref_.as_str()),
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
             canonical_digest: None,
         });
 
@@ -917,6 +1033,25 @@ pub struct MetadataOnlyInput {
     /// either omit the field or pass `false`.
     #[serde(default)]
     pub dry_run: bool,
+}
+
+/// JSON-schema-derived input for the `doiget_resolve_paper` MCP tool.
+///
+/// Mirrors `docs/MCP_TOOLS.md` §1 (the tool name and shape) and §10
+/// (`dry_run` does **not** apply to `doiget_resolve_paper`).
+/// `deny_unknown_fields` rejects an attempted `dry_run` field as a
+/// schema violation at the rmcp transport boundary, so the tool body
+/// never observes it. Agents that need a preview must call
+/// `doiget_metadata_only` with `dry_run: true` instead.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct ResolvePaperInput {
+    /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
+    /// `INVALID_REF` per `docs/ERRORS.md`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -97,6 +97,12 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_batch_fetch"),
         "tools/list must include doiget_batch_fetch; got: {names:?}"
     );
+    // Slice 7: doiget_resolve_paper advertised — metadata resolution with
+    // no local persistence (audit log row only).
+    assert!(
+        names.contains(&"doiget_resolve_paper"),
+        "tools/list must include doiget_resolve_paper; got: {names:?}"
+    );
     // Slice 8: 4x read-path tools advertised.
     assert!(
         names.contains(&"doiget_info"),

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -1,0 +1,299 @@
+//! Slice 7 — end-to-end coverage for `doiget_resolve_paper`
+//! (wiremock-driven; NO outbound network).
+//!
+//! ## Network purity
+//!
+//! Per the workspace network-purity guard, this file imports `wiremock`
+//! to mount fake origins; no `reqwest::*` items are imported directly.
+//! All HTTP traffic terminates at a `wiremock::MockServer` on
+//! `127.0.0.1:N`. The escape-hatch comment below covers the future
+//! addition of any `reqwest::*` import without further intervention.
+// allow: outbound-network
+//!
+//! ## What is asserted
+//!
+//! `doiget_resolve_paper` is the audit-trail-preserving sibling of
+//! `doiget_metadata_only`: each consulted resolver still emits a
+//! provenance row through `ctx.log`, but the orchestrator MUST NOT write
+//! the metadata TOML to the store. These tests exercise the wire
+//! contract documented in `docs/MCP_TOOLS.md` §1 (Phase 3 baseline tool
+//! list).
+//!
+//! Three test cases:
+//!
+//! 1. `doiget_resolve_paper_invalid_ref_returns_invalid_ref_envelope` —
+//!    a malformed `ref` collapses to the closed `INVALID_REF` error code.
+//! 2. `doiget_resolve_paper_arxiv_happy_path_returns_metadata_envelope` —
+//!    an arXiv id is resolved through a wiremocked Atom feed.
+//! 3. `doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope` —
+//!    a DOI is resolved through a wiremocked Crossref response.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use doiget_core::CapabilityProfile;
+use doiget_mcp::Server;
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+
+/// RAII helper mirroring `initialize_handshake::EnvGuard` and
+/// `fetch_paper_e2e::EnvGuard`. Scoped env mutations so a panic
+/// mid-test does not leak state across the single-threaded
+/// `serial_test::serial` group.
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+const ENV_KEYS: &[&str] = &[
+    "DOIGET_LOG_PATH",
+    "DOIGET_ARXIV_BASE",
+    "DOIGET_CROSSREF_BASE",
+    "DOIGET_UNPAYWALL_BASE",
+    "DOIGET_CONTACT_EMAIL",
+    "DOIGET_UNPAYWALL_EMAIL",
+];
+
+async fn boot_in_memory_server() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+    Ok((client, server_handle))
+}
+
+/// Synthetic Atom payload mirroring the Slice 1 reference. Do not hit
+/// real arXiv.
+const SAMPLE_ATOM_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <updated>2024-02-01T00:00:00Z</updated>
+    <published>2024-01-15T00:00:00Z</published>
+    <title>Example arXiv Paper Title</title>
+    <summary>This is an example abstract.</summary>
+    <author><name>Jane Doe</name></author>
+    <author><name>John Roe</name></author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="stat.ML" scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"#;
+
+/// Synthetic Crossref `message` payload. Carries an OA URL in
+/// `message.link[]` so `extract_crossref_oa_url` returns `Some(...)`.
+const SAMPLE_CROSSREF_RESPONSE: &str = r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://example.org/oa.pdf"}]}}"#;
+
+// ---------------------------------------------------------------------------
+// 1. invalid ref -> INVALID_REF
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn doiget_resolve_paper_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("not a doi"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_paper uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF"),
+        "envelope: {structured:?}"
+    );
+    assert!(
+        structured["error"]["message"]
+            .as_str()
+            .map(|s| s.contains("invalid ref"))
+            .unwrap_or(false),
+        "INVALID_REF message must mention 'invalid ref'; got: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 2. arxiv happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_resolve_paper_arxiv_happy_path_returns_metadata_envelope() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-resolve.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_ARXIV_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("2401.12345"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_paper uses CallToolResult::structured");
+
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    assert_eq!(structured["source"], serde_json::json!("arxiv"));
+    assert_eq!(structured["resolver_profile"], serde_json::json!("arxiv"));
+    assert_eq!(structured["ref"], serde_json::json!("2401.12345"));
+    assert_eq!(structured["license"], serde_json::json!("arxiv-default"));
+    // arXiv branch never surfaces an OA URL (the abstract page is not
+    // a PDF URL) — the field is emitted as `null`.
+    assert_eq!(structured["oa_url"], serde_json::Value::Null);
+    assert_eq!(
+        structured["metadata"]["title"],
+        serde_json::json!("Example arXiv Paper Title")
+    );
+    assert_eq!(
+        structured["metadata"]["authors"],
+        serde_json::json!(["Jane Doe", "John Roe"])
+    );
+
+    // Provenance log was opened and at least one row was appended
+    // (SessionStart + Fetch + SessionEnd).
+    assert!(
+        log_path.exists(),
+        "provenance log not created at {log_path}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 3. DOI crossref happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope(
+) -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/example"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_CROSSREF_RESPONSE))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-resolve.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_paper uses CallToolResult::structured");
+
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    assert_eq!(structured["source"], serde_json::json!("crossref"));
+    assert_eq!(structured["resolver_profile"], serde_json::json!("crossref"));
+    assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
+    // Crossref does not surface a license directly; the channel for
+    // license is Unpaywall (not consulted on the happy path).
+    assert_eq!(structured["license"], serde_json::Value::Null);
+    // OA URL is mined from message.link[].URL.
+    assert_eq!(
+        structured["oa_url"],
+        serde_json::json!("https://example.org/oa.pdf")
+    );
+    assert_eq!(
+        structured["metadata"]["title"],
+        serde_json::json!(["Example Paper"])
+    );
+
+    assert!(
+        log_path.exists(),
+        "provenance log not created at {log_path}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -197,7 +197,10 @@ async fn doiget_resolve_paper_arxiv_happy_path_returns_metadata_envelope() -> an
     // Bind the store root to the same tempdir so the no-store-write
     // assertion below is meaningful — without this, an accidental
     // store write would target the developer's real ~/papers/.
-    env.set("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8 tempdir"));
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
 
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -287,7 +290,10 @@ async fn doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope(
     env.set("DOIGET_LOG_PATH", log_path.as_str());
     env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
     // Bind store root to the tempdir; see arxiv test for rationale.
-    env.set("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8 tempdir"));
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
 
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -309,7 +315,10 @@ async fn doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope(
         "envelope: {structured:?}"
     );
     assert_eq!(structured["source"], serde_json::json!("crossref"));
-    assert_eq!(structured["resolver_profile"], serde_json::json!("crossref"));
+    assert_eq!(
+        structured["resolver_profile"],
+        serde_json::json!("crossref")
+    );
     assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
     // Crossref does not surface a license directly; the channel for
     // license is Unpaywall (not consulted on the happy path).

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -65,6 +65,11 @@ impl Drop for EnvGuard {
 }
 
 const ENV_KEYS: &[&str] = &[
+    // DOIGET_STORE_ROOT is included so any accidental store write
+    // (a regression that violates the resolve_only no-persistence
+    // contract) lands inside the test's TempDir rather than the
+    // developer's real ~/papers/.
+    "DOIGET_STORE_ROOT",
     "DOIGET_LOG_PATH",
     "DOIGET_ARXIV_BASE",
     "DOIGET_CROSSREF_BASE",
@@ -72,6 +77,22 @@ const ENV_KEYS: &[&str] = &[
     "DOIGET_CONTACT_EMAIL",
     "DOIGET_UNPAYWALL_EMAIL",
 ];
+
+/// Count regular files under `<store_root>/.metadata/`. The binding
+/// contract for `resolve_only` (and therefore `doiget_resolve_paper`)
+/// is that this count remains 0 after any successful resolve, even
+/// after Phase 2.x adds the store-write to `metadata_only`. The two
+/// happy-path tests below use this to assert the contract.
+fn count_metadata_files(store_root: &std::path::Path) -> usize {
+    let meta = store_root.join(".metadata");
+    match std::fs::read_dir(&meta) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            .count(),
+        Err(_) => 0,
+    }
+}
 
 async fn boot_in_memory_server() -> anyhow::Result<(
     rmcp::service::RunningService<rmcp::RoleClient, ()>,
@@ -173,6 +194,10 @@ async fn doiget_resolve_paper_arxiv_happy_path_returns_metadata_envelope() -> an
     let env = EnvGuard::new(ENV_KEYS);
     env.set("DOIGET_ARXIV_BASE", &server.uri());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
+    // Bind the store root to the same tempdir so the no-store-write
+    // assertion below is meaningful — without this, an accidental
+    // store write would target the developer's real ~/papers/.
+    env.set("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8 tempdir"));
 
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -216,6 +241,17 @@ async fn doiget_resolve_paper_arxiv_happy_path_returns_metadata_envelope() -> an
         "provenance log not created at {log_path}"
     );
 
+    // Binding contract (resolve_only's doc-comment): NO metadata TOML
+    // is written to the store, even after Phase 2.x adds the store
+    // write to `metadata_only`. Today the two functions are equivalent
+    // because metadata_only itself doesn't write; this assertion is
+    // the regression guard for that future divergence.
+    assert_eq!(
+        count_metadata_files(td.path()),
+        0,
+        "doiget_resolve_paper MUST NOT write metadata TOML to the store"
+    );
+
     client.cancel().await?;
     server_handle.await??;
     drop(env);
@@ -250,6 +286,8 @@ async fn doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope(
     env.set("DOIGET_CROSSREF_BASE", &server.uri());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
     env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+    // Bind store root to the tempdir; see arxiv test for rationale.
+    env.set("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8 tempdir"));
 
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -291,9 +329,77 @@ async fn doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope(
         "provenance log not created at {log_path}"
     );
 
+    // Binding contract: NO metadata TOML written. See arxiv test for
+    // the full rationale; this assertion guards the same invariant on
+    // the DOI/Crossref branch.
+    assert_eq!(
+        count_metadata_files(td.path()),
+        0,
+        "doiget_resolve_paper MUST NOT write metadata TOML to the store"
+    );
+
     client.cancel().await?;
     server_handle.await??;
     drop(env);
     drop(td);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 4. dry_run field rejection
+// ---------------------------------------------------------------------------
+
+/// Per `docs/MCP_TOOLS.md` §10 / §211, `doiget_resolve_paper` is in the
+/// "dry_run does not apply" set. The `ResolvePaperInput` struct carries
+/// both `#[serde(deny_unknown_fields)]` and `#[schemars(deny_unknown_fields)]`
+/// so an attempted `dry_run` field is rejected at the deserialize
+/// boundary BEFORE the tool body runs.
+///
+/// This test sends `{"ref": "10.1234/example", "dry_run": true}` and
+/// asserts the call surfaces as an error from the transport layer — it
+/// MUST NOT be silently accepted (which would happen if only the
+/// schemars-side attribute were present).
+#[tokio::test]
+async fn doiget_resolve_paper_dry_run_field_is_rejected() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    args.insert("dry_run".to_string(), serde_json::json!(true));
+
+    let outcome = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await;
+
+    // rmcp surfaces deserialize failures as a transport-level error
+    // (the call_tool future resolves to Err(...)) rather than an
+    // ok:false envelope. Either way, the call MUST NOT succeed with
+    // `dry_run` silently dropped.
+    match outcome {
+        Err(_) => {
+            // Transport-level rejection. Expected path with
+            // #[serde(deny_unknown_fields)] in place.
+        }
+        Ok(result) => {
+            // Some MCP hosts may translate the deserialize error into
+            // an `is_error: true` CallToolResult instead. Accept that
+            // shape too — but the call MUST NOT return a normal
+            // success envelope with the dry_run field ignored.
+            assert!(
+                result.is_error.unwrap_or(false)
+                    || result
+                        .structured_content
+                        .as_ref()
+                        .map(|s| s["ok"] == serde_json::json!(false))
+                        .unwrap_or(false),
+                "dry_run field was silently accepted on doiget_resolve_paper; \
+                 deny_unknown_fields enforcement is missing. result: {result:?}"
+            );
+        }
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Wires the **6th of 10** Phase-3 baseline MCP tools: `doiget_resolve_paper`.
- Adds `doiget_core::orchestrator::resolve_only`, an audit-trail-preserving sibling of `metadata_only` whose binding contract is **no metadata TOML store-write, ever** (present or future).
- 3 new e2e tests + 1 added `tools/list` assertion; all 9 `doiget-mcp` tests pass locally.

## Wire contract (`docs/MCP_TOOLS.md` §1)

| Tool | network | provenance row | metadata.toml store-write | PDF leg |
|---|---|---|---|---|
| `doiget_metadata_only` | yes | yes | yes (when Phase 2.x lands) | no |
| **`doiget_resolve_paper`** | **yes** | **yes** | **never** | **no** |
| `doiget_fetch_paper` | yes | yes | yes | yes |

`dry_run` is **not** a supported input field on `doiget_resolve_paper` (per spec §10/§211). `ResolvePaperInput` uses `schemars(deny_unknown_fields)` so an attempted `dry_run` is rejected at the rmcp transport boundary. The tool description explicitly redirects agents to `doiget_metadata_only` with `dry_run: true` for preview use cases.

## Why a separate orchestrator function

Today `resolve_only` delegates to `metadata_only` because the latter does not yet write to the store (the Phase 2.x TODO inside `metadata_only_doi` and the arXiv branch). When Phase 2.x lands the store-write for `metadata_only`, `resolve_only` MUST be refactored to call the inner dispatchers (`metadata_only_doi` + the arXiv-Atom path) with the store-write step excluded — NOT continue delegating. Reserving the symbol now means that future refactor lands purely inside `doiget-core` without touching the MCP tool wiring. The doc-comment on `resolve_only` codifies this contract.

## Test plan

- [x] `cargo check -p doiget-mcp` green locally (58s)
- [x] `cargo test -p doiget-mcp --test resolve_paper_e2e` — 3 new tests pass
- [x] `cargo test -p doiget-mcp --test initialize_handshake` — 6 existing tests still pass (tools/list assertion update is additive)
- [ ] CI matrix (3 OS × 3 features) green
- [ ] posture-lint workflow green (no `reqwest::*` import added; `// allow: outbound-network` marker present on the new test binary)

## Files changed (+574 / -1)

- `crates/doiget-core/src/orchestrator.rs` — adds `pub async fn resolve_only`
- `crates/doiget-mcp/src/lib.rs` — adds `doiget_resolve_paper` tool method, `ResolvePaperInput` struct, `resolve_only` import
- `crates/doiget-mcp/tests/resolve_paper_e2e.rs` — new test binary (3 tests)
- `crates/doiget-mcp/tests/initialize_handshake.rs` — additive `tools/list` assertion
- `CHANGELOG.md` — Slice 7 section + Phase 3 close-out preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)