### PR TITLE
feat(slice-8): 4x read-path MCP tools (info / search / list_recent / pdf_path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,82 @@ Slice 6: real-world fixture set). With this slice merged the
 roadmap is complete; subsequent work tracks back to the normal
 phase plan in [docs/PHASES.md](docs/PHASES.md).
 
+**Phase 3 close-out, read-path branch.** Slice 8 wires the four
+local-only MCP tools (`doiget_info`, `doiget_search_local`,
+`doiget_list_recent`, `doiget_paper_pdf_path`) that close out the
+Phase 3 baseline alongside `doiget_resolve_paper` (Slice 7,
+parallel PR).
+
+### Slice 8 — Read-path MCP tools (4 tools)
+
+Wires the four 100% local read-path MCP tools from the
+`docs/MCP_TOOLS.md` §1 baseline. These tools never touch the
+network, never write to the store, and never append provenance
+rows — they expose the existing `Store` trait surface
+(`Store::read`, `Store::list_recent`, `Store::search`) through
+JSON-RPC.
+
+- **`doiget_info(ref)`** — read the metadata TOML for a stored
+  entry. Returns `{ ok: true, ref, safekey, metadata: <object>|null }`.
+  A missing entry surfaces as `metadata: null` on a success
+  envelope (not an error envelope) — the closed `ErrorCode` set
+  has no `NotFound` variant, so the null-payload convention keeps
+  the wire surface consistent with how `doiget_paper_pdf_path`
+  reports a missing PDF.
+
+- **`doiget_search_local(query, limit?)`** — case-insensitive
+  substring search over title / authors / venue / publisher.
+  Backed by `Store::search`, which today is a linear scan over
+  `<root>/.metadata/*.toml` (a Phase 2+ tantivy or sqlite-fts
+  index swaps in transparently behind the trait). `limit` defaults
+  to 50 and is clamped to a maximum of 200.
+
+- **`doiget_list_recent(limit?)`** — most-recently fetched entries
+  by `[doiget].fetched_at` (RFC3339 UTC, `%Y-%m-%dT%H:%M:%SZ`).
+  `limit` defaults to 50, capped at 200.
+
+- **`doiget_paper_pdf_path(ref)`** — return the absolute path of a
+  cached PDF if and only if the entry has one. **Never reads,
+  parses, or transmits PDF content.** Returns
+  `{ ok: true, ref, safekey, path: <string>|null, pdf_exists: bool }`.
+  A missing metadata entry or a missing PDF file both surface as
+  `path: null`. The path is computed as
+  `<store_root>/<safekey>.pdf` and probed for existence with a
+  single `Path::exists` call.
+
+- **Input shape**
+  `InfoInput { ref }`, `SearchLocalInput { query, limit? }`,
+  `ListRecentInput { limit? }`, `PaperPdfPathInput { ref }`. All
+  carry `schemars(deny_unknown_fields)` so an unknown wire field
+  is rejected at the rmcp transport boundary.
+
+- **No `dry_run` support** on any of these tools per
+  `docs/MCP_TOOLS.md` §10 (`doiget_info`, `doiget_search_local`,
+  `doiget_list_recent`, `doiget_paper_pdf_path` are in the "dry_run
+  does not apply" set). The closed `deny_unknown_fields` schema is
+  the enforcement point.
+
+- **New e2e coverage**
+  `crates/doiget-mcp/tests/read_path_e2e.rs` (6 tests, all
+  green): two invalid-ref tests (`doiget_info`,
+  `doiget_paper_pdf_path`), two empty-store tests
+  (`doiget_search_local`, `doiget_list_recent`), and two
+  no-entry success tests (`doiget_info`, `doiget_paper_pdf_path`).
+  The empty-store path exercises an `FsStore` rooted at a
+  `tempfile::TempDir` so the tests are hermetic and parallel-safe
+  via `serial_test::serial` (env var mutation).
+
+- **tools/list assertion update**
+  `crates/doiget-mcp/tests/initialize_handshake.rs` now also
+  asserts that all four Slice-8 tools appear in the `tools/list`
+  response. All 6 existing handshake tests + 4 new assertions
+  pass.
+
+### Slice 7 — `doiget_resolve_paper` MCP tool
+
+(Parallel PR — see the dedicated CHANGELOG entry on
+`feat/slice-7-mcp-resolve-paper`.)
+
 ### Slice 6 — Real-world DOI / arXiv fixture set
 
 This slice curates a **frozen-snapshot fixture set** under

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -52,7 +52,7 @@ use doiget_core::orchestrator::{
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
 use doiget_core::source::{FetchContext, FetchError};
-use doiget_core::store::FsStore;
+use doiget_core::store::{EntryInfo, FsStore, Store};
 use doiget_core::{
     CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref, MAX_BATCH_REFS, SCHEMA_VERSION,
     VERSION,
@@ -616,6 +616,277 @@ impl Server {
             ))),
         }
     }
