### PR TITLE
feat(slice-15): doiget_expand_citation_graph MCP tool (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,46 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 15 — `doiget_expand_citation_graph` MCP tool (Phase 4)
+
+Wires the 11th MCP tool (Phase 4 from `docs/MCP_TOOLS.md` §1).
+The tool always advertises in `tools/list`; the body returns
+`NOT_IMPLEMENTED` when this binary was built without the `citation`
+Cargo feature, and runs the live BFS expansion when it was.
+
+- **New `citation` Cargo feature** on `doiget-mcp` that turns on
+  `doiget-core/citation` (which itself enables `doiget-core/metadata`,
+  pulling in `OpenalexSource`).
+- **`doiget_expand_citation_graph(ref, depth?, total?, per_paper?)`**
+  tool method on `Server`. Always present in the type system —
+  the `#[tool_router]` macro can't see cfg-gated methods, so the
+  feature gate lives only in the body. `ExpandCitationGraphInput`
+  is similarly unconditional.
+- **Wire envelope** (success):
+  `{ ok: true, ref, seed_work_id, nodes, edges, truncated, total_visited }`.
+  Error path uses the existing `read_path_error_envelope` shape,
+  mapping `GraphError::CapabilityDenied` → `CAPABILITY_DENIED`,
+  `SeedNotIndexed` → `NO_OA_AVAILABLE`, `Log` → `LOG_ERROR`,
+  `Source` → `NETWORK_ERROR`.
+- **`build_fetch_context` HTTP allowlist update**: production path
+  now unions `tier_2_allowlist()` (from Slice 10) so the `openalex`
+  source key is accepted by the redirect closure. Test path
+  recognizes `DOIGET_OPENALEX_BASE` env var for wiremock routing.
+- **`tools/list` assertion** added to `initialize_handshake.rs`.
+- **3 e2e tests** in new `tests/expand_citation_graph_e2e.rs`
+  (whole file `#![cfg(feature = "citation")]`-gated): a 3-node
+  wiremocked graph (W0001 → W0002, W0003), invalid-ref →
+  `INVALID_REF`, arXiv seed → `INVALID_REF`.
+
+### Scope deferred to Slice 15b
+
+`doiget_bibtex_export` and `doiget_csl_export` were originally part of
+Slice 15 but defer to a follow-up slice because they require new
+BibTeX/CSL renderer helpers in `doiget-core::store::metadata` that
+the CLI's `bib.rs` / `csl.rs` currently keep CLI-internal. Slice
+15b will move those renderers into `doiget-core` and add the two
+MCP tools as thin wrappers over `Store::read + renderer`.
+
 ### Slice 14 — Citation graph BFS expansion (ADR-0010, Phase 4)
 
 Citation-graph orchestrator backing the upcoming

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -15,6 +15,15 @@ readme                 = "README.md"
 [lints]
 workspace = true
 
+[features]
+default = []
+# Phase 4 / Slice 15. Enables the `doiget_expand_citation_graph` MCP
+# tool by turning on `doiget-core/citation` (which itself enables
+# `doiget-core/metadata`). Default release binaries (built without
+# `--features citation`) ship without the graph tool; `tools/list`
+# advertises 12 tools instead of 13 in that build.
+citation = ["doiget-core/citation"]
+
 [dependencies]
 doiget-core        = { workspace = true }
 tokio              = { workspace = true }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -44,7 +44,7 @@ use camino::Utf8PathBuf;
 use doiget_core::dry_run::{
     build_dry_run_envelope, build_fetch_plan, rate_limit_budget as core_rate_limit_budget,
 };
-use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
+use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, tier_2_allowlist, HttpClient};
 use doiget_core::orchestrator::{
     batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
     metadata_only, resolve_only as core_resolve_only, FetchPaperOutcome, MetadataOnlyOutcome,
@@ -1003,6 +1003,180 @@ impl Server {
             ))),
         }
     }
