### PR TITLE
feat(slice-9): replace mcp-smoke placeholder with Phase-3 CI gate

### DIFF
--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -51,11 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      - name: Install Rust toolchain
-        # rust-toolchain.toml at the repo root pins the channel.
-        run: |
-          rustc --version
-          cargo --version
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4   # v2.9.1
       - name: cargo test (doiget-mcp)
         run: |
           cargo test -p doiget-mcp --tests
@@ -66,53 +63,109 @@ jobs:
     needs: in-process-smoke
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      - name: Install Rust toolchain
-        run: |
-          rustc --version
-          cargo --version
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4   # v2.9.1
       - name: Build doiget-cli (release)
         run: |
           cargo build -p doiget-cli --release
       - name: Run stdout-purity probe
-        # Send `initialize` + initialized notification + `tools/list`
-        # over stdin, close stdin to trigger graceful shutdown, capture
-        # stdout. Every non-blank line of stdout MUST parse as JSON
-        # (the JSON-RPC framing rmcp uses is one JSON object per line
-        # on stdio transport). Stderr is allowed to carry tracing
-        # output; we redirect it to a separate file but do not assert
-        # on its contents (docs/SECURITY.md §3 reserves stdout, not
-        # stderr).
+        # Send `initialize` + initialized notification + `tools/list` +
+        # `tools/call doiget_health` over stdin (the full §9 sequence
+        # documented in docs/MCP_TOOLS.md), close stdin to trigger
+        # graceful shutdown, capture stdout. Every non-blank line of
+        # stdout MUST parse as JSON (rmcp's stdio transport emits one
+        # JSON object per line). Stderr is allowed to carry tracing
+        # output (docs/SECURITY.md §3 reserves stdout, not stderr).
+        #
+        # Hard-failure cases (each surfaces as `::error::...`):
+        #   - server exits with a status other than 0 (clean exit) or
+        #     124 (timeout on stdin EOF — the expected graceful path);
+        #   - stdout is empty;
+        #   - any non-blank stdout line is not valid JSON;
+        #   - the `tools/list` response does not advertise `doiget_health`;
+        #   - the `tools/call doiget_health` response is not `ok: true`.
         run: |
           set -euo pipefail
           mkdir -p /tmp/mcp-smoke
+          # `timeout` exits 124 when it kills the child; in this script
+          # that is the expected case because the child completes its
+          # JSON-RPC responses but the rmcp service loop waits for
+          # stdin EOF before unwinding. We separate that benign exit
+          # from real failures (panic = 101, SIGSEGV = 139, binary
+          # missing = 127, etc.) so a crash mid-stream cannot slip
+          # through as a silent green.
+          set +e
           (
             printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-smoke","version":"0.0.0"}}}'
             printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
             printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+            printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"doiget_health"}}'
           ) | timeout 10s ./target/release/doiget serve \
               > /tmp/mcp-smoke/stdout.log \
-              2> /tmp/mcp-smoke/stderr.log || true
+              2> /tmp/mcp-smoke/stderr.log
+          serve_exit=$?
+          set -e
+          echo "doiget serve exit code: $serve_exit"
           echo "----- stdout -----"
           cat /tmp/mcp-smoke/stdout.log
           echo "----- stderr (informational) -----"
-          tail -n 50 /tmp/mcp-smoke/stderr.log || true
-          echo "----- assert stdout is pure JSON (one object per line) -----"
-          # Empty stdout is a failure: the server should have answered.
-          if [ ! -s /tmp/mcp-smoke/stdout.log ]; then
-            echo "::error::doiget serve produced empty stdout — initialize/tools-list never received a response."
+          [ -f /tmp/mcp-smoke/stderr.log ] && tail -n 50 /tmp/mcp-smoke/stderr.log
+          if [ "$serve_exit" -ne 0 ] && [ "$serve_exit" -ne 124 ]; then
+            echo "::error::doiget serve exited $serve_exit (only 0 or 124 are accepted)"
             exit 1
           fi
