### PR TITLE
feat(slice-11): OpenAlex source impl (Tier 2, Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,49 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 11 — OpenAlex source implementation (Phase 4 / Tier 2)
+
+First concrete Tier 2 source. Adds `OpenalexSource` behind the
+`metadata` Cargo feature gate plus runtime capability check
+(`profile.metadata.openalex`).
+
+- **New module** `crates/doiget-core/src/sources/openalex.rs`
+  declared in `sources/mod.rs` under
+  `#[cfg(feature = "metadata")] pub mod openalex;`. Default build
+  (`oa-only`) excludes the module entirely so no Tier 2 code paths
+  ship in the default release binary.
+
+- **Production constructor `OpenalexSource::new(contact_email)`**
+  hard-codes `https://api.openalex.org` as the base URL.
+  **Test-only constructor `with_base`** lets wiremock substitute an
+  `http://127.0.0.1:N` origin via a future `DOIGET_OPENALEX_BASE`
+  env var (orchestrator wiring lands in a follow-up).
+
+- **`Source` impl wire shape:**
+  - `name() = "openalex"`
+  - `can_serve(profile, ref_) = profile.metadata.openalex && Ref::Doi(_)`
+  - `fetch`: `GET <base>/works/<doi>?mailto=<contact>`, parses the
+    Work record JSON, emits one `LogEvent::Fetch` provenance row
+    under `Capability::Metadata` (per `docs/PROVENANCE_LOG.md` §3),
+    returns `FetchResult { source: "openalex", license: "unknown",
+    pdf_bytes: None, metadata_json: Some(work) }`.
+  - Metadata-only contract: `pdf_bytes` is always `None`
+    (`docs/SOURCES.md` §4).
+
+- **Defensive shape check**: an OpenAlex response missing the `id`
+  field is treated as an error payload and surfaces as
+  `FetchError::SourceSchema` with the first 200 chars of the body
+  in the hint.
+
+- **Defense-in-depth capability gate**: even if `can_serve` is
+  bypassed, `fetch` rejects with `FetchError::NotEligible` when
+  `profile.metadata.openalex == false`.
+
+- **4 unit tests** in `sources::openalex::tests` (all green):
+  happy path (asserts `display_name` + `referenced_works[0]`),
+  arXiv ref rejection, capability-flag-off rejection, malformed
+  response → `SourceSchema`.
+
 ### Slice 10 — Tier 2 redirect-allowlist scaffolding (Phase 4 starts)
 
 First Phase-4 slice: lands the redirect-allowlist data for the three

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -1,9 +1,20 @@
-//! Tier-1 source implementations (Phase 1+).
+//! Source implementations.
 //!
-//! Each source is a concrete `Source` trait impl. Per `docs/SOURCES.md` §1, Tier 1
-//! is the always-on Open Access tier (Crossref / Unpaywall / arXiv). Tier 2/3
-//! sources land in Phase 4/5.
+//! Each source is a concrete `Source` trait impl. Per `docs/SOURCES.md` §1:
+//!
+//! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
+//! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
+//!   feature): OpenAlex / Semantic Scholar / DOAJ.
+//! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
+//!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
 pub mod arxiv;
 pub mod crossref;
 pub mod unpaywall;
+
+// ---------------------------------------------------------------------------
+// Tier 2 (Phase 4) — compile-gated by the `metadata` Cargo feature.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "metadata")]
+pub mod openalex;

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -1,0 +1,384 @@
+//! OpenAlex source — DOI metadata enrichment (Phase 4 / Tier 2).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4 "OpenAlex / Semantic
+//! Scholar / DOAJ". OpenAlex is a free, no-auth metadata API. Polite
+//! pool is opted into via a `mailto` query parameter; the contact
+//! email is supplied through [`OpenalexSource::new`] (same channel
+//! Crossref uses).
+//!
+//! ## Capability gate
+//!
+//! [`OpenalexSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.openalex`](crate::CapabilityProfile)
+//! is `true` AND the ref is a [`Ref::Doi`]. The metadata bool is set
+//! by [`CapabilityProfile::from_env`] from the
+//! `DOIGET_ENABLE_OPENALEX` environment variable (presence-checked),
+//! and only when the `metadata` Cargo feature is compiled in
+//! (`docs/CAPABILITY.md` §2).
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4, this source is **metadata-only**.
+//! [`OpenalexSource::fetch`] never returns PDF bytes
+//! (`FetchResult.pdf_bytes` is always `None`). The citation graph
+//! orchestrator (Slice 14) consumes the `referenced_works` array
+//! from the response metadata to expand the graph; that array lists
+//! OpenAlex Work IDs, not DOIs, so the orchestrator does its own ID
+//! resolution.
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production OpenAlex REST API base URL.
+///
+/// Hard-coded per `docs/SOURCES.md` §1 Tier-2 row. Tests inject a
+/// wiremock origin via [`OpenalexSource::with_base`], identical to
+/// the pattern used by `CrossrefSource`.
+const DEFAULT_BASE: &str = "https://api.openalex.org";
+
+/// OpenAlex [`Source`] impl — DOI → enriched bibliographic metadata.
+///
+/// See module docs for the capability-gate and metadata-only contract.
+#[derive(Clone, Debug)]
+pub struct OpenalexSource {
+    /// API base URL. Production constructor pins this to
+    /// `https://api.openalex.org`; the [`with_base`](Self::with_base)
+    /// test-only constructor lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+    /// Polite-pool contact email per `docs/SOURCES.md` §6. OpenAlex
+    /// accepts this as a `?mailto=<email>` query parameter; doiget
+    /// uses the query-parameter route so callers reading raw URLs in
+    /// the provenance log can see the polite-pool opt-in directly.
+    contact_email: String,
+}
+
+impl OpenalexSource {
+    /// Production constructor: hard-codes `https://api.openalex.org`
+    /// as the base URL.
+    #[must_use]
+    pub fn new(contact_email: String) -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+            contact_email,
+        }
+    }
+
+    /// Construct with an arbitrary base URL.
+    ///
+    /// The orchestrator uses this to honor the `DOIGET_OPENALEX_BASE`
+    /// env var (Slice 11+ wiring), which lets integration tests point
+    /// the source at a wiremock origin without compile-time gates.
+    /// Production callers use [`OpenalexSource::new`].
+    pub fn with_base(base: Url, contact_email: String) -> Self {
+        Self {
+            base,
+            contact_email,
+        }
+    }
+
+    /// Build the `/works/{doi}?mailto=<contact>` URL.
+    ///
+    /// OpenAlex accepts the bare DOI in the path. The `mailto` query
+    /// parameter opts into the polite pool per `docs/SOURCES.md` §6.
+    /// When `contact_email` is empty, the query parameter is omitted.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let path = format!("/works/{}", doi.as_str());
+        let mut url = self
+            .base
+            .join(&path)
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("openalex URL construction failed: {e}"),
+            })?;
+        if !self.contact_email.is_empty() {
+            url.query_pairs_mut()
+                .append_pair("mailto", &self.contact_email);
+        }
+        Ok(url)
+    }
+}
+
+#[async_trait]
+impl Source for OpenalexSource {
+    fn name(&self) -> &str {
+        "openalex"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        // Gated by both the runtime capability flag AND the ref kind.
+        // arXiv ids are not OpenAlex Work IDs and OpenAlex's
+        // `/works/<id>` endpoint expects either a DOI or an OpenAlex
+        // Work ID; we only accept DOI here.
+        profile.metadata.openalex && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "openalex".into(),
+                });
+            }
+        };
+
+        // Defense-in-depth capability gate — the orchestrator should
+        // have called `can_serve` first, but the source enforces too.
+        if !profile.metadata.openalex {
+            return Err(FetchError::NotEligible {
+                source_key: "openalex".into(),
+            });
+        }
+
+        // Step 1: rate limiter (politeness — `docs/SOURCES.md` §6).
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        // Step 2: HTTP fetch. Body is JSON; OpenAlex Work records are
+        // tens of KB even for highly-cited papers, well under the
+        // `PDF_MAX_BYTES` cap.
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        // Step 3: parse the response. OpenAlex returns the Work
+        // record directly at the top level (no envelope, unlike
+        // Crossref).
+        let work: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("openalex returned non-JSON: {e}"),
+            })?;
+
+        // Defensive shape check — every real Work record has an
+        // `id` field. An error payload has an `error` field instead
+        // (and no `id`). Use missing `id` as the "not a Work record"
+        // signal.
+        if work.get("id").is_none() {
+            return Err(FetchError::SourceSchema {
+                hint: format!(
+                    "openalex response missing `id` field — likely an error \
+                     payload (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            });
+        }
+
+        // Step 4: provenance row. Tier 2 sources emit under
+        // `Capability::Metadata` per `docs/PROVENANCE_LOG.md` §3.
+        // ADR-0021 §1 canonical-digest: promote the ref under the
+        // "openalex" resolver profile.
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            // OpenAlex Work records carry a `best_oa_location.license`
+            // field but a missing-or-null value is the common case
+            // for non-OA works. Surface it via `metadata_json` and let
+            // the orchestrator decide; report a neutral marker here.
+            license: "unknown".into(),
+            // Metadata-only contract (docs/SOURCES.md §4).
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(work),
+        })
+    }
+}
+
+/// Truncate a response body to a short prefix for inclusion in error
+/// hints. Avoids dumping a multi-KB payload into a single log line
+/// when the response is malformed; 200 chars is enough to identify the
+/// shape (HTML 404 page vs. JSON error envelope vs. truncated work).
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{ArxivId, CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// Hand-crafted (not a snapshot) OpenAlex Work record. Kept small
+    /// and synthetic to avoid third-party redistribution concerns.
+    const SAMPLE_WORK: &str = r#"{
+        "id": "https://openalex.org/W2741809807",
+        "doi": "https://doi.org/10.1234/example",
+        "display_name": "Example Work Title",
+        "publication_year": 2024,
+        "referenced_works": [
+            "https://openalex.org/W2000000001",
+            "https://openalex.org/W2000000002"
+        ]
+    }"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "openalex",
+            wiremock_host,
+        ));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter,
+            log,
+            session_id,
+        };
+        (td, ctx)
+    }
+
+    fn profile_with_openalex_enabled() -> CapabilityProfile {
+        // Build a clean profile, then flip the openalex flag. We avoid
+        // touching the real env vars so the test runs single-threaded
+        // without `serial_test`.
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: true,
+            semantic_scholar: false,
+            doaj: false,
+        };
+        p
+    }
+
+    #[tokio::test]
+    async fn fetch_doi_returns_work_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .and(query_param("mailto", "doiget@localhost"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_WORK))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = OpenalexSource::with_base(
+            Url::parse(&server.uri()).expect("wiremock URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(result.source, "openalex");
+        assert!(result.pdf_bytes.is_none(), "metadata-only contract");
+        let meta = result.metadata_json.expect("metadata_json present");
+        assert_eq!(meta["display_name"], "Example Work Title");
+        assert_eq!(
+            meta["referenced_works"][0],
+            "https://openalex.org/W2000000001"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_arxiv_id_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = OpenalexSource::with_base(
+            Url::parse("http://127.0.0.1:1").expect("URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let ref_ = Ref::Arxiv(ArxivId::parse("2401.12345").expect("arXiv id parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("arXiv ref must be rejected");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[tokio::test]
+    async fn fetch_without_capability_flag_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = OpenalexSource::with_base(
+            Url::parse("http://127.0.0.1:1").expect("URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        // Profile with metadata.openalex == false (default).
+        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        assert!(
+            !src.can_serve(&profile, &ref_),
+            "can_serve must be false without DOIGET_ENABLE_OPENALEX"
+        );
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("fetch must reject when capability is denied");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[tokio::test]
+    async fn fetch_malformed_response_returns_source_schema_error() {
+        let server = MockServer::start().await;
+        // Response has no `id` field — defensive shape check trips.
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"error":"not found"}"#))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = OpenalexSource::with_base(
+            Url::parse(&server.uri()).expect("wiremock URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("missing `id` must surface as SourceSchema");
+        assert!(matches!(err, FetchError::SourceSchema { .. }));
+    }
+}


### PR DESCRIPTION
## Summary

Second Phase-4 slice. First concrete Tier 2 source: `OpenalexSource` lands behind the `metadata` Cargo feature gate.

- **`Source` impl shape:**
  - `name()` = `"openalex"`
  - `can_serve(profile, ref_)` = `profile.metadata.openalex && Ref::Doi(_)`
  - `fetch`: `GET <base>/works/<doi>?mailto=<contact>` → emits `LogEvent::Fetch` row under `Capability::Metadata` → returns `FetchResult { source: "openalex", license: "unknown", pdf_bytes: None, metadata_json: Some(work) }`
  - **Metadata-only contract**: `pdf_bytes: None` is invariant (per `docs/SOURCES.md` §4).

- **Defensive shape check**: missing `id` field → `FetchError::SourceSchema`.
- **Defense-in-depth**: `fetch` re-checks `profile.metadata.openalex` so a `can_serve` bypass cannot leak through.

## Base branch

Stacked on PR #97 (`feat/slice-10-tier2-scaffolding`) since this consumes `tier_2_allowlist()`. Merge order: #97 first, then this.

## Test plan

- [x] `cargo check` (default `oa-only`) green — module is gated out
- [x] `cargo check --features metadata -p doiget-core` green
- [x] `cargo test --features metadata -p doiget-core --lib openalex` — 4/4 pass
  - `fetch_doi_returns_work_metadata` — happy path with wiremock
  - `fetch_arxiv_id_is_not_eligible` — arXiv rejected
  - `fetch_without_capability_flag_is_not_eligible` — `metadata.openalex=false` rejected
  - `fetch_malformed_response_returns_source_schema_error` — missing `id` → SourceSchema
- [ ] CI matrix green

## Out of scope (follow-up slices)

- Orchestrator wiring (Tier 2 fallback chain in `metadata_only`) — pending Slice 13 so all 3 Tier 2 sources land together
- `DOIGET_OPENALEX_BASE` env-var support in the orchestrator's source constructors — same follow-up
- Slice 12 Semantic Scholar source (parallel-able)
- Slice 13 DOAJ source (parallel-able)
- Slice 14 citation_graph orchestrator (consumes `referenced_works[]` from this response)

## Files changed (+442 / -4)

- `crates/doiget-core/src/sources/openalex.rs` (new, ~370 lines incl. 4 tests)
- `crates/doiget-core/src/sources/mod.rs` (declares conditional `pub mod openalex;`)
- `CHANGELOG.md` (Slice 11 section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)