### PR TITLE
feat(slice-14): citation_graph BFS expansion (ADR-0010, Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,57 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 14 — Citation graph BFS expansion (ADR-0010, Phase 4)
+
+Citation-graph orchestrator backing the upcoming
+`doiget_expand_citation_graph` MCP tool (Slice 15) and `doiget graph`
+CLI subcommand (Slice 16).
+
+- **New module** `crates/doiget-core/src/citation_graph.rs`,
+  compile-gated by the `citation` Cargo feature (which itself
+  enables `metadata` so `OpenalexSource` is available).
+
+- **`expand(seed_doi, caps, source, profile, ctx)`** runs a BFS
+  walk via OpenAlex. The seed `Doi` is resolved through
+  `OpenalexSource::fetch` (so the seed lands in the audit trail
+  via the documented path); subsequent works are fetched directly
+  via `ctx.http.fetch_bytes("openalex", url)` for Work-ID lookups
+  (the redirect allowlist already permits the `openalex` source
+  key from Slice 10). Each successful fetch appends one
+  `LogEvent::Fetch` row under `Capability::Metadata`. Failed
+  fetches log `LogResult::Err` rows and continue the walk with
+  `truncated = true`.
+
+- **ADR-0010 hard caps enforced via `GraphCaps::clamped`**:
+  `MAX_DEPTH = 3`, `MAX_TOTAL = 100`, `MAX_PER_PAPER = 20`. Any
+  caller-supplied value is clamped before walking — this is the
+  load-bearing enforcement point per the ADR's binding contract.
+  `truncated: true` is set on the result when any cap is hit.
+
+- **Cycle detection** via `HashSet<String>` of visited Work IDs.
+  Duplicate parents still get edges added (so structural cycles
+  are visible in the result) but are not re-queued.
+
+- **TDM-free invariant**: per ADR-0010, this module never consults
+  any Tier 3 source. Even S2 / DOAJ are not used — only OpenAlex
+  exposes `referenced_works[]` in a single round-trip, so the
+  walker is OpenAlex-only by design.
+
+- **New `GraphError` enum**: `Source(FetchError)`, `Log(LogError)`,
+  `SeedNotIndexed`, `CapabilityDenied`. Provenance-log failures
+  abort the expansion (fail-closed per
+  `docs/PROVENANCE_LOG.md` §5).
+
+- **`DOIGET_OPENALEX_BASE` env var** is read at Work-ID fetch
+  time so wiremock tests can swap the origin. Production callers
+  leave the env unset and the default `https://api.openalex.org`
+  applies.
+
+- **3 unit tests** in `citation_graph::tests` green:
+  `caps_clamps_to_adr_0010_maxima`, `expand_walks_depth_2_graph`
+  (a 4-node wiremocked graph: W0001 seed → W0002/W0003 → W0004),
+  `expand_without_capability_flag_errors`.
+
 ### Slice 11 — OpenAlex source implementation (Phase 4 / Tier 2)
 
 First concrete Tier 2 source. Adds `OpenalexSource` behind the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,49 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 11 — OpenAlex source implementation (Phase 4 / Tier 2)
+
+First concrete Tier 2 source. Adds `OpenalexSource` behind the
+`metadata` Cargo feature gate plus runtime capability check
+(`profile.metadata.openalex`).
+
+- **New module** `crates/doiget-core/src/sources/openalex.rs`
+  declared in `sources/mod.rs` under
+  `#[cfg(feature = "metadata")] pub mod openalex;`. Default build
+  (`oa-only`) excludes the module entirely so no Tier 2 code paths
+  ship in the default release binary.
+
+- **Production constructor `OpenalexSource::new(contact_email)`**
+  hard-codes `https://api.openalex.org` as the base URL.
+  **Test-only constructor `with_base`** lets wiremock substitute an
+  `http://127.0.0.1:N` origin via a future `DOIGET_OPENALEX_BASE`
+  env var (orchestrator wiring lands in a follow-up).
+
+- **`Source` impl wire shape:**
+  - `name() = "openalex"`
+  - `can_serve(profile, ref_) = profile.metadata.openalex && Ref::Doi(_)`
+  - `fetch`: `GET <base>/works/<doi>?mailto=<contact>`, parses the
+    Work record JSON, emits one `LogEvent::Fetch` provenance row
+    under `Capability::Metadata` (per `docs/PROVENANCE_LOG.md` §3),
+    returns `FetchResult { source: "openalex", license: "unknown",
+    pdf_bytes: None, metadata_json: Some(work) }`.
+  - Metadata-only contract: `pdf_bytes` is always `None`
+    (`docs/SOURCES.md` §4).
+
+- **Defensive shape check**: an OpenAlex response missing the `id`
+  field is treated as an error payload and surfaces as
+  `FetchError::SourceSchema` with the first 200 chars of the body
+  in the hint.
+
+- **Defense-in-depth capability gate**: even if `can_serve` is
+  bypassed, `fetch` rejects with `FetchError::NotEligible` when
+  `profile.metadata.openalex == false`.
+
+- **4 unit tests** in `sources::openalex::tests` (all green):
+  happy path (asserts `display_name` + `referenced_works[0]`),
+  arXiv ref rejection, capability-flag-off rejection, malformed
+  response → `SourceSchema`.
+
 ### Slice 10 — Tier 2 redirect-allowlist scaffolding (Phase 4 starts)
 
 First Phase-4 slice: lands the redirect-allowlist data for the three

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -1,0 +1,532 @@
+//! Citation graph BFS expansion (Phase 4 / ADR-0010).
+//!
+//! Spec: [`docs/DECISIONS/0010-citation-graph-hard-cap.md`].
+//!
+//! ## Binding contract
+//!
+//! - Library-const hard caps (depth=3, total=100, per-paper=20)
+//!   apply regardless of caller-supplied parameters. Callers MAY ask
+//!   for less; they MUST NOT exceed the caps. [`GraphCaps::clamped`]
+//!   enforces this — the public entry point [`expand`] runs
+//!   `clamped()` on whatever the caller passed.
+//! - `truncated: true` is set in [`GraphResult`] when ANY cap is hit
+//!   (the total cap or per-paper cap or depth cap).
+//! - Cycle detection is mandatory: a `visited` set tracks every
+//!   work id added to the graph; duplicates are dropped.
+//! - TDM sources (Tier 3) are NEVER consulted during citation graph
+//!   expansion. This module only uses OpenAlex via `ctx.http` (the
+//!   `openalex` redirect-allowlist key from
+//!   [`crate::http::tier_2_allowlist`]).
+//!
+//! ## How it walks
+//!
+//! 1. The seed `Doi` is resolved through [`OpenalexSource::fetch`]
+//!    so the seed lands in the audit trail under
+//!    `Capability::Metadata`. The response yields the seed's
+//!    OpenAlex Work ID + its `referenced_works` array.
+//! 2. The BFS queue holds `(work_id, depth)` pairs. For each
+//!    dequeued work whose depth is `< caps.depth`, we fetch
+//!    `<openalex_base>/works/<work_id>` directly via
+//!    `ctx.http.fetch_bytes("openalex", url)` (same source-key the
+//!    seed used, so the redirect closure stays happy), parse the
+//!    `referenced_works` array, and queue up to `caps.per_paper`
+//!    children.
+//! 3. The BFS terminates when the queue is empty OR
+//!    `total_visited >= caps.total`. In the latter case
+//!    `truncated = true`.
+//!
+//! ## What is not in this slice (follow-up)
+//!
+//! - The fetches issued during the BFS walk reuse the OpenAlex
+//!   redirect-allowlist key and the `ctx.http` shared client, but
+//!   they do NOT go through [`OpenalexSource::fetch`] (which only
+//!   accepts a DOI ref). A future refactor may add
+//!   `OpenalexSource::fetch_by_work_id` so the per-fetch provenance
+//!   row is emitted the same way the seed's is; today the BFS
+//!   walker emits its own `LogEvent::Fetch` rows directly via
+//!   `ctx.log.append`.
+//! - S2 / DOAJ fallback: not used. The graph walker is OpenAlex-
+//!   only by design — only OpenAlex Work records expose the
+//!   `referenced_works` array in a single round-trip.
+
+#![cfg(feature = "citation")]
+
+use std::collections::{HashSet, VecDeque};
+
+use serde::Serialize;
+use url::Url;
+
+use crate::provenance::{Capability, LogError, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, Source};
+use crate::sources::openalex::OpenalexSource;
+use crate::{CapabilityProfile, Doi, Ref};
+
+/// Hard caps from ADR-0010. Library const defaults; callers may
+/// request a smaller value, but the maximums below are enforced by
+/// [`Self::clamped`].
+#[derive(Debug, Clone, Copy)]
+pub struct GraphCaps {
+    /// Maximum BFS depth (default 3, max 3). Depth 0 is the seed
+    /// only.
+    pub depth: usize,
+    /// Maximum total number of nodes in the result (default 100,
+    /// max 100). When the cap is hit the result is
+    /// `truncated: true`.
+    pub total: usize,
+    /// Maximum number of children expanded per parent (default 20,
+    /// max 20). Excess `referenced_works` entries from a single
+    /// parent are dropped (and flip `truncated`).
+    pub per_paper: usize,
+}
+
+impl GraphCaps {
+    /// Library-const maximum depth per ADR-0010.
+    pub const MAX_DEPTH: usize = 3;
+    /// Library-const maximum total nodes per ADR-0010.
+    pub const MAX_TOTAL: usize = 100;
+    /// Library-const maximum per-paper children per ADR-0010.
+    pub const MAX_PER_PAPER: usize = 20;
+
+    /// Returns a `GraphCaps` clamped to the ADR-0010 maxima.
+    ///
+    /// Values greater than the corresponding `MAX_*` constants are
+    /// silently reduced; `0` is left as-is so callers can ask for
+    /// "seed only" with `depth: 0`. This is the load-bearing
+    /// enforcement point per ADR-0010: "expand_citation_graph
+    /// applies library const hard-caps regardless of caller-supplied
+    /// parameters."
+    #[must_use]
+    pub fn clamped(self) -> Self {
+        Self {
+            depth: self.depth.min(Self::MAX_DEPTH),
+            total: self.total.min(Self::MAX_TOTAL),
+            per_paper: self.per_paper.min(Self::MAX_PER_PAPER),
+        }
+    }
+}
+
+impl Default for GraphCaps {
+    fn default() -> Self {
+        Self {
+            depth: Self::MAX_DEPTH,
+            total: Self::MAX_TOTAL,
+            per_paper: Self::MAX_PER_PAPER,
+        }
+    }
+}
+
+/// One node in the citation graph result.
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphNode {
+    /// OpenAlex Work ID (short form, e.g. `"W2741809807"`).
+    pub id: String,
+    /// BFS depth from the seed. `0` is the seed itself.
+    pub depth: usize,
+}
+
+/// One edge: `from` cites `to`.
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphEdge {
+    pub from: String,
+    pub to: String,
+}
+
+/// Result of [`expand`].
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphResult {
+    pub seed_work_id: String,
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    pub truncated: bool,
+    pub total_visited: usize,
+}
+
+/// Errors from citation-graph expansion.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum GraphError {
+    #[error("openalex source error: {0}")]
+    Source(#[from] FetchError),
+    /// Provenance log write failed — fail-closed (the expansion is
+    /// aborted partway through). Matches the rest of the codebase's
+    /// posture per `docs/PROVENANCE_LOG.md` §5.
+    #[error("provenance log error during graph expansion: {0}")]
+    Log(#[from] LogError),
+    #[error("seed DOI not indexed by OpenAlex (no `id` field in response)")]
+    SeedNotIndexed,
+    #[error("citation graph requires DOIGET_ENABLE_OPENALEX + --features metadata")]
+    CapabilityDenied,
+}
+
+/// Expand the citation graph for `seed_doi` via OpenAlex.
+pub async fn expand(
+    seed_doi: &Doi,
+    caps: GraphCaps,
+    source: &OpenalexSource,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+) -> Result<GraphResult, GraphError> {
+    if !profile.metadata.openalex {
+        return Err(GraphError::CapabilityDenied);
+    }
+    let caps = caps.clamped();
+
+    // Step 1: resolve the seed through OpenalexSource so the seed
+    // fetch lands in the audit trail under the documented path.
+    let ref_ = Ref::Doi(seed_doi.clone());
+    let seed_result = source.fetch(&ref_, profile, ctx).await?;
+    let seed_work = seed_result
+        .metadata_json
+        .ok_or(GraphError::SeedNotIndexed)?;
+
+    let seed_work_id = extract_work_id(&seed_work).ok_or(GraphError::SeedNotIndexed)?;
+    let seed_refs = extract_referenced_works(&seed_work);
+
+    let mut nodes = vec![GraphNode {
+        id: seed_work_id.clone(),
+        depth: 0,
+    }];
+    let mut edges: Vec<GraphEdge> = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(seed_work_id.clone());
+    let mut truncated = false;
+    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+
+    enqueue_children(
+        &seed_work_id,
+        &seed_refs,
+        1,
+        &caps,
+        &mut nodes,
+        &mut edges,
+        &mut visited,
+        &mut queue,
+        &mut truncated,
+    );
+
+    while let Some((work_id, depth)) = queue.pop_front() {
+        if depth >= caps.depth {
+            truncated = true;
+            continue;
+        }
+        if nodes.len() >= caps.total {
+            truncated = true;
+            break;
+        }
+        let work_url = match build_openalex_work_url(&work_id) {
+            Ok(u) => u,
+            Err(_) => {
+                truncated = true;
+                continue;
+            }
+        };
+        let body = match ctx.http.fetch_bytes("openalex", work_url).await {
+            Ok((b, _final)) => b,
+            Err(e) => {
+                let _ = ctx.log.append(RowInput {
+                    event: LogEvent::Fetch,
+                    result: LogResult::Err,
+                    capability: Capability::Metadata,
+                    ref_: Some(work_id.as_str()),
+                    source: Some("openalex"),
+                    error_code: None,
+                    size_bytes: None,
+                    license: None,
+                    store_path: None,
+                    canonical_digest: None,
+                });
+                tracing::warn!(work_id = %work_id, error = %e, "citation-graph step failed");
+                truncated = true;
+                continue;
+            }
+        };
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(work_id.as_str()),
+            source: Some("openalex"),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: None,
+        })?;
+        let work: serde_json::Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(_) => {
+                truncated = true;
+                continue;
+            }
+        };
+        let refs = extract_referenced_works(&work);
+        enqueue_children(
+            &work_id,
+            &refs,
+            depth + 1,
+            &caps,
+            &mut nodes,
+            &mut edges,
+            &mut visited,
+            &mut queue,
+            &mut truncated,
+        );
+    }
+
+    Ok(GraphResult {
+        seed_work_id,
+        total_visited: nodes.len(),
+        nodes,
+        edges,
+        truncated,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enqueue_children(
+    parent_id: &str,
+    refs: &[String],
+    child_depth: usize,
+    caps: &GraphCaps,
+    nodes: &mut Vec<GraphNode>,
+    edges: &mut Vec<GraphEdge>,
+    visited: &mut HashSet<String>,
+    queue: &mut VecDeque<(String, usize)>,
+    truncated: &mut bool,
+) {
+    if refs.len() > caps.per_paper {
+        *truncated = true;
+    }
+    for child in refs.iter().take(caps.per_paper) {
+        if visited.contains(child) {
+            edges.push(GraphEdge {
+                from: parent_id.to_string(),
+                to: child.to_string(),
+            });
+            continue;
+        }
+        if nodes.len() >= caps.total {
+            *truncated = true;
+            return;
+        }
+        visited.insert(child.clone());
+        nodes.push(GraphNode {
+            id: child.clone(),
+            depth: child_depth,
+        });
+        edges.push(GraphEdge {
+            from: parent_id.to_string(),
+            to: child.clone(),
+        });
+        queue.push_back((child.clone(), child_depth));
+    }
+}
+
+/// Extract the short OpenAlex Work ID from a Work record's `id`
+/// field (the response carries the full URL `https://openalex.org/W...`;
+/// the graph stores the short form).
+fn extract_work_id(work: &serde_json::Value) -> Option<String> {
+    let full = work.get("id")?.as_str()?;
+    Some(full.rsplit('/').next().unwrap_or(full).to_string())
+}
+
+/// Extract `referenced_works` as `Vec<short_work_id>`.
+fn extract_referenced_works(work: &serde_json::Value) -> Vec<String> {
+    work.get("referenced_works")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| s.as_str())
+                .map(|s| s.rsplit('/').next().unwrap_or(s).to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Build a URL for `<openalex_base>/works/<work_id>`. Honors the
+/// `DOIGET_OPENALEX_BASE` env var so wiremock tests can swap the
+/// origin.
+fn build_openalex_work_url(work_id: &str) -> Result<Url, FetchError> {
+    let base_str =
+        std::env::var("DOIGET_OPENALEX_BASE").unwrap_or_else(|_| "https://api.openalex.org".into());
+    let base = Url::parse(&base_str).map_err(|e| FetchError::SourceSchema {
+        hint: format!("openalex base URL invalid: {e}"),
+    })?;
+    base.join(&format!("/works/{}", work_id))
+        .map_err(|e| FetchError::SourceSchema {
+            hint: format!("openalex Work URL construction failed: {e}"),
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits};
+
+    const SEED_WORK: &str = r#"{
+        "id": "https://openalex.org/W0001",
+        "doi": "https://doi.org/10.1234/seed",
+        "display_name": "Seed Paper",
+        "referenced_works": [
+            "https://openalex.org/W0002",
+            "https://openalex.org/W0003"
+        ]
+    }"#;
+
+    const HOP_W0002: &str = r#"{
+        "id": "https://openalex.org/W0002",
+        "referenced_works": ["https://openalex.org/W0004"]
+    }"#;
+
+    const HOP_W0003: &str = r#"{
+        "id": "https://openalex.org/W0003",
+        "referenced_works": []
+    }"#;
+
+    const HOP_W0004: &str = r#"{
+        "id": "https://openalex.org/W0004",
+        "referenced_works": []
+    }"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "openalex",
+            wiremock_host,
+        ));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter,
+            log,
+            session_id,
+        };
+        (td, ctx)
+    }
+
+    fn profile_with_openalex_enabled() -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: true,
+            semantic_scholar: false,
+            doaj: false,
+        };
+        p
+    }
+
+    #[tokio::test]
+    async fn caps_clamps_to_adr_0010_maxima() {
+        let huge = GraphCaps {
+            depth: 99,
+            total: 99999,
+            per_paper: 999,
+        };
+        let c = huge.clamped();
+        assert_eq!(c.depth, GraphCaps::MAX_DEPTH);
+        assert_eq!(c.total, GraphCaps::MAX_TOTAL);
+        assert_eq!(c.per_paper, GraphCaps::MAX_PER_PAPER);
+
+        let small = GraphCaps {
+            depth: 1,
+            total: 5,
+            per_paper: 2,
+        };
+        let c2 = small.clamped();
+        assert_eq!(c2.depth, 1);
+        assert_eq!(c2.total, 5);
+        assert_eq!(c2.per_paper, 2);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn expand_walks_depth_2_graph() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/seed"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/works/W0002"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(HOP_W0002))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/works/W0003"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(HOP_W0003))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/works/W0004"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(HOP_W0004))
+            .mount(&server)
+            .await;
+
+        let prev = std::env::var("DOIGET_OPENALEX_BASE").ok();
+        std::env::set_var("DOIGET_OPENALEX_BASE", server.uri());
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = OpenalexSource::with_base(
+            Url::parse(&server.uri()).expect("wiremock URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let seed = Doi::parse("10.1234/seed").expect("DOI parses");
+
+        let result = expand(&seed, GraphCaps::default(), &src, &profile, &ctx).await;
+
+        // Restore env var BEFORE asserting so a panic doesn't leak it.
+        match prev {
+            Some(v) => std::env::set_var("DOIGET_OPENALEX_BASE", v),
+            None => std::env::remove_var("DOIGET_OPENALEX_BASE"),
+        }
+
+        let result = result.expect("expand ok");
+        assert_eq!(result.seed_work_id, "W0001");
+        assert_eq!(result.total_visited, 4, "nodes: {:?}", result.nodes);
+        assert_eq!(result.nodes[0].id, "W0001");
+        assert_eq!(result.nodes[0].depth, 0);
+        assert_eq!(result.edges.len(), 3);
+        assert!(!result.truncated, "graph should be complete");
+    }
+
+    #[tokio::test]
+    async fn expand_without_capability_flag_errors() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = OpenalexSource::with_base(
+            Url::parse("http://127.0.0.1:1").expect("URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let seed = Doi::parse("10.1234/seed").expect("DOI parses");
+
+        let err = expand(&seed, GraphCaps::default(), &src, &profile, &ctx)
+            .await
+            .expect_err("missing openalex capability must error");
+        assert!(matches!(err, GraphError::CapabilityDenied));
+    }
+}

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -25,6 +25,12 @@ pub mod source;
 pub mod sources;
 pub mod store;
 
+// Phase 4 citation graph (ADR-0010). Compile-gated by the `citation`
+// Cargo feature, which itself enables the `metadata` feature so the
+// Tier-2 source impls are available.
+#[cfg(feature = "citation")]
+pub mod citation_graph;
+
 // Re-export the canonical-tuple audit-identity types at the crate root
 // per ADR-0024 / `docs/PUBLIC_API.md` §1. The types themselves live in
 // the [`canonical`] submodule.

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -1,9 +1,20 @@
-//! Tier-1 source implementations (Phase 1+).
+//! Source implementations.
 //!
-//! Each source is a concrete `Source` trait impl. Per `docs/SOURCES.md` §1, Tier 1
-//! is the always-on Open Access tier (Crossref / Unpaywall / arXiv). Tier 2/3
-//! sources land in Phase 4/5.
+//! Each source is a concrete `Source` trait impl. Per `docs/SOURCES.md` §1:
+//!
+//! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
+//! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
+//!   feature): OpenAlex / Semantic Scholar / DOAJ.
+//! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
+//!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
 pub mod arxiv;
 pub mod crossref;
 pub mod unpaywall;
+
+// ---------------------------------------------------------------------------
+// Tier 2 (Phase 4) — compile-gated by the `metadata` Cargo feature.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "metadata")]
+pub mod openalex;

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -1,0 +1,384 @@
+//! OpenAlex source — DOI metadata enrichment (Phase 4 / Tier 2).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4 "OpenAlex / Semantic
+//! Scholar / DOAJ". OpenAlex is a free, no-auth metadata API. Polite
+//! pool is opted into via a `mailto` query parameter; the contact
+//! email is supplied through [`OpenalexSource::new`] (same channel
+//! Crossref uses).
+//!
+//! ## Capability gate
+//!
+//! [`OpenalexSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.openalex`](crate::CapabilityProfile)
+//! is `true` AND the ref is a [`Ref::Doi`]. The metadata bool is set
+//! by [`CapabilityProfile::from_env`] from the
+//! `DOIGET_ENABLE_OPENALEX` environment variable (presence-checked),
+//! and only when the `metadata` Cargo feature is compiled in
+//! (`docs/CAPABILITY.md` §2).
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4, this source is **metadata-only**.
+//! [`OpenalexSource::fetch`] never returns PDF bytes
+//! (`FetchResult.pdf_bytes` is always `None`). The citation graph
+//! orchestrator (Slice 14) consumes the `referenced_works` array
+//! from the response metadata to expand the graph; that array lists
+//! OpenAlex Work IDs, not DOIs, so the orchestrator does its own ID
+//! resolution.
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production OpenAlex REST API base URL.
+///
+/// Hard-coded per `docs/SOURCES.md` §1 Tier-2 row. Tests inject a
+/// wiremock origin via [`OpenalexSource::with_base`], identical to
+/// the pattern used by `CrossrefSource`.
+const DEFAULT_BASE: &str = "https://api.openalex.org";
+
+/// OpenAlex [`Source`] impl — DOI → enriched bibliographic metadata.
+///
+/// See module docs for the capability-gate and metadata-only contract.
+#[derive(Clone, Debug)]
+pub struct OpenalexSource {
+    /// API base URL. Production constructor pins this to
+    /// `https://api.openalex.org`; the [`with_base`](Self::with_base)
+    /// test-only constructor lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+    /// Polite-pool contact email per `docs/SOURCES.md` §6. OpenAlex
+    /// accepts this as a `?mailto=<email>` query parameter; doiget
+    /// uses the query-parameter route so callers reading raw URLs in
+    /// the provenance log can see the polite-pool opt-in directly.
+    contact_email: String,
+}
+
+impl OpenalexSource {
+    /// Production constructor: hard-codes `https://api.openalex.org`
+    /// as the base URL.
+    #[must_use]
+    pub fn new(contact_email: String) -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+            contact_email,
+        }
+    }
+
+    /// Construct with an arbitrary base URL.
+    ///
+    /// The orchestrator uses this to honor the `DOIGET_OPENALEX_BASE`
+    /// env var (Slice 11+ wiring), which lets integration tests point
+    /// the source at a wiremock origin without compile-time gates.
+    /// Production callers use [`OpenalexSource::new`].
+    pub fn with_base(base: Url, contact_email: String) -> Self {
+        Self {
+            base,
+            contact_email,
+        }
+    }
+
+    /// Build the `/works/{doi}?mailto=<contact>` URL.
+    ///
+    /// OpenAlex accepts the bare DOI in the path. The `mailto` query
+    /// parameter opts into the polite pool per `docs/SOURCES.md` §6.
+    /// When `contact_email` is empty, the query parameter is omitted.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let path = format!("/works/{}", doi.as_str());
+        let mut url = self
+            .base
+            .join(&path)
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("openalex URL construction failed: {e}"),
+            })?;
+        if !self.contact_email.is_empty() {
+            url.query_pairs_mut()
+                .append_pair("mailto", &self.contact_email);
+        }
+        Ok(url)
+    }
+}
+
+#[async_trait]
+impl Source for OpenalexSource {
+    fn name(&self) -> &str {
+        "openalex"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        // Gated by both the runtime capability flag AND the ref kind.
+        // arXiv ids are not OpenAlex Work IDs and OpenAlex's
+        // `/works/<id>` endpoint expects either a DOI or an OpenAlex
+        // Work ID; we only accept DOI here.
+        profile.metadata.openalex && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "openalex".into(),
+                });
+            }
+        };
+
+        // Defense-in-depth capability gate — the orchestrator should
+        // have called `can_serve` first, but the source enforces too.
+        if !profile.metadata.openalex {
+            return Err(FetchError::NotEligible {
+                source_key: "openalex".into(),
+            });
+        }
+
+        // Step 1: rate limiter (politeness — `docs/SOURCES.md` §6).
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        // Step 2: HTTP fetch. Body is JSON; OpenAlex Work records are
+        // tens of KB even for highly-cited papers, well under the
+        // `PDF_MAX_BYTES` cap.
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        // Step 3: parse the response. OpenAlex returns the Work
+        // record directly at the top level (no envelope, unlike
+        // Crossref).
+        let work: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("openalex returned non-JSON: {e}"),
+            })?;
+
+        // Defensive shape check — every real Work record has an
+        // `id` field. An error payload has an `error` field instead
+        // (and no `id`). Use missing `id` as the "not a Work record"
+        // signal.
+        if work.get("id").is_none() {
+            return Err(FetchError::SourceSchema {
+                hint: format!(
+                    "openalex response missing `id` field — likely an error \
+                     payload (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            });
+        }
+
+        // Step 4: provenance row. Tier 2 sources emit under
+        // `Capability::Metadata` per `docs/PROVENANCE_LOG.md` §3.
+        // ADR-0021 §1 canonical-digest: promote the ref under the
+        // "openalex" resolver profile.
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            // OpenAlex Work records carry a `best_oa_location.license`
+            // field but a missing-or-null value is the common case
+            // for non-OA works. Surface it via `metadata_json` and let
+            // the orchestrator decide; report a neutral marker here.
+            license: "unknown".into(),
+            // Metadata-only contract (docs/SOURCES.md §4).
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(work),
+        })
+    }
+}
+
+/// Truncate a response body to a short prefix for inclusion in error
+/// hints. Avoids dumping a multi-KB payload into a single log line
+/// when the response is malformed; 200 chars is enough to identify the
+/// shape (HTML 404 page vs. JSON error envelope vs. truncated work).
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{ArxivId, CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// Hand-crafted (not a snapshot) OpenAlex Work record. Kept small
+    /// and synthetic to avoid third-party redistribution concerns.
+    const SAMPLE_WORK: &str = r#"{
+        "id": "https://openalex.org/W2741809807",
+        "doi": "https://doi.org/10.1234/example",
+        "display_name": "Example Work Title",
+        "publication_year": 2024,
+        "referenced_works": [
+            "https://openalex.org/W2000000001",
+            "https://openalex.org/W2000000002"
+        ]
+    }"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "openalex",
+            wiremock_host,
+        ));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter,
+            log,
+            session_id,
+        };
+        (td, ctx)
+    }
+
+    fn profile_with_openalex_enabled() -> CapabilityProfile {
+        // Build a clean profile, then flip the openalex flag. We avoid
+        // touching the real env vars so the test runs single-threaded
+        // without `serial_test`.
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: true,
+            semantic_scholar: false,
+            doaj: false,
+        };
+        p
+    }
+
+    #[tokio::test]
+    async fn fetch_doi_returns_work_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .and(query_param("mailto", "doiget@localhost"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_WORK))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = OpenalexSource::with_base(
+            Url::parse(&server.uri()).expect("wiremock URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(result.source, "openalex");
+        assert!(result.pdf_bytes.is_none(), "metadata-only contract");
+        let meta = result.metadata_json.expect("metadata_json present");
+        assert_eq!(meta["display_name"], "Example Work Title");
+        assert_eq!(
+            meta["referenced_works"][0],
+            "https://openalex.org/W2000000001"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_arxiv_id_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = OpenalexSource::with_base(
+            Url::parse("http://127.0.0.1:1").expect("URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let ref_ = Ref::Arxiv(ArxivId::parse("2401.12345").expect("arXiv id parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("arXiv ref must be rejected");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[tokio::test]
+    async fn fetch_without_capability_flag_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = OpenalexSource::with_base(
+            Url::parse("http://127.0.0.1:1").expect("URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        // Profile with metadata.openalex == false (default).
+        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        assert!(
+            !src.can_serve(&profile, &ref_),
+            "can_serve must be false without DOIGET_ENABLE_OPENALEX"
+        );
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("fetch must reject when capability is denied");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[tokio::test]
+    async fn fetch_malformed_response_returns_source_schema_error() {
+        let server = MockServer::start().await;
+        // Response has no `id` field — defensive shape check trips.
+        Mock::given(method("GET"))
+            .and(path("/works/10.1234/example"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"error":"not found"}"#))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = OpenalexSource::with_base(
+            Url::parse(&server.uri()).expect("wiremock URI parses"),
+            "doiget@localhost".to_string(),
+        );
+        let profile = profile_with_openalex_enabled();
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("missing `id` must surface as SourceSchema");
+        assert!(matches!(err, FetchError::SourceSchema { .. }));
+    }
+}


### PR DESCRIPTION
## Summary

Fifth Phase-4 slice. Citation-graph orchestrator backing upcoming MCP tool + CLI subcommand.

- **`expand(seed_doi, caps, source, profile, ctx)`** in new `crates/doiget-core/src/citation_graph.rs` (gated by `citation` Cargo feature → enables `metadata`).
- **BFS walk** via OpenAlex: seed through `OpenalexSource::fetch` (DOI path), neighbors via direct `ctx.http.fetch_bytes('openalex', url)` for Work-ID lookups. Each fetch emits a provenance row.
- **ADR-0010 hard caps**: `GraphCaps::clamped` enforces `MAX_DEPTH=3`, `MAX_TOTAL=100`, `MAX_PER_PAPER=20`. `truncated: true` flags incomplete result.
- **Cycle detection** via `HashSet<String>` of visited Work IDs.
- **TDM-free invariant** per ADR-0010: only OpenAlex consulted; S2/DOAJ deliberately not used (they don't expose `referenced_works` in one round-trip).
- **`DOIGET_OPENALEX_BASE` env var** is honored at Work-ID fetch time so wiremock tests can swap origin.

## Base branch

Stacked on PR #98 (Slice 11 OpenAlex). After #97+#98 merge, this can be retargeted to main.

## Test plan

- [x] `cargo check --features citation` green
- [x] `cargo test --features citation -p doiget-core --lib citation_graph` — 3/3 pass
  - `caps_clamps_to_adr_0010_maxima` — verify clamping
  - `expand_walks_depth_2_graph` — 4-node wiremocked graph (W0001 seed → W0002/W0003 → W0004)
  - `expand_without_capability_flag_errors` — `CapabilityDenied`
- [ ] CI matrix green

## Out of scope (follow-up slices)

- Slice 15: `doiget_expand_citation_graph` + `doiget_bibtex_export` + `doiget_csl_export` MCP tools
- Slice 16: `doiget graph <ref>` CLI subcommand
- Per-Work-ID fetch routing through a future `OpenalexSource::fetch_by_work_id` for cleaner provenance attribution
- S2 / DOAJ fallback in graph walk (deliberately not used in this slice — see ADR-0010 rationale in source comments)

## Files changed (+589)

- `crates/doiget-core/src/citation_graph.rs` (new, ~470 lines incl. 3 tests)
- `crates/doiget-core/src/lib.rs` (gated `pub mod citation_graph`)
- `CHANGELOG.md` (Slice 14 section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)