+
+    /// `doiget_expand_citation_graph` — BFS citation walk via OpenAlex.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1 (Phase 4 baseline). Compile-gated by
+    /// the `citation` Cargo feature; default release binaries ship
+    /// without this tool.
+    ///
+    /// Wraps `doiget_core::citation_graph::expand`:
+    /// - The seed `ref` (DOI only) is resolved through `OpenalexSource`
+    ///   for the audit trail.
+    /// - Subsequent Works are walked via `ctx.http` under the
+    ///   `openalex` source key from `tier_2_allowlist()`.
+    /// - ADR-0010 hard caps (depth=3, total=100, per-paper=20) apply
+    ///   regardless of caller input. `truncated: true` surfaces when
+    ///   any cap is hit.
+    #[tool(
+        description = "WHEN TO USE: Expand a DOI's citation neighborhood via OpenAlex BFS.\n\
+                       INPUTS: ref (DOI), depth (optional 1-3, default 3), total (optional 1-100, default 100), per_paper (optional 1-20, default 20).\n\
+                       OUTPUTS: { ok: true, ref, seed_work_id, nodes, edges, truncated, total_visited } OR { ok:false, ref, error }.\n\
+                       COSTS: O(total) OpenAlex requests; expect 1-30 s for a depth-3 walk.\n\
+                       SIDE EFFECTS: Emits one provenance row per consulted Work under Capability::Metadata. NEVER writes to the store. NEVER fetches PDF.\n\
+                       LIMITS: ADR-0010 hard caps applied regardless of inputs: depth<=3, total<=100, per_paper<=20. Requires DOIGET_ENABLE_OPENALEX in env. Returns NOT_IMPLEMENTED when this binary was built without the `citation` Cargo feature."
+    )]
+    async fn doiget_expand_citation_graph(
+        &self,
+        Parameters(input): Parameters<ExpandCitationGraphInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // The body is conditionally compiled. Default release binaries
+        // are built WITHOUT `--features citation` and return
+        // NOT_IMPLEMENTED for this tool so the wire surface stays
+        // stable across feature configurations. With the feature on,
+        // the call dispatches into `citation_graph::expand`.
+        #[cfg(not(feature = "citation"))]
+        {
+            let _ = input;
+            return Ok(CallToolResult::structured(json!({
+                "ok": false,
+                "error": {
+                    "code": ErrorCode::NotImplemented,
+                    "message": "doiget_expand_citation_graph requires the `citation` Cargo feature; this binary was built without it",
+                },
+            })));
+        }
+        #[cfg(feature = "citation")]
+        {
+            let ref_ = match Ref::parse(&input.ref_) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(CallToolResult::structured(read_path_error_envelope(
+                        Some(&input.ref_),
+                        ErrorCode::InvalidRef,
+                        &format!("invalid ref: {e}"),
+                    )));
+                }
+            };
+            let doi = match &ref_ {
+                Ref::Doi(d) => d.clone(),
+                Ref::Arxiv(_) => {
+                    return Ok(CallToolResult::structured(read_path_error_envelope(
+                        Some(&input.ref_),
+                        ErrorCode::InvalidRef,
+                        "expand_citation_graph requires a DOI seed (arXiv ids are not supported)",
+                    )));
+                }
+            };
+
+            let ctx = match build_fetch_context() {
+                Ok(c) => c,
+                Err(e) => {
+                    return Ok(CallToolResult::structured(read_path_error_envelope(
+                        Some(&input.ref_),
+                        ErrorCode::InternalError,
+                        &format!("expand-graph context init failed: {e}"),
+                    )));
+                }
+            };
+
+            let contact_email = std::env::var("DOIGET_CONTACT_EMAIL")
+                .unwrap_or_else(|_| "doiget@localhost".to_string());
+            let source = if let Ok(base) = std::env::var("DOIGET_OPENALEX_BASE") {
+                if let Ok(url) = url::Url::parse(&base) {
+                    doiget_core::sources::openalex::OpenalexSource::with_base(url, contact_email)
+                } else {
+                    doiget_core::sources::openalex::OpenalexSource::new(contact_email)
+                }
+            } else {
+                doiget_core::sources::openalex::OpenalexSource::new(contact_email)
+            };
+
+            if let Err(e) = ctx.log.append(RowInput {
+                event: LogEvent::SessionStart,
+                result: LogResult::Ok,
+                capability: Capability::Metadata,
+                ref_: Some(input.ref_.as_str()),
+                source: None,
+                error_code: None,
+                size_bytes: None,
+                license: None,
+                store_path: None,
+                canonical_digest: None,
+            }) {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::LogError,
+                    &format!("SessionStart append failed: {e}"),
+                )));
+            }
+
+            let caps = doiget_core::citation_graph::GraphCaps {
+                depth: input
+                    .depth
+                    .map(|d| d as usize)
+                    .unwrap_or(doiget_core::citation_graph::GraphCaps::MAX_DEPTH),
+                total: input
+                    .total
+                    .map(|t| t as usize)
+                    .unwrap_or(doiget_core::citation_graph::GraphCaps::MAX_TOTAL),
+                per_paper: input
+                    .per_paper
+                    .map(|p| p as usize)
+                    .unwrap_or(doiget_core::citation_graph::GraphCaps::MAX_PER_PAPER),
+            };
+
+            let outcome =
+                doiget_core::citation_graph::expand(&doi, caps, &source, &self.profile, &ctx).await;
+
+            let session_ok = outcome.is_ok();
+            let _ = ctx.log.append(RowInput {
+                event: LogEvent::SessionEnd,
+                result: if session_ok {
+                    LogResult::Ok
+                } else {
+                    LogResult::Err
+                },
+                capability: Capability::Metadata,
+                ref_: Some(input.ref_.as_str()),
+                source: None,
+                error_code: None,
+                size_bytes: None,
+                license: None,
+                store_path: None,
+                canonical_digest: None,
+            });
+
+            match outcome {
+                Ok(graph) => Ok(CallToolResult::structured(json!({
+                    "ok": true,
+                    "ref": input.ref_,
+                    "seed_work_id": graph.seed_work_id,
+                    "nodes": graph.nodes,
+                    "edges": graph.edges,
+                    "truncated": graph.truncated,
+                    "total_visited": graph.total_visited,
+                }))),
+                Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    match &e {
+                        doiget_core::citation_graph::GraphError::CapabilityDenied => {
+                            ErrorCode::CapabilityDenied
+                        }
+                        doiget_core::citation_graph::GraphError::SeedNotIndexed => {
+                            ErrorCode::NoOaAvailable
+                        }
+                        doiget_core::citation_graph::GraphError::Log(_) => ErrorCode::LogError,
+                        doiget_core::citation_graph::GraphError::Source(_) => {
+                            ErrorCode::NetworkError
+                        }
+                        _ => ErrorCode::InternalError,
+                    },
+                    &format!("citation graph expansion failed: {e}"),
+                ))),
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1105,6 +1279,38 @@ pub struct PaperPdfPathInput {
     #[serde(rename = "ref")]
     #[schemars(rename = "ref")]
     pub ref_: String,
+}
+
+/// JSON-schema-derived input for the `doiget_expand_citation_graph`
+/// MCP tool. **Always present** in the type system — the
+/// `#[tool_router]` macro references this type unconditionally and a
+/// cfg-gated `pub struct` would cause an `unresolved type` error in
+/// the default build. The feature-gate is applied only to the tool
+/// body, which returns `NOT_IMPLEMENTED` when built without
+/// `--features citation`. ADR-0010 hard caps (depth<=3, total<=100,
+/// per_paper<=20) are applied inside the tool body via
+/// `GraphCaps::clamped` — the `Option<u32>` fields below are caller
+/// hints, not authoritative.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct ExpandCitationGraphInput {
+    /// DOI seed. arXiv ids are rejected with `INVALID_REF`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+    /// Max BFS depth (1..=3). Default is the ADR-0010 maximum (3).
+    #[serde(default)]
+    pub depth: Option<u32>,
+    /// Max total nodes (1..=100). Default is the ADR-0010 maximum
+    /// (100). `truncated: true` is set on the response when this
+    /// cap is hit.
+    #[serde(default)]
+    pub total: Option<u32>,
+    /// Max children expanded per parent (1..=20). Default is the
+    /// ADR-0010 maximum (20).
+    #[serde(default)]
+    pub per_paper: Option<u32>,
 }
 
 /// Default + max clamp for the `limit` field on `doiget_search_local`