-          # Every non-blank line of stdout MUST parse as JSON. python3
-          # is always available on ubuntu-latest runners.
-          while IFS= read -r line; do
-            [ -z "$line" ] && continue
-            echo "$line" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' \
-              || { echo "::error::Non-JSON line on stdout: $line"; exit 1; }
-          done < /tmp/mcp-smoke/stdout.log
+          if [ ! -s /tmp/mcp-smoke/stdout.log ]; then
+            echo "::error::doiget serve produced empty stdout — no JSON-RPC responses written"
+            exit 1
+          fi
+          # Single-invocation Python validator: parses every non-blank
+          # line, asserts the tools/list response advertises
+          # doiget_health, and asserts the doiget_health response shape.
+          # Per-line error messages include line numbers for fast triage.
+          python3 - /tmp/mcp-smoke/stdout.log <<'PYEOF'
+          import json, sys
+          path = sys.argv[1]
+          lines = []
+          for i, raw in enumerate(open(path), 1):
+              line = raw.rstrip('\n')
+              if not line:
+                  continue
+              try:
+                  lines.append((i, json.loads(line)))
+              except json.JSONDecodeError as e:
+                  print(f"::error::Non-JSON line {i}: {line!r} ({e})")
+                  sys.exit(1)
+
+          # tools/list response (id=2): the rmcp server MUST advertise
+          # doiget_health (per docs/MCP_TOOLS.md §1 baseline).
+          tl = next((obj for _, obj in lines if obj.get("id") == 2), None)
+          if tl is None:
+              print("::error::no tools/list response (id=2) on stdout")
+              sys.exit(1)
+          tools = (tl.get("result") or {}).get("tools") or []
+          names = [t.get("name") for t in tools]
+          if "doiget_health" not in names:
+              print(f"::error::tools/list did not advertise doiget_health; got: {names}")
+              sys.exit(1)
+          print(f"tools/list advertises {len(names)} tools: {names}")
+
+          # tools/call doiget_health response (id=3): structured
+          # content MUST report ok=true.
+          th = next((obj for _, obj in lines if obj.get("id") == 3), None)
+          if th is None:
+              print("::error::no tools/call doiget_health response (id=3) on stdout")
+              sys.exit(1)
+          result = th.get("result") or {}
+          structured = result.get("structuredContent") or {}
+          if structured.get("ok") is not True:
+              print(f"::error::doiget_health did not return ok=true; got: {result}")
+              sys.exit(1)
+          print("doiget_health returned ok=true")
+          PYEOF
           echo "stdout-purity: OK"
       - name: Upload logs (always)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356b520e9a168e888d8d25c6e1d9f1   # v4
         with:
           name: mcp-smoke-logs
           path: /tmp/mcp-smoke/

--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -1,29 +1,23 @@
-# mcp-smoke — MCP server stdio smoke test
+# mcp-smoke — MCP server stdio smoke test (Slice 9 / Phase 3).
 #
-# STATUS (Phase 0): placeholder. Reserves the workflow slot referenced by
-# docs/MCP_TOOLS.md §9 ("A CI workflow `mcp-smoke.yml` (Phase 3) spawns the
-# server, sends a minimal sequence ...") so the path filter below already
-# triggers on changes that will matter once the real check lands.
+# Two complementary jobs:
 #
