### PR TITLE
feat(site): GH Pages deploy workflow + docs-sync script + site README

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -35,11 +35,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
 
       - name: Install Zola
         # Zola is a single static binary; no toolchain setup needed.
+        #
+        # `set -o pipefail` is critical: without it, a curl failure
+        # (404 / network timeout / DNS) exits non-zero on the left
+        # side of the pipe, but tar receives empty stdin and exits 0
+        # — the step would then pass with no zola binary extracted.
+        # The subsequent `zola --version` would catch the missing
+        # binary, but the failure mode would be confusing. pipefail
+        # surfaces the curl failure directly.
         run: |
+          set -euo pipefail
           ZOLA_VERSION="v0.19.2"
           curl -fsSL "https://github.com/getzola/zola/releases/download/${ZOLA_VERSION}/zola-${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
             | tar -xz -C /usr/local/bin
@@ -68,7 +77,7 @@ jobs:
           zola build --base-url "https://sotashimozono.github.io/doiget/"
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356b520e9a168e888d8d25c6e1d9f1   # v4
         with:
           name: site-public
           path: site/public/
@@ -83,16 +92,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
 
       - name: Download site artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16   # v4
         with:
           name: site-public
           path: site/public/
 
       - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e   # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site/public

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -77,7 +77,7 @@ jobs:
           zola build --base-url "https://sotashimozono.github.io/doiget/"
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@6f51ac03b9356b520e9a168e888d8d25c6e1d9f1   # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02   # v4
         with:
           name: site-public
           path: site/public/
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
 
       - name: Download site artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16   # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093   # v4
         with:
           name: site-public
           path: site/public/

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,103 @@
+# Build and deploy the public-docs Zola site to GitHub Pages.
+#
+# - On push to main: build site/, then publish to the gh-pages branch.
+# - On pull_request:  build site/ only (no publish), so we catch breakage
+#                     before merge. This mirrors the docs-build invariant
+#                     captured in the team's standing feedback that PR CI
+#                     must run docs builds, not just main.
+#
+# Hosting target: GH Pages on `sotashimozono.github.io/doiget/`. The
+# existing `codes.sota-shimozono.com` CNAME continues to be managed at
+# the user-site level; this workflow does NOT publish a CNAME row.
+name: site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "docs/**"
+      - "scripts/sync_docs_to_site.sh"
+      - ".github/workflows/site.yml"
+  pull_request:
+    paths:
+      - "site/**"
+      - "docs/**"
+      - "scripts/sync_docs_to_site.sh"
+      - ".github/workflows/site.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (zola)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Zola
+        # Zola is a single static binary; no toolchain setup needed.
+        run: |
+          ZOLA_VERSION="v0.19.2"
+          curl -fsSL "https://github.com/getzola/zola/releases/download/${ZOLA_VERSION}/zola-${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C /usr/local/bin
+          zola --version
+
+      - name: Sync docs/ -> site/content/
+        # Re-project the canonical docs/*.md into site/content/* before
+        # building. If the projection drifts from what's committed, the
+        # diff will fail the projection-check step below.
+        run: |
+          bash scripts/sync_docs_to_site.sh
+
+      - name: Verify projection is up-to-date
+        # The committed site/content/ MUST match the freshly-projected
+        # output. If it doesn't, the contributor forgot to run
+        # `scripts/sync_docs_to_site.sh` before committing — fail loud.
+        run: |
+          if ! git diff --exit-code site/content/; then
+            echo "::error::site/content/ is stale; run scripts/sync_docs_to_site.sh and commit the result." >&2
+            exit 1
+          fi
+
+      - name: Build site
+        run: |
+          cd site
+          zola build --base-url "https://sotashimozono.github.io/doiget/"
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-public
+          path: site/public/
+          retention-days: 7
+
+  deploy:
+    name: deploy (gh-pages)
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-public
+          path: site/public/
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site/public
+          # Custom domain managed at user-site level; not set here.
+          force_orphan: true
+          user_name: "github-actions[bot]"
+          user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          commit_message: "deploy: ${{ github.event.head_commit.message }}"