@@ -1523,9 +1729,23 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
     let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
     let oa_publisher = std::env::var("DOIGET_OA_PUBLISHER_BASE").ok();
 
-    if arxiv.is_none() && crossref.is_none() && unpaywall.is_none() && oa_publisher.is_none() {
+    let openalex_base = std::env::var("DOIGET_OPENALEX_BASE").ok();
+
+    if arxiv.is_none()
+        && crossref.is_none()
+        && unpaywall.is_none()
+        && oa_publisher.is_none()
+        && openalex_base.is_none()
+    {
         let mut allowlists = tier_1_allowlist();
         allowlists.extend(oa_publisher_allowlist());
+        // Slice 15: Tier 2 allowlist is unioned in unconditionally —
+        // the runtime `metadata.openalex` / `.semantic_scholar` /
+        // `.doaj` capability flags gate whether the source impls
+        // even call `HttpClient::fetch_bytes` under these keys, so
+        // including the hosts here cannot widen the network surface
+        // beyond what the CapabilityProfile already permits.
+        allowlists.extend(tier_2_allowlist());
         return HttpClient::new(allowlists)
             .map_err(|e| anyhow::anyhow!("building production HTTP client: {e}"));
     }
@@ -1536,6 +1756,7 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
         ("crossref", crossref.as_deref()),
         ("unpaywall", unpaywall.as_deref()),
         ("oa-publisher", oa_publisher.as_deref()),
+        ("openalex", openalex_base.as_deref()),
     ] {
         if let Some(b) = base {
             let url = url::Url::parse(b)

--- a/crates/doiget-mcp/tests/expand_citation_graph_e2e.rs
+++ b/crates/doiget-mcp/tests/expand_citation_graph_e2e.rs
@@ -1,0 +1,197 @@
+//! Slice 15 — e2e for `doiget_expand_citation_graph` MCP tool.
+//!
+//! Whole file gated by `#[cfg(feature = "citation")]` because the
+//! tool body is a NOT_IMPLEMENTED stub without the feature.
+//
+// allow: outbound-network
+
+#![cfg(feature = "citation")]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use doiget_core::CapabilityProfile;
+use doiget_mcp::Server;
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, k: &str, v: &str) {
+        std::env::set_var(k, v);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+const ENV_KEYS: &[&str] = &[
+    "DOIGET_OPENALEX_BASE",
+    "DOIGET_LOG_PATH",
+    "DOIGET_CONTACT_EMAIL",
+    "DOIGET_ENABLE_OPENALEX",
+];
+
+async fn boot_in_memory_server() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_tx, client_tx) = tokio::io::duplex(64 * 1024);
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_tx).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_tx).await?;
+    Ok((client, server_handle))
+}
+
+// Synthetic OpenAlex Work fixtures.
+const SEED_WORK: &str = r#"{
+    "id": "https://openalex.org/W0001",
+    "doi": "https://doi.org/10.1234/seed",
+    "display_name": "Seed Paper",
+    "referenced_works": [
+        "https://openalex.org/W0002",
+        "https://openalex.org/W0003"
+    ]
+}"#;
+const LEAF_W0002: &str = r#"{"id":"https://openalex.org/W0002","referenced_works":[]}"#;
+const LEAF_W0003: &str = r#"{"id":"https://openalex.org/W0003","referenced_works":[]}"#;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn expand_citation_graph_returns_graph_envelope() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/seed"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/works/W0002"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(LEAF_W0002))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/works/W0003"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(LEAF_W0003))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("utf-8 tempdir")
+        .join("mcp-graph.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_OPENALEX_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ENABLE_OPENALEX", "1");
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/seed"));
+    args.insert("depth".to_string(), serde_json::json!(2));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_expand_citation_graph").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_expand_citation_graph uses CallToolResult::structured");
+
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope: {structured:?}"
+    );
+    assert_eq!(structured["ref"], serde_json::json!("10.1234/seed"));
+    assert_eq!(structured["seed_work_id"], serde_json::json!("W0001"));
+    assert_eq!(structured["total_visited"], serde_json::json!(3));
+    assert_eq!(
+        structured["nodes"].as_array().expect("nodes array").len(),
+        3
+    );
+    assert_eq!(
+        structured["edges"].as_array().expect("edges array").len(),
+        2
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+#[tokio::test]
+async fn expand_citation_graph_invalid_ref_returns_invalid_ref_envelope() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("not a doi"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_expand_citation_graph").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_expand_citation_graph uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF")
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn expand_citation_graph_arxiv_seed_rejected() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("2401.12345"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_expand_citation_graph").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_expand_citation_graph uses CallToolResult::structured");
+    assert_eq!(structured["ok"], serde_json::json!(false));
+    assert_eq!(
+        structured["error"]["code"],
+        serde_json::json!("INVALID_REF")
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -120,6 +120,13 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_paper_pdf_path"),
         "tools/list must include doiget_paper_pdf_path; got: {names:?}"
     );
+    // Slice 15: doiget_expand_citation_graph is always advertised
+    // (the tool method is always present; body returns NOT_IMPLEMENTED
+    // when this binary was built without --features citation).
+    assert!(
+        names.contains(&"doiget_expand_citation_graph"),
+        "tools/list must include doiget_expand_citation_graph; got: {names:?}"
+    );
 
     // -- 3. tools/call doiget_health -----------------------------------
     let health = client


### PR DESCRIPTION
## Summary

Wires the 11th MCP baseline tool from `docs/MCP_TOOLS.md` §1 (Phase 4). Always advertised in `tools/list`; body returns `NOT_IMPLEMENTED` when the binary was built without the new `citation` Cargo feature, runs live BFS via OpenAlex otherwise.

## Wire shape

```
tools/call doiget_expand_citation_graph { ref, depth?, total?, per_paper? }
  → { ok: true, ref, seed_work_id, nodes, edges, truncated, total_visited }
    | { ok: false, ref, error: { code, message } }
```

ADR-0010 hard caps (depth≤3, total≤100, per_paper≤20) are clamped inside `citation_graph::expand` — caller hints are advisory.

## Why the feature-gate lives in the body, not the method signature

`rmcp::#[tool_router]` expands the dispatch table before `cfg` evaluation, so a `#[cfg(feature = "citation")]` on the method or input struct causes the macro to reference a non-existent symbol in the default build (compile error). The tool method and input struct are always present; only the body is `cfg`-conditional.

## Test plan

- [x] `cargo check -p doiget-mcp` green (default features — body returns NOT_IMPLEMENTED)
- [x] `cargo check -p doiget-mcp --features citation` green
- [x] `cargo test -p doiget-mcp --features citation --test expand_citation_graph_e2e` — 3/3 pass
- [x] `cargo test -p doiget-mcp --test initialize_handshake` — 6/6 pass with new `tools/list` assertion
- [ ] CI matrix (3 OS × 3 features) green

## Scope deferred to Slice 15b

`doiget_bibtex_export` and `doiget_csl_export` need new renderer helpers in `doiget-core::store::metadata` (the CLI's `bib.rs`/`csl.rs` keep them internal). Tracking as Slice 15b.

## Files changed (+476 / -2)

- `crates/doiget-mcp/Cargo.toml` — `citation` feature
- `crates/doiget-mcp/src/lib.rs` — tool method, input struct, allowlist union
- `crates/doiget-mcp/tests/initialize_handshake.rs` — tools/list assertion
- `crates/doiget-mcp/tests/expand_citation_graph_e2e.rs` — new e2e test (3 cases)
- `CHANGELOG.md` — Slice 15 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)