### PR TITLE
feat(slice-10): tier_2_allowlist() — Phase 4 starts (redirect-allowlist scaffolding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,36 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 10 — Tier 2 redirect-allowlist scaffolding (Phase 4 starts)
+
+First Phase-4 slice: lands the redirect-allowlist data for the three
+Tier 2 metadata sources (`docs/SOURCES.md` §1 Tier-2 row). No source
+impls yet — subsequent slices add OpenAlex (11), Semantic Scholar
+(12), and DOAJ (13) concretely.
+
+- **New `tier_2_allowlist()` function** in
+  `crates/doiget-core/src/http.rs`. Sibling to the existing
+  `tier_1_allowlist()` and `oa_publisher_allowlist()`. Returns three
+  `SourceAllowlist` entries with the production hosts:
+  - `"openalex"` → `api.openalex.org`
+  - `"semantic_scholar"` → `api.semanticscholar.org`
+  - `"doaj"` → `doaj.org` + `*.doaj.org`
+
+- **No behavioral change yet.** The function is declared but not
+  consumed by any source impl. Tier 2 source impls (Slice 11/12/13)
+  will pass this list into `HttpClient::new` so the redirect closure
+  denies off-list hosts under each Tier 2 source key.
+
+- **Capability gate, unchanged.** `CapabilityProfile.metadata.{openalex,
+  semantic_scholar, doaj}` and the `DOIGET_ENABLE_OPENALEX` /
+  `DOIGET_ENABLE_S2` / `DOIGET_ENABLE_DOAJ` env vars were already
+  wired during Phase 0; this slice does not touch them.
+
+- **No new tests in this slice.** `tier_2_allowlist()` is pure data;
+  a sibling unit test (mirroring `tier_1_allowlist_includes_crossref`)
+  lands in Slice 11 alongside the first concrete source impl, so the
+  assertion has a producer to protect.
+
 ### Slice 8 — Read-path MCP tools (4 tools)
 
 Wires the four 100% local read-path MCP tools from the

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -135,6 +135,39 @@ pub fn tier_1_allowlist() -> Vec<SourceAllowlist> {
     ]
 }
 
+/// Hard-coded Phase 4 allowlist for Tier 2 metadata sources (OpenAlex,
+/// Semantic Scholar, DOAJ). Sourced from `docs/SOURCES.md` §1 (the Tier 2
+/// table) and `docs/REDIRECT_ALLOWLIST.md` §3 (same redirect-allowlist
+/// policy as Tier 1, distinct source keys).
+///
+/// Returned hosts:
+///
+/// - `"openalex"` → `api.openalex.org` (production OpenAlex REST API).
+/// - `"semantic_scholar"` → `api.semanticscholar.org` (S2 Graph API base).
+/// - `"doaj"` → `doaj.org` + `*.doaj.org` (DOAJ public API; wildcard
+///   covers `api.doaj.org` and any v4+ subdomain split).
+///
+/// Per `docs/SOURCES.md` §4 "OpenAlex / Semantic Scholar / DOAJ", these
+/// sources are **metadata-only**: their `Source::fetch` impls MUST
+/// return `pdf_bytes: None`. The redirect closure in [`HttpClient`]
+/// uses this list to deny redirects to off-list hosts under each Tier
+/// 2 source key — identical mechanism to Tier 1, but the per-tool
+/// capability gate (`profile.metadata.openalex` etc.) is layered on
+/// top so the network surface remains capability-aware.
+pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
+    vec![
+        SourceAllowlist::new("openalex", vec!["api.openalex.org".to_string()]),
+        SourceAllowlist::new(
+            "semantic_scholar",
+            vec!["api.semanticscholar.org".to_string()],
+        ),
+        SourceAllowlist::new(
+            "doaj",
+            vec!["doaj.org".to_string(), "*.doaj.org".to_string()],
+        ),
+    ]
+}
+
 /// Hard-coded Phase 1 allowlist for the synthetic `"oa-publisher"` source —
 /// the publisher / preprint / repository hosts to which Unpaywall's
 /// `best_oa_location.url` (or `url_for_pdf`) typically resolves.


### PR DESCRIPTION
## Summary

First Phase 4 slice. Adds the redirect-allowlist data for the 3 Tier-2 metadata sources per `docs/SOURCES.md` §1 Tier-2 row:

- `openalex` → `api.openalex.org`
- `semantic_scholar` → `api.semanticscholar.org`
- `doaj` → `doaj.org` + `*.doaj.org`

Function lives in `crates/doiget-core/src/http.rs`, sibling to existing `tier_1_allowlist()` and `oa_publisher_allowlist()`. Same redirect-closure pattern, distinct source keys so per-tool capability gates aren't bypassed by cross-tier redirects.

## What this PR does NOT do (follow-up slices)

- No Source trait impls — those land in Slice 11 (OpenAlex), Slice 12 (S2), Slice 13 (DOAJ).
- No orchestrator wiring — Tier 2 fallback chain in metadata_only after Slice 11-13.
- No new tests yet — the per-host assertion test lands alongside Slice 11 so it has a producer to protect.
- No CapabilityProfile / env-var changes — `CapabilityProfile.metadata.{openalex, semantic_scholar, doaj}` was already wired during Phase 0.

## Phase 4 slice plan

```
Slice 10 (this PR) -> 11 OpenAlex -> 14 citation_graph -> 15 MCP tools -> 16 CLI
                   -> 12 S2       /
                   -> 13 DOAJ     /
```

## Files changed (+63)

- `crates/doiget-core/src/http.rs` (+33)
- `CHANGELOG.md` (+30)

## Test plan

- [x] `cargo check` green locally
- [x] `cargo fmt --all` clean
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)