-# PHASE 3 SCOPE (the work this file will do once doiget-mcp exists):
-#   1. Install the rust toolchain pinned by rust-toolchain.toml.
-#   2. `cargo build -p doiget-mcp` (default features = oa-only).
-#   3. Spawn the resulting binary as a child process.
-#   4. Write a minimal JSON-RPC sequence to its stdin per ADR-0001
-#      (stdio only, no network transport): `initialize` then `tools/list`
-#      then `tools/call doiget_health`.
-#   5. Assert the `tools/list` response shape: exactly the 9 Phase 3
-#      tools enumerated in docs/MCP_TOOLS.md §1, all snake_case with the
-#      `doiget_` prefix per ADR-0012.
-#   6. Assert that no stray bytes appear on stdout outside JSON-RPC frames
-#      (per docs/SECURITY.md §3 — banner / log / progress on stdout is
-#      forbidden; tracing must go to stderr).
-#   7. Assert no telemetry / outbound network calls during the smoke run
-#      per ADR-0015 (no-telemetry posture).
+#   1. `in-process-smoke` — runs the cargo-side MCP smoke tests
+#      (initialize_handshake + the per-tool e2e binaries). These tests
+#      stand up the rmcp server inside the same process via a duplex
+#      pipe and exercise `initialize`, `tools/list`, `tools/call` for
+#      every wired Phase-3 tool. Hermetic and OS-independent on the
+#      Cargo side; ubuntu-latest is enough.
 #
-# Until Phase 3, this workflow only prints a placeholder line and exits 0
-# so the path-filter trigger and required-check wiring can be validated
-# end-to-end without blocking unrelated PRs.
+#   2. `stdout-purity` — exercises the REAL `doiget serve` subprocess
+#      stdout path. The in-process tests cannot see whether the binary
+#      accidentally writes diagnostics to stdout outside JSON-RPC
+#      frames (docs/SECURITY.md §3 forbids that — tracing must go to
+#      stderr). This job spawns `target/release/doiget serve`, sends a
+#      minimal initialize + tools/list sequence via stdin, captures
+#      stdout to a file, and asserts every line of captured stdout
+#      parses as a JSON object. Any line that fails to parse (a
+#      banner, a log line, a progress message) is a hard failure.
 
 name: mcp-smoke
 
@@ -31,12 +25,16 @@ on:
   pull_request:
     paths:
       - "crates/doiget-mcp/**"
+      - "crates/doiget-cli/**"
+      - "crates/doiget-core/**"
       - "docs/MCP_TOOLS.md"
       - ".github/workflows/mcp-smoke.yml"
   push:
     branches: [main]
     paths:
       - "crates/doiget-mcp/**"
+      - "crates/doiget-cli/**"
+      - "crates/doiget-core/**"
       - "docs/MCP_TOOLS.md"
       - ".github/workflows/mcp-smoke.yml"
 