--- a/scripts/sync_docs_to_site.sh
+++ b/scripts/sync_docs_to_site.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# sync_docs_to_site.sh — copy curated docs/* sources into site/content/* with
+# TOML front-matter injected so Zola can render them.
+#
+# Sync strategy: site/content/* is git-managed so the docs/ -> site/
+# projection is auditable in PR diffs. Run this script locally (or in CI)
+# after editing docs/*.md, then commit BOTH the source (docs/) and the
+# projection (site/content/).
+#
+# The script is intentionally a thin bash helper — no Python / Node / jq —
+# so it Just Works from any contributor's shell on Linux, macOS, and Git
+# Bash on Windows. Each docs/*.md page maps to ONE site/content/<layer>/<slug>.md
+# file. The layer mapping is the MAPPINGS table below.
+#
+# Files in docs/DECISIONS/ are NOT projected by this script — ADRs are a
+# self-contained corpus and contributors should follow the GitHub link on
+# the contribute/ section landing page rather than have ADRs duplicated as
+# Zola pages.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DOCS_DIR="$REPO_ROOT/docs"
+SITE_CONTENT="$REPO_ROOT/site/content"
+
+if [ ! -d "$DOCS_DIR" ]; then
+  echo "error: docs directory not found at $DOCS_DIR" >&2
+  exit 1
+fi
+
+if [ ! -d "$SITE_CONTENT" ]; then
+  echo "error: site/content directory not found at $SITE_CONTENT" >&2
+  echo "       run this script after the Zola scaffold has landed." >&2
+  exit 1
+fi
+
+# Mapping table: <docs-file>:<site-relative-output-path>:<title>:<weight>
+# Weights start at 100 to leave room for hand-written stubs at 10-90.
+MAPPINGS=(
+  "ARCHITECTURE.md:contribute/architecture.md:Architecture:100"
+  "CAPABILITY.md:developer/capability.md:Capability profile:110"
+  "CACHE.md:developer/cache.md:Cache:120"
+  "CONFIG.md:developer/config.md:Configuration:130"
+  "ERRORS.md:developer/errors.md:Error codes:140"
+  "LEGAL.md:use/legal.md:Legal posture:140"
+  "MCP_TOOLS.md:developer/mcp-tools.md:MCP tools:100"
+  "MIGRATION.md:use/migration.md:BiblioFetch.jl migration:130"
+  "PHASES.md:contribute/phases.md:Phase plan:110"
+  "PROVENANCE_LOG.md:developer/provenance-log.md:Provenance log:150"
+  "PUBLIC_API.md:developer/public-api.md:Public API:160"
+  "REDIRECT_ALLOWLIST.md:developer/redirect-allowlist.md:Redirect allowlist:170"
+  "SAFEKEY.md:developer/safekey.md:Safekey algorithm:180"
+  "SCOPE.md:use/scope.md:Scope (what doiget does and does not do):130"
+  "SECURITY.md:developer/security.md:Security:190"
+  "SOURCES.md:developer/sources.md:Sources matrix:200"
+  "STORE.md:developer/store.md:Store contract:210"
+)
+
+projected=0
+skipped=0
+
+for mapping in "${MAPPINGS[@]}"; do
+  src_name="${mapping%%:*}"
+  rest="${mapping#*:}"
+  out_rel="${rest%%:*}"
+  rest="${rest#*:}"
+  title="${rest%%:*}"
+  weight="${rest#*:}"
+
+  src="$DOCS_DIR/$src_name"
+  out="$SITE_CONTENT/$out_rel"
+
+  if [ ! -f "$src" ]; then
+    echo "skip: $src_name not present in docs/ (pre-Phase resource)" >&2
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  mkdir -p "$(dirname "$out")"
+
+  # First non-empty non-directive prose line becomes the description
+  # (truncated to 200 chars). Skip H1/H2 headings and blockquote markers.
+  description=$(awk '
+    /^[[:space:]]*$/ { next }
+    /^# / { next }
+    /^## / { next }
+    /^> / { next }
+    { print; exit }
+  ' "$src" | head -c 200 | tr -d '\r' | sed 's/"/\\"/g')
+
+  {
+    printf '+++\n'
+    printf 'title = "%s"\n' "$title"
+    printf 'description = "%s"\n' "$description"
+    printf 'weight = %s\n' "$weight"
+    printf '+++\n'
+    printf '\n'
+    cat "$src"
+  } > "$out"
+
+  echo "wrote: site/content/$out_rel  (title='$title', weight=$weight)"
+  projected=$((projected + 1))
+done
+
+echo
+echo "projected $projected docs/*.md page(s) to site/content/*."
+if [ "$skipped" -gt 0 ]; then
+  echo "skipped $skipped mapping(s) due to missing docs/ source."
+fi

--- a/scripts/sync_docs_to_site.sh
+++ b/scripts/sync_docs_to_site.sh
@@ -81,14 +81,26 @@ for mapping in "${MAPPINGS[@]}"; do
   mkdir -p "$(dirname "$out")"
 
   # First non-empty non-directive prose line becomes the description
-  # (truncated to 200 chars). Skip H1/H2 headings and blockquote markers.
+  # (truncated to 200 chars). Skip blanks, H1/H2 headings, blockquote
+  # markers, horizontal rules (`---`), and HTML comments (`<!--`) so
+  # the extracted description is real prose rather than markdown
+  # chrome.
   description=$(awk '
     /^[[:space:]]*$/ { next }
     /^# / { next }
     /^## / { next }
     /^> / { next }
+    /^---[[:space:]]*$/ { next }
+    /^<!--/ { next }
     { print; exit }
   ' "$src" | head -c 200 | tr -d '\r' | sed 's/"/\\"/g')
+
+  # Fall back to the title if the source had no prose line we could
+  # extract — emitting `description = ""` produces a misleading empty
+  # `<meta description>` SEO tag downstream.
+  if [ -z "$description" ]; then
+    description="$title"
+  fi
 
   {
     printf '+++\n'
@@ -107,5 +119,12 @@ done
 echo
 echo "projected $projected docs/*.md page(s) to site/content/*."
 if [ "$skipped" -gt 0 ]; then
-  echo "skipped $skipped mapping(s) due to missing docs/ source."
+  # Skipped mappings cause silent partial projection: the drift check
+  # in site.yml uses `git diff --exit-code site/content/`, which
+  # passes when the on-disk projection happens to match what was
+  # previously committed for that mapping. So a partial sync can ship
+  # a stale page without a CI signal. Fail the script explicitly so
+  # the partial-projection failure is loud.
+  echo "::error::skipped $skipped mapping(s) due to missing docs/ source — fix MAPPINGS or add the source." >&2
+  exit 1
 fi

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,78 @@
+# site/
+
+Public-docs Zola site for doiget.
+
+Hosting target: GitHub Pages on `https://sotashimozono.github.io/doiget/`.
+
+## What's in here
+
+- `config.toml` — Zola root config (base_url, title, theme defaults, search index).
+- `templates/` — Tera templates (`base.html`, `index.html`, `section.html`, `page.html`). All extend `base.html`. No JavaScript.
+- `static/style.css` — minimal stylesheet (serif body, monospace code, dark-mode via `prefers-color-scheme`).
+- `content/` — markdown content organized into three reader segments:
+  - `content/use/` — End-user docs (CLI install, quickstart, batch, contact, legal).
+  - `content/developer/` — MCP server + library integration docs.
+  - `content/contribute/` — Architecture, phase plan, ADR index.
+
+## Local build
+
+```sh
+cargo install zola         # one-time, ~30s
+cd site
+zola serve                 # http://127.0.0.1:1111, live reload
+```
+
+For a one-shot production-style build:
+
+```sh
+cd site
+zola build --base-url "https://sotashimozono.github.io/doiget/"
+# output lands in site/public/
+```
+
+## Syncing from `docs/`
+
+The canonical specs live in the repo's top-level `docs/` directory. To
+re-project them into `site/content/` (with TOML front-matter injected):
+
+```sh
+bash scripts/sync_docs_to_site.sh
+```
+
+This is **idempotent** and **required before committing** any `docs/`
+edit — the `site.yml` workflow's projection-check step fails CI if the
+committed `site/content/` differs from a fresh projection. See the
+script header for the mapping table.
+
+## Deployment
+
+`.github/workflows/site.yml`:
+
+- On every PR touching `site/`, `docs/`, the sync script, or this
+  workflow: build the site and upload `site/public/` as an artifact (no
+  deploy).
+- On push to `main`: build, then publish `site/public/` to the
+  `gh-pages` branch via `peaceiris/actions-gh-pages@v4`.
+
+## Custom domain
+
+The `codes.sota-shimozono.com` CNAME is managed at the user-site level,
+not at this project-site. To switch this site to a custom domain in the
+future:
+
+1. Add a `CNAME` file under `site/static/` with the domain string.
+2. Update `base_url` in `site/config.toml` accordingly.
+3. Update the `--base-url` flag in `.github/workflows/site.yml`.
+4. Configure the DNS A/CNAME record per
+   [GitHub's docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site).
+
+## Why Zola?
+
+- Single Rust binary; no Node / npm / Python toolchain in CI.
+- Built-in syntax highlighting (Syntect) and search index
+  (elasticlunr) — sufficient for a docs site without extra plugins.
+- Tera templating is close enough to Jinja2 to be readable on first
+  encounter for contributors familiar with Python templating.
+- The default look is minimal, matching the team preference for
+  "documentation that looks like documentation" rather than a polished
+  marketing site.

--- a/site/README.md
+++ b/site/README.md
@@ -16,8 +16,25 @@ Hosting target: GitHub Pages on `https://sotashimozono.github.io/doiget/`.
 
 ## Local build
 
+Install Zola (one-time). The `zola` crate on crates.io is a stub, so
+`cargo install zola` does NOT work — use one of these instead:
+
 ```sh
-cargo install zola         # one-time, ~30s
+# macOS (Homebrew):
+brew install zola
+
+# Linux (Snap):
+sudo snap install --edge zola
+
+# Any platform — direct binary from GH releases:
+ZOLA_VERSION="v0.19.2"
+curl -fsSL "https://github.com/getzola/zola/releases/download/${ZOLA_VERSION}/zola-${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+  | tar -xz -C /usr/local/bin/   # adjust path for your OS
+```
+
+Then preview the site locally:
+
+```sh
 cd site
 zola serve                 # http://127.0.0.1:1111, live reload
 ```

--- a/site/config.toml
+++ b/site/config.toml
@@ -18,7 +18,7 @@ theme = ""
 compile_sass = false
 minify_html = false
 build_search_index = true
-generate_feed = false
+generate_feeds = false
 
 taxonomies = []
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -13,7 +13,6 @@ base_url = "https://sotashimozono.github.io/doiget"
 title = "doiget"
 description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
 default_language = "en"
-theme = ""
 
 compile_sass = false
 minify_html = false

--- a/site/content/contribute/architecture.md
+++ b/site/content/contribute/architecture.md
@@ -1,29 +1,110 @@
 +++
 title = "Architecture"
-description = "Workspace layout, crate dependency rules, and core trait surface. Binding spec lives in docs/ARCHITECTURE.md."
+description = "doiget is a Rust workspace of three crates (`doiget-core`, `doiget-cli`, `doiget-mcp`)"
 weight = 100
 +++
 
-The canonical architecture document is
-[`docs/ARCHITECTURE.md`]({{ config.extra.github_url }}/blob/main/docs/ARCHITECTURE.md)
-in the repository. This page is a thin orientation — the binding
-content lives there.
+# Architecture
 
-## One-paragraph summary
+> **Status: INFORMATIVE.** This document describes the high-level architecture of doiget
+> and is intended to orient new contributors. The binding contracts referenced from here
+> live in their own NORMATIVE docs (each linked below).
 
-doiget is a Rust workspace of three crates (`doiget-core`,
-`doiget-cli`, `doiget-mcp`) plus an optional fourth
-(`doiget-obsidian`). The library crate `doiget-core` defines the
-abstract `Source` and `Store` traits and provides Open Access source
-implementations. A runtime `CapabilityProfile` resolved from
-environment variables gates which sources are allowed for the current
-invocation. CLI subcommands consume `doiget-core` directly. The MCP
-server is a separate library that wraps `doiget-core` and is invoked
-from `doiget-cli` via the `serve` subcommand. Every fetch passes
-through a fail-closed provenance log (JSON Lines + SHA-256 hash chain)
-before reaching the store.
+---
 
-## Crate dependency rules
+## 1. One-paragraph summary
+
+doiget is a Rust workspace of three crates (`doiget-core`, `doiget-cli`, `doiget-mcp`)
+plus an optional fourth (`doiget-obsidian`). The library crate `doiget-core` defines the
+abstract `Source` and `Store` traits and provides Open Access source implementations. A
+runtime `CapabilityProfile` resolved from environment variables gates which sources are
+allowed for the current invocation. CLI subcommands consume `doiget-core` directly. The
+MCP server is a separate library that wraps `doiget-core` and is invoked from `doiget-cli`
+via the `serve` subcommand. Every fetch passes through a fail-closed provenance log
+(JSON Lines + SHA-256 hash chain) before reaching the store.
+
+## 2. System diagram
+
+```mermaid
+flowchart TB
+    User[CLI user / Agent host]
+    User --> CLI[doiget-cli<br/>fetch / batch / info / serve]
+    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 9 tools]
+    CLI --> Core[doiget-core]
+    MCP --> Core
+
+    Core --> Cap{CapabilityProfile<br/>oa / metadata / tdm-*}
+    Cap -->|always on| OA[Tier 1 OA<br/>Crossref / Unpaywall / arXiv]
+    Cap -->|opt-in env| Meta[Tier 2 metadata<br/>OpenAlex / S2 / DOAJ<br/>Phase 4]
+    Cap -->|opt-in env + key + agree<br/>compile-time gated| TDM[Tier 3 TDM<br/>Springer OA / APS / Elsevier<br/>Phase 5a/5b/5c]
+
+    OA --> Fetcher[Fetcher<br/>rate-cap 5/sec, size cap, redirect allowlist]
+    Meta -.-> Fetcher
+    TDM -.-> Fetcher
+
+    Fetcher --> Log[Provenance Log<br/>JSON Lines + SHA256 hash chain<br/>fail-closed]
+    Fetcher --> Store[Store<br/>~/papers/ + TOML metadata<br/>BiblioFetch.jl 互換]
+
+    classDef hot fill:#fbb,stroke:#900
+    classDef oa fill:#bfb,stroke:#060
+    classDef gated fill:#fec,stroke:#a60
+    class Cap hot
+    class OA oa
+    class TDM gated
+```
+
+## 3. Workspace layout
+
+```
+doiget/                              # workspace root
+├── Cargo.toml                       # workspace + shared deps + features
+├── Cargo.lock                       # committed
+├── rust-toolchain.toml              # MSRV pin
+├── deny.toml                        # cargo-deny banned crate list
+├── clippy.toml                      # workspace lints
+├── .cargo/config.toml               # build flags
+│
+├── crates/
+│   ├── doiget-core/                 # ★ library, semver-strict
+│   ├── doiget-cli/                  # binary `doiget`
+│   ├── doiget-mcp/                  # MCP server library
+│   └── doiget-obsidian/             # Phase 7 optional, default OFF
+│
+├── examples/
+│   ├── 01-basic-fetch/
+│   ├── 02-batch/
+│   └── 03-mcp-host-integration/
+│
+├── tests/                           # integration tests
+│   ├── cli_fetch.rs
+│   ├── mcp_smoke.rs
+│   ├── safekey_vectors.rs
+│   ├── bibliofetch_roundtrip.rs
+│   └── fixtures/
+│
+└── docs/                            # NORMATIVE + INFORMATIVE specs
+```
+
+See [ADR-0008](DECISIONS/) for the rationale of this layout.
+
+## 4. Crate dependency graph
+
+```mermaid
+flowchart LR
+    cli[doiget-cli<br/>binary] --> core[doiget-core<br/>library, semver-strict]
+    cli --> mcp[doiget-mcp<br/>library]
+    mcp --> core
+    obs[doiget-obsidian<br/>Phase 7 optional] --> core
+
+    classDef core fill:#bfb,stroke:#060
+    classDef bin fill:#bef,stroke:#069
+    classDef mcp fill:#fec,stroke:#a60
+    classDef opt fill:#eee,stroke:#666,stroke-dasharray:4
+    class core core
+    class cli bin
+    class mcp mcp
+    class obs opt
+```
 
 Forbidden directions (CI-enforced):
 
@@ -31,8 +112,117 @@ Forbidden directions (CI-enforced):
 - `doiget-core` → `doiget-mcp` (lib must not depend on server).
 - `doiget-mcp` → `doiget-cli` (server must not depend on CLI).
 
-## Further reading
+## 5. Core trait surface (`doiget-core`)
 
-- [`docs/ARCHITECTURE.md`]({{ config.extra.github_url }}/blob/main/docs/ARCHITECTURE.md) &mdash; binding spec with mermaid system diagram.
-- [Phase plan]({{ get_url(path='@/contribute/phases.md') | safe }}) &mdash; what work is in flight.
-- [`docs/DECISIONS/`]({{ config.extra.github_url }}/tree/main/docs/DECISIONS) &mdash; the 24 ADRs that bind major design choices.
+```rust
+pub trait Source: Send + Sync {
+    fn name(&self) -> &str;
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool;
+    async fn fetch(&self, ref_: &Ref, profile: &CapabilityProfile, ctx: &FetchContext)
+        -> Result<FetchResult, FetchError>;
+}
+
+pub trait Store: Send + Sync {
+    fn read(&self, key: &Safekey) -> Result<Option<Metadata>, StoreError>;
+    fn write(&self, key: &Safekey, m: &Metadata, pdf: Option<&Path>) -> Result<(), StoreError>;
+    fn list_recent(&self, limit: usize) -> Result<Vec<EntryInfo>, StoreError>;
+    fn search(&self, query: &str, limit: usize) -> Result<Vec<EntryInfo>, StoreError>;
+}
+
+pub enum Ref { Doi(Doi), Arxiv(ArxivId) }
+pub struct Safekey(String);
+pub struct Metadata { /* ... */ }
+pub struct CapabilityProfile { /* see CAPABILITY.md */ }
+```
+
+The full normative API surface is in [`PUBLIC_API.md`](PUBLIC_API.md). This is the
+semver-locked public contract for `doiget-core`.
+
+## 6. Data flow: a single `fetch_paper(doi)`
+
+```mermaid
+sequenceDiagram
+    participant U as User / Agent
+    participant R as Resolver (doiget-core)
+    participant P as CapabilityProfile
+    participant S as Source (e.g. Unpaywall)
+    participant L as Provenance Log
+    participant FS as Store
+
+    U->>R: fetch_paper("10.1234/example")
+    R->>R: validate ref (regex, length)
+    R->>P: which sources can_serve?
+    P-->>R: [Crossref, Unpaywall]
+    R->>S: try Unpaywall.fetch(ref, profile, ctx)
+    S->>S: HTTPS GET api.unpaywall.org/...
+    S-->>R: PDF URL + license
+    R->>S: HTTPS GET PDF (size cap, redirect allowlist)
+    S-->>R: PDF bytes
+    R->>R: validate magic bytes (%PDF-)
+    R->>L: append { ts, ref, source, license, ... } + SHA256 chain
+    L-->>R: ok (if write fails: Err and abort)
+    R->>FS: atomic write metadata + PDF
+    FS-->>R: ok
+    R-->>U: FetchResult { ok: true, path, source, license }
+```
+
+## 7. Document index
+
+| Document | Status | Topic |
+|---|---|---|
+| [README.md](../README.md) | Entry | Project overview, posture |
+| [LEGAL.md](LEGAL.md) | NORMATIVE | Posture, jurisdictional caveat, eight safeguards |
+| [SCOPE.md](SCOPE.md) | NORMATIVE | Permanent non-goals |
+| [SECURITY.md](SECURITY.md) | NORMATIVE | Threat model, supply chain |
+| [STORE.md](STORE.md) | NORMATIVE | Store layout, schema versioning, flock, atomic write |
+| [SAFEKEY.md](SAFEKEY.md) | NORMATIVE | safekey algorithm + reference test vectors |
+| [CAPABILITY.md](CAPABILITY.md) | NORMATIVE | CapabilityProfile spec, env var precedence |
+| [PROVENANCE_LOG.md](PROVENANCE_LOG.md) | NORMATIVE | JSON Lines + hash chain log spec |
+| [CACHE.md](CACHE.md) | NORMATIVE | Resolver / citation cache layout, TTL |
+| [ERRORS.md](ERRORS.md) | NORMATIVE | Error taxonomy × persona presentation |
+| [CONFIG.md](CONFIG.md) | NORMATIVE | env / file / flag precedence |
+| [PUBLIC_API.md](PUBLIC_API.md) | NORMATIVE | semver-locked Rust API surface |
+| [MCP_TOOLS.md](MCP_TOOLS.md) | NORMATIVE | MCP tool spec (9 + 3) |
+| [SOURCES.md](SOURCES.md) | NORMATIVE | Source list, ToS links, prerequisites |
+| [PHASES.md](PHASES.md) | INFORMATIVE | Phase plan + Phase 0 deliverable checklist |
+| [MIGRATION.md](MIGRATION.md) | INFORMATIVE | BiblioFetch.jl ↔ doiget migration |
+| [INTEGRATION/](INTEGRATION/) | INFORMATIVE | MCP host install snippets |
+| [DECISIONS/](DECISIONS/) | NORMATIVE | ADRs (Architecture Decision Records) |
+| [CONTACT.md](../CONTACT.md) | Entry | Takedown / SLA / DMCA / security disclosure |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Process | PR rules, doc style, scope-reopening meta-rule |
+
+## 8. Phase plan summary
+
+The full plan is in [`PHASES.md`](PHASES.md). Headline:
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 0 | Repo bootstrap, normative specs, ADRs, Cargo workspace skeleton, CI | 5–7 days |
+| 1 | Core resolver + Tier 1 sources + `fetch` / `batch` CLI | 1.5 weeks |
+| 2 | Store + `info` / `search` / `bib` / `csl` | 1 week |
+| 3 | MCP server + 9 tools + strict stdio | 1.5 weeks |
+| **MVP shipping point** | | **5 weeks** |
+| 4 | Tier 2 sources + citation graph (Phase 4) | 1.5 weeks |
+| 5 | TDM (5a Springer OA / 5b APS / 5c Elsevier) | 3–5 weeks, optional |
+| 6 | Release + marketplace + polish | 1 week |
+| 7 | Optional (`vault`, `obsidian`) | per feature |
+
+## 9. Cross-tool relationship with BiblioFetch.jl
+
+doiget shares the on-disk store format with [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl).
+The boundary contracts are documented as part of [`STORE.md`](STORE.md):
+
+- TOML schema versioning (`schema_version = "1.0"`).
+- Concurrent access via `flock` on `<safekey>.toml.lock`.
+- Atomic write protocol (`tmp` → `fsync` → `rename` → `fsync` parent).
+- A shared `safekey` algorithm with 100 reference test vectors in
+  [`SAFEKEY.md`](SAFEKEY.md).
+
+## 10. Where to start as a new contributor
+
+1. Read [README.md](../README.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
+2. Read [LEGAL.md](LEGAL.md) and [SCOPE.md](SCOPE.md). These set the boundaries on what
+   contributions are accepted.
+3. Skim [DECISIONS/](DECISIONS/) — the ADRs explain why doiget is shaped the way it is.
+4. Pick a Phase 0 task from [PHASES.md](PHASES.md) §"Phase 0 deliverable checklist" or
+   open an issue to discuss a contribution outside it.

--- a/site/content/contribute/phases.md
+++ b/site/content/contribute/phases.md
@@ -1,33 +1,147 @@
 +++
 title = "Phase plan"
-description = "MVP-to-Phase-6 roadmap. The binding contract lives in docs/PHASES.md in the repo."
+description = "| Phase | Scope | Effort |"
 weight = 110
 +++
 
-The canonical phase plan is
-[`docs/PHASES.md`]({{ config.extra.github_url }}/blob/main/docs/PHASES.md)
-in the repository. This page is a thin orientation; the binding
-content lives there.
+# Phase plan
 
-## Phase headline
+> **Status: INFORMATIVE.** Snapshot of the implementation plan as of 2026-05-05.
+> Effort estimates are best-guess and will drift; the Phase **content** is the binding
+> part. Substantive changes to Phase content require an ADR.
 
-| Phase | Scope |
-|---|---|
-| **0** | Repo bootstrap, normative specs, ADRs, Cargo workspace, CI |
-| **1** | Core resolver + Tier 1 sources + `fetch` / `batch` CLI |
-| **2** | Store + `info` / `search` / `bib` / `csl` |
-| **3** | MCP server + 10 tools + strict stdio |
-| **3.5** | Marketplace draft + landing page (this site) |
-| **4** | Tier 2 sources + citation graph |
-| **5** | TDM Springer / APS / Elsevier (deferred-by-default) |
-| **6** | Release: OIDC + sigstore + SBOM + auto-tag |
-| **7** | Optional features (vault, obsidian) |
+## 1. Phase headline
 
-Until Phase 6 ships, the workspace version stays at `0.0.0` and no
-crates.io publication occurs.
+| Phase | Scope | Effort |
+|---|---|---|
+| **0** | Repo bootstrap, normative specs, ADRs, Cargo workspace skeleton, CI | 5–7 days |
+| **1** | Core resolver + Tier 1 sources + `fetch` / `batch` CLI | 1.5 weeks |
+| **2** | Store + `info` / `search` / `bib` / `csl` | 1 week |
+| **3** | MCP server + 9 tools + strict stdio | 1.5 weeks |
+| **MVP shipping point** | | **5 weeks** |
+| 3.5 | Early marketplace draft + landing page (overlap with Phase 4) | concurrent |
+| 4 | Tier 2 sources + citation graph | 1.5 weeks |
+| 5a | TDM Springer Nature OA — author opt-in to start | 1 week + 1–2 wk cooldown |
+| 5b | TDM APS Harvest — author opt-in to start | 1 week + 1–2 wk cooldown |
+| 5c | TDM Elsevier ScienceDirect — author re-decision required | 1 week |
+| 6 | Release: OIDC + sigstore + SBOM + landing page polish + auto-tag (`release-plz`) | 1 week |
+| 7 | Optional features (`vault`, `obsidian`) | per feature |
 
-## Current state
+> **Phase 6 auto-tag note.** Version bumps and tags are deferred to Phase 6 via
+> [`release-plz`](https://release-plz.dev) — Conventional Commits drive a
+> Cargo.toml version bump PR, which when merged tags and (with OIDC trusted
+> publishing) ships to crates.io. Phase 0 carries no `release-plz.toml` yet;
+> until Phase 6 the version stays `0.0.0` and tags are not minted.
 
-See [`docs/PHASES.md`]({{ config.extra.github_url }}/blob/main/docs/PHASES.md)
-for the live checklist. Substantive changes to phase scope require an
-ADR per `docs/DECISIONS/`.
+**Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
+Phase 0–4 production usage and any publisher-side correspondence.
+
+## 2. Phase 0 deliverable checklist
+
+Phase 0 is complete when **all** of the following are committed.
+
+### Code
+
+- [x] Cargo workspace with members `doiget-core`, `doiget-cli`, `doiget-mcp`.
+- [x] `cargo build` succeeds (default features = `oa-only`).
+- [x] `cargo build --no-default-features` succeeds (sanity: nothing under `oa-only` is actually load-bearing for compilation in Phase 0).
+- [x] `doiget --help` runs (no subcommands implemented yet).
+
+### Configuration files
+
+- [x] [`Cargo.toml`](../Cargo.toml) workspace + features matrix.
+- [x] `Cargo.lock` committed.
+- [x] [`rust-toolchain.toml`](../rust-toolchain.toml) — MSRV 1.86 declared (channel: stable).
+- [x] [`deny.toml`](../deny.toml) — banned crate list.
+- [x] [`clippy.toml`](../clippy.toml) — workspace lints.
+- [x] [`.cargo/config.toml`](../.cargo/config.toml) — build flags.
+
+### NORMATIVE docs
+
+- [x] [`README.md`](../README.md)
+- [x] [`LICENSE`](../LICENSE)
+- [x] [`CONTACT.md`](../CONTACT.md)
+- [x] [`docs/LEGAL.md`](LEGAL.md)
+- [x] [`docs/SCOPE.md`](SCOPE.md)
+- [x] [`docs/SECURITY.md`](SECURITY.md)
+- [x] [`docs/STORE.md`](STORE.md)
+- [x] [`docs/SAFEKEY.md`](SAFEKEY.md)
+- [x] [`docs/CAPABILITY.md`](CAPABILITY.md)
+- [x] [`docs/PROVENANCE_LOG.md`](PROVENANCE_LOG.md)
+- [x] [`docs/ERRORS.md`](ERRORS.md)
+- [x] [`docs/CONFIG.md`](CONFIG.md)
+- [x] [`docs/CACHE.md`](CACHE.md)
+- [x] [`docs/PUBLIC_API.md`](PUBLIC_API.md)
+- [x] [`docs/MCP_TOOLS.md`](MCP_TOOLS.md)
+- [x] [`docs/SOURCES.md`](SOURCES.md)
+- [x] [`docs/REDIRECT_ALLOWLIST.md`](REDIRECT_ALLOWLIST.md)
+- [x] [`CHANGELOG.md`](../CHANGELOG.md) (Keep a Changelog format)
+
+### INFORMATIVE docs
+
+- [x] [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- [x] [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
+- [x] [`docs/PHASES.md`](.) (this document)
+- [x] [`docs/MIGRATION.md`](MIGRATION.md) (placeholder; full content Phase 2)
+- [x] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0020
+
+### CI workflows
+
+- [x] `.github/workflows/ci.yml` (fmt, clippy, test on a 3 OS × 3 features matrix)
+- [x] `.github/workflows/audit.yml` (cargo audit + cargo deny)
+- [x] `.github/workflows/posture-lint.yml` (forbidden term / crate guard)
+- [x] `.github/workflows/codeql.yml` (Phase 0 onward)
+- [x] `.github/workflows/safekey-vectors.yml` (vector-set parity)
+- [x] `.github/workflows/cross-tool-compat.yml` (BiblioFetch.jl round-trip; placeholder until Phase 2)
+- [x] `.github/workflows/msrv-drift.yml` (weekly: detect transitive-dep MSRV bumps past declared 1.86)
+- [x] `.github/dependabot.yml` (auto-merge disabled)
+
+### Repo-level settings (manual; cannot be committed)
+
+- [ ] Branch protection on `main`: required PR review, required status checks, signed
+      commits.
+- [ ] 2FA mandatory on the maintainer account.
+- [ ] Default branch protection includes Action SHA pinning policy.
+
+### Test fixtures
+
+- [x] `tests/fixtures/safekey/vectors.json` — 100 reference test vectors.
+- [x] `tests/fixtures/golden/` — placeholder.
+
+### Pre-flight items (must be confirmed before Phase 0 begins)
+
+- [ ] Confirm BiblioFetch.jl's current safekey algorithm matches
+      [`SAFEKEY.md`](SAFEKEY.md) §3, or arrange a coordinated bump.
+- [ ] Confirm BiblioFetch.jl's current TOML `schema_version`.
+- [ ] Verify maintainer's `crates.io` account is set up for trusted publishing (OIDC).
+- [ ] Verify GitHub Environment is configurable for the release workflow.
+
+## 3. Phase 0 working principles
+
+- **Docs and code can be written in parallel.** Multiple agents (or a person and an
+  agent) can advance docs and code skeleton concurrently.
+- **No source impl in Phase 0.** Phase 0 ships the workspace skeleton only; actual
+  `Source::fetch` implementations begin in Phase 1.
+- **No external services touched.** Phase 0 makes no real fetches.
+
+## 4. Phase 1 readiness criteria (informational)
+
+Phase 1 begins when Phase 0's deliverable checklist is complete and the pre-flight items
+have been confirmed. Phase 1's success criterion is:
+
+- `doiget fetch <DOI>` succeeds for at least one Open Access DOI from each of Crossref,
+  Unpaywall, and arXiv.
+- `doiget batch <refs.txt>` honors the rate cap and writes a hash-chained provenance
+  log.
+- `cargo test --workspace` is green.
+
+## 5. Tracking
+
+Phase progress is tracked through:
+
+- This file's checklist.
+- `CHANGELOG.md` `[Unreleased]` section.
+- GitHub issues labeled `phase-0`, `phase-1`, etc.
+
+When a Phase completes, this document gets updated with the completion date and a brief
+summary, and the next Phase's checklist becomes active.

--- a/site/content/developer/cache.md
+++ b/site/content/developer/cache.md
@@ -1,0 +1,71 @@
++++
+title = "Cache"
+description = "```"
+weight = 120
++++
+
+# Cache
+
+> **Status: NORMATIVE.** Defines local cache layout and TTLs.
+
+## 1. Layout
+
+```
+~/.cache/doiget/
+├── resolver/
+│   └── <safekey>.toml       # Crossref / Unpaywall response cache (Phase 1+)
+└── citations/
+    └── <safekey>.toml       # citation graph expansion cache (Phase 4+)
+```
+
+Override root via `DOIGET_CACHE_ROOT` env or `[cache] root` in `config.toml`.
+
+## 2. Cache entry format
+
+```toml
+schema_version = "1.0"
+fetched_at     = "2026-05-05T08:30:12Z"
+ttl_seconds    = 604800            # 7 days for resolver, 30*24*3600 for citations
+source         = "crossref"
+
+[response]
+# raw or normalized response body, source-specific
+```
+
+A cache entry is invalid if `now() > fetched_at + ttl_seconds`. Invalid entries are
+ignored (treated as cache miss) and replaced on the next fetch.
+
+## 3. TTLs
+
+| Cache | Default TTL | Constant |
+|---|---|---|
+| `resolver/` | 7 days | `RESOLVER_CACHE_TTL_DAYS = 7` |
+| `citations/` | 30 days | `CITATION_CACHE_TTL_DAYS = 30` |
+
+These are library constants, not config. A future ADR could expose them to config if
+demand arises.
+
+## 4. Atomic writes
+
+Cache writes follow the same atomic write protocol as the store
+(see [`STORE.md`](STORE.md) §5): write to `<safekey>.toml.tmp`, fsync, rename, fsync
+parent. No locking is required because cache entries are write-once-then-replace; a
+concurrent loser overwrites the other's identical content.
+
+## 5. Cache disablement
+
+- Per-invocation: `--no-cache` flag on relevant subcommands.
+- Permanent: `[cache] disabled = true` in `config.toml` or `DOIGET_CACHE_DISABLED=1`.
+
+When disabled, doiget neither reads from nor writes to the cache. Resolver / citation
+calls go directly to the source.
+
+## 6. Cache cleanup
+
+```sh
+doiget cache prune          # delete expired entries
+doiget cache clear          # delete all cache entries
+doiget cache size           # report disk usage
+```
+
+The cache is safe to delete entirely at any time; doiget will rebuild it lazily.

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -1,0 +1,217 @@
++++
+title = "Capability profile"
+description = "```rust"
+weight = 110
++++
+
+# CapabilityProfile
+
+> **Status: NORMATIVE.** Defines the runtime capability gate that authorizes which
+> sources may be invoked. Every `Source::fetch` implementation MUST require a
+> `&CapabilityProfile` argument; sources whose capability is not granted at startup
+> cannot be invoked at the type level.
+
+## 1. Type definition
+
+```rust
+// Phase 1+ target module path; Phase 0 ships these types in monolithic lib.rs.
+
+use secrecy::Secret;
+use chrono::{DateTime, Utc};
+
+// All structs below are #[non_exhaustive] in the Rust source. External crates
+// cannot construct them via struct-literal syntax — go through
+// `CapabilityProfile::from_env()` (see §2). The shapes shown are the Phase 1+
+// target; the Phase 0 stub omits `TdmGrant::api_key` (added non-breakingly
+// later via `#[non_exhaustive]`).
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CapabilityProfile {
+    pub oa: AlwaysOn,
+    pub metadata: MetadataAccess,
+    pub tdm_elsevier: Option<TdmGrant>,
+    pub tdm_aps: Option<TdmGrant>,
+    pub tdm_springer: Option<TdmGrant>,
+    pub rate_limits: RateLimits,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AlwaysOn;   // unit struct — Tier 1 OA is always permitted
+
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct MetadataAccess {
+    pub openalex: bool,            // Phase 4+
+    pub semantic_scholar: bool,
+    pub doaj: bool,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TdmGrant {
+    pub api_key:       Secret<String>,    // added in Phase 1
+    pub agreed_at:     DateTime<Utc>,
+    pub agree_env_var: String,            // e.g. "DOIGET_AGREE_TDM_ELSEVIER"
+}
+
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct RateLimits {
+    pub(crate) max_concurrent_fetches: u32, // hard-coded 5 (LEGAL §6 safeguard 8)
+    pub(crate) max_fetches_per_second: f32, // hard-coded 5.0
+    pub(crate) per_source_backoff_ms:  u64, // hard-coded 200
+}
+
+impl RateLimits {
+    /// Sole public constructor. There is no other way to obtain a
+    /// `RateLimits` outside of `doiget-core`: fields are `pub(crate)`, the
+    /// struct is `#[non_exhaustive]`, and no public `new`-style function
+    /// exists. This closes the legal-safeguard loophole that bare `pub`
+    /// fields would create (cf. `docs/LEGAL.md` §6 safeguard 8).
+    pub const HARD_CODED: Self = Self {
+        max_concurrent_fetches: 5,
+        max_fetches_per_second: 5.0,
+        per_source_backoff_ms:  200,
+    };
+
+    pub const fn max_concurrent_fetches(&self) -> u32 { self.max_concurrent_fetches }
+    pub const fn max_fetches_per_second(&self) -> f32 { self.max_fetches_per_second }
+    pub const fn per_source_backoff_ms(&self)  -> u64 { self.per_source_backoff_ms }
+}
+```
+
+### External construction
+
+External crates always go through:
+
+```rust
+let profile = CapabilityProfile::from_env()?;
+```
+
+Struct-literal construction (`CapabilityProfile { oa: ..., ... }`) is blocked
+outside `doiget-core` by `#[non_exhaustive]`. Tests inside `doiget-core` may
+still construct profiles directly for fixture purposes.
+
+`api_key` is wrapped in `secrecy::Secret<String>` so that `Display` and `Debug` print
+`****`. Logs use a redactor for known sensitive field names.
+
+## 2. Resolution algorithm
+
+```rust
+impl CapabilityProfile {
+    pub fn from_env() -> Result<Self, CapabilityError> {
+        Ok(Self {
+            oa: AlwaysOn,
+            metadata: MetadataAccess {
+                openalex:        env::var("DOIGET_ENABLE_OPENALEX").is_ok(),
+                semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
+                doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
+            },
+            tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
+            tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
+            tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
+            rate_limits:  RateLimits::HARD_CODED,
+        })
+    }
+}
+
+fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, CapabilityError> {
+    let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
+    let key    = env::var(key_var).ok();
+    match (agreed, key) {
+        (true, Some(k)) => Ok(Some(TdmGrant {
+            api_key:       Secret::new(k),
+            agreed_at:     Utc::now(),
+            agree_env_var: agree_var.to_string(),
+        })),
+        (true, None)    => Err(CapabilityError::AgreedButNoKey {
+            agree_var: agree_var.into(), key_var: key_var.into(),
+        }),
+        (false, Some(_)) => Err(CapabilityError::KeyButNotAgreed {
+            agree_var: agree_var.into(),
+        }),
+        (false, None)   => Ok(None),
+    }
+}
+```
+
+### Three resolution rules
+
+1. **`agree=1` + key present** → `Some(TdmGrant)`. The source is enabled this session.
+2. **`agree=1` but key missing** → `Err(AgreedButNoKey)`. Startup fails; user has agreed
+   but provided no credential. Silent skip would mask a misconfiguration.
+3. **`agree` unset but key present** → `Err(KeyButNotAgreed)`. Startup fails; we require
+   the explicit agreement env var even when the key is set. Otherwise a leaked
+   `DOIGET_KEY_ELSEVIER` from a parent shell environment could enable a source the user
+   did not intend.
+
+## 3. Environment variable reference
+
+| Variable | Type | Effect |
+|---|---|---|
+| `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). Phase 4+. |
+| `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. Phase 4+. |
+| `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. Phase 4+. |
+| `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
+| `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
+| `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |
+| `DOIGET_KEY_APS` | secret string | APS API key. |
+| `DOIGET_AGREE_TDM_SPRINGER` | `=1` | Acknowledges Springer Nature OA ToS. |
+| `DOIGET_KEY_SPRINGER` | secret string | Springer API key. |
+
+Setting `DOIGET_AGREE_TDM_*` only makes the relevant source eligible. The corresponding
+TDM-specific Cargo feature must also have been compiled in (`cargo build --features
+tdm-elsevier` etc.). Default release binaries do not contain TDM source code at all.
+
+## 4. Source trait integration
+
+```rust
+pub trait Source: Send + Sync {
+    fn name(&self) -> &str;
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool;
+    async fn fetch(&self, ref_: &Ref, profile: &CapabilityProfile, ctx: &FetchContext)
+        -> Result<FetchResult, FetchError>;
+}
+
+// Example: Elsevier TDM source (only compiled when feature = "tdm-elsevier")
+#[cfg(feature = "tdm-elsevier")]
+impl Source for ElsevierTdm {
+    fn can_serve(&self, p: &CapabilityProfile, _: &Ref) -> bool {
+        p.tdm_elsevier.is_some()
+    }
+    async fn fetch(&self, ref_: &Ref, profile: &CapabilityProfile, ctx: &FetchContext)
+        -> Result<FetchResult, FetchError>
+    {
+        let grant = profile.tdm_elsevier.as_ref()
+            .ok_or(FetchError::CapabilityDenied)?;
+        // grant.api_key.expose_secret() — use the API key
+        // ...
+    }
+}
+```
+
+## 5. Startup banner (auditability)
+
+On startup, `doiget` (CLI or MCP server) writes a single line to **stderr** describing
+the resolved profile. Example:
+
+```
+[doiget] capability: oa=on metadata=[openalex] tdm=[elsevier(agreed=2026-05-05T08:00:00Z)]
+```
+
+The banner is on stderr in all modes, including MCP mode (where stdout is reserved for
+JSON-RPC). The banner does not include any portion of any API key.
+
+## 6. Reload semantics
+
+`CapabilityProfile` is **immutable for the lifetime of the process**. A change to
+`DOIGET_AGREE_TDM_*` or a key environment variable while the process is running has no
+effect; the user must restart. This avoids partial-state security weakening.
+
+## 7. MCP tool exposure
+
+The MCP tool `doiget_capability_profile` (see [`MCP_TOOLS.md`](MCP_TOOLS.md)) reports the
+current profile to agents in a redacted form (no API keys, just booleans / source names
+and `agreed_at` timestamps). Agents can use this to decide whether a `fetch_paper(...)`
+call against a TDM source will succeed before issuing it.

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -1,0 +1,136 @@
++++
+title = "Configuration"
+description = "```"
+weight = 130
++++
+
+# Configuration
+
+> **Status: NORMATIVE.** Defines configuration sources and their precedence.
+
+## 1. Sources, in priority order
+
+```
+1. CLI flags                        (highest)
+2. Environment variables
+3. User config file ~/.config/doiget/config.toml
+4. Built-in defaults                (lowest)
+```
+
+A value set higher in the chain overrides any value set lower.
+
+## 2. Built-in defaults
+
+| Key | Default |
+|---|---|
+| `store.root` | POSIX: `$HOME/papers`. Windows: `%USERPROFILE%\papers`. |
+| `cache.root` | POSIX: `$HOME/.cache/doiget`. Windows: `%LOCALAPPDATA%\doiget\cache`. |
+| `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
+| `log.retention_days` | `90` |
+| `network.user_agent` | `doiget/<version> (+https://github.com/sotashimozono/doiget)` |
+| `network.unpaywall_email` | unset; if unset, Unpaywall calls go to non-polite pool |
+| `network.connect_timeout_sec` | `10` |
+| `network.read_timeout_sec` | `60` |
+| `network.total_timeout_sec` | `300` |
+| `output.mode` | `quiet` (see [`ARCHITECTURE.md`](ARCHITECTURE.md) §personas) |
+| `output.color` | `auto` (honors `NO_COLOR` env) |
+| `output.progress` | `false` |
+| `output.emoji` | `false` |
+
+## 3. config.toml schema
+
+```toml
+# ~/.config/doiget/config.toml — all fields optional
+
+[store]
+root = "/home/alice/papers"
+
+[cache]
+root = "/home/alice/.cache/doiget"
+
+[log]
+path = "/home/alice/.config/doiget/access.log"
+retention_days = 90
+
+[network]
+user_agent = "doiget/0.1.0 (+https://github.com/sotashimozono/doiget; user=alice@example.org)"
+unpaywall_email = "alice@example.org"
+connect_timeout_sec = 10
+read_timeout_sec = 60
+total_timeout_sec = 300
+
+[output]
+mode = "human"          # human | json | quiet | mcp
+color = "auto"          # auto | always | never
+progress = false
+emoji = false
+```
+
+doiget reads only the keys it knows about. Unknown keys cause a startup warning but do
+not fail.
+
+## 4. Environment variables
+
+All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` / `0`,
+`true` / `false`. Path env vars take a single absolute path.
+
+| Variable | Maps to |
+|---|---|
+| `DOIGET_STORE_ROOT` | `store.root` |
+| `DOIGET_CACHE_ROOT` | `cache.root` |
+| `DOIGET_LOG_PATH` | `log.path` |
+| `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
+| `DOIGET_USER_AGENT` | `network.user_agent` |
+| `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
+| `DOIGET_MODE` | `output.mode` |
+| `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
+| `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
+
+CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
+
+## 5. CLI flags
+
+CLI flags use `--kebab-case`. Any path-or-string value with a config equivalent is
+overridable by flag:
+
+| Flag | Maps to |
+|---|---|
+| `--store-root <path>` | `store.root` |
+| `--log-path <path>` | `log.path` |
+| `--mode <human\|json\|quiet\|mcp>` | `output.mode` |
+| `--color <auto\|always\|never>` | `output.color` |
+| `--progress` / `--no-progress` | `output.progress` |
+| `--quiet` / `-q` | implies `--mode=quiet` |
+| `--json` | implies `--mode=json` |
+
+`doiget serve` always runs in `mcp` mode regardless of flags. Other subcommands honor the
+mode resolution above.
+
+## 6. Credentials file
+
+```toml
+# ~/.config/doiget/credentials.toml — optional, alternative to env vars
+# Permissions MUST be 0600 on POSIX; doiget warns at startup otherwise.
+
+[tdm.elsevier]
+api_key = "..."
+agreed = true
+
+[tdm.aps]
+api_key = "..."
+agreed = true
+
+[tdm.springer]
+api_key = "..."
+agreed = true
+```
+
+If both env var and credentials.toml provide the same key, env var wins.
+
+## 7. Inspecting effective config
+
+```sh
+doiget config show          # prints the resolved config (with API keys redacted as ****)
+doiget config path          # prints the path of the config file in use
+doiget config doctor        # checks file permissions, reachability, sanity
+```

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -1,0 +1,138 @@
++++
+title = "Error codes"
+description = "```rust"
+weight = 140
++++
+
+# Error taxonomy
+
+> **Status: NORMATIVE.** Defines the closed set of error codes that doiget surfaces and
+> how each persona experiences each code. Adding a new error code is a minor semver
+> bump; renaming or repurposing one is a breaking change.
+
+## 1. ErrorCode enum
+
+```rust
+// Phase 1+ target module path; Phase 0 ships ErrorCode in monolithic lib.rs.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    InvalidRef,
+    NoOaAvailable,
+    RateLimited,
+    NetworkError,
+    StoreError,
+    LogError,
+    CapabilityDenied,
+    FetchTimeout,
+    SchemaTooNew,
+    LockTimeout,
+    InternalError,
+    NotImplemented,
+}
+```
+
+Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
+
+## 2. Code semantics
+
+| Code | Meaning | Recoverable? |
+|---|---|---|
+| `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
+| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
+| `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
+| `NETWORK_ERROR` | Transport / DNS / TLS failure. | Retry usually fine. |
+| `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
+| `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
+| `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |
+| `FETCH_TIMEOUT` | Per-request timeout exceeded. | Retry. |
+| `SCHEMA_TOO_NEW` | Store entry's `schema_version` is ahead. | Upgrade doiget. |
+| `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | Retry; another process holds it. |
+| `INTERNAL_ERROR` | Bug. | Report at <https://github.com/sotashimozono/doiget/issues>. |
+| `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | Wait for next minor release; do not retry. |
+
+## 3. Persona × error matrix
+
+| Persona | Surface |
+|---|---|
+| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context? } }`. Never throws. |
+| Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?}}`. Exit code = number of failures (capped at 255). |
+| Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
+
+### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
+
+The `error` envelope MAY carry an additional structured `denial_context`
+field for machine-readable recovery. The field is **optional and additive** —
+consumers MUST tolerate both its presence and its absence — and is
+populated by the producer on the denial classes named in the §5 mapping
+table below.
+
+`denial_context.reason` is a **closed** enum (per ADR-0023):
+
+```jsonc
+"denial_context": {
+  "reason":    "redirect_not_in_allowlist",   // closed enum, snake_case
+  "source":    "crossref",                     // resolver source key, optional
+  "attempted": "evil.example.com",             // host/path/value, optional
+  "expected":  ["api.crossref.org",
+                "*.crossref.org"],             // allowlist entries; the field
+                                                //   is ABSENT when the producer
+                                                //   did not populate it. An
+                                                //   explicit [] means "empty
+                                                //   allowlist" (ADR-0023 §3
+                                                //   None/Some(vec![])
+                                                //   disambiguation).
+  "hop_index": 1,                              // redirect-chain position, optional
+  "cap":       104857600,                      // size/rate cap, optional
+  "actual":    209715200                       // observed value, optional
+}
+```
+
+Closed `reason` set: `redirect_not_in_allowlist`, `insecure_scheme`,
+`host_in_block_list`, `size_cap_exceeded`, `schema_drift`,
+`capability_not_granted`, `rate_limit_window`, `ssrf_private_address`,
+`content_type_mismatch`. Adding a new variant is a minor semver bump;
+renaming or repurposing one is a breaking change.
+
+`error.message` MUST continue to embed the same parameters in human-readable
+form — `denial_context` is a parallel channel, not a replacement.
+
+## 4. CLI exit codes
+
+| Exit | Meaning |
+|---|---|
+| `0` | Success (all refs ok). |
+| `1` | At least one fetch failed. |
+| `2` | Misuse (bad arguments, missing config). |
+| `3` | Capability denied (no source could serve). |
+| `4` | I/O failure (store / log unwritable). |
+| `64..=78` | `sysexits.h` mapping for select cases. |
+| `124` | Timeout (matches GNU `timeout`). |
+| `255` | Capped failure count for `batch`. |
+
+## 5. Error wrapping
+
+- `doiget-core` exports `FetchError` (typed, `thiserror`). Each variant carries an
+  `ErrorCode` and any context data needed by callers.
+- `doiget-cli` uses `anyhow::Error` for context, mapping the leaf `FetchError` to a CLI
+  presentation per persona.
+- `doiget-mcp` translates `FetchError` to the MCP `{ok: false, error}` shape and never
+  throws across the JSON-RPC boundary.
+
+### 5.1 `DenialContext` mapping (ADR-0023 §4)
+
+The producer-side mapping from internal error variants to `DenialContext` is
+defined in [`DECISIONS/0023-denial-context-structured.md`](DECISIONS/0023-denial-context-structured.md)
+§4 (NORMATIVE table). Summary: every `HttpError::RedirectDenied`,
+`OversizedBody`, `NotAPdf`, `InsecureRedirect`, and every
+`FetchError::NotEligible` produces a populated `Option<DenialContext>` via
+`From` impls in `doiget-core`. Other error variants leave `denial_context`
+unset.
+
+## 6. No silent failures
+
+doiget MUST NOT return a "success" result with placeholder data when a real fetch
+failed. A fetch either succeeds with a real PDF + license + metadata, or returns an
+error with one of the codes above.

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -1,0 +1,275 @@
++++
+title = "MCP tools"
+description = "`doiget` runs as a Model Context Protocol server when invoked as `doiget serve`. It"
+weight = 100
++++
+
+# MCP tools
+
+> **Status: NORMATIVE.** Defines the tool surface exposed by `doiget serve` over stdio
+> JSON-RPC. Renaming or removing a tool is a breaking change.
+
+`doiget` runs as a Model Context Protocol server when invoked as `doiget serve`. It
+speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal 6).
+
+## 1. Tool list (Phase 3 baseline)
+
+| Tool | Purpose |
+|---|---|
+| `doiget_resolve_paper` | Resolve DOI / arXiv id to authoritative metadata. |
+| `doiget_fetch_paper` | Resolve and download a single PDF to the store. Accepts `dry_run`. |
+| `doiget_metadata_only` | Resolve to metadata. **Guarantees no PDF / publisher fetch.** Accepts `dry_run`. |
+| `doiget_batch_fetch` | Up to 100 refs in one call. Accepts `dry_run`. |
+| `doiget_info` | Retrieve a store entry's metadata. |
+| `doiget_search_local` | Search store metadata (title / authors / venue). |
+| `doiget_list_recent` | Last N fetched entries. |
+| `doiget_paper_pdf_path` | Return the local path of a cached PDF. **Does not read, parse, or transmit content.** |
+| `doiget_capability_profile` | Report which sources this instance is allowed to use. |
+| `doiget_health` | Operational sanity (store writable, version, schema). |
+
+Phase 4 adds:
+
+| Tool | Purpose |
+|---|---|
+| `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. |
+| `doiget_bibtex_export` | BibTeX for one or many entries. |
+| `doiget_csl_export` | CSL JSON for one or many entries. |
+
+## 2. Naming and convention
+
+- All tools use `snake_case` with the `doiget_` prefix.
+- Inputs are validated via JSON Schema declared in the tool's `inputSchema` (per MCP).
+- Outputs are structured: `{ ok: true, ... }` or `{ ok: false, error: { code, message } }`.
+  Tools never throw across the JSON-RPC boundary.
+- Error `code` values are the closed set defined in [`ERRORS.md`](ERRORS.md).
+
+## 3. Tool description format
+
+Each tool's `description` field follows this six-section format so LLM agents can pick
+the right tool with minimal mistakes:
+
+```
+WHEN TO USE: <one sentence>
+INPUTS: <field-by-field>
+OUTPUTS: <shape on success>
+COSTS: <network / time / quota>
+SIDE EFFECTS: <what writes to disk / log / store>
+LIMITS: <hard caps>
+```
+
+## 4. Example tool spec — `doiget_fetch_paper`
+
+```jsonc
+{
+  "name": "doiget_fetch_paper",
+  "description": "WHEN TO USE: User wants to download a paper PDF given a DOI or arXiv id.\nINPUTS: ref: DOI ('10.1234/abc') or arXiv id ('2401.12345').\nOUTPUTS: { ok: true, ref, source, path, license, size_bytes } or { ok: false, error: { code, message } }.\nCOSTS: 1-3 s network call. May fail if not Open Access.\nSIDE EFFECTS: Writes PDF to the store. Appends a row to the provenance log.\nLIMITS: Max 5 fetches/sec. Use doiget_batch_fetch for >5 refs.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["ref"],
+    "properties": {
+      "ref": {
+        "type": "string",
+        "minLength": 7,
+        "maxLength": 256,
+        "pattern": "^(10\\.\\d{4,9}/[A-Za-z0-9._/()-]+|arXiv:\\d{4}\\.\\d{4,5}|\\d{4}\\.\\d{4,5})$"
+      }
+    },
+    "additionalProperties": false
+  }
+}
+```
+
+## 5. Output shape (NORMATIVE)
+
+```typescript
+type FetchResult =
+  | { ok: true,
+      ref: string,
+      source: "crossref" | "unpaywall" | "arxiv"
+            | "openalex" | "s2" | "doaj" | "oa-publisher"
+            | "tdm-elsevier" | "tdm-aps" | "tdm-springer",
+      // ADR-0021 §4 / ADR-0024 (Slice 4): the resolver profile under
+      // which the canonical-digest for this fetch was minted. Equal to
+      // `source` verbatim in Slice 4; kept distinct so future slices
+      // can decouple the two when overlapping resolvers ship.
+      resolver_profile: string,
+      path: string,
+      license: string,
+      size_bytes: number,
+      schema_version: string,
+    }
+  | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
+      rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
+  | { ok: false,
+      ref: string,
+      error: { code: ErrorCode, message: string, denial_context?: DenialContext }
+    };
+
+type DenialContext = {
+  reason: "redirect_not_in_allowlist" | "insecure_scheme"
+        | "host_in_block_list"
+        | "size_cap_exceeded" | "schema_drift" | "capability_not_granted"
+        | "rate_limit_window" | "ssrf_private_address" | "content_type_mismatch",
+  source?: string,
+  attempted?: string,
+  // `expected?` is absent when the producer did not populate this field for
+  // this reason. An empty array (`"expected": []`) is the distinct
+  // "explicit empty allowlist" signal — see ADR-0023 §3 for the
+  // None / Some(vec![]) disambiguation.
+  expected?: string[],
+  hop_index?: number,
+  cap?: number,
+  actual?: number,
+};
+```
+
+`ErrorCode` is the closed enum in [`ERRORS.md`](ERRORS.md). `DenialContext`
+is the optional structured-recovery payload defined in
+[ADR-0023](DECISIONS/0023-denial-context-structured.md). `FetchPlan` is the
+dry-run preview shape — see §10 below.
+
+## 6. Excluded tools (permanent)
+
+The following are intentionally **not** offered as MCP tools and will not be added.
+See [`SCOPE.md`](SCOPE.md) §"Credential / safety non-goals":
+
+- `doiget_delete_paper(...)` — destructive store ops are CLI-only.
+- `doiget_set_credentials(...)` — credentials never enter the MCP surface.
+- `doiget_run_shell(...)` — no generic command escape.
+- `doiget_fetch_url(url: ...)` — SSRF surface; only DOI / arXiv id input.
+
+## 7. Capability awareness
+
+Agents can call `doiget_capability_profile` first to determine which sources the
+instance is allowed to use. The output is redacted (no API key contents) and is suitable
+for an agent to use in planning whether a TDM-class fetch will succeed.
+
+```typescript
+type CapabilityProfileResponse = {
+  oa_enabled: true,
+  metadata_sources: string[],          // e.g. ["openalex"]
+  tdm_enabled: boolean,                // disjunction over individual TDM grants
+  tdm_elsevier: boolean,
+  tdm_aps: boolean,
+  tdm_springer: boolean,
+  rate_limit_per_sec: number,          // always 5.0
+};
+```
+
+## 8. Server lifecycle
+
+- Started by an MCP host as `doiget serve`.
+- stdin EOF triggers a 5-second graceful shutdown that completes ongoing fetches and
+  releases store locks.
+- stdout carries only JSON-RPC frames (banner, log, progress all forbidden, see
+  [`SECURITY.md`](SECURITY.md) §3).
+- stderr carries `tracing-subscriber` output (`RUST_LOG` controlled).
+
+## 9. Smoke test
+
+A CI workflow `mcp-smoke.yml` (Phase 3) spawns the server, sends a minimal sequence
+(`initialize` → `tools/list` → `tools/call doiget_health`), asserts the responses, and
+asserts that no stray bytes appeared on stdout outside JSON-RPC frames.
+
+## 10. Dry-run preview (NORMATIVE; ADR-0022)
+
+`doiget_fetch_paper`, `doiget_metadata_only`, and `doiget_batch_fetch` accept
+an optional `dry_run: boolean` input field, defaulting to `false`. When
+`true`:
+
+- The orchestrator builds a `FetchPlan` and returns it without touching the
+  network or the filesystem and without appending a provenance row.
+- The result envelope is `{ ok: true, dry_run: true, ref, plan,
+  rate_limit_budget }`.
+- The `plan.pdf_sources[].candidate_hosts` list is the **static allowlist**
+  for the resolver, not a prediction of the single host the real fetch would
+  hit. doiget cannot resolve the post-Unpaywall OA URL host without making
+  the Unpaywall call, and `dry_run` MUST NOT make it.
+- The `plan.candidate_hosts_are_upper_bound` boolean is always `true` in
+  Phase 1 and machine-encodes the bullet above (ADR-0022 §4) directly into
+  the wire envelope, so an agent can detect the upper-bound semantics
+  without consulting the spec.
+
+```jsonc
+{
+  "ok": true,
+  "dry_run": true,
+  "ref": { "doi": "10.1234/foo" },
+  "plan": {
+    "metadata_sources": ["crossref", "unpaywall"],
+    "pdf_sources":      [{
+      "key":             "oa-publisher",
+      "candidate_hosts": ["*.springer.com", "*.springeropen.com"]
+    }],
+    "redirect_allowlists_loaded":      ["crossref", "unpaywall", "arxiv", "oa-publisher"],
+    "candidate_hosts_are_upper_bound": true,
+    "target_pdf_path":                 "/home/.../store/doi_10.1234_foo.pdf",
+    "target_metadata_path":            "/home/.../store/doi_10.1234_foo.toml",
+    "would_append_provenance":         true
+  },
+  "rate_limit_budget": {
+    "global_per_sec":        5.0,
+    "per_source_min_gap_ms": 200
+  }
+}
+```
+
+Tools where `dry_run` does not apply (`doiget_info`, `doiget_search_local`,
+`doiget_list_recent`, `doiget_paper_pdf_path`, `doiget_capability_profile`,
+`doiget_health`, `doiget_resolve_paper`) reject the field as
+`INVALID_REF`-class — i.e. surface as
+`{ok:false, error:{code:"INVALID_REF", ...}}`.
+
+## 11. `doiget_metadata_only` (NORMATIVE)
+
+`doiget_metadata_only` resolves a `ref` through the configured metadata
+sources (Crossref + Unpaywall + arXiv-meta) and returns the resulting
+metadata. It **MUST NOT** trigger a publisher-side PDF fetch, even when the
+metadata source returns an OA URL. The OA URL, when known, is surfaced in the
+response as `oa_url` (string) for the caller to act on separately.
+
+```jsonc
+{
+  "name": "doiget_metadata_only",
+  "description": "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\nINPUTS: ref (DOI or arXiv id), dry_run (optional bool).\nOUTPUTS: { ok: true, ref, source, license?, oa_url:string|null, metadata } or { ok:false, error }.\nCOSTS: 1-2 s metadata round-trip. No publisher fetch.\nSIDE EFFECTS: Appends a provenance row tagged 'metadata-only' (unless dry_run). Writes the metadata TOML to the store.\nLIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["ref"],
+    "properties": {
+      "ref": {
+        "type": "string",
+        "minLength": 7,
+        "maxLength": 256,
+        "pattern": "^(10\\.\\d{4,9}/[A-Za-z0-9._/()-]+|arXiv:\\d{4}\\.\\d{4,5}|\\d{4}\\.\\d{4,5})$"
+      },
+      "dry_run": { "type": "boolean", "default": false }
+    },
+    "additionalProperties": false
+  }
+}
+```
+
+Output:
+
+```typescript
+type MetadataOnlyResult =
+  | { ok: true,
+      ref: string,
+      source: "crossref" | "unpaywall" | "arxiv",
+      // ADR-0021 §4 / ADR-0024: the resolver profile under which the
+      // canonical-digest for this metadata-only call was minted.
+      // Equal to `source` verbatim in Slice 4.
+      resolver_profile: string,
+      license: string,
+      oa_url: string | null,
+      metadata: object,
+      schema_version: string,
+    }
+  | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
+      rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
+  | { ok: false, ref: string, error: { code: ErrorCode, message: string, denial_context?: DenialContext } };
+```
+
+Posture: covered by the same posture-lint check as ADR-0022 §5 — a
+`metadata_only` codepath that reaches `HttpClient::fetch_pdf` is a hard
+failure.

--- a/site/content/developer/provenance-log.md
+++ b/site/content/developer/provenance-log.md
@@ -1,0 +1,179 @@
++++
+title = "Provenance log"
+description = "```"
+weight = 150
++++
+
+# Provenance log
+
+> **Status: NORMATIVE.** Defines the on-disk audit log format. The log is fail-closed:
+> a fetch that cannot be logged MUST NOT proceed.
+
+## 1. Location
+
+```
+~/.config/doiget/access.log               # current
+~/.config/doiget/access.log.<DATE>.gz     # rotated
+```
+
+Override path via `DOIGET_LOG_PATH` env or `[log] path` in `config.toml` (see
+[`CONFIG.md`](CONFIG.md)).
+
+## 2. Format
+
+JSON Lines. One JSON object per line, terminated by `\n` (LF). UTF-8. Timezone is UTC
+in all timestamps.
+
+## 3. Row schema
+
+```json
+{
+  "ts":               "2026-05-05T08:30:12.345Z",
+  "ts_seq":           1234,
+  "event":            "fetch",
+  "ref":              "10.1234/example",
+  "source":           "unpaywall",
+  "result":           "ok",
+  "license":          "CC-BY-4.0",
+  "size_bytes":       1234567,
+  "store_path":       "papers/doi_10.1234_example.pdf",
+  "capability":       "oa",
+  "session_id":       "01JCKZ7Q...",
+  "schema_version":   "v2",
+  "canonical_digest": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+  "prev_hash":        "9f86d081884c7d659a2feaa0c55ad015...",
+  "this_hash":        "a948904f2f0f479b8f8197694b30184b..."
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `ts` | RFC3339 UTC, millisecond precision | yes | |
+| `ts_seq` | `u64` | yes | Per-session monotonic sequence number. |
+| `event` | enum | yes | `session_start`, `capability_resolved`, `resolve`, `fetch`, `store_write`, `session_end` |
+| `ref` | string | event-dependent | DOI or arXiv id (validated; no log injection). |
+| `source` | enum | event-dependent | `crossref`/`unpaywall`/`arxiv`/`openalex`/`s2`/`doaj`/`tdm-elsevier`/`tdm-aps`/`tdm-springer` |
+| `result` | enum | yes | `ok` / `err` / `denied` |
+| `license` | string | event=fetch ok | OA license string, or `"unknown"` |
+| `size_bytes` | `u64` | event=fetch ok | |
+| `store_path` | string | event=fetch ok | Relative to store root. |
+| `capability` | enum | yes | `oa` / `metadata` / `tdm-elsevier` / `tdm-aps` / `tdm-springer` |
+| `session_id` | ULID (26 chars) | yes | One per process invocation. |
+| `schema_version` | string | yes | Always the literal `"v2"` for rows written by current builds (ADR-0024). v1 rows (pre-Slice-4) lack this field; the migration tool in §"Schema migration" below brings them onto the v2 shape. |
+| `canonical_digest` | hex SHA-256 (64 lowercase chars) | event-dependent | ADR-0021 §1 canonical-digest of the `(source_type, source_id, resolver_profile, version)` tuple. Present on rows with a `ref` (`fetch` / `resolve` / `store_write`); `null` on session bookend rows. Two fetches of the same DOI through Crossref vs. Unpaywall produce two distinct digests. |
+| `prev_hash` | hex SHA-256 | yes (except first row) | Equals previous row's `this_hash`. First row of a fresh log uses literal `"GENESIS"`. |
+| `this_hash` | hex SHA-256 | yes | SHA-256 of the canonical-JSON of this row excluding `this_hash`. |
+
+## 3.1 Schema migration (v1 → v2)
+
+> **Status: NORMATIVE.** Implemented in Slice 4 per
+> [ADR-0024](DECISIONS/0024-canonical-ref-impl.md), supersedes the
+> spec-only posture of [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md).
+
+Pre-Slice-4 logs are **v1**: rows have neither a `schema_version`
+field nor a `canonical_digest` field, and `#[serde(deny_unknown_fields)]`
+plus the non-defaulted `schema_version` mean v1 rows fail to parse
+under v2 with a clear `corrupted log at line N` error. Operators MUST
+migrate before the v2 binary will read their existing log.
+
+The migration is exposed via the CLI as
+`doiget provenance migrate [--dry-run]` and via the library as
+`doiget_core::provenance::migrate_v1_to_v2(log_path, dry_run)`.
+
+**Algorithm.**
+
+1. Read all v1 rows.
+2. For each row with a `ref`: derive `canonical_digest` by promoting
+   `(source_type from ref shape, source_id = ref, resolver_profile = source, version = None)`
+   through [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md) §1.
+   Rows without a `ref` (session bookends) keep `canonical_digest = null`.
+3. Recompute the SHA-256 hash chain across the new row payloads — the
+   v1 chain is invalidated by the schema change (the v2
+   canonical-JSON includes the two new fields, so old `this_hash`
+   values no longer match).
+4. **Idempotency**: if the input file already contains v2 rows, the
+   migrator re-parses them via a v2 fallback and produces
+   byte-equivalent output. Re-running on a v2 log is a no-op.
+5. **Dry-run**: `--dry-run` returns a `MigrationReport` summarizing
+   `rows_rewritten`, the first-row v1 chain anchor, and the first-row
+   v2 chain anchor without touching disk.
+6. **Live**: on success, the original is preserved at
+   `<log_path>.v1-backup` and the migrated v2 log is atomically
+   renamed onto `<log_path>` from a staged `<log_path>.v2-migrated`.
+   The staged file MUST pass `verify()` before the rename; failure
+   aborts the migration without touching the live log.
+
+Test vectors: synthetic v1 fixture at
+`tests/fixtures/provenance/migration_v1_to_v2.json`; the migration
+end-to-end suite lives at
+`crates/doiget-core/tests/provenance_migration_e2e.rs`.
+
+## 4. Hash chain
+
+Canonical JSON = compact (no whitespace), keys sorted lexicographically, no trailing
+whitespace.
+
+```
+this_hash = hex(SHA256(canonical_json(row \ {this_hash})))
+prev_hash[N] = this_hash[N-1]  (chain)
+```
+
+Tampering is detected by `doiget audit-log --verify`, which recomputes every row's
+`this_hash` and validates the chain.
+
+## 5. Failure mode (fail-closed at the operation boundary)
+
+If the log writer cannot append a row (disk full, permission denied, fsync error),
+the caller MUST receive `Err(LogError)` and the surrounding fetch MUST NOT proceed.
+The user can recover by clearing the obstruction (free disk, fix permissions) and
+retrying — `LogError` is classified as recoverable in
+[`ERRORS.md`](ERRORS.md) §2.
+
+This makes the log a **best-effort tamper-evident local audit record**, not a
+cryptographic enforcement mechanism: a determined local attacker with write access
+to `~/.config/doiget/` can still modify or replay the log (see §8 below). The
+fail-closed behavior closes the easiest evasion path (silently dropping rows
+without the user noticing), but the legal posture in
+[`LEGAL.md`](LEGAL.md) does not depend on the log being unforgeable. The log is
+documentary evidence of intent and operation, evaluated as such.
+
+If the log directory is missing at startup, doiget creates it (`mkdir -p`, `0700`
+on POSIX) and writes a `session_start` row.
+
+## 6. Rotation and retention
+
+- A log file rotates when its size exceeds **100 MB**: it is gzip-compressed and renamed
+  to `access.log.<YYYY-MM-DD-HHMMSS>.gz`. A new `access.log` opens.
+- The new file's first row uses `prev_hash = "GENESIS"` (chain restart).
+- Files older than **90 days** (default) are auto-deleted at startup. Configurable via
+  `DOIGET_LOG_RETENTION_DAYS=N`. `N=0` disables auto-deletion.
+
+## 7. Audit tool
+
+```sh
+doiget audit-log --verify
+doiget audit-log --since 2026-01-01
+doiget audit-log --source elsevier
+doiget audit-log --session 01JCKZ7Q...
+```
+
+`--verify` recomputes the hash chain and reports any mismatches.
+
+## 8. Tamper resistance
+
+doiget makes a best-effort attempt to set the log file append-only on Linux:
+
+- `chattr +a access.log` (ignored if not root or unsupported).
+- On macOS / Windows: no equivalent generally available; rely on hash chain detection.
+- A determined local attacker with write access to `~/.config/doiget/` can still rewrite
+  history. The hash chain ensures rewrites are detectable, not impossible.
+
+## 9. Privacy
+
+- The log is **local only**. doiget does not transmit log contents anywhere.
+- The log contains DOIs/arXiv ids the user has fetched. Users who consider that
+  sensitive should use file-system encryption (e.g., per-user disk encryption) at the OS
+  level.
+- API keys are NEVER logged in any field. The capability resolution log row records
+  which env var name granted access (e.g., `agree_env_var: "DOIGET_AGREE_TDM_ELSEVIER"`)
+  but never the key value.

--- a/site/content/developer/public-api.md
+++ b/site/content/developer/public-api.md
@@ -1,0 +1,281 @@
++++
+title = "Public API"
+description = "`doiget-cli` and `doiget-mcp` are not bound by this guarantee — they are end-user"
+weight = 160
++++
+
+# Public API (`doiget-core`)
+
+> **Status: NORMATIVE.** This is the semver-locked Rust API surface of the `doiget-core`
+> crate. Breaking changes to any item here require a major version bump and an ADR.
+> Adding new items is a minor bump.
+
+`doiget-cli` and `doiget-mcp` are not bound by this guarantee — they are end-user
+binaries / servers and may evolve more freely.
+
+## 1. Re-exports (top of `lib.rs`)
+
+> **Phase 0 note:** the module paths shown below (`crate::ref_`,
+> `crate::capability`, `crate::source`, `crate::store`, `crate::error`,
+> `crate::provenance`) describe the **Phase 1+ target layout**. At Phase 0
+> HEAD, `doiget-core` is a single `lib.rs` and the same items are visible
+> directly from the crate root. The semver-locked surface is the public
+> identifier set, not the submodule layout — Phase 1 may split files
+> without a major bump.
+
+```rust
+pub use crate::ref_::{Ref, Doi, ArxivId};
+pub use crate::safekey::Safekey;
+pub use crate::capability::{
+    AlwaysOn, CapabilityProfile, MetadataAccess, RateLimits, TdmGrant,
+};
+pub use crate::source::{Source, FetchContext, FetchResult, FetchError};
+pub use crate::store::{Store, Metadata, EntryInfo, StoreError};
+pub use crate::error::{ErrorCode, DenialContext, DenialReason};
+pub use crate::provenance::{ProvenanceLog, LogEvent, LogError};
+// Slice 4 / ADR-0024 — audit-identity surface:
+pub use crate::canonical::{CanonicalRef, SourceType};
+```
+
+## 2. Trait surface
+
+```rust
+pub trait Source: Send + Sync {
+    fn name(&self) -> &str;
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool;
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError>;
+}
+
+pub trait Store: Send + Sync {
+    fn read(&self, key: &Safekey) -> Result<Option<Metadata>, StoreError>;
+    fn write(
+        &self,
+        key: &Safekey,
+        m: &Metadata,
+        pdf: Option<&Path>,
+    ) -> Result<(), StoreError>;
+    fn list_recent(&self, limit: usize) -> Result<Vec<EntryInfo>, StoreError>;
+    fn search(&self, query: &str, limit: usize) -> Result<Vec<EntryInfo>, StoreError>;
+}
+```
+
+## 3. Core types
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum Ref {
+    Doi(Doi),
+    Arxiv(ArxivId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Doi(pub(crate) String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct ArxivId(pub(crate) String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Safekey(pub(crate) String);
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Metadata {
+    pub schema_version: String,
+    pub title:    String,
+    pub authors:  Vec<String>,
+    pub year:     Option<i32>,
+    pub doi:      Option<Doi>,
+    pub arxiv_id: Option<ArxivId>,
+    pub abstract_: Option<String>,
+    pub venue:    Option<String>,
+    pub publisher: Option<String>,
+    pub issn:     Option<String>,
+    pub isbn:     Option<String>,
+    pub type_:    Option<String>,
+    pub keywords: Vec<String>,
+    pub doiget:   Option<DoigetExtension>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DoigetExtension {
+    pub fetched_at: chrono::DateTime<chrono::Utc>,
+    pub source:     String,
+    pub license:    String,
+    pub size_bytes: u64,
+    pub mcp_call_id: Option<String>,
+}
+```
+
+## 4. Constructors and validation
+
+```rust
+impl Doi {
+    pub fn parse(s: &str) -> Result<Self, RefParseError>;
+    pub fn as_str(&self) -> &str;
+}
+
+impl ArxivId {
+    pub fn parse(s: &str) -> Result<Self, RefParseError>;
+    pub fn as_str(&self) -> &str;
+}
+
+impl Ref {
+    pub fn parse(s: &str) -> Result<Self, RefParseError>;
+    pub fn safekey(&self) -> Safekey;
+}
+```
+
+`parse` returns a [`RefParseError`] variant naming the specific rejection
+category (`Empty`, `MissingDoiPrefix`, `MissingDoiSuffixSeparator`,
+`InvalidDoiRegistrant`, `EmptyDoiSuffix`, `DoiSuffixTooLong { len, max }`,
+`InvalidDoiSuffixChar { ch }`, `InvalidArxivShape`). The granular shape is
+preserved for tests and future log breadcrumbs; at the public MCP / CLI
+boundary, all variants funnel to [`ErrorCode::InvalidRef`] via the
+`impl From<RefParseError> for ErrorCode` blanket conversion, so `?`
+propagation collapses to `INVALID_REF` automatically.
+
+`RefParseError` is `#[non_exhaustive]`; adding new categories is a
+non-breaking change. Pattern-match with a wildcard arm.
+
+History: prior revisions of this section documented the signature as
+`Result<Self, ErrorCode>` (a Phase 0 placeholder before the parse impls
+landed). PR #55 introduced the dedicated `RefParseError` type; see also
+the [`Unreleased`] entry in [`CHANGELOG.md`](../CHANGELOG.md).
+
+## 5. CapabilityProfile
+
+```rust
+impl CapabilityProfile {
+    pub fn from_env() -> Result<Self, CapabilityError>;
+}
+
+pub enum CapabilityError {
+    AgreedButNoKey { agree_var: String, key_var: String },
+    KeyButNotAgreed { agree_var: String },
+}
+```
+
+See [`CAPABILITY.md`](CAPABILITY.md) for the full type definition and resolution rules.
+
+## 6. Stability guarantees
+
+- A type listed here may gain new fields if they are `#[non_exhaustive]` or behind a
+  `Default` value; this is a minor bump.
+- Removing or renaming any item listed here is a breaking change requiring a major
+  version bump and an ADR.
+- Items not listed here (private types, `pub(crate)`, types under `__internal::`) carry
+  no stability guarantee.
+- During the `0.x` line, breaking changes are allowed at any minor bump but must still
+  be documented in `CHANGELOG.md` and an ADR. Phase 6 freezes this surface as `1.0`.
+
+## 7. MSRV
+
+`doiget-core`'s declared MSRV (`Cargo.toml [workspace.package] rust-version`) is
+**1.86**. Active development tracks `channel = "stable"` in `rust-toolchain.toml`,
+so day-to-day builds use the latest stable toolchain; the CI `msrv` job pins
+explicitly to 1.86 to verify the declared floor still holds.
+
+Raising the declared MSRV is a **minor** version bump and requires a CHANGELOG
+entry. Lowering it requires an ADR (we do not retroactively re-support older
+toolchains without explicit reason). Phase 6 may re-evaluate the policy and
+adopt a stable-channel-tracks-current-stable-minus-N rule at that point.
+
+## 8. Structured denial context (NORMATIVE; ADR-0023)
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenialReason {
+    RedirectNotInAllowlist,
+    InsecureScheme,
+    HostInBlockList,
+    SizeCapExceeded,
+    SchemaDrift,
+    CapabilityNotGranted,
+    RateLimitWindow,
+    SsrfPrivateAddress,
+    ContentTypeMismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DenialContext {
+    pub reason:    DenialReason,
+    pub source:    Option<String>,
+    pub attempted: Option<String>,
+    pub expected:  Option<Vec<String>>,
+    pub hop_index: Option<u8>,
+    pub cap:       Option<u64>,
+    pub actual:    Option<u64>,
+}
+
+impl From<&crate::http::HttpError> for Option<DenialContext> { /* … */ }
+impl From<&crate::source::FetchError> for Option<DenialContext> { /* … */ }
+```
+
+The `DenialReason` enum is **closed**: adding a variant is a minor semver
+bump, renaming or repurposing one is breaking. The `DenialContext` struct is
+**not** `#[non_exhaustive]` because `deny_unknown_fields` already prevents
+forward-compatible field additions on the wire — adding a field is a
+breaking change. See [`ERRORS.md`](ERRORS.md) §3.1, §5.1 for the runtime
+surface and [`MCP_TOOLS.md`](MCP_TOOLS.md) §5 for the JSON envelope.
+
+## 9. Audit-identity: `CanonicalRef` (NORMATIVE; ADR-0021, ADR-0024)
+
+Slice 4 ships the four-tuple audit identity reserved by
+[ADR-0021](DECISIONS/0021-canonical-tuple-identity.md) and implemented per
+[ADR-0024](DECISIONS/0024-canonical-ref-impl.md). The re-exports are listed
+in §1 (`CanonicalRef`, `SourceType`).
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum SourceType {
+    Doi,
+    Arxiv,
+    // future: Pmid, Handle, ...
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub struct CanonicalRef {
+    pub source_type: SourceType,
+    pub source_id: String,
+    pub resolver_profile: String, // e.g. "crossref", "unpaywall", "arxiv", "oa-publisher"
+    pub version: Option<String>,  // e.g. arXiv "v2"; None encodes the empty trailing input
+}
+
+impl CanonicalRef {
+    pub fn new(
+        source_type: SourceType,
+        source_id: impl Into<String>,
+        resolver_profile: impl Into<String>,
+        version: Option<String>,
+    ) -> Self;
+    pub fn digest(&self) -> [u8; 32];
+    pub fn digest_hex(&self) -> String;
+}
+
+impl Ref {
+    /// Promote a `Ref` to a `CanonicalRef` with the given resolver
+    /// profile and optional version (ADR-0021 §1).
+    pub fn promote(&self, resolver_profile: &str, version: Option<&str>) -> CanonicalRef;
+}
+```
+
+The digest algorithm is the NORMATIVE
+`SHA256(source_type | 0x00 | source_id | 0x00 | resolver_profile | 0x00 | version_or_empty)`
+shape — `version_or_empty` is the empty byte sequence when `version` is
+`None`, NOT a sentinel.
+
+The companion provenance-log row schema bump (v1 → v2) is documented in
+[`PROVENANCE_LOG.md`](PROVENANCE_LOG.md) §3 + §3.1. The one-shot
+migration ships as `doiget provenance migrate [--dry-run]`.

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -1,0 +1,242 @@
++++
+title = "Redirect allowlist"
+description = "Defense-in-depth against open-redirect SSRF and against publisher / metadata-source"
+weight = 170
++++
+
+# Redirect allowlist
+
+> **Status: NORMATIVE.** Binding for the doiget HTTP redirect policy. Changes require
+> an ADR.
+
+## 1. Purpose
+
+Defense-in-depth against open-redirect SSRF and against publisher / metadata-source
+responses being abused to misroute a fetch to an attacker-controlled host. Even though
+[`SECURITY.md`](SECURITY.md) §1.3 already restricts redirects to `https://` and bounds
+the redirect chain to ten hops, those mitigations alone do not stop a redirect to an
+arbitrary attacker-owned HTTPS host. The redirect allowlist closes that gap by
+constraining each source's redirect targets to a small, source-specific set of hosts
+that the source legitimately uses.
+
+The allowlist is consulted on **every** redirect hop, not only the final location, and
+on the OA URL discovered through metadata sources before the actual PDF fetch is issued
+(see [`SECURITY.md`](SECURITY.md) §1.4 entry on Crossref re-validation).
+
+## 2. Format
+
+The allowlist is a structured table keyed by `source` (the same `source` key used in
+[`SOURCES.md`](SOURCES.md) §1).
+
+### 2.1 Required fields per source
+
+| Field | Type | Description |
+|---|---|---|
+| `source` | string | Source key. MUST match a `source` value in [`SOURCES.md`](SOURCES.md) §1 (e.g. `crossref`, `unpaywall`, `arxiv`). |
+| `redirect_hosts` | array of strings | Allowed redirect target host patterns. Each entry is either an exact FQDN or a wildcard suffix pattern as defined in §2.2. |
+
+### 2.2 Host matching rule (NORMATIVE)
+
+Each entry in `redirect_hosts` matches a candidate redirect target host as follows.
+
+1. The candidate host is the lowercased hostname of the redirect target URL — i.e.
+   the value of `Url::host_str()` after parse, lowercased. Port, path, query, and
+   fragment are ignored. Userinfo is rejected unconditionally.
+2. **Exact-FQDN form**: an entry without a leading `*.` matches only when the
+   candidate host is byte-identical to the entry, after lowercasing.
+3. **Suffix-glob form**: an entry of the form `*.<suffix>` matches when the candidate
+   host either equals `<suffix>` exactly **or** ends with `.<suffix>`. This means
+   `*.example.com` matches both `example.com` and `cdn.example.com`, but does **not**
+   match `notexample.com`.
+4. The matching rule is byte-level on the lowercased ASCII form of the host. IDN
+   hosts MUST be Punycoded before comparison; raw Unicode in `redirect_hosts` is a
+   spec violation and rejected at config-load time.
+5. A redirect is permitted if and only if at least one entry in the source's
+   `redirect_hosts` matches. No global fallback; an empty or missing
+   `redirect_hosts` for a source means "no redirects permitted from this source".
+
+### 2.3 Reference encoding
+
+The allowlist data is stored as a single TOML document at
+`crates/doiget-core/src/sources/redirect_allowlist.toml`, embedded into the binary via
+`include_str!` and parsed once at process start. The Phase 1 implementation is
+expected to consume that file. Schema:
+
+```toml
+# Reference TOML form. The file declares one [[source]] entry per integrated source.
+[[source]]
+source = "crossref"
+redirect_hosts = [
+  "api.crossref.org",
+  "*.crossref.org",
+]
+
+[[source]]
+source = "unpaywall"
+redirect_hosts = [
+  "api.unpaywall.org",
+]
+# ...
+```
+
+The exact list of entries is given in §3.
+
+## 3. Phase 1 entries
+
+> **Informed-best-effort.** The hosts below are the canonical hosts each Tier 1
+> source advertises in its public API documentation as of this document's authoring.
+> They are NOT a substitute for empirical validation. The Phase 1 implementation MUST
+> validate this list by replaying real fetches against representative DOIs / arXiv
+> ids and adjusting the allowlist before merging the Phase 1 fetcher to `main`. Any
+> entry below marked `(unverified)` MUST be either confirmed by a real fetch or
+> removed.
+
+The Tier 1 sources are taken from [`SOURCES.md`](SOURCES.md) §1: Crossref, Unpaywall,
+arXiv. Tier 2 / Tier 3 sources are out of scope for Phase 1; see §4.
+
+### 3.1 `crossref`
+
+| Field | Value |
+|---|---|
+| `source` | `crossref` |
+| `redirect_hosts` | `api.crossref.org`, `*.crossref.org` |
+
+Notes:
+
+- `api.crossref.org` is the documented endpoint host.
+- `*.crossref.org` covers any internal Crossref subdomain redirects (e.g. legacy or
+  CDN-fronted variants).
+- Crossref's `link` array can contain publisher-side OA URLs whose host is NOT under
+  `crossref.org`. Those URLs are NOT followed under the `crossref` source's
+  allowlist; they are instead handed to the publisher-side fetch path, which is
+  governed by the allowlist of the source that owns that publisher (Phase 2+
+  responsibility — see §4).
+
+### 3.2 `unpaywall`
+
+| Field | Value |
+|---|---|
+| `source` | `unpaywall` |
+| `redirect_hosts` | `api.unpaywall.org` |
+
+Notes:
+
+- `api.unpaywall.org` is the documented endpoint host.
+- Unpaywall's response describes an OA URL hosted on a third-party server (publisher,
+  preprint server, institutional repository). Redirects encountered while fetching
+  that OA URL are NOT subject to the `unpaywall` allowlist; they are subject to the
+  allowlist of the source that owns the publisher host. In Phase 1 the only Tier 1
+  publisher-host source is `arxiv`; OA URLs that resolve to non-allowlisted hosts
+  abort the fetch.
+
+### 3.3 `arxiv`
+
+| Field | Value |
+|---|---|
+| `source` | `arxiv` |
+| `redirect_hosts` | `arxiv.org`, `export.arxiv.org`, `*.arxiv.org` |
+
+Notes:
+
+- `arxiv.org` and `export.arxiv.org` are the documented endpoint hosts (HTML / API
+  vs. metadata export).
+- `*.arxiv.org` covers redirects to subdomains arXiv may use for PDF delivery
+  (`(unverified)` — Phase 1 implementation MUST confirm whether arXiv actually
+  redirects PDF requests to a subdomain, and either keep or drop this entry based on
+  observation).
+- arXiv MAY in some configurations redirect to a CDN host outside `arxiv.org`. If
+  the Phase 1 fetcher observes such a redirect, the response is to add the
+  CDN's host suffix here via ADR — NOT to silently widen the allowlist at runtime.
+
+### 3.4 `oa-publisher`
+
+| Field | Value |
+|---|---|
+| `source` | `oa-publisher` (synthetic — see notes) |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `arxiv.org`, `*.arxiv.org` |
+
+Notes:
+
+- **Synthetic source key.** Unlike the other §3 entries, `oa-publisher` is not
+  one of the integrated metadata sources in [`SOURCES.md`](SOURCES.md) §1. It is
+  the source key the Phase 1 orchestrator uses when fetching the PDF that
+  Unpaywall's `best_oa_location.url_for_pdf` (or `best_oa_location.url`)
+  resolves to — i.e. the URL Unpaywall hands back, which lives on a publisher /
+  preprint / repository host, not on `api.unpaywall.org`. The redirect-policy
+  closure is the same per-source one used everywhere else; the orchestrator
+  registers an `HttpClient` with this allowlist and calls
+  `HttpClient::fetch_pdf("oa-publisher", url)`.
+- **Informed-best-effort.** Per §3 above, every entry below is the documented
+  OA host for the named publisher / repository as of the implementation
+  authoring; they have NOT all been validated against real fetch traces. Each
+  entry below is `(unverified)` for Phase 1 and MUST be either confirmed or
+  removed before Phase 1 closes.
+- **Partial-success semantics.** When the OA URL host is NOT on this list, the
+  redirect is denied at the closure boundary (`HttpError::RedirectDenied`) and
+  the orchestrator falls back to metadata-only success — the metadata is still
+  useful. The PDF outcome is logged as a distinct `Fetch` provenance row with
+  `source = "oa-publisher"` and `result = err` /
+  `error_code = "NETWORK_ERROR"`.
+- **Host families** (each `(unverified)`):
+  - Springer Nature OA imprints: `*.springer.com`, `*.springeropen.com`,
+    `*.springernature.com`, `*.nature.com`.
+  - Wiley OA: `*.wiley.com`.
+  - Elsevier OA route only: `*.elsevier.com`, `*.sciencedirect.com`. The TDM
+    gated path is a separate Tier 3 source (`elsevier-tdm`, Phase 5c).
+  - Frontiers: `*.frontiersin.org`.
+  - MDPI: `*.mdpi.com`.
+  - PLOS: `*.plos.org`.
+  - Preprint servers: `*.biorxiv.org`, `*.medrxiv.org`.
+  - Europe PMC + NIH PMC: `europepmc.org`, `*.europepmc.org`, `*.nih.gov`,
+    `*.ncbi.nlm.nih.gov`.
+  - arXiv: `arxiv.org`, `*.arxiv.org` (mirrors §3.3 because the Unpaywall
+    flow re-derives an arXiv URL through the `oa-publisher` source key, not
+    the tier-1 `arxiv` key).
+- Additions or removals follow the §5 update process.
+
+## 4. Phase 2 / Phase 3 entries
+
+| Source | Tier | Phase | Status |
+|---|---|---|---|
+| `openalex` | 2 | 4 | (reserved) |
+| `semantic-scholar` | 2 | 4 | (reserved) |
+| `doaj` | 2 | 4 | (reserved) |
+| `springer-tdm` | 3 | 5a | (reserved) |
+| `aps-tdm` | 3 | 5b | (reserved) |
+| `elsevier-tdm` | 3 | 5c | (reserved) |
+
+Each `(reserved)` entry will be filled in when its owning Phase begins, via the
+update process in §5. Until then, attempts to use these sources are blocked by their
+Cargo feature gate ([`SOURCES.md`](SOURCES.md) §3) and never reach the redirect
+policy.
+
+## 5. Update process
+
+Changes to this allowlist are user-impacting: a fetch that previously worked may
+stop working (a redirect target host is removed) or a fetch that previously failed
+may start working (a host is added). Both directions are subject to the same
+process:
+
+1. **ADR.** Add or update a `docs/DECISIONS/NNNN-redirect-allowlist-<source>.md` ADR
+   that names the source, lists the host(s) added or removed, and explains why
+   (e.g., "observed in real fetch traces", "publisher migrated CDN").
+2. **CHANGELOG.** Add an entry under `[Unreleased] -> Changed` (or `Added` / `Removed`
+   as appropriate) in [`CHANGELOG.md`](../CHANGELOG.md) referencing the ADR.
+3. **Reference file.** Update the TOML reference file described in §2.3.
+4. **Tests.** Update or add a test in `crates/doiget-core/tests/` that asserts the
+   new entry matches / does not match the relevant host strings, including the
+   suffix-glob negative case (`notexample.com` MUST NOT match `*.example.com`).
+
+The Phase 1 implementation MAY treat the very first population of the §3 entries as
+in-scope of the Phase 1 ADR series rather than minting a separate allowlist ADR per
+source. Subsequent changes always require a dedicated ADR.
+
+## 6. Non-goals
+
+- This document does NOT govern the initial fetch URL; that is constructed from
+  validated identifiers via source-side URL templates and is bounded by the
+  `https://`-only redirect policy in [`SECURITY.md`](SECURITY.md) §1.3.
+- This document does NOT define rate-limiting, retry behavior, or politeness; see
+  [`SOURCES.md`](SOURCES.md) §6.
+- This document does NOT govern outbound DNS, proxying, or anonymization; see
+  [`SECURITY.md`](SECURITY.md) §1.10.

--- a/site/content/developer/safekey.md
+++ b/site/content/developer/safekey.md
@@ -1,0 +1,187 @@
++++
+title = "Safekey algorithm"
+description = "Map any DOI or arXiv id to a deterministic, cross-platform, bit-identical filesystem-safe"
+weight = 180
++++
+
+# safekey algorithm
+
+> **Status: NORMATIVE (shared spec).** Binding for both doiget and BiblioFetch.jl.
+> Any change requires a coordinated ADR and an update to the reference test vectors at
+> `tests/fixtures/safekey/vectors.json`.
+
+## 1. Goal
+
+Map any DOI or arXiv id to a deterministic, cross-platform, bit-identical filesystem-safe
+key. The same input must produce the same `safekey` output on Linux, macOS, and Windows,
+and across both Rust and Julia implementations.
+
+## 2. Constraints
+
+- Path-safe: no `/`, `\`, `..`, `:`, control chars, or other characters problematic on any
+  major filesystem.
+- Bounded length: ≤ 200 characters (filesystem limits).
+- Collision-resistant: two distinct refs must produce two distinct safekeys with high
+  probability (cryptographic, not just statistical).
+- Visually traceable: a human reading a safekey should be able to recognize the original
+  ref class (DOI vs arXiv) and significant prefix.
+- Deterministic: no clock, no random, no host-dependent state.
+
+## 3. Algorithm (NORMATIVE)
+
+```rust
+pub fn safekey(ref_: &Ref) -> Safekey {
+    // Step 0: normalize. `Doi::as_str()` and `ArxivId::as_str()` return the
+    // identifier WITHOUT a `doi:` / `arxiv:` URI scheme prefix — `Ref::parse`
+    // is responsible for stripping those at construction time. The vectors
+    // in §5 ("doi:..." / "arxiv:..." in the input column) document the
+    // user-facing input form; by the time we reach `safekey`, the scheme
+    // has already been removed. The single `doi_` / `arxiv_` prefix is
+    // added here, exactly once, in step 0.
+    let raw = match ref_ {
+        Ref::Doi(d)   => format!("doi_{}",   d.as_str()),
+        Ref::Arxiv(a) => format!("arxiv_{}", a.as_str()),
+    };
+
+    // Step 1: replace unsafe chars with '_'
+    let escaped: String = raw.chars().map(|c| match c {
+        'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '-' | '_' => c,
+        _ => '_',
+    }).collect();
+
+    // Step 2: collapse consecutive '_' runs to a single '_'
+    let collapsed = collapse_underscores(&escaped);
+
+    // Step 3: trim leading/trailing '_'
+    let trimmed = collapsed.trim_matches('_');
+
+    // Step 4: length-bound. If > 192 chars, take prefix(192) + '_' + 8-hex SHA256
+    if trimmed.len() > 192 {
+        let hash = hex::encode(&sha2::Sha256::digest(raw.as_bytes())[..4]);
+        format!("{}_{}", &trimmed[..192], hash)
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn collapse_underscores(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_was_underscore = false;
+    for c in s.chars() {
+        if c == '_' {
+            if !last_was_underscore { out.push('_'); }
+            last_was_underscore = true;
+        } else {
+            out.push(c);
+            last_was_underscore = false;
+        }
+    }
+    out
+}
+```
+
+## 4. Equivalent Julia reference
+
+```julia
+const SAFE_CHAR_RE = r"[A-Za-z0-9._\-]"
+
+function safekey(ref::AbstractString)::String
+    raw = startswith(ref, "10.") ? "doi_$ref" : "arxiv_$ref"
+    escaped = replace(raw, r"[^A-Za-z0-9._\-]" => "_")
+    collapsed = replace(escaped, r"_+" => "_")
+    trimmed = strip(collapsed, '_')
+    if length(trimmed) > 192
+        h = bytes2hex(SHA.sha256(codeunits(raw))[1:4])
+        return string(trimmed[1:192], "_", h)
+    end
+    return String(trimmed)
+end
+```
+
+The two implementations MUST produce bit-identical output for every entry in the
+reference vector set.
+
+### 3.1 Filename derivation inputs (NORMATIVE)
+
+The safekey is derived **solely from the canonical `Ref` string** (a validated
+DOI or arXiv id, both already path-traversal-checked at parse time). doiget
+MUST NOT use any of the following as filename input:
+
+- HTTP `Content-Disposition` header (`filename=...` or `filename*=...`).
+- Redirect URL path or any URL component returned by the network.
+- Server-suggested filename (any header carrying a string the publisher
+  proposes as a download name).
+- Any byte stream from the network.
+
+This guarantees that an attacker controlling a redirect target or a response
+header cannot influence the on-disk path. The derivation is a pure function
+of `Ref`, computed before the first network byte is sent.
+
+This rule is the spec-side counterpart to the audit-trail
+`canonical_digest` introduced by [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md):
+the on-disk identity stays keyed on `Ref` (so BiblioFetch.jl round-trip
+keeps working — see §7), while the *audit* identity gains the resolver
+profile.
+
+## 5. Reference test vectors (sample)
+
+Full set: `tests/fixtures/safekey/vectors.json` (100 entries, NORMATIVE).
+
+Selected:
+
+| Input ref | safekey output |
+|---|---|
+| `doi:10.1234/example` | `doi_10.1234_example` |
+| `doi:10.1103/PhysRevLett.130.200601` | `doi_10.1103_PhysRevLett.130.200601` |
+| `doi:10.1016/S0370-1573(98)00122-3` | `doi_10.1016_S0370-1573_98_00122-3` |
+| `doi:10.1234/foo bar` | `doi_10.1234_foo_bar` |
+| `doi:10.1234/foo  bar` | `doi_10.1234_foo_bar` (consecutive `_` collapsed) |
+| `doi:10.1234/_leading` | `doi_10.1234_leading` (trim leading `_`) |
+| `arxiv:2401.12345` | `arxiv_2401.12345` |
+| `arxiv:2401.12345v2` | `arxiv_2401.12345v2` |
+| `arxiv:cond-mat/9501001` | `arxiv_cond-mat_9501001` |
+
+For very long refs (e.g. 250-char DOI suffix from a malformed source), the safekey is
+truncated at 192 chars and an 8-hex SHA-256 prefix of the original is appended:
+
+```
+doi:10.1234/aaaaa...aaaaa(220 chars)  →  doi_10.1234_aaaaa...aaaaa(192 chars)_DEADBEEF
+```
+
+## 6. Property tests
+
+```rust
+proptest! {
+    #[test]
+    fn safekey_is_path_safe(ref_ in arb_ref()) {
+        let key = safekey(&ref_);
+        prop_assert!(!key.contains(".."));
+        prop_assert!(!key.contains('/'));
+        prop_assert!(!key.contains('\\'));
+        prop_assert!(key.chars().all(|c|
+            c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'
+        ));
+        prop_assert!(!key.starts_with('_'));
+        prop_assert!(!key.ends_with('_'));
+        prop_assert!(key.len() <= 201);    // 192 + '_' + 8
+    }
+
+    #[test]
+    fn safekey_is_deterministic(ref_ in arb_ref()) {
+        prop_assert_eq!(safekey(&ref_), safekey(&ref_));
+    }
+
+    #[test]
+    fn safekey_distinct_refs_distinct_keys(r1 in arb_ref(), r2 in arb_ref()) {
+        prop_assume!(r1.canonical() != r2.canonical());
+        prop_assert_ne!(safekey(&r1), safekey(&r2));
+    }
+}
+```
+
+## 7. Backwards compatibility note
+
+Older BiblioFetch.jl versions used a slightly different algorithm (the H2 issue). When
+this NORMATIVE spec is adopted, BiblioFetch.jl will publish a migration tool that
+re-keys existing entries to the new spec. doiget will only ever read or write entries
+produced by the spec defined in this document.

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -1,0 +1,187 @@
++++
+title = "Security"
+description = "For vulnerability reporting, see [`../CONTACT.md`](../CONTACT.md). **Do not file a public"
+weight = 190
++++
+
+# Security
+
+> **Status: NORMATIVE.** This document defines binding security contracts and threat
+> surfaces. Implementations and reviewers MUST address each surface before introducing
+> code in the affected area. Changes require a new ADR in [`DECISIONS/`](DECISIONS/).
+
+For vulnerability reporting, see [`../CONTACT.md`](../CONTACT.md). **Do not file a public
+issue for security disclosures.**
+
+---
+
+## 1. Threat surfaces
+
+### 1.1 Input — DOI / arXiv id strings
+
+Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
+
+| Vector | Mitigation |
+|---|---|
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). |
+| Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
+| Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
+| Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |
+
+### 1.2 HTTP responses
+
+Source: publisher / source API. Trust level: **partially trusted** (TLS-authenticated host, content-typed payload).
+
+| Vector | Mitigation |
+|---|---|
+| Oversized PDF | Streaming download with body cap (`PDF_MAX_BYTES = 100_000_000`); writes to a temp file, validated then renamed. |
+| Malformed JSON | `serde_json` strict mode; deserialization errors map to `STORE_ERROR` or `NETWORK_ERROR`. |
+| Magic-byte mismatch | PDFs are checked for `%PDF-` header. Files failing this are deleted and the fetch errors. |
+| Slowloris-style stalled response | `reqwest` per-request timeouts (`connect 10s`, `read 60s`, total `300s`). |
+
+### 1.3 HTTP redirects
+
+| Vector | Mitigation |
+|---|---|
+| Redirect to `file://`, `data:`, internal | reqwest is configured with redirect policy `RedirectPolicy::custom`: only `https://` redirects allowed. |
+| Redirect to attacker host | Per-source allowlist of redirect target hosts; redirects outside the allowlist abort the fetch. See [`REDIRECT_ALLOWLIST.md`](REDIRECT_ALLOWLIST.md). |
+| Redirect loop | `redirect_limit = 10`. |
+| Open-redirect SSRF chain | Tool inputs never accept URLs (only DOI / arXiv id). All URLs are constructed from validated source-side templates. |
+
+### 1.4 MCP server inputs
+
+Source: MCP host (LLM agent loop). Trust level: **untrusted** — even when the host is a
+trusted application, the agent may relay attacker-controlled paper text or hallucinated
+identifiers.
+
+| Vector | Mitigation |
+|---|---|
+| Hallucinated DOI | `INVALID_REF` returned; never crashes the server. |
+| Prompt injection from paper abstract | doiget never reads paper content; tool inputs are typed, not free text. |
+| `fetch_url(url: ...)` style abuse | Permanent non-goal. No tool accepts a URL. |
+| Crafted long ref to overflow log | `DOI_SUFFIX_MAX_LEN = 256` truncate-or-reject before log. |
+| Per-session fetch flood | `MAX_CONCURRENT_FETCHES = 5` (process-wide), `MCP_BATCH_MAX_SIZE = 100`, queue depth `MCP_QUEUE_DEPTH_MAX = 100` returns `RATE_LIMITED`. |
+| Crafted Crossref response that misroutes a fetch | All fetch URLs are constructed from validated identifiers; we trust the source's TLS-authenticated response only for OA URL discovery, then re-validate the resulting URL against the per-source allowlist. |
+
+### 1.5 Filesystem (Store, Cache, Log)
+
+| Vector | Mitigation |
+|---|---|
+| Path traversal in safekey | `safekey` algorithm replaces every character outside `[A-Za-z0-9._\-_]` with `_`. Reference test vectors in [`SAFEKEY.md`](SAFEKEY.md). |
+| Concurrent writers (BiblioFetch.jl + doiget) | `flock` on `<safekey>.toml.lock`, 5s timeout. ([`STORE.md`](STORE.md) §Contract 2) |
+| Partial write on crash | Write to `<safekey>.toml.tmp` → `fsync` → `rename` → `fsync` parent. ([`STORE.md`](STORE.md) §Contract 3) |
+| Log file tampering | SHA-256 hash chain; `chattr +a` attempted on Linux; `doiget audit-log --verify` recomputes the chain. |
+| Disk-full DoS via large PDFs | Per-fetch size cap; on disk-full the fetch errors and the partial temp file is cleaned up. |
+| Credential file readable to other users | Startup warns if `credentials.toml` permissions are not `0600` on POSIX. |
+
+### 1.6 Secrets / credentials
+
+| Vector | Mitigation |
+|---|---|
+| Bundled API key in binary | Banned by code review; CI greps source for known publisher key formats. No constant string in source matching `sk-`, `Bearer `, etc. |
+| Logged in raw form | All credential types are `secrecy::Secret<String>`; `Display` and `Debug` print `****`; `tracing` uses a redactor for known field names. |
+| Leaked via error message | Errors avoid printing source URLs that contain query-param keys (e.g., `?apikey=...`). |
+| Persisted in shell history | Recommend `~/.config/doiget/credentials.toml` over inline env in shell rc; documented in [`CONFIG.md`](CONFIG.md). |
+
+### 1.7 PDF content (after fetch)
+
+doiget does **not** parse PDF content (ADR-0003). Malicious PDFs (embedded JS, exploits)
+are stored as opaque blobs; their handling is the responsibility of any downstream tool
+the user pipes the path into.
+
+This is a deliberate design choice. doiget does not implement countermeasures for
+malicious PDFs because doiget does not interact with their content.
+
+### 1.8 Concurrent processes (multiple `doiget` invocations)
+
+| Vector | Mitigation |
+|---|---|
+| Race on store write | `flock` (see 1.5). |
+| Log write interleaving | Process-local mutex on log appender; fsync per write in audit-grade mode. |
+| Cache race | `~/.cache/doiget/` writes go through atomic rename. |
+
+### 1.9 Supply chain
+
+| Vector | Mitigation |
+|---|---|
+| Malicious dependency update | `cargo-vet` audit chain; `cargo-deny` allowlist; pinned `Cargo.lock`. |
+| Hijacked author GitHub account | 2FA required; verified-signed commits enforced on `main`; release workflow gated by GitHub Environment with manual approval. |
+| Malicious release artifact swap | Sigstore keyless signing of release binaries; verifiable with `cosign verify-blob`. |
+| `cargo publish` token leak | Use crates.io trusted publishing (OIDC) — no long-lived token in repo. |
+| 3rd-party Action injection | All Actions pinned by SHA, not floating tag; Dependabot updates SHAs. |
+| Reproducible builds | `Cargo.lock` committed; `rust-toolchain.toml` pins rustc; `RUSTFLAGS` fixed in release.yml. |
+
+### 1.10 Network side channel
+
+doiget cannot prevent third parties (ISP, institution DNS resolver, transit network) from
+observing **the existence** of fetches, even with correctly configured TLS:
+
+- DNS lookups for `api.elsevier.com`, `unpaywall.org`, etc., are visible to the resolver.
+- TLS SNI is plaintext on networks that do not implement Encrypted ClientHello.
+
+doiget honors the user's `HTTPS_PROXY` environment variable; users who require
+unobservability should configure their network layer (Tor, VPN) externally. doiget does
+not provide its own proxying or anonymization.
+
+doiget sends a stable `User-Agent` header per fetch to comply with each source's
+politeness policy:
+
+```
+User-Agent: doiget/<version> (+https://github.com/sotashimozono/doiget)
+```
+
+### 1.11 Auto-update / telemetry
+
+doiget contains no auto-update path, no version check, no crash report transmission, and
+no usage analytics. (ADR-0015) These are denied at the dependency level via `cargo-deny`
+to prevent inadvertent introduction.
+
+## 2. Defense-in-depth controls (Phase 0)
+
+Phase 0 must establish:
+
+- [`Cargo.lock`](../Cargo.lock) committed.
+- `cargo audit` and `cargo deny check` in CI (`audit.yml`).
+- `cargo-vet` baseline.
+- `posture-lint.yml` denying telemetry / HTTP server / self-update crate imports.
+- `safekey-vectors.yml` validating 100 reference vectors against the algorithm.
+- `cross-tool-compat.yml` round-tripping a sample DOI through BiblioFetch.jl + doiget.
+- Branch protection on `main`: required PR review, status checks must pass, signed
+  commits.
+- Author 2FA mandatory.
+
+## 3. Phase 3 (MCP) additional controls
+
+- `clippy::print_stdout` denied workspace-wide (and especially in `doiget-mcp`).
+- `tracing-subscriber` global writer redirected to stderr; `std::panic::set_hook`
+  redirects panic output to stderr.
+- `mcp-smoke.yml` asserts that `doiget serve | head -c 1` over its stdin/stdout produces
+  only well-formed JSON-RPC frames after `initialize` (zero stray bytes on stdout).
+- All tool inputs validated with `serde` strict mode and explicit JSON Schema declared in
+  `inputSchema`.
+
+## 4. Phase 6 (release) additional controls
+
+- crates.io trusted publishing (OIDC).
+- GitHub Environment-protected release workflow (manual approval).
+- Sigstore keyless signing of binaries.
+- `cargo-sbom` SPDX SBOM per release artifact.
+- musl-static (Linux), universal (macOS), msvc (Windows). No glibc, gnu, or openssl
+  variants.
+
+## 5. Vulnerability disclosure
+
+See [`../CONTACT.md`](../CONTACT.md) §"Security disclosures". Do not file a public issue.
+
+## 6. Limitations (transparently acknowledged)
+
+doiget cannot defend against:
+
+- A user who deliberately misconfigures their environment to violate a publisher ToS.
+- A network adversary who can rewrite TLS connections (CA compromise).
+- An OS-level adversary with root / Administrator on the user's machine.
+- A compromise of an upstream publisher API responding with malicious URLs that resolve
+  to a host inside the per-source allowlist.
+
+These are out of scope for doiget's threat model and are noted here to set realistic
+expectations.

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -1,0 +1,121 @@
++++
+title = "Sources matrix"
+description = "| Source | Tier | Phase | Auth | ToS link | doiget feature |"
+weight = 200
++++
+
+# Sources
+
+> **Status: NORMATIVE (user responsibility advisory).** This document lists every source
+> doiget integrates with, the access prerequisites, and a pointer to each source's
+> official Terms of Service. **Users are responsible for ensuring they have the right
+> to access content via these sources and for compliance with each source's ToS.**
+
+---
+
+## 1. Source matrix
+
+| Source | Tier | Phase | Auth | ToS link | doiget feature |
+|---|---|---|---|---|---|
+| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/services/metadata-retrieval/rest-api/> | always-on |
+| Unpaywall | 1 (OA) | 1 | email (polite pool) | <https://unpaywall.org/products/api> | always-on |
+| arXiv | 1 (OA) | 1 | none | <https://info.arxiv.org/help/api/index.html> | always-on |
+| OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
+| Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
+| DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
+| APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
+| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+
+## 2. User responsibility
+
+For each source the user invokes, the user is the contracting party. doiget does not
+hold any credential for any user. Before enabling a source, ensure that you:
+
+- Have read and accepted the source's Terms of Service.
+- Hold the institutional or personal access rights the source requires.
+- Comply with the source's politeness policy (rate limit, attribution).
+- Are operating from a network and device authorized to use those rights.
+
+doiget enforces a hard rate cap of **5 fetches per second** per process to make polite
+behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
+
+## 3. Default release binaries
+
+`cargo install doiget` (default) compiles Tier 1 only. Tier 2 metadata sources require
+an opt-in build:
+
+```sh
+cargo install doiget --features metadata
+```
+
+Tier 3 TDM sources are individually feature-flagged and require user-driven build:
+
+```sh
+cargo install doiget --features metadata,tdm-springer
+cargo install doiget --features metadata,tdm-aps
+cargo install doiget --features metadata,tdm-elsevier
+```
+
+There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 16).
+
+## 4. Source-specific notes
+
+### Crossref
+
+- Public, no-auth API. Polite pool requires `User-Agent` with contact email
+  (`[network] user_agent` in `config.toml`).
+- doiget uses Crossref for: DOI → metadata; OA URL where Crossref's `link` array
+  contains a free-to-read entry.
+
+### Unpaywall
+
+- Free, but the polite pool requires `email=alice@example.org` in the URL. Set
+  `[network] unpaywall_email` in `config.toml`.
+- doiget uses Unpaywall for: OA URL discovery for a given DOI, with license metadata.
+
+### arXiv
+
+- Public, no-auth API, but the API has a 3-second-per-request rate guideline. doiget's
+  global 5/sec cap respects this.
+- doiget uses arXiv for: arXiv id → PDF + metadata.
+
+### OpenAlex / Semantic Scholar / DOAJ (Phase 4)
+
+- Metadata enrichment only. doiget will not fetch PDFs from these unless the response
+  includes an OA URL whose host is on the per-source allowlist.
+
+### TDM sources (Phase 5)
+
+Each requires:
+
+1. A Cargo feature compiled in (`tdm-elsevier`, `tdm-aps`, `tdm-springer`).
+2. The user's API key in `DOIGET_KEY_<PUBLISHER>` env or `[tdm.<publisher>] api_key` in
+   credentials.toml.
+3. The agreement env `DOIGET_AGREE_TDM_<PUBLISHER>=1`.
+
+If any of the three is missing, the source is unavailable at runtime
+([`CAPABILITY.md`](CAPABILITY.md) §2).
+
+## 5. Adding a new source
+
+A new source addition requires:
+
+1. A new GitHub Discussion describing the source, its access pattern, and Tier
+   classification.
+2. An ADR locking the Tier and (if Tier 3) the Cargo feature name.
+3. An entry in this document with the official ToS link and prerequisites.
+4. A doc in `INTEGRATION/<source>.md` if user-side configuration is non-trivial.
+5. Update of this matrix.
+
+## 6. Politeness defaults
+
+doiget's defaults are designed to be on the polite side of every source we know of:
+
+- 5 fetches per second, regardless of source.
+- Per-source backoff of 200 ms between consecutive requests.
+- `User-Agent: doiget/<version> (+https://github.com/sotashimozono/doiget)`.
+- Honors `Retry-After` headers (treats 429 as `RATE_LIMITED` with the indicated wait).
+
+If a source publishes a stricter rate guideline, doiget will adopt the stricter value at
+the per-source level rather than relax the global cap.

--- a/site/content/developer/store.md
+++ b/site/content/developer/store.md
@@ -1,0 +1,188 @@
++++
+title = "Store contract"
+description = "```"
+weight = 210
++++
+
+# Store layout
+
+> **Status: NORMATIVE (shared spec).** This document is binding for both doiget and
+> BiblioFetch.jl. Implementations on either side MUST conform. Changes require an ADR
+> coordinated across both projects.
+
+## 1. Layout
+
+```
+~/papers/
+├── <safekey>.pdf                    # PDF blob (immutable after write)
+└── .metadata/
+    ├── <safekey>.toml               # metadata
+    └── <safekey>.toml.lock          # advisory lock file (see §3)
+```
+
+Store root path is configurable per [`CONFIG.md`](CONFIG.md). Default: `~/papers/`.
+The `<safekey>` is computed from the DOI / arXiv id by the algorithm in
+[`SAFEKEY.md`](SAFEKEY.md).
+
+## 2. Schema (TOML)
+
+```toml
+schema_version = "1.0"
+
+# --- Reserved top-level fields (shared with BiblioFetch.jl) ---
+title       = "Example Paper Title"
+authors     = ["Alice Researcher", "Bob Coauthor"]
+year        = 2026
+doi         = "10.1234/example"
+arxiv_id    = "2401.12345"           # optional
+abstract    = "..."                   # optional
+venue       = "Phys. Rev. X"          # optional
+publisher   = "American Physical Society"   # optional
+issn        = "2160-3308"             # optional
+isbn        = ""                      # optional, for books
+type        = "journal-article"       # crossref taxonomy
+keywords    = ["physics", "..."]      # optional
+
+# --- doiget extension table (BiblioFetch.jl ignores these) ---
+[doiget]
+fetched_at  = "2026-05-05T08:30:12Z"  # RFC3339 UTC
+source      = "unpaywall"             # which Source produced this entry
+license     = "CC-BY-4.0"             # OA license string, or "unknown"
+size_bytes  = 1234567
+mcp_call_id = "01JCKZ7Q..."           # optional, ULID, present if fetched via MCP
+```
+
+### Reserved top-level field list
+
+```
+schema_version, title, authors, year, doi, arxiv_id, abstract, venue, keywords,
+type, publisher, issn, isbn, url, pdf_path
+```
+
+Both implementations MUST NOT write top-level fields outside this list. Tool-specific
+fields go in a tool-named table (`[doiget]`, `[bibliofetch]`).
+
+## 3. Schema versioning
+
+`schema_version` is a string of the form `<MAJOR>.<MINOR>`.
+
+- **Minor bump** (`1.0` → `1.1`): backward-compatible additions only (new optional fields,
+  new tables). Implementations on `1.x` are required to read `1.x` files for any
+  `x ≤ self.MINOR`. They MUST treat unknown fields as opaque (not delete, not error).
+- **Major bump** (`1.x` → `2.0`): breaking changes (renamed or removed reserved fields).
+  Implementations not yet on `2.x` MUST refuse to write to `2.x` files (read-only mode,
+  warn).
+
+When an implementation encounters a file with `schema_version` greater than its own, it
+enters **read-only mode** for that file: reads return `Ok(Some(metadata))` after a warn,
+writes return `Err(StoreError::SchemaTooNew { theirs, ours })`.
+
+## 4. Concurrent access (Contract: lock protocol)
+
+Both implementations MUST use file-system advisory locking on the **separate lock file**
+`<safekey>.toml.lock` for the duration of any read-modify-write or write sequence.
+
+- POSIX: `flock(..., LOCK_EX)` (Rust: `fs2::FileExt::lock_exclusive`).
+- Windows: `LockFileEx(..., LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY)`.
+
+Lock acquisition timeout: **5 seconds**. On timeout, return `StoreError::LockTimeout`.
+
+Locks are advisory; a third-party process that ignores the lock can corrupt the store.
+Both doiget and BiblioFetch.jl honor the lock. Anyone integrating a third tool with
+`~/papers/` is expected to follow the same contract.
+
+The lock file itself is created on demand (`O_CREAT | O_RDWR`) and is never deleted
+during normal operation. It may be safely deleted when no process holds it.
+
+## 5. Atomic write (Contract)
+
+Every metadata write MUST follow this sequence:
+
+```text
+1. Open <safekey>.toml.tmp with O_CREAT | O_TRUNC | O_WRONLY (POSIX)
+   or CREATE_ALWAYS, GENERIC_WRITE  (Windows).
+2. Write the full serialized TOML.
+3. fsync(<safekey>.toml.tmp).
+4. rename(<safekey>.toml.tmp, <safekey>.toml).
+5. fsync(parent directory).
+```
+
+On Windows, step 4 is `MoveFileEx(.., MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)`.
+Rust's `std::fs::rename` performs this on Windows.
+
+PDF writes follow the same pattern: write to `<safekey>.pdf.tmp`, fsync, rename, fsync
+parent.
+
+A crash mid-write leaves either:
+
+- The old file intact (if crash before step 4), or
+- The new file fully written and visible (if crash after step 4).
+
+It never leaves a partially-visible new file. The lone `.tmp` artifact may be reaped at
+startup.
+
+## 6. doiget-side write discipline
+
+When doiget writes to a `<safekey>.toml` that already exists (e.g., a re-fetch):
+
+- doiget MUST NOT modify reserved top-level fields written by BiblioFetch.jl. doiget may
+  upgrade a missing field, but never overwrite an existing one.
+- doiget writes only inside the `[doiget]` table for state it owns (`fetched_at`,
+  `source`, `license`, etc.).
+- Exception: `schema_version` may be bumped on a coordinated minor revision.
+
+This rule prevents a user who runs both BiblioFetch.jl and doiget against the same store
+from losing BiblioFetch-authored fields.
+
+## 7. TOML normalization
+
+To make `bib` / `csl` / TOML output diff-stable across implementations:
+
+- Keys at the top level appear in this order: `schema_version` first, then reserved fields
+  alphabetically.
+- Tool tables (`[doiget]`, `[bibliofetch]`) appear after all top-level fields, in
+  alphabetical order of table name. Within a table, keys are alphabetical.
+- String quoting: ASCII-safe single-line strings use `"..."`. Multi-line strings use
+  `"""..."""`.
+- Line endings: LF (`\n`) only. No CR.
+- Trailing newline at end of file.
+
+A reference normalizer is provided by `doiget-core::store::normalize_toml(&Metadata)
+-> String`. CI uses it to detect drift.
+
+## 8. Reading
+
+Both implementations MUST tolerate:
+
+- Unknown top-level fields (warn once, ignore).
+- Unknown tables (ignore silently).
+- Future minor `schema_version` (degrade to read-only with warn).
+- Missing optional fields (`arxiv_id`, `abstract`, `venue`, `[doiget]`, etc.).
+
+Both implementations MUST refuse:
+
+- Missing `schema_version`, `title`, `authors`, or year-equivalent.
+- Future major `schema_version` for write operations.
+
+## 9. Round-trip CI test
+
+A CI workflow (`cross-tool-compat.yml`) exercises this every PR:
+
+```text
+1. Julia: BiblioFetch fetch DOI X            (creates <safekey>.toml + .pdf)
+2. doiget info X                             (reads, asserts metadata matches expected)
+3. doiget bib X | diff - expected_bibtex     (asserts bib output is bit-identical)
+4. doiget fetch DOI Y                        (writes a different entry)
+5. Julia: BiblioFetch info Y                 (reads doiget output, must succeed)
+```
+
+This guarantees real round-trip compatibility, not just spec conformance.
+
+## 10. Migration story
+
+See [`MIGRATION.md`](MIGRATION.md) for end-user migration scenarios:
+
+- A BiblioFetch.jl user trying doiget for the first time.
+- A doiget user installing BiblioFetch.jl alongside.
+- Moving a store between hosts.
+- Recovering from a corrupted lock file.

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -1,0 +1,234 @@
++++
+title = "Legal posture"
+description = "This document is the canonical statement of doiget's legal posture. It exists so that"
+weight = 140
++++
+
+# Legal posture
+
+> **Status: NORMATIVE.** This document defines binding contracts. Implementations and
+> contributors MUST conform. Changes require a new ADR in [`DECISIONS/`](DECISIONS/) and
+> review by the maintainer.
+
+This document is the canonical statement of doiget's legal posture. It exists so that
+users, contributors, publisher legal teams, and future reviewers can locate a single
+authoritative description of what doiget is, what it is not, and the basis on which it
+operates.
+
+---
+
+## 1. Posture (one paragraph)
+
+doiget is a general-purpose automation tool for retrieving academic papers via official
+publisher APIs. It only attempts retrieval through (a) public Open Access sources and
+(b) credentials the user has personally configured for their own institutional or personal
+subscriptions. It does not bypass any access control mechanism, redistribute papers, host
+content, operate as a SaaS, or bundle any publisher API keys. Users are responsible for
+ensuring they have the right to access the content they request and for compliance with
+each source's Terms of Service.
+
+## 2. Own-network-only access (binding constraint)
+
+A core design constraint of doiget — added explicitly to the posture in 2026-05 — is that
+**doiget only retrieves content that is reachable through the running user's own network
+and credentials.** doiget does not proxy, share, or relay access of any kind across user
+boundaries.
+
+This is enforced structurally rather than only by documentation:
+
+- Default released binaries include only Open Access sources (Crossref, Unpaywall, arXiv).
+- Institutional / TDM source code paths are gated by Cargo features (`tdm-elsevier`,
+  `tdm-aps`, `tdm-springer`) and are **not present** in the default published binary; a
+  user wishing to enable them must rebuild from source. See [`SCOPE.md`](SCOPE.md) and
+  ADR-0002.
+- Even when compiled in, TDM sources require both an explicit per-publisher
+  agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
+  user-provided API key. Both must be present, otherwise the source is unavailable at
+  runtime. See [`CAPABILITY.md`](CAPABILITY.md).
+- A hard-coded rate limit (5 concurrent fetches, 5/second) prevents bulk-scraping
+  patterns and cannot be overridden by configuration.
+
+## 3. Tool-neutrality framing
+
+doiget is positioned as a **general-purpose automation tool** in the sense familiar from
+prior cases involving recording devices, format converters, and protocol clients. A
+browser is not held liable for the contents a user fetches with it; a feed reader is not
+held liable for the feeds a user subscribes to.
+
+doiget likewise:
+
+- **Performs no PDF content interpretation, summarization, or republication.**
+  PDFs are stored as opaque blobs; doiget does not extract text, run OCR,
+  generate summaries, or parse citations from PDF content. Bibliographic
+  metadata (title / authors / venue / abstract / keywords) is consumed from
+  publisher APIs and stored in the local TOML metadata for `bib` / `csl` /
+  `search_local` operations — that is bibliographic indexing, distinct from
+  content interpretation. The PDF content boundary is documented as a
+  Permanent Non-Goal in [`SCOPE.md`](SCOPE.md) and ADR-0003.
+- Receives all access credentials from the running user, not from the maintainer.
+- Records every fetch in a local provenance log under user control (best-effort
+  tamper-evident; see [`PROVENANCE_LOG.md`](PROVENANCE_LOG.md) §8).
+- Operates only on the local user's behalf, with no network listening surface.
+
+Tool-neutrality is a framing principle, not a guarantee against any specific legal
+outcome in any specific jurisdiction. See §5 below.
+
+## 4. The user is the contract party
+
+For every source doiget integrates with, the **user** is the party who:
+
+- Holds the API key (where required).
+- Accepts the source's Terms of Service (typically by registering for the API).
+- Bears institutional access rights (e.g., campus subscription).
+- Is identified in API request audit logs by their key, IP, or institutional credential.
+
+doiget the project is not a contracting party with any publisher. doiget the maintainer
+does not hold publisher API keys, does not negotiate publisher contracts, and does not
+operate any service that proxies user requests through a maintainer-controlled endpoint.
+
+## 5. Jurisdictional caveat
+
+The posture above relies on:
+
+- The general principle of tool-neutrality (informed by, but not legally identical to,
+  cases like *Sony Corp. of America v. Universal City Studios, Inc.* (US, 1984)).
+- The structural fact that the user is the contract party with each source.
+- The absence of any access-control circumvention.
+
+These are reasoned, defensible positions. They are **not** specific case-law guarantees in
+any jurisdiction. The doiget maintainer is based in Japan; major publisher entities are
+based variously in the United States, the Netherlands, Germany, and elsewhere.
+Cross-border Internet utilities like doiget are subject to whichever jurisdiction's
+courts a party chooses to invoke. A reasonable, well-grounded takedown request from any
+jurisdiction will be evaluated on its merits per [`../CONTACT.md`](../CONTACT.md).
+
+doiget makes no claim that the posture above will prevail in any specific case in any
+specific jurisdiction. The posture is offered in good faith and is operationally
+defended by the safeguards in §6.
+
+## 6. Safeguards
+
+doiget's posture is defended by two distinct kinds of safeguard. The distinction
+matters: the first kind is a control the codebase or CI pipeline mechanically
+enforces; the second is a policy commitment the maintainer makes and intends to
+honor but which a determined contributor or future maintainer could weaken
+without machine-checkable resistance.
+
+### 6a. Enforced controls (5)
+
+These are mechanically enforced by code, type system, Cargo, or CI. Removing
+them requires changing source files that are gated by branch protection.
+
+1. **No bundled credentials.** No publisher API key is shipped in any doiget
+   binary. Credentials are read at runtime from environment variables or
+   `~/.config/doiget/credentials.toml`, wrapped in `secrecy::Secret`, and never
+   logged in raw form. *Enforced by:* `secrecy::Secret` types in
+   `doiget-core`; `tracing` redactor; CI grep for embedded key patterns.
+
+2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
+   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
+   `DOIGET_KEY_<PUBLISHER>`. Missing or partial configurations fail closed at
+   `CapabilityProfile::from_env`. *Enforced by:* `CapabilityProfile`
+   resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
+
+3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
+   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`). Default builds and crates.io
+   artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
+   `[features]` declarations; `posture-lint.yml` import-pattern grep;
+   ADR-0002.
+
+4. **Runtime CapabilityProfile.** All `Source` implementations require a
+   `&CapabilityProfile` parameter at the type level. A source whose capability
+   is not granted at startup cannot be invoked. *Enforced by:* `Source` trait
+   signature in `doiget-core`; `#[non_exhaustive]` on `CapabilityProfile`;
+   ADR-0005.
+
+5. **Hard-coded rate limit.** `MAX_CONCURRENT_FETCHES = 5` and
+   `MAX_FETCHES_PER_SECOND = 5.0` are library constants. The struct
+   `RateLimits` exposes only `HARD_CODED`; field visibility is `pub(crate)`,
+   so external callers cannot synthesize a `RateLimits` with different
+   values. *Enforced by:* `pub(crate)` field visibility,
+   `#[non_exhaustive]` on `RateLimits`, smoke tests in `lib.rs::tests`.
+
+### 6b. Policy commitments (3)
+
+These are commitments the maintainer makes, but a future contributor could
+violate them without the type system or CI reliably catching it. They are
+real safeguards in the sense that the maintainer intends to keep them and
+will reject contradicting PRs, but they rely on human review.
+
+6. **User responsibility documented.** [`SOURCES.md`](SOURCES.md) lists every
+   source's official ToS link and explicitly states the user's responsibility
+   for compliance. The README front-loads this point in the Posture section.
+   *Mechanism:* documentation; CI does not assert that the wording remains in
+   place over time.
+
+7. **Takedown contact with SLA.** [`../CONTACT.md`](../CONTACT.md) defines an
+   SLA-bound channel (7 days first response, 30 days substantive response)
+   for publisher legal teams or other parties with concerns. *Mechanism:*
+   maintainer commitment; the SLA itself is not machine-asserted.
+
+8. **Marketing-language self-policing.** A CI workflow
+   (`.github/workflows/posture-lint.yml`) scans **`README.md` only** for
+   prohibited terms (`bypass`, `circumvent`, `free papers`, `sci-hub`) and
+   fails any PR that introduces them in the README. *Scope deliberately
+   narrow:* the policy / legal docs (LEGAL, SCOPE, CONTACT, CONTRIBUTING)
+   legitimately need to use these words to describe what doiget does **not**
+   do. README is the front-page marketing surface where positive uses are
+   the actual concern. The other steps in `posture-lint.yml` (forbidden HTTP
+   server / telemetry / TLS-backend imports) scan source code and ARE
+   enforced controls; they belong in §6a above and are listed there
+   indirectly via #3.
+
+### Why the split matters
+
+A reader (publisher legal team, security researcher, future maintainer) who
+reads "safeguards" and assumes mechanical controls will be over-confident if
+items 6–8 are presented identically to 1–5. The wording in §1 (and in
+README's Posture section) intentionally uses neutral language; this section
+spells the distinction out so the picture stays honest.
+
+## 7. Risk planning
+
+doiget does not publish probability estimates of legal action because we lack data to
+ground them. We instead **plan against the worst plausible case**: a single contested
+takedown or formal legal action whose remediation cost remains within the maintainer's
+self-described affordable bound (on the order of ¥1–3 million in the worst plausible
+scenario).
+
+The eight safeguards above are designed to reduce both the probability and the severity
+of such an event without relying on probability assumptions.
+
+## 8. Permanent non-goals (legal-relevant subset)
+
+The full list is in [`SCOPE.md`](SCOPE.md). Items relevant here:
+
+- No SaaS / hosted `doiget.example` service.
+- No MCP HTTP / SSE / WebSocket transport (would shift doiget toward multi-tenant).
+- No paper hosting, redistribution, or "share-vault" feature.
+- No credential sharing between users.
+- No bulk download mode (the rate limit is the hard upper bound).
+- No `tdm-all` umbrella feature flag (each TDM source must be opted in individually).
+
+## 9. Provenance log
+
+Every fetch is recorded locally in `~/.config/doiget/access.log` as a JSON Lines record
+with a SHA-256 hash chain. The log is **fail-closed**: a fetch that cannot be logged is
+not allowed to proceed. See [`PROVENANCE_LOG.md`](PROVENANCE_LOG.md) for the format and
+ADR-0006 for the design rationale.
+
+The log is local-only. doiget does not transmit log data anywhere.
+
+## 10. Telemetry and self-update
+
+doiget contains no telemetry, no phone-home, no version check, no crash report
+transmission, and no self-update mechanism. These are permanent non-goals (ADR-0015) and
+are enforced by `cargo-deny` denials of relevant crates.
+
+## 11. Inquiries
+
+For takedown requests, formal legal correspondence, or security disclosures, see
+[`../CONTACT.md`](../CONTACT.md).
+
+For general questions and discussion, please use
+[GitHub Discussions](https://github.com/sotashimozono/doiget/discussions).

--- a/site/content/use/migration.md
+++ b/site/content/use/migration.md
@@ -1,0 +1,77 @@
++++
+title = "BiblioFetch.jl migration"
+description = "This document will cover migration scenarios between doiget and"
+weight = 130
++++
+
+# Migration
+
+> **Status: INFORMATIVE (placeholder).** Full migration recipes will be filled in during
+> Phase 2 once the round-trip test suite (`cross-tool-compat.yml`) passes. The
+> binding contract underlying these scenarios is in [`STORE.md`](STORE.md).
+
+This document will cover migration scenarios between doiget and
+[BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl), and between
+machines.
+
+## Scenarios (to be expanded)
+
+### 1. BiblioFetch.jl user trying doiget for the first time
+
+```sh
+cargo install doiget
+doiget info <DOI of an existing entry>      # should read what BiblioFetch wrote
+```
+
+Expected outcome: doiget reads the existing TOML metadata and PDF without modification.
+
+### 2. doiget user installing BiblioFetch.jl alongside
+
+Add BiblioFetch.jl to a Julia project and point both tools at the same `~/papers/`.
+BiblioFetch.jl will see doiget's `[doiget]` extension table and ignore it.
+
+### 3. Moving a store between hosts
+
+```sh
+rsync -av ~/papers/ remote:/home/alice/papers/
+```
+
+The store layout is portable. The provenance log is **not** synced — it is per-host.
+
+### 4. Recovering from a corrupted lock file
+
+If a `.toml.lock` file persists after a crash:
+
+```sh
+rm ~/papers/.metadata/<safekey>.toml.lock
+```
+
+doiget will recreate the lock on the next operation. There is no risk of data loss
+because the lock is advisory and the entry's `.toml` itself is written atomically.
+
+### 5. Forward migration on a `schema_version` major bump
+
+A future `schema_version = "2.0"` would require both implementations to ship the new
+version before either writes `2.0` files. doiget will provide:
+
+```sh
+doiget store migrate --to 2.0
+```
+
+at that time. Until then, doiget never writes anything other than `1.x`.
+
+### 6. Removing doiget while keeping the store
+
+The store is just files under `~/papers/`. Uninstalling doiget (`cargo uninstall
+doiget`) does not touch the store. BiblioFetch.jl can continue to read and write it.
+
+## Future content
+
+This file will expand to:
+
+- Step-by-step recipes with expected output.
+- Failure-mode walkthroughs.
+- Cross-platform path handling (Windows ↔ POSIX) notes.
+- Troubleshooting `cross-tool-compat.yml` failures.
+
+Until then, see [`STORE.md`](STORE.md) for the binding spec.

--- a/site/content/use/scope.md
+++ b/site/content/use/scope.md
@@ -1,0 +1,177 @@
++++
+title = "Scope (what doiget does and does not do)"
+description = "A single-binary CLI plus stdio MCP server that:"
+weight = 130
++++
+
+# Scope and Permanent Non-Goals
+
+> **Status: NORMATIVE.** This document defines binding contracts. Implementations MUST
+> conform. Items listed under "Permanent non-goals" cannot be reversed by a PR; see
+> [`../CONTRIBUTING.md`](../CONTRIBUTING.md) §"Scope-reopening meta-rule".
+
+## What doiget is
+
+A single-binary CLI plus stdio MCP server that:
+
+1. Resolves DOI / arXiv id input to authoritative metadata via Crossref / Unpaywall / arXiv
+   (Phase 1).
+2. Fetches PDFs through Open Access sources by default; opens additional metadata sources
+   in Phase 4 and gated TDM sources in Phase 5 only when the user has explicitly opted in
+   at build time and runtime.
+3. Stores fetched papers in a `~/papers/` layout that is bit-compatible with BiblioFetch.jl
+   (see [`STORE.md`](STORE.md)).
+4. Exposes a stdio MCP server with a fixed set of structured tools to agent hosts (see
+   [`MCP_TOOLS.md`](MCP_TOOLS.md)).
+
+That is the totality of doiget's intended scope. All other functionality is either
+explicitly out of scope below or requires a new ADR.
+
+## Two classes of non-goal
+
+doiget's non-goals split into two classes:
+
+- **Permanent non-goals.** Reversing one would weaken the
+  [`LEGAL.md`](LEGAL.md) posture, the [`SECURITY.md`](SECURITY.md) threat
+  model, or the contract-party structure that makes doiget a user-driven
+  local tool. They can be re-evaluated **only** by opening a GitHub
+  Discussion titled `[scope-reopening] <topic>` and obtaining explicit
+  maintainer approval before any code is written. PRs that effectively
+  reverse one will be closed.
+- **Current design choices.** Operational / UX preferences that are
+  *currently* out of scope, but whose reversal does not threaten the posture
+  or threat model. They can be changed by a regular ADR (no
+  scope-reopening Discussion required).
+
+The first class is the disciplined heart of doiget; the second class is here
+so contributors know the maintainer's preferences without needing to ask.
+
+A future ADR may freely move an item from "Current design choices" to
+"Permanent non-goals" — that direction tightens scope and never requires a
+scope-reopening Discussion. Moving the other way (Permanent → Current →
+Removed) requires the full meta-rule.
+
+## Permanent non-goals (14)
+
+### Content / processing
+
+1. **PDF content processing.** doiget does not extract text, perform OCR,
+   summarize, parse citations from PDF text, extract annotations, or read
+   bibliographic data from PDF metadata streams. PDFs are treated as opaque
+   blobs. (ADR-0003; see also [`MCP_TOOLS.md`](MCP_TOOLS.md): `paper_pdf_path`
+   returns only a path.) Bibliographic indexing from publisher API responses
+   (title / authors / venue / abstract for `search_local`) is in scope and
+   distinct from PDF content interpretation; see [`LEGAL.md`](LEGAL.md) §3.
+
+### Distribution / hosting
+
+2. **No SaaS / hosted service.** doiget does not operate `doiget.example`, a
+   hosted MCP endpoint, a public proxy, or any maintainer-controlled service
+   that fetches on behalf of users.
+3. **No paper hosting, redistribution, or "share-vault".** doiget does not
+   redistribute fetched PDFs and does not provide any mechanism for one user
+   to share their `~/papers/` store with another. The `Store` is local-only.
+
+### Network / transport
+
+4. **No MCP HTTP / SSE / WebSocket transport.** doiget supports MCP via stdio
+   only. This is intentional, not a TODO. (ADR-0001.) A multi-tenant
+   network-exposed doiget would shift the user's role from contract party to
+   service consumer, which conflicts with the [`LEGAL.md`](LEGAL.md) posture.
+5. **No `doiget_fetch_url(url: ...)` MCP tool.** Tools accept DOI / arXiv id
+   input only, never arbitrary URLs (SSRF surface; see
+   [`SECURITY.md`](SECURITY.md) §1.4).
+
+### Credential / safety
+
+6. **No bundled API keys.** No publisher API key is shipped in any doiget
+   binary.
+7. **No credential sharing feature.** doiget does not provide a mechanism for
+   sharing API keys, sessions, or institutional access between users.
+8. **No `doiget_set_credentials(...)` MCP tool.** Credentials are read from
+   env or `credentials.toml` only; the MCP surface does not accept credential
+   writes.
+
+### Operational
+
+9.  **No bulk download mode.** Rate limiting
+    (`MAX_CONCURRENT_FETCHES = 5`, `MAX_FETCHES_PER_SECOND = 5.0`) is hard-coded
+    as library constants. There is no flag or config to raise these.
+10. **No telemetry / phone-home / crash reporting / version check.** doiget
+    makes no network connection that is not the result of a user-initiated
+    fetch. (ADR-0015.)
+11. **No self-update / `doiget upgrade`.** doiget does not modify its own
+    binary. (ADR-0015.)
+
+### Build / distribution
+
+12. **No `tdm-all` umbrella feature flag.** Each TDM source must be opted in
+    individually. (ADR-0002.) Removing the per-publisher friction is the same
+    kind of LEGAL-posture weakening as bundling keys.
+13. **No public binary release that includes any TDM source code.** TDM
+    features are available only by user-driven `cargo install` / `cargo build`
+    with the appropriate `--features tdm-<publisher>` flag.
+
+### Posture interpretation
+
+14. **No re-classification of bibliographic indexing as "PDF content
+    processing".** Implementing `search_local` over title/authors/venue is
+    explicitly in scope and is **not** governed by item #1 above. This is the
+    same boundary [`LEGAL.md`](LEGAL.md) §3 documents.
+
+## Current design choices (5)
+
+These are out of scope **today** because the maintainer judges them more
+trouble than they're worth at the current Phase, but they do not threaten the
+LEGAL posture or threat model. Reversing one is a regular ADR, not a
+scope-reopening Discussion.
+
+15. **No `doiget_delete_paper(...)` MCP tool.** Destructive store operations
+    are CLI-only. *Why current-only:* the operational caution (agents
+    shouldn't delete user data accidentally) is real, but a future agent
+    workflow with explicit user confirmation could revisit this.
+16. **No generic shell / exec MCP tool.** doiget never exposes a tool that
+    lets an agent run arbitrary commands. *Why current-only:* the security
+    boundary is correct today, but composability with sandboxed shells could
+    be revisited in Phase 5+.
+17. **No bidirectional Obsidian sync.** Obsidian export, when available
+    (Phase 7), writes only one direction: store → vault. *Why current-only:*
+    conflict resolution complexity is the only reason; if a clean
+    last-writer-wins or three-way-merge design surfaces, this can change.
+18. **No Obsidian vault auto-discovery.** The vault path is always passed
+    explicitly by the user. *Why current-only:* false-positive scanning is
+    the only concern; a workspace-style `.doiget/vault.toml` could
+    legitimately revisit this.
+19. **No `INTEGRATION/` host snippets at Phase 0.** Phase 3 ships them
+    alongside `doiget serve`. *Why current-only:* sequencing, not principle.
+
+## Boundaries with adjacent tools
+
+doiget composes with content-processing tools rather than incorporating them:
+
+- For PDF text extraction / OCR / summarization: pair doiget with
+  [paper-qa](https://github.com/whitead/paper-qa),
+  [marker](https://github.com/VikParuchuri/marker), or other dedicated tools. See
+  `INTEGRATION/chain-with-paperqa.md` (Phase 3+).
+- For Julia REPL workflows: use BiblioFetch.jl directly; doiget and BiblioFetch.jl share
+  the on-disk store format ([`STORE.md`](STORE.md)).
+
+## Why these are non-goals
+
+The non-goal list is the most direct mechanism for keeping doiget's
+[`LEGAL.md`](LEGAL.md) posture, [`SECURITY.md`](SECURITY.md) threat model, and operational
+simplicity intact. Each non-goal corresponds to a specific risk:
+
+| Non-goal | Primary risk if added |
+|---|---|
+| PDF content processing | Derivative-work copyright posture; tool-neutrality framing weakens. |
+| MCP HTTP transport | Multi-tenant operational status; user is no longer the contract party. |
+| Bundled API keys | Direct ToS violation; doiget becomes the contracting party. |
+| `fetch_url(...)` tool | Generic SSRF surface; bypasses source-list discipline. |
+| Bulk download mode | Bulk-scraper signature pattern; publisher-side flag-and-block. |
+| Telemetry / self-update | Phone-home surface; supply-chain risk multiplier. |
+| `tdm-all` umbrella flag | Removes the "agree per publisher" friction that grounds opt-in. |
+| Bidirectional Obsidian sync | Conflict resolution complexity; user file overwrite incidents. |
+
+If a future situation appears to motivate reversing one of these, the right path is a new
+Discussion, not an in-line PR.


### PR DESCRIPTION
## Summary

Closes out the Zola-site scaffold (PR #92) with the operational pieces:

- **`scripts/sync_docs_to_site.sh`** — projects 17 mapped `docs/*.md` pages into `site/content/{use,developer,contribute}/` with TOML front-matter injected (`title`, `description`, `weight`). Pure bash; no Python / Node / jq dependency. Idempotent and re-runnable.
- **`.github/workflows/site.yml`** — Zola build on every PR; deploy to `gh-pages` only on push to `main`. Includes a projection-drift check that fails CI if the committed `site/content/` differs from a fresh sync output (catches "I forgot to run the sync script before committing" mistakes).
- **`site/README.md`** — local build / preview / custom-domain instructions.

## Base branch

This PR is based on `feat/zola-site-skeleton` (PR #92), not `main`, so the workflow has the `site/` tree to build against. **Merge order: #92 first, then this PR.** After #92 lands, this can be re-targeted to `main` with no rebase needed.

## Custom domain

The `codes.sota-shimozono.com` CNAME is managed at the user-site level. This workflow does NOT publish a CNAME row, so the default `sotashimozono.github.io/doiget/` URL applies until a custom domain is configured per the `site/README.md` "Custom domain" section.

## Test plan

- [ ] Locally: `bash scripts/sync_docs_to_site.sh` projects all 17 `docs/*.md` to `site/content/*` without warning.
- [ ] Locally: `cd site && zola build` produces a clean `site/public/` after the projection step.
- [ ] PR CI runs the `build` job successfully (Zola installs from GH release; sync script runs without error; `zola build` exits 0).
- [ ] PR CI does NOT run the `deploy` job (gated by `github.event_name == 'push' && github.ref == 'refs/heads/main'`).
- [ ] Post-merge to `main`: `deploy` job pushes to `gh-pages` and `https://sotashimozono.github.io/doiget/` returns 200.
- [ ] Projection-drift check works: edit a `docs/*.md`, commit without re-running the sync — CI fails with the expected error message.

## Files changed (+292)

- `.github/workflows/site.yml` (97 lines)
- `scripts/sync_docs_to_site.sh` (122 lines)
- `site/README.md` (73 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)