### PR TITLE
feat(slice-16): doiget graph <ref> CLI subcommand (Phase 4 complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,45 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 16 — `doiget graph <ref>` CLI subcommand (Phase 4)
+
+Final Phase-4 slice. Adds the `doiget graph <ref>` subcommand that
+wraps `doiget_core::citation_graph::expand` and emits the result
+as pretty-printed JSON on stdout. Mirrors the
+`doiget_expand_citation_graph` MCP tool (Slice 15) wire shape.
+
+- **New module** `crates/doiget-cli/src/commands/graph.rs`, declared
+  in `commands/mod.rs` under
+  `#[cfg(feature = "citation")] pub mod graph;`. Default build
+  (`oa-only`) excludes the module entirely.
+- **CLI surface**:
+  `doiget graph <ref> [--depth N] [--total N] [--per-paper N]`
+  (feature-gated `Command::Graph` variant). DOI seeds only; arXiv
+  ids are rejected at the orchestrator layer.
+- **`build_http_client` fix**: production path now also unions
+  `tier_2_allowlist()` (gated on the `citation` feature) so the
+  `openalex` source key passes the redirect closure. Test path
+  recognizes `DOIGET_OPENALEX_BASE` env var for wiremock routing.
+  Mirrors the parallel fix applied to `doiget-mcp/src/lib.rs`
+  during Slice 15.
+- **Output**: pretty JSON of `GraphResult { seed_work_id, nodes,
+  edges, truncated, total_visited }` on stdout. Uses
+  `writeln!(stdout().lock(), ...)` per `docs/SECURITY.md` §3 (the
+  workspace `print_stdout` lint is denied; `writeln!` against an
+  explicit `stdout().lock()` is the sanctioned escape hatch).
+- **2 e2e tests** in new `tests/graph_e2e.rs` (whole file
+  `#![cfg(feature = "citation")]`-gated): subprocess run via
+  `assert_cmd` against a wiremocked OpenAlex; asserts the stdout
+  JSON shape (`seed_work_id`, `total_visited`, `nodes` / `edges`
+  array lengths, `truncated`). Plus a non-async test that
+  rejects arXiv seeds with non-zero exit.
+
+This closes Phase 4. Eleven Phase-4-baseline MCP tools wired,
+3 Tier 2 metadata sources implemented, citation-graph BFS
+orchestrator with ADR-0010 hard caps in place, and the
+`doiget graph` CLI subcommand now lets users walk graphs
+without standing up an MCP host.
+
 ### Slice 15 — `doiget_expand_citation_graph` MCP tool (Phase 4)
 
 Wires the 11th MCP tool (Phase 4 from `docs/MCP_TOOLS.md` §1).

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -45,6 +45,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
 
+#[cfg(feature = "citation")]
+use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
 use doiget_core::orchestrator::{fetch_paper as core_fetch_paper, FetchPaperOutcome};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
@@ -165,10 +167,28 @@ fn build_http_client() -> Result<HttpClient> {
     let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
     let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
     let oa_publisher = std::env::var("DOIGET_OA_PUBLISHER_BASE").ok();
+    // Slice 16: `DOIGET_OPENALEX_BASE` selects a wiremock host for the
+    // citation-graph BFS. Only meaningful with `--features citation`,
+    // but reading the env unconditionally keeps the branch logic
+    // simple and is harmless for default builds.
+    let openalex_base = std::env::var("DOIGET_OPENALEX_BASE").ok();
 
-    if arxiv.is_none() && crossref.is_none() && unpaywall.is_none() && oa_publisher.is_none() {
+    if arxiv.is_none()
+        && crossref.is_none()
+        && unpaywall.is_none()
+        && oa_publisher.is_none()
+        && openalex_base.is_none()
+    {
         let mut allowlists = tier_1_allowlist();
         allowlists.extend(oa_publisher_allowlist());
+        // Slice 16: when the `citation` feature is compiled in, the
+        // graph subcommand walks OpenAlex Work IDs via
+        // `ctx.http.fetch_bytes("openalex", ...)`. The Tier 2
+        // allowlist registers the `api.openalex.org` host under
+        // that source key. CapabilityProfile.metadata.openalex is
+        // the runtime gate; the allowlist is the transport gate.
+        #[cfg(feature = "citation")]
+        allowlists.extend(tier_2_allowlist());
         return HttpClient::new(allowlists).context("building HTTP client");
     }
 
@@ -179,6 +199,7 @@ fn build_http_client() -> Result<HttpClient> {
         ("crossref", crossref.as_deref()),
         ("unpaywall", unpaywall.as_deref()),
         ("oa-publisher", oa_publisher.as_deref()),
+        ("openalex", openalex_base.as_deref()),
     ] {
         if let Some(b) = base {
             let url = url::Url::parse(b)

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -1,0 +1,116 @@
+//! `doiget graph <ref>` subcommand — citation-graph BFS via OpenAlex.
+//!
+//! Slice 16 / Phase 4. Compile-gated by the `citation` Cargo feature
+//! (declared in `doiget-cli/Cargo.toml`). Builds the shared
+//! `FetchHarness` (HTTP + ProvenanceLog + RateLimiter + Profile),
+//! then delegates to [`doiget_core::citation_graph::expand`] with
+//! the ADR-0010 hard caps applied via `GraphCaps::clamped`.
+//!
+//! Output is pretty-printed JSON on stdout (the same shape as the
+//! `doiget_expand_citation_graph` MCP tool returns):
+//!
+//! ```json
+//! {
+//!   "seed_work_id": "W2741809807",
+//!   "nodes": [{"id":"W...","depth":0}, ...],
+//!   "edges": [{"from":"W...","to":"W..."}, ...],
+//!   "truncated": false,
+//!   "total_visited": 17
+//! }
+//! ```
+//!
+//! `pdf_bytes` is NEVER returned (metadata-only contract). The
+//! graph walker only consults OpenAlex; S2 / DOAJ are deliberately
+//! not used (only OpenAlex exposes `referenced_works[]`).
+
+#![cfg(feature = "citation")]
+
+use std::io::Write;
+
+use anyhow::{bail, Context, Result};
+
+use doiget_core::citation_graph::{expand, GraphCaps, GraphError};
+use doiget_core::sources::openalex::OpenalexSource;
+use doiget_core::Ref;
+
+use super::fetch::FetchHarness;
+
+/// Run the `graph` subcommand against the live source set.
+///
+/// `input` is the user-supplied ref string (DOI only — arXiv ids are
+/// rejected because OpenAlex's `referenced_works` field is keyed on
+/// DOI-derived Work IDs).
+///
+/// `depth` / `total` / `per_paper` are optional caller hints; each
+/// is clamped to the ADR-0010 maximum (3 / 100 / 20). Passing `None`
+/// uses the maximum.
+pub async fn run(
+    input: String,
+    depth: Option<u32>,
+    total: Option<u32>,
+    per_paper: Option<u32>,
+) -> Result<()> {
+    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let doi = match &ref_ {
+        Ref::Doi(d) => d.clone(),
+        Ref::Arxiv(_) => bail!(
+            "doiget graph requires a DOI seed; arXiv ids are not in OpenAlex's referenced_works \
+             keyspace"
+        ),
+    };
+
+    let harness = FetchHarness::from_env().context("building fetch harness")?;
+    if !harness.profile.metadata.openalex {
+        bail!(
+            "doiget graph requires DOIGET_ENABLE_OPENALEX in env AND the binary built with \
+             `--features citation`. CapabilityProfile.metadata.openalex is currently false."
+        );
+    }
+
+    let contact_email =
+        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    let source = if let Ok(base) = std::env::var("DOIGET_OPENALEX_BASE") {
+        if let Ok(url) = url::Url::parse(&base) {
+            OpenalexSource::with_base(url, contact_email)
+        } else {
+            OpenalexSource::new(contact_email)
+        }
+    } else {
+        OpenalexSource::new(contact_email)
+    };
+
+    harness
+        .log_session_start(Some(&input))
+        .context("logging session start")?;
+
+    let caps = GraphCaps {
+        depth: depth.map(|d| d as usize).unwrap_or(GraphCaps::MAX_DEPTH),
+        total: total.map(|t| t as usize).unwrap_or(GraphCaps::MAX_TOTAL),
+        per_paper: per_paper
+            .map(|p| p as usize)
+            .unwrap_or(GraphCaps::MAX_PER_PAPER),
+    };
+    let ctx = harness.fetch_context();
+
+    let outcome = expand(&doi, caps, &source, &harness.profile, &ctx).await;
+    let session_ok = outcome.is_ok();
+    harness.log_session_end(session_ok, Some(&input));
+
+    let graph = outcome.map_err(|e| match e {
+        GraphError::CapabilityDenied => anyhow::anyhow!(
+            "OpenAlex capability denied: set DOIGET_ENABLE_OPENALEX and rebuild with \
+             --features citation"
+        ),
+        GraphError::SeedNotIndexed => {
+            anyhow::anyhow!("seed DOI '{input}' is not indexed by OpenAlex")
+        }
+        other => anyhow::Error::new(other),
+    })?;
+
+    let json = serde_json::to_string_pretty(&graph)
+        .context("serializing GraphResult to JSON for stdout")?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    writeln!(out, "{json}").context("writing graph JSON to stdout")?;
+    Ok(())
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -31,6 +31,11 @@ pub mod list_recent;
 pub mod provenance;
 pub mod search;
 
+// Phase 4 / Slice 16. Compile-gated by the `citation` Cargo feature
+// (which itself enables `doiget-core/citation`).
+#[cfg(feature = "citation")]
+pub mod graph;
+
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -110,6 +110,24 @@ enum Command {
         /// `show` / `path` / `doctor`
         action: String,
     },
+    /// Expand a DOI's citation neighborhood via OpenAlex (BFS,
+    /// ADR-0010 hard caps). Requires `--features citation` AND
+    /// `DOIGET_ENABLE_OPENALEX` in env.
+    #[cfg(feature = "citation")]
+    Graph {
+        /// DOI seed. arXiv ids are rejected (OpenAlex's
+        /// `referenced_works` is DOI-keyed).
+        ref_: String,
+        /// Max BFS depth (1..=3). Default = 3 (ADR-0010 maximum).
+        #[arg(long)]
+        depth: Option<u32>,
+        /// Max total nodes (1..=100). Default = 100.
+        #[arg(long)]
+        total: Option<u32>,
+        /// Max children per parent (1..=20). Default = 20.
+        #[arg(long)]
+        per_paper: Option<u32>,
+    },
 }
 
 #[tokio::main]
@@ -156,5 +174,14 @@ async fn main() -> anyhow::Result<()> {
             let profile = doiget_core::CapabilityProfile::from_env()?;
             doiget_mcp::Server::new(profile).run().await
         }
+        // Phase 4 / Slice 16. Feature-gated to keep default release
+        // binaries free of the OpenAlex-only citation walker.
+        #[cfg(feature = "citation")]
+        Some(Command::Graph {
+            ref_,
+            depth,
+            total,
+            per_paper,
+        }) => doiget_cli::commands::graph::run(ref_, depth, total, per_paper).await,
     }
 }

--- a/crates/doiget-cli/tests/graph_e2e.rs
+++ b/crates/doiget-cli/tests/graph_e2e.rs
@@ -1,0 +1,96 @@
+//! Slice 16 — e2e for `doiget graph <ref>` CLI subcommand.
+//!
+//! Whole file gated by `#[cfg(feature = "citation")]`. Runs the
+//! binary as a subprocess via `assert_cmd`, routes OpenAlex
+//! through a wiremock origin via `DOIGET_OPENALEX_BASE`, and
+//! asserts the stdout JSON envelope shape.
+//
+// allow: outbound-network
+
+#![cfg(feature = "citation")]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+
+const SEED_WORK: &str = r#"{
+    "id": "https://openalex.org/W0001",
+    "doi": "https://doi.org/10.1234/seed",
+    "display_name": "Seed Paper",
+    "referenced_works": [
+        "https://openalex.org/W0002",
+        "https://openalex.org/W0003"
+    ]
+}"#;
+const LEAF_W0002: &str = r#"{"id":"https://openalex.org/W0002","referenced_works":[]}"#;
+const LEAF_W0003: &str = r#"{"id":"https://openalex.org/W0003","referenced_works":[]}"#;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn graph_subcommand_emits_pretty_json_envelope() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/seed"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/works/W0002"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(LEAF_W0002))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/works/W0003"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(LEAF_W0003))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("utf-8 tempdir")
+        .join("graph.jsonl");
+
+    let assert = Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .env("DOIGET_OPENALEX_BASE", server.uri())
+        .env("DOIGET_LOG_PATH", log_path.as_str())
+        .env(
+            "DOIGET_STORE_ROOT",
+            td.path().to_str().expect("utf-8 tempdir"),
+        )
+        .env("DOIGET_ENABLE_OPENALEX", "1")
+        .env("DOIGET_CONTACT_EMAIL", "doiget@localhost")
+        .args(["graph", "10.1234/seed", "--depth", "2"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8 stdout");
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}; stdout={stdout}"));
+    assert_eq!(json["seed_work_id"], "W0001");
+    assert_eq!(json["total_visited"], 3);
+    assert_eq!(json["nodes"].as_array().expect("nodes array").len(), 3);
+    assert_eq!(json["edges"].as_array().expect("edges array").len(), 2);
+    assert_eq!(json["truncated"], false);
+
+    drop(td);
+    Ok(())
+}
+
+#[test]
+fn graph_subcommand_rejects_arxiv_seed() {
+    let td = tempfile::TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .env(
+            "DOIGET_STORE_ROOT",
+            td.path().to_str().expect("utf-8 tempdir"),
+        )
+        .env("DOIGET_LOG_PATH", "")
+        .env("DOIGET_ENABLE_OPENALEX", "1")
+        .args(["graph", "2401.12345"])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## Summary

Final Phase-4 slice. Adds `doiget graph <ref>` CLI subcommand that wraps `doiget_core::citation_graph::expand` and emits the result as pretty JSON on stdout. Mirrors the Slice-15 `doiget_expand_citation_graph` MCP tool wire shape.

```
doiget graph 10.1234/example [--depth 3] [--total 100] [--per-paper 20]
  → { seed_work_id: "W...", nodes: [...], edges: [...], truncated: bool, total_visited: N }
```

ADR-0010 hard caps (depth≤3, total≤100, per_paper≤20) are clamped in `citation_graph::expand`; CLI flags are advisory.

## Files changed

- `crates/doiget-cli/Cargo.toml` — `citation` feature already declared
- `crates/doiget-cli/src/commands/graph.rs` — new, feature-gated
- `crates/doiget-cli/src/commands/mod.rs` — feature-gated `pub mod graph`
- `crates/doiget-cli/src/main.rs` — feature-gated `Command::Graph` variant + dispatch arm
- `crates/doiget-cli/src/commands/fetch.rs::build_http_client` — production path now unions `tier_2_allowlist()` (citation feature) so `openalex` source key passes redirect closure; test path honors `DOIGET_OPENALEX_BASE`. Same pattern as the Slice-15 MCP-side fix.
- `crates/doiget-cli/tests/graph_e2e.rs` — 2 e2e tests (whole file `#![cfg(feature='citation')]`)
- `CHANGELOG.md` — Slice 16 section

## Test plan

- [x] `cargo check -p doiget-cli` green (default features, graph subcommand absent from `--help`)
- [x] `cargo check -p doiget-cli --features citation` green
- [x] `cargo test -p doiget-cli --features citation --test graph_e2e` — 2/2 pass
  - `graph_subcommand_emits_pretty_json_envelope` — subprocess via `assert_cmd` against wiremocked OpenAlex; asserts `seed_work_id`, `total_visited`, node/edge counts, `truncated`
  - `graph_subcommand_rejects_arxiv_seed` — non-zero exit
- [ ] CI matrix green

## Phase 4 complete

This closes Phase 4: 3 Tier 2 metadata sources (OpenAlex / S2 / DOAJ), citation-graph BFS orchestrator with ADR-0010 hard caps, MCP tool + CLI subcommand. Deferred: `doiget_bibtex_export` + `doiget_csl_export` MCP tools (Slice 15b — needs new renderer helpers in `doiget-core::store::metadata`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)