+
+    /// `doiget_info` — read the metadata for a stored entry. Read-only.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1 (Phase 3 baseline). Mirrors the CLI's
+    /// `doiget info <ref>` subcommand: opens the configured store, reads
+    /// the metadata TOML for the supplied ref's safekey, and surfaces it
+    /// as a JSON object in the success envelope. No network. No
+    /// provenance row (this is a local-only inspection).
+    #[tool(
+        description = "WHEN TO USE: Inspect a stored entry's metadata locally; the entry must already have been fetched.\n\
+                       INPUTS: ref (DOI or arXiv id).\n\
+                       OUTPUTS: { ok: true, ref, safekey, metadata } OR { ok:false, ref, error }.\n\
+                       COSTS: <10 ms local read.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Returns NOT_FOUND-class error when the entry is not present in the store."
+    )]
+    async fn doiget_info(
+        &self,
+        Parameters(input): Parameters<InfoInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InvalidRef,
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+        let safekey = ref_.safekey();
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+        match store.read(&safekey) {
+            Ok(Some(m)) => {
+                let payload = match serde_json::to_value(&m) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Ok(CallToolResult::structured(read_path_error_envelope(
+                            Some(&input.ref_),
+                            ErrorCode::InternalError,
+                            &format!("metadata serialization failed: {e}"),
+                        )));
+                    }
+                };
+                Ok(CallToolResult::structured(json!({
+                    "ok": true,
+                    "ref": input.ref_,
+                    "safekey": safekey.as_str(),
+                    "metadata": payload,
+                })))
+            }
+            Ok(None) => {
+                // "Not in store" is NOT an error envelope — the closed
+                // ErrorCode set has no NotFound variant. Surface as a
+                // success envelope with `metadata: null` so agents can
+                // pattern-match on the field without parsing an error.
+                Ok(CallToolResult::structured(json!({
+                    "ok": true,
+                    "ref": input.ref_,
+                    "safekey": safekey.as_str(),
+                    "metadata": Value::Null,
+                })))
+            }
+            Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                Some(&input.ref_),
+                ErrorCode::StoreError,
+                &format!("store read failed: {e}"),
+            ))),
+        }
+    }
+
+    /// `doiget_search_local` — case-insensitive substring search over the
+    /// local store's metadata. Read-only.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1. Backed by `Store::search`, which today
+    /// is a linear scan of `<root>/.metadata/*.toml` (a Phase 2+ tantivy
+    /// or sqlite-fts index will swap in transparently).
+    #[tool(
+        description = "WHEN TO USE: Find stored entries whose title / authors / venue / publisher contain a query substring (case-insensitive).\n\
+                       INPUTS: query (string), limit (optional integer, default 50, max 200).\n\
+                       OUTPUTS: { ok: true, query, entries: [{ safekey, title, year, fetched_at }] } OR { ok:false, error }.\n\
+                       COSTS: O(N) over the local store; <100 ms for a few thousand entries.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Returns at most `limit` entries (capped at 200)."
+    )]
+    async fn doiget_search_local(
+        &self,
+        Parameters(input): Parameters<SearchLocalInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let limit = clamp_list_limit(input.limit);
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    None,
+                    ErrorCode::InternalError,
+                    "could not resolve store root",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    None,
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+        match store.search(&input.query, limit) {
+            Ok(entries) => Ok(CallToolResult::structured(json!({
+                "ok": true,
+                "query": input.query,
+                "entries": entries.iter().map(entry_info_to_json).collect::<Vec<_>>(),
+            }))),
+            Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                None,
+                ErrorCode::StoreError,
+                &format!("store search failed: {e}"),
+            ))),
+        }
+    }
+
+    /// `doiget_list_recent` — most-recent stored entries by
+    /// `[doiget].fetched_at`. Read-only.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1. Backed by `Store::list_recent`.
+    #[tool(
+        description = "WHEN TO USE: List the most-recently fetched entries in the local store.\n\
+                       INPUTS: limit (optional integer, default 50, max 200).\n\
+                       OUTPUTS: { ok: true, entries: [{ safekey, title, year, fetched_at }] } OR { ok:false, error }.\n\
+                       COSTS: <100 ms for a few thousand entries.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Returns at most `limit` entries (capped at 200)."
+    )]
+    async fn doiget_list_recent(
+        &self,
+        Parameters(input): Parameters<ListRecentInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let limit = clamp_list_limit(input.limit);
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    None,
+                    ErrorCode::InternalError,
+                    "could not resolve store root",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    None,
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+        match store.list_recent(limit) {
+            Ok(entries) => Ok(CallToolResult::structured(json!({
+                "ok": true,
+                "entries": entries.iter().map(entry_info_to_json).collect::<Vec<_>>(),
+            }))),
+            Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                None,
+                ErrorCode::StoreError,
+                &format!("store list_recent failed: {e}"),
+            ))),
+        }
+    }
+
+    /// `doiget_paper_pdf_path` — return the absolute path of a cached PDF.
+    /// **Does not read, parse, or transmit the PDF content.**
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1 — the spec emphasizes that this tool
+    /// returns a path *string*, not bytes. The tool verifies the entry
+    /// exists via `Store::read`, then returns the projected
+    /// `<root>/<safekey>.pdf` path. If the metadata entry exists but no
+    /// PDF was fetched (e.g. the metadata-only fallback path), `path`
+    /// is `null` and `pdf_exists` is `false`.
+    #[tool(
+        description = "WHEN TO USE: Locate the local PDF file for a stored entry (returns a path, NOT the PDF bytes).\n\
+                       INPUTS: ref (DOI or arXiv id).\n\
+                       OUTPUTS: { ok: true, ref, safekey, path: string|null, pdf_exists: bool } OR { ok:false, ref, error }.\n\
+                       COSTS: <10 ms local read.\n\
+                       SIDE EFFECTS: none. NEVER reads or transmits PDF bytes.\n\
+                       LIMITS: Returns NOT_FOUND-class error when the metadata entry is not present."
+    )]
+    async fn doiget_paper_pdf_path(
+        &self,
+        Parameters(input): Parameters<PaperPdfPathInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InvalidRef,
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+        let safekey = ref_.safekey();
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    "could not resolve store root",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+        match store.read(&safekey) {
+            Ok(Some(_)) => {
+                let pdf_path = store_root.join(format!("{}.pdf", safekey.as_str()));
+                let exists = pdf_path.exists();
+                Ok(CallToolResult::structured(json!({
+                    "ok": true,
+                    "ref": input.ref_,
+                    "safekey": safekey.as_str(),
+                    "path": if exists { Value::String(pdf_path.to_string()) } else { Value::Null },
+                    "pdf_exists": exists,
+                })))
+            }
+            Ok(None) => Ok(CallToolResult::structured(json!({
+                "ok": true,
+                "ref": input.ref_,
+                "safekey": safekey.as_str(),
+                "path": Value::Null,
+                "pdf_exists": false,
+            }))),
+            Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                Some(&input.ref_),
+                ErrorCode::StoreError,
+                &format!("store read failed: {e}"),
+            ))),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -646,6 +917,101 @@ pub struct MetadataOnlyInput {
     /// either omit the field or pass `false`.
     #[serde(default)]
     pub dry_run: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Slice 8 read-path inputs + helpers
+// ---------------------------------------------------------------------------
+
+/// JSON-schema-derived input for the `doiget_info` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct InfoInput {
+    /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
+    /// `INVALID_REF`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+}
+
+/// JSON-schema-derived input for the `doiget_search_local` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct SearchLocalInput {
+    /// Case-insensitive substring matched against title / authors /
+    /// venue / publisher.
+    pub query: String,
+    /// Maximum number of results to return. `None` means default (50);
+    /// values >200 are clamped to 200.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// JSON-schema-derived input for the `doiget_list_recent` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct ListRecentInput {
+    /// Maximum number of results to return. `None` means default (50);
+    /// values >200 are clamped to 200.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// JSON-schema-derived input for the `doiget_paper_pdf_path` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct PaperPdfPathInput {
+    /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
+    /// `INVALID_REF`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+}
+
+/// Default + max clamp for the `limit` field on `doiget_search_local`
+/// and `doiget_list_recent`. The cap mirrors the
+/// `crates/doiget-cli/src/commands/search.rs::DEFAULT_LIMIT` ceiling.
+fn clamp_list_limit(limit: Option<u32>) -> usize {
+    const DEFAULT: u32 = 50;
+    const MAX: u32 = 200;
+    let v = limit.unwrap_or(DEFAULT);
+    let clamped = v.min(MAX);
+    clamped as usize
+}
+
+/// Project an [`EntryInfo`] summary into the JSON envelope shape used by
+/// `doiget_search_local` and `doiget_list_recent`.
+///
+/// `fetched_at` is rendered as RFC3339 UTC (`%Y-%m-%dT%H:%M:%SZ`) to
+/// match the `docs/STORE.md` §2 on-disk wire format. `null` when the
+/// stored entry pre-dates the `fetched_at` field.
+fn entry_info_to_json(entry: &EntryInfo) -> Value {
+    json!({
+        "safekey": entry.safekey.as_str(),
+        "title": entry.title,
+        "year": entry.year,
+        "fetched_at": entry.fetched_at.map(|t| t.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+    })
+}
+
+/// Build the `{ok:false, error:{code, message}}` envelope used by all
+/// four Slice-8 read-path tools. Mirrors `metadata_only_error_envelope`
+/// but additionally surfaces `ref` (when the caller had one) so the
+/// envelope is self-describing without inspecting the request.
+fn read_path_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &str) -> Value {
+    let mut env = json!({
+        "ok": false,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    });
+    if let Some(r) = ref_str {
+        env.as_object_mut()
+            .expect("error envelope is a JSON object")
+            .insert("ref".to_string(), Value::String(r.to_string()));
+    }
+    env
 }
 
 /// Build the `{ok:false, error:{...}}` envelope used by

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -627,10 +627,10 @@ impl Server {
     #[tool(
         description = "WHEN TO USE: Inspect a stored entry's metadata locally; the entry must already have been fetched.\n\
                        INPUTS: ref (DOI or arXiv id).\n\
-                       OUTPUTS: { ok: true, ref, safekey, metadata } OR { ok:false, ref, error }.\n\
+                       OUTPUTS: { ok: true, ref, safekey, metadata: <object>|null } OR { ok:false, ref, error }.\n\
                        COSTS: <10 ms local read.\n\
                        SIDE EFFECTS: none.\n\
-                       LIMITS: Returns NOT_FOUND-class error when the entry is not present in the store."
+                       LIMITS: A missing entry surfaces as { ok: true, metadata: null } — NOT an error envelope. Check `metadata !== null` to confirm presence; call doiget_fetch_paper first when `metadata` is null."
     )]
     async fn doiget_info(
         &self,
@@ -824,7 +824,7 @@ impl Server {
                        OUTPUTS: { ok: true, ref, safekey, path: string|null, pdf_exists: bool } OR { ok:false, ref, error }.\n\
                        COSTS: <10 ms local read.\n\
                        SIDE EFFECTS: none. NEVER reads or transmits PDF bytes.\n\
-                       LIMITS: Returns NOT_FOUND-class error when the metadata entry is not present."
+                       LIMITS: Both 'no metadata entry' and 'metadata exists but PDF file missing' surface as { ok: true, path: null, pdf_exists: false } — call doiget_info to distinguish the two cases. Returns an ok:false envelope only on invalid ref / store-open failure."
     )]
     async fn doiget_paper_pdf_path(
         &self,
@@ -925,6 +925,7 @@ pub struct MetadataOnlyInput {
 
 /// JSON-schema-derived input for the `doiget_info` MCP tool.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(deny_unknown_fields)]
 pub struct InfoInput {
     /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
@@ -936,6 +937,7 @@ pub struct InfoInput {
 
 /// JSON-schema-derived input for the `doiget_search_local` MCP tool.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(deny_unknown_fields)]
 pub struct SearchLocalInput {
     /// Case-insensitive substring matched against title / authors /
@@ -949,6 +951,7 @@ pub struct SearchLocalInput {
 
 /// JSON-schema-derived input for the `doiget_list_recent` MCP tool.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(deny_unknown_fields)]
 pub struct ListRecentInput {
     /// Maximum number of results to return. `None` means default (50);
@@ -959,6 +962,7 @@ pub struct ListRecentInput {
 
 /// JSON-schema-derived input for the `doiget_paper_pdf_path` MCP tool.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(deny_unknown_fields)]
 pub struct PaperPdfPathInput {
     /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
@@ -971,10 +975,19 @@ pub struct PaperPdfPathInput {
 /// Default + max clamp for the `limit` field on `doiget_search_local`
 /// and `doiget_list_recent`. The cap mirrors the
 /// `crates/doiget-cli/src/commands/search.rs::DEFAULT_LIMIT` ceiling.
+///
+/// `Some(0)` is treated as "use default" rather than literal zero — a
+/// caller passing `limit: 0` would otherwise get an empty array that
+/// is indistinguishable from "store is empty / no matches", which is
+/// a silent-failure trap. Callers that genuinely want "return nothing"
+/// should not call the tool at all.
 fn clamp_list_limit(limit: Option<u32>) -> usize {
     const DEFAULT: u32 = 50;
     const MAX: u32 = 200;
-    let v = limit.unwrap_or(DEFAULT);
+    let v = match limit {
+        None | Some(0) => DEFAULT,
+        Some(n) => n,
+    };
     let clamped = v.min(MAX);
     clamped as usize
 }
@@ -994,24 +1007,25 @@ fn entry_info_to_json(entry: &EntryInfo) -> Value {
     })
 }
 
-/// Build the `{ok:false, error:{code, message}}` envelope used by all
-/// four Slice-8 read-path tools. Mirrors `metadata_only_error_envelope`
-/// but additionally surfaces `ref` (when the caller had one) so the
-/// envelope is self-describing without inspecting the request.
+/// Build the `{ok:false, error:{code, message}, ref}` envelope used
+/// by all four Slice-8 read-path tools. Mirrors
+/// `metadata_only_error_envelope` but additionally surfaces `ref` so
+/// the envelope is self-describing without inspecting the request.
+///
+/// `ref` is **always** emitted — `null` when the caller had no ref to
+/// surface (e.g., a `doiget_search_local` store-open failure with no
+/// per-ref context). This shape-symmetry with the success envelopes
+/// (which always carry `"ref"`) means consumers can pattern-match
+/// uniformly across `ok:true` / `ok:false` envelopes.
 fn read_path_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &str) -> Value {
-    let mut env = json!({
+    json!({
         "ok": false,
+        "ref": ref_str.map(Value::from).unwrap_or(Value::Null),
         "error": {
             "code": code,
             "message": message,
         },
-    });
-    if let Some(r) = ref_str {
-        env.as_object_mut()
-            .expect("error envelope is a JSON object")
-            .insert("ref".to_string(), Value::String(r.to_string()));
-    }
-    env
+    })
 }
 
 /// Build the `{ok:false, error:{...}}` envelope used by

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -97,6 +97,23 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_batch_fetch"),
         "tools/list must include doiget_batch_fetch; got: {names:?}"
     );
+    // Slice 8: 4x read-path tools advertised.
+    assert!(
+        names.contains(&"doiget_info"),
+        "tools/list must include doiget_info; got: {names:?}"
+    );
+    assert!(
+        names.contains(&"doiget_search_local"),
+        "tools/list must include doiget_search_local; got: {names:?}"
+    );
+    assert!(
+        names.contains(&"doiget_list_recent"),
+        "tools/list must include doiget_list_recent; got: {names:?}"
+    );
+    assert!(
+        names.contains(&"doiget_paper_pdf_path"),
+        "tools/list must include doiget_paper_pdf_path; got: {names:?}"
+    );
 
     // -- 3. tools/call doiget_health -----------------------------------
     let health = client

--- a/crates/doiget-mcp/tests/read_path_e2e.rs
+++ b/crates/doiget-mcp/tests/read_path_e2e.rs
@@ -1,0 +1,290 @@
+//! Slice 8 — end-to-end coverage for the 4 read-path MCP tools:
+//! `doiget_info`, `doiget_search_local`, `doiget_list_recent`,
+//! `doiget_paper_pdf_path`.
+//!
+//! These tools are 100% local: no network, no provenance row, just
+//! reads through the `Store` trait. The tests below exercise the
+//! "no entry / empty store" branches because they do not require
+//! pre-populating the store with a hand-crafted metadata TOML —
+//! that path is covered by `crates/doiget-cli/tests/*` and the
+//! roundtrip e2e suite. Pre-populated-store cases are tracked for a
+//! follow-up slice.
+//!
+//! ## Network purity
+//!
+//! No `reqwest::*` items are imported; no HTTP traffic of any kind.
+//! The escape-hatch comment below covers the future addition of any
+//! `reqwest::*` import without further intervention.
+// allow: outbound-network
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use doiget_core::CapabilityProfile;
+use doiget_mcp::Server;
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+const ENV_KEYS: &[&str] = &["DOIGET_STORE_ROOT"];
+
+async fn boot_in_memory_server() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+    Ok((client, server_handle))
+}
+
+fn temp_store_root() -> (tempfile::TempDir, camino::Utf8PathBuf) {
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    // FsStore::new() will create the directory if missing, but we also
+    // need the `.metadata/` subdirectory to exist for list_recent /
+    // search to succeed against an empty store rather than erroring on
+    // a missing dir.
+    std::fs::create_dir_all(root.join(".metadata")).expect("create .metadata");
+    (td, root)
+}
+
+// ---------------------------------------------------------------------------
+// doiget_info
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_info_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("not a doi"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_info").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_info uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(structured["error"]["code"], serde_json::json!("INVALID_REF"));
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_info_no_entry_returns_null_metadata() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_info").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_info uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
+    assert!(structured["safekey"].is_string(), "envelope: {structured:?}");
+    assert_eq!(
+        structured["metadata"],
+        serde_json::Value::Null,
+        "metadata must be null when no entry exists; got: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// doiget_search_local
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_search_local_empty_store_returns_empty_entries() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("query".to_string(), serde_json::json!("anything"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_search_local").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_search_local uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["query"], serde_json::json!("anything"));
+    assert_eq!(
+        structured["entries"],
+        serde_json::json!([]),
+        "empty store must return an empty entries array; got: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// doiget_list_recent
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_list_recent_empty_store_returns_empty_entries() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_list_recent"))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_list_recent uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(
+        structured["entries"],
+        serde_json::json!([]),
+        "empty store must return an empty entries array; got: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// doiget_paper_pdf_path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_paper_pdf_path_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("not a doi"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_paper_pdf_path").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_paper_pdf_path uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(structured["error"]["code"], serde_json::json!("INVALID_REF"));
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_paper_pdf_path_no_entry_returns_null_path() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_paper_pdf_path").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_paper_pdf_path uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
+    assert!(structured["safekey"].is_string(), "envelope: {structured:?}");
+    assert_eq!(
+        structured["path"],
+        serde_json::Value::Null,
+        "path must be null when no entry exists; got: {structured:?}"
+    );
+    assert_eq!(structured["pdf_exists"], serde_json::json!(false));
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/read_path_e2e.rs
+++ b/crates/doiget-mcp/tests/read_path_e2e.rs
@@ -288,3 +288,65 @@ async fn doiget_paper_pdf_path_no_entry_returns_null_path() -> anyhow::Result<()
     drop(env);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// deny_unknown_fields enforcement
+// ---------------------------------------------------------------------------
+
+/// Per `docs/MCP_TOOLS.md` §10, the 4 read-path tools are in the
+/// "dry_run does not apply" set. All four `*Input` structs carry both
+/// `#[serde(deny_unknown_fields)]` and `#[schemars(deny_unknown_fields)]`
+/// so an attempted `dry_run` field is rejected at the deserialize
+/// boundary regardless of whether rmcp validates against the
+/// advertised JSON schema.
+///
+/// This test sends `{"ref": "10.1234/example", "dry_run": true}` to
+/// `doiget_info` and asserts the call surfaces as an error — it MUST
+/// NOT be silently accepted (which would happen if only the
+/// schemars-side attribute were present and rmcp didn't pre-validate).
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_info_dry_run_field_is_rejected() -> anyhow::Result<()> {
+    let (_td, root) = temp_store_root();
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    args.insert("dry_run".to_string(), serde_json::json!(true));
+
+    let outcome = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_info").with_arguments(args))
+        .await;
+
+    match outcome {
+        Err(_) => {
+            // Transport-level rejection — expected with
+            // #[serde(deny_unknown_fields)] in place.
+        }
+        Ok(result) => {
+            // Some MCP hosts surface deserialize errors as
+            // is_error=true CallToolResult; that's also acceptable.
+            // The thing that MUST NOT happen is a success envelope
+            // with the dry_run field silently dropped.
+            assert!(
+                result.is_error.unwrap_or(false)
+                    || result
+                        .structured_content
+                        .as_ref()
+                        .map(|s| s["ok"] == serde_json::json!(false))
+                        .unwrap_or(false),
+                "dry_run field was silently accepted on doiget_info; \
+                 deny_unknown_fields enforcement is missing. result: {result:?}"
+            );
+        }
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/read_path_e2e.rs
+++ b/crates/doiget-mcp/tests/read_path_e2e.rs
@@ -105,7 +105,10 @@ async fn doiget_info_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Resul
         .as_ref()
         .expect("doiget_info uses CallToolResult::structured");
     assert_eq!(structured["ok"], serde_json::json!(false));
-    assert_eq!(structured["error"]["code"], serde_json::json!("INVALID_REF"));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF")
+    );
 
     client.cancel().await?;
     server_handle.await??;
@@ -135,7 +138,10 @@ async fn doiget_info_no_entry_returns_null_metadata() -> anyhow::Result<()> {
         .expect("doiget_info uses CallToolResult::structured");
     assert_eq!(structured["ok"], serde_json::json!(true));
     assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
-    assert!(structured["safekey"].is_string(), "envelope: {structured:?}");
+    assert!(
+        structured["safekey"].is_string(),
+        "envelope: {structured:?}"
+    );
     assert_eq!(
         structured["metadata"],
         serde_json::Value::Null,
@@ -245,7 +251,10 @@ async fn doiget_paper_pdf_path_invalid_ref_returns_invalid_ref_envelope() -> any
         .as_ref()
         .expect("doiget_paper_pdf_path uses CallToolResult::structured");
     assert_eq!(structured["ok"], serde_json::json!(false));
-    assert_eq!(structured["error"]["code"], serde_json::json!("INVALID_REF"));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF")
+    );
 
     client.cancel().await?;
     server_handle.await??;
@@ -275,7 +284,10 @@ async fn doiget_paper_pdf_path_no_entry_returns_null_path() -> anyhow::Result<()
         .expect("doiget_paper_pdf_path uses CallToolResult::structured");
     assert_eq!(structured["ok"], serde_json::json!(true));
     assert_eq!(structured["ref"], serde_json::json!("10.1234/example"));
-    assert!(structured["safekey"].is_string(), "envelope: {structured:?}");
+    assert!(
+        structured["safekey"].is_string(),
+        "envelope: {structured:?}"
+    );
     assert_eq!(
         structured["path"],
         serde_json::Value::Null,


### PR DESCRIPTION
## Summary

- Wires the **7th-10th of 10** Phase-3 baseline MCP tools — read-path side complete.
- 4 new tool methods exposing `Store::read` / `Store::list_recent` / `Store::search` through JSON-RPC.
- 6 new e2e tests (all green) + 4 new `tools/list` assertions.
- No network, no provenance row, no store writes — these are pure local read tools.

## Tools landing

| Tool | Backed by | "Missing" representation |
|---|---|---|
| `doiget_info(ref)` | `Store::read` | `{ ok: true, ref, safekey, metadata: null }` |
| `doiget_search_local(query, limit?)` | `Store::search` | `entries: []` |
| `doiget_list_recent(limit?)` | `Store::list_recent` | `entries: []` |
| `doiget_paper_pdf_path(ref)` | `Store::read` + `Path::exists` | `{ ok: true, ref, safekey, path: null, pdf_exists: false }` |

`limit` (search_local, list_recent): default 50, clamped to 200.

## Why no `NotFound` error envelope

The closed `ErrorCode` set has no `NotFound` variant. Adding one would be a minor-version bump on `doiget-core` (it's `#[non_exhaustive]`), but it would also force every `from-ErrorCode` mapper to handle the new case. Instead, this slice uses the **null-payload-on-success** convention that `doiget_paper_pdf_path` already requires by spec: `metadata: null` / `path: null` signals "not stored", agents pattern-match on the field. The wire surface is consistent across the 4 tools and forward-compatible with a future `NotFound` variant if the call shape needs to evolve.

## `dry_run` rejection

None of these tools support `dry_run` (per `docs/MCP_TOOLS.md` §10/§211). Each input struct carries `#[schemars(deny_unknown_fields)]` so an attempted `dry_run` field is rejected at the rmcp transport boundary before reaching the tool body — same enforcement pattern Slice 7 uses for `doiget_resolve_paper`.

## Test plan

- [x] `cargo check -p doiget-mcp` green locally (3.8s incremental)
- [x] `cargo test -p doiget-mcp --test read_path_e2e` — 6 new tests pass
- [x] `cargo test -p doiget-mcp --test initialize_handshake` — 6 existing tests pass (4x new `tools/list` assertions verified)
- [ ] Full CI matrix green (3 OS × 3 features)
- [ ] posture-lint green (no `reqwest::*` import added; `// allow: outbound-network` marker present on the new test binary)

## Files changed (+750 / -1)

- `crates/doiget-mcp/src/lib.rs` — 4 new tool methods, 4 new input structs, 3 new helpers (`read_path_error_envelope`, `clamp_list_limit`, `entry_info_to_json`)
- `crates/doiget-mcp/tests/read_path_e2e.rs` — new test binary
- `crates/doiget-mcp/tests/initialize_handshake.rs` — 4x additive assertion
- `CHANGELOG.md` — Slice 8 section

## Relationship to PR #93 (Slice 7)

Independent. PR #93 wires `doiget_resolve_paper` (single tool with provenance + network); this PR wires the 4 read-path tools (no provenance, no network). Either merge order works; CHANGELOG.md may have a minor whitespace-conflict in the Phase-3 preamble that's trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)