@@ -48,12 +46,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  placeholder:
-    name: placeholder (Phase 0)
+  in-process-smoke:
+    name: in-process smoke (cargo test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      - name: Announce placeholder
+      - name: Install Rust toolchain
+        # rust-toolchain.toml at the repo root pins the channel.
         run: |
-          echo "mcp-smoke: Phase 0 placeholder — no MCP server invocation."
-          echo "Phase 3 will pipe a JSON-RPC initialize request to doiget-mcp and assert the tools/list response per ADR-0001 (stdio only) and ADR-0012 (tool naming)."
+          rustc --version
+          cargo --version
+      - name: cargo test (doiget-mcp)
+        run: |
+          cargo test -p doiget-mcp --tests
+
+  stdout-purity:
+    name: stdout purity (doiget serve subprocess)
+    runs-on: ubuntu-latest
+    needs: in-process-smoke
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      - name: Install Rust toolchain
+        run: |
+          rustc --version
+          cargo --version
+      - name: Build doiget-cli (release)
+        run: |
+          cargo build -p doiget-cli --release
+      - name: Run stdout-purity probe
+        # Send `initialize` + initialized notification + `tools/list`
+        # over stdin, close stdin to trigger graceful shutdown, capture
+        # stdout. Every non-blank line of stdout MUST parse as JSON
+        # (the JSON-RPC framing rmcp uses is one JSON object per line
+        # on stdio transport). Stderr is allowed to carry tracing
+        # output; we redirect it to a separate file but do not assert
+        # on its contents (docs/SECURITY.md §3 reserves stdout, not
+        # stderr).
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/mcp-smoke
+          (
+            printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-smoke","version":"0.0.0"}}}'
+            printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+            printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+          ) | timeout 10s ./target/release/doiget serve \
+              > /tmp/mcp-smoke/stdout.log \
+              2> /tmp/mcp-smoke/stderr.log || true
+          echo "----- stdout -----"
+          cat /tmp/mcp-smoke/stdout.log
+          echo "----- stderr (informational) -----"
+          tail -n 50 /tmp/mcp-smoke/stderr.log || true
+          echo "----- assert stdout is pure JSON (one object per line) -----"
+          # Empty stdout is a failure: the server should have answered.
+          if [ ! -s /tmp/mcp-smoke/stdout.log ]; then
+            echo "::error::doiget serve produced empty stdout — initialize/tools-list never received a response."
+            exit 1
+          fi
+          # Every non-blank line of stdout MUST parse as JSON. python3
+          # is always available on ubuntu-latest runners.
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            echo "$line" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' \
+              || { echo "::error::Non-JSON line on stdout: $line"; exit 1; }
+          done < /tmp/mcp-smoke/stdout.log
+          echo "stdout-purity: OK"
+      - name: Upload logs (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-smoke-logs
+          path: /tmp/mcp-smoke/
+          retention-days: 7

--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -104,12 +104,18 @@ jobs:
               > /tmp/mcp-smoke/stdout.log \
               2> /tmp/mcp-smoke/stderr.log
           serve_exit=$?
-          set -e
+          # Restore BOTH errexit and pipefail — `set +e` above may have
+          # implicitly cleared pipefail in some bash builds; `set -e`
+          # alone would leave pipefail off and silently break future
+          # pipeline-using commands appended below.
+          set -eo pipefail
           echo "doiget serve exit code: $serve_exit"
           echo "----- stdout -----"
           cat /tmp/mcp-smoke/stdout.log
           echo "----- stderr (informational) -----"
-          [ -f /tmp/mcp-smoke/stderr.log ] && tail -n 50 /tmp/mcp-smoke/stderr.log
+          # stderr.log is always created by `2> ...` redirection above
+          # (even on serve failure), so no -f guard needed.
+          tail -n 50 /tmp/mcp-smoke/stderr.log
           if [ "$serve_exit" -ne 0 ] && [ "$serve_exit" -ne 124 ]; then
             echo "::error::doiget serve exited $serve_exit (only 0 or 124 are accepted)"
             exit 1
@@ -122,11 +128,10 @@ jobs:
           # line, asserts the tools/list response advertises
           # doiget_health, and asserts the doiget_health response shape.
           # Per-line error messages include line numbers for fast triage.
-          python3 - /tmp/mcp-smoke/stdout.log <<'PYEOF'
+          python3 <<'PYEOF'
           import json, sys
-          path = sys.argv[1]
           lines = []
-          for i, raw in enumerate(open(path), 1):
+          for i, raw in enumerate(open("/tmp/mcp-smoke/stdout.log"), 1):
               line = raw.rstrip('\n')
               if not line:
                   continue

--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -170,7 +170,7 @@ jobs:
           echo "stdout-purity: OK"
       - name: Upload logs (always)
         if: always()
-        uses: actions/upload-artifact@6f51ac03b9356b520e9a168e888d8d25c6e1d9f1   # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02   # v4
         with:
           name: mcp-smoke-logs
           path: /tmp/mcp-smoke/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,35 @@ sees the difference without consulting the spec.
   documentation slice may add a §N normative subsection mirroring
   the `metadata_only` §11 / `fetch_paper` §4 detail blocks.
 
+### Slice 9 — `mcp-smoke.yml` Phase-0 placeholder → real CI gate
+
+Replaces the placeholder `mcp-smoke.yml` workflow with the actual
+Phase-3 gate documented in `docs/MCP_TOOLS.md` §9. Two jobs:
+
+- **`in-process-smoke`** — runs `cargo test -p doiget-mcp --tests`,
+  exercising all rmcp tool-router methods via the in-process duplex
+  pipe (`initialize_handshake`, `fetch_paper_e2e`, and any per-slice
+  e2e binary that has landed — Slice 7 `resolve_paper_e2e` and
+  Slice 8 `read_path_e2e` if those PRs have merged). Hermetic.
+
+- **`stdout-purity`** — builds `doiget-cli` in release, spawns
+  `target/release/doiget serve`, pipes
+  `initialize` + `notifications/initialized` + `tools/list` to
+  stdin, closes stdin, captures stdout, and asserts every non-blank
+  line of stdout parses as a JSON object. This catches the failure
+  mode that the in-process pipe cannot see: a banner / log / progress
+  line accidentally written to the real stdout. Per
+  `docs/SECURITY.md` §3, stdout is reserved for JSON-RPC frames
+  only; this job is the load-bearing CI check for that invariant.
+
+- **Logs uploaded as artifact** (`/tmp/mcp-smoke/`) on every run so a
+  failed smoke is debuggable without re-running.
+
+The previous workflow's `placeholder` job is replaced (it only
+echoed a Phase-0 notice). The path filter is expanded to include
+`crates/doiget-cli/**` and `crates/doiget-core/**` since the
+subprocess-style probe depends on both crates.
+
 ### Slice 6 — Real-world DOI / arXiv fixture set
 
 This slice curates a **frozen-snapshot fixture set** under

--- a/site/config.toml
+++ b/site/config.toml
@@ -13,7 +13,6 @@ base_url = "https://sotashimozono.github.io/doiget"
 title = "doiget"
 description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
 default_language = "en"
-theme = ""
 
 compile_sass = false
 minify_html = false


### PR DESCRIPTION
## Summary

Replaces the Phase-0 placeholder in `.github/workflows/mcp-smoke.yml` with the actual Phase-3 CI gate documented in `docs/MCP_TOOLS.md` §9.

Two jobs:

- **`in-process-smoke`** — `cargo test -p doiget-mcp --tests`. Picks up every per-tool e2e binary that has landed (`initialize_handshake`, `fetch_paper_e2e`, plus `resolve_paper_e2e` / `read_path_e2e` once their parallel PRs merge).
- **`stdout-purity`** — builds `doiget-cli` in release, spawns `doiget serve`, pipes `initialize` + `notifications/initialized` + `tools/list` to stdin, closes stdin, captures stdout, and asserts every non-blank line parses as a JSON object. Catches the failure mode the in-process duplex pipe cannot see: a banner / log / progress line accidentally written to **real stdout**. Per `docs/SECURITY.md` §3 stdout is reserved for JSON-RPC frames only — this is the load-bearing CI check for that invariant.

Logs are uploaded as a workflow artifact (`/tmp/mcp-smoke/`) on every run so a failed smoke is debuggable without re-running.

## Path filter

Expanded to include `crates/doiget-cli/**` and `crates/doiget-core/**` since the stdout-purity probe depends on both crates (the CLI defines `doiget serve` and the core defines the `CapabilityProfile` the server reads at startup).

## Out of scope (for follow-up)

The INTEGRATION/* docs (`claude-desktop.md`, `cursor.md`, `codex.md`, `claude-code.md`) are still placeholders. They will be unblocked in a separate slice to keep this PR focused on the CI gate.

## Test plan

- [ ] CI on this PR runs the workflow itself; both jobs green.
- [ ] `stdout-purity` job uploads `mcp-smoke-logs` artifact regardless of pass/fail.
- [ ] If a future PR accidentally calls `println!` or `eprintln!` (to stdout) inside doiget-mcp, the `stdout-purity` job goes red with `::error::Non-JSON line on stdout: ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)