### PR TITLE
Slice 18 — APS Harvest TDM source (Phase 5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,35 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 18 — APS Harvest TDM source (Phase 5b)
+
+Second Phase-5 / Tier-3 slice. Adds the `tdm-aps` source: a
+metadata-only APS Harvest TDM fetcher that turns a DOI into the
+single article record from `/v2/article/<DOI>`. Whole module
+compile-gated by the `tdm-aps` Cargo feature.
+
+- **New module** `crates/doiget-core/src/sources/tdm_aps.rs`,
+  declared in `sources/mod.rs` under
+  `#[cfg(feature = "tdm-aps")] pub mod tdm_aps;`.
+- **Three-gate activation**: Cargo feature `tdm-aps` compiled in +
+  `DOIGET_KEY_APS=<api-key>` + `DOIGET_AGREE_TDM_APS=1`.
+- **Transport gate**: new `tier_3_aps_allowlist()` in
+  `crates/doiget-core/src/http.rs` mapping `"tdm-aps"` to
+  `harvest.aps.org` + `*.aps.org`.
+- **Provenance**: emits `LogEvent::Fetch` rows with
+  `capability: Capability::TdmAps`.
+- **Metadata-only**: `FetchResult.pdf_bytes` is always `None`.
+- **Known limitation**: APS expects the API key in the `X-API-Key`
+  header. `HttpClient` does not yet expose a per-source header hook,
+  so the header is NOT attached on the wire in this slice — wiremock
+  tests pass with header matching disabled. The wiring will be added
+  alongside Slice 19 (Elsevier needs the same hook). See in-file
+  TODO and `docs/SOURCES.md` §4 follow-up.
+- **Tests**: three wiremock cases — happy path (DOI percent-encoded
+  in path), no-grant `NotEligible`, non-object response
+  `SourceSchema`. `#[serial_test::serial]` because the happy-path
+  mutates `DOIGET_KEY_APS`.
+
 ### Slice 17 — Springer Nature OA TDM source (Phase 5a)
 
 First Phase-5 / Tier-3 slice. Adds the `tdm-springer` source: a

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -194,6 +194,28 @@ pub fn tier_3_springer_allowlist() -> Vec<SourceAllowlist> {
     )]
 }
 
+/// Hard-coded Phase 5b allowlist for the APS Harvest TDM source.
+/// Compile-gated by the `tdm-aps` Cargo feature so default release
+/// binaries never include the host pattern (per ADR-0002 and
+/// `docs/SOURCES.md` §3).
+///
+/// Returned entry:
+/// - `"tdm-aps"` → `harvest.aps.org` (production base) +
+///   `*.aps.org` (covers load-balancing subdomains; the redirect
+///   closure denies anything outside the wildcard).
+///
+/// Three-gate activation: Cargo feature compiled in,
+/// `DOIGET_KEY_APS` env var present, and `DOIGET_AGREE_TDM_APS=1`.
+/// The `CapabilityProfile` gate enforces the env-var pair; this
+/// allowlist is the transport gate.
+#[cfg(feature = "tdm-aps")]
+pub fn tier_3_aps_allowlist() -> Vec<SourceAllowlist> {
+    vec![SourceAllowlist::new(
+        "tdm-aps",
+        vec!["harvest.aps.org".to_string(), "*.aps.org".to_string()],
+    )]
+}
+
 /// Hard-coded Phase 1 allowlist for the synthetic `"oa-publisher"` source —
 /// the publisher / preprint / repository hosts to which Unpaywall's
 /// `best_oa_location.url` (or `url_for_pdf`) typically resolves.

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -33,3 +33,6 @@ pub mod doaj;
 
 #[cfg(feature = "tdm-springer")]
 pub mod tdm_springer;
+
+#[cfg(feature = "tdm-aps")]
+pub mod tdm_aps;

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -1,0 +1,367 @@
+//! APS Harvest TDM source — DOI metadata via the
+//! `/v2/article/<DOI>` endpoint (Phase 5b / Tier 3).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 3 row + §4 "TDM sources (Phase 5)",
+//! `docs/CAPABILITY.md` §2, ADR-0002 (per-publisher Cargo features),
+//! ADR-0019 (eight safeguards).
+//!
+//! Whole module gated by `#[cfg(feature = "tdm-aps")]` so default
+//! release binaries never include the host pattern or the env-var
+//! read path (ADR-0002).
+//!
+//! ## Three-gate activation
+//!
+//! Per `docs/CAPABILITY.md` §2 a fetch only succeeds when ALL THREE
+//! gates pass:
+//!
+//! 1. The binary was built with `--features tdm-aps`.
+//! 2. The user set `DOIGET_KEY_APS=<api-key>`.
+//! 3. The user set `DOIGET_AGREE_TDM_APS=1`.
+//!
+//! Gates 2 + 3 are checked at startup by
+//! [`CapabilityProfile::from_env`] and surface as
+//! `profile.tdm_aps = Some(TdmGrant)`. This source mirrors that
+//! check in [`can_serve`](TdmApsSource::can_serve) and again in
+//! [`fetch`](TdmApsSource::fetch) (defensive). APS expects the key
+//! in the `X-API-Key` header (not a URL parameter, unlike Springer);
+//! `TdmGrant` does not currently store the key, so the source
+//! re-reads `DOIGET_KEY_APS` at fetch time.
+//!
+//! ## Metadata-only contract (Phase 5b)
+//!
+//! `FetchResult.pdf_bytes` is always `None`. APS Harvest exposes
+//! full-text article-manifest URLs in the response, but Phase 5b
+//! deliberately stays metadata-only — fetching those payloads
+//! requires the eight ADR-0019 safeguards wired through the
+//! orchestrator, which lands later in Phase 5.
+
+#![cfg(feature = "tdm-aps")]
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production APS Harvest API base URL.
+const DEFAULT_BASE: &str = "https://harvest.aps.org";
+
+/// Env var holding the per-tenant API key. Presence is one of the
+/// three activation gates (`docs/CAPABILITY.md` §2); the value is
+/// read at fetch time and would be sent as the `X-API-Key` header
+/// once `HttpClient` grows a per-source header hook (TODO in
+/// `fetch`).
+const KEY_ENV_VAR: &str = "DOIGET_KEY_APS";
+
+/// APS Harvest [`Source`] impl — DOI → `/v2/article/<DOI>` JSON
+/// record.
+#[derive(Clone, Debug)]
+pub struct TdmApsSource {
+    /// API base URL. Production pins `https://harvest.aps.org`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl TdmApsSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build the `/v2/article/<doi>` URL.
+    ///
+    /// APS encodes the DOI directly in the path; the `/` separator
+    /// in the DOI suffix must be percent-encoded.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let path = format!(
+            "/v2/article/{}",
+            percent_encode_path_segment(doi.as_str())
+        );
+        self.base
+            .join(&path)
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("tdm-aps URL construction failed: {e}"),
+            })
+    }
+}
+
+impl Default for TdmApsSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for TdmApsSource {
+    fn name(&self) -> &str {
+        "tdm-aps"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.tdm_aps.is_some() && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "tdm-aps".into(),
+                });
+            }
+        };
+
+        // Defensive gate (1/3): runtime grant must be populated.
+        if profile.tdm_aps.is_none() {
+            return Err(FetchError::NotEligible {
+                source_key: "tdm-aps".into(),
+            });
+        }
+
+        // Defensive gate (2/3): re-read the key env var. A missing
+        // key here means env changed mid-process — fail-close as
+        // NotEligible so the orchestrator can fall through.
+        //
+        // NOTE: Phase 5b relies on the shared `FetchContext.http`
+        // for the GET, which does not yet surface a per-source
+        // header hook. The `X-API-Key` header is therefore NOT
+        // attached on the wire in this slice; the call would 401 in
+        // production until the HttpClient is extended (the same
+        // hook Slice 19 / Elsevier needs). The wiremock test below
+        // exercises the path with header matching disabled. See
+        // `docs/SOURCES.md` §4 "TDM sources (Phase 5)" follow-up.
+        let api_key = std::env::var(KEY_ENV_VAR).map_err(|_| FetchError::NotEligible {
+            source_key: "tdm-aps".into(),
+        })?;
+        if api_key.is_empty() {
+            return Err(FetchError::NotEligible {
+                source_key: "tdm-aps".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("tdm-aps returned non-JSON: {e}"),
+            })?;
+
+        // APS Harvest article envelope: { id, doi, title, ..., links: [...] }.
+        // Shape check: must be a JSON object with at least a `doi`
+        // or `id` field.
+        if !envelope.is_object() {
+            return Err(FetchError::SourceSchema {
+                hint: format!(
+                    "tdm-aps response is not a JSON object (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            });
+        }
+        if envelope.get("doi").is_none() && envelope.get("id").is_none() {
+            return Err(FetchError::SourceSchema {
+                hint: "tdm-aps response missing both `doi` and `id` fields".to_string(),
+            });
+        }
+
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::TdmAps,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license: "unknown".into(),
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(envelope),
+        })
+    }
+}
+
+/// Percent-encode a path segment, preserving the RFC 3986 unreserved
+/// set. `/` and other reserved characters are percent-encoded.
+fn percent_encode_path_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    for b in segment.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{:02X}", b));
+        }
+    }
+    out
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, RateLimits, Ref, TdmGrant};
+
+    const SAMPLE_ARTICLE_HIT: &str = r#"{
+        "id": "PhysRevX.10.011001",
+        "doi": "10.1103/PhysRevX.10.011001",
+        "title": "Example APS Harvest Article",
+        "journal": "Physical Review X"
+    }"#;
+
+    const SAMPLE_BAD_SHAPE: &str = r#"[1, 2, 3]"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "tdm-aps",
+            wiremock_host,
+        ));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter,
+            log,
+            session_id,
+        };
+        (td, ctx)
+    }
+
+    fn profile_with_aps_grant() -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.tdm_aps = Some(TdmGrant {
+            agree_env_var: "DOIGET_AGREE_TDM_APS".to_string(),
+            ..Default::default()
+        });
+        p
+    }
+
+    const TEST_KEY: &str = "aps-test-key-xyz";
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_doi_returns_article_object() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            // APS path with percent-encoded DOI (`/` → `%2F`).
+            .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ARTICLE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = TdmApsSource::with_base(Url::parse(&server.uri()).expect("wiremock URI parses"));
+        let profile = profile_with_aps_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
+
+        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
+        let result = src.fetch(&ref_, &profile, &ctx).await;
+        std::env::remove_var(KEY_ENV_VAR);
+        let result = result.expect("fetch ok");
+
+        assert_eq!(result.source, "tdm-aps");
+        assert!(result.pdf_bytes.is_none(), "metadata-only contract");
+        let meta = result.metadata_json.expect("metadata_json present");
+        assert_eq!(meta["title"], "Example APS Harvest Article");
+        assert_eq!(meta["doi"], "10.1103/PhysRevX.10.011001");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_without_grant_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = TdmApsSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
+        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
+
+        assert!(
+            !src.can_serve(&profile, &ref_),
+            "can_serve must be false without TdmGrant"
+        );
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("fetch must reject when grant is absent");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_non_object_returns_source_schema() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_BAD_SHAPE))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = TdmApsSource::with_base(Url::parse(&server.uri()).expect("wiremock URI parses"));
+        let profile = profile_with_aps_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
+
+        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
+        let result = src.fetch(&ref_, &profile, &ctx).await;
+        std::env::remove_var(KEY_ENV_VAR);
+
+        let err = result.expect_err("non-object response must surface as SourceSchema");
+        assert!(matches!(err, FetchError::SourceSchema { .. }));
+    }
+}

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -84,15 +84,10 @@ impl TdmApsSource {
     /// APS encodes the DOI directly in the path; the `/` separator
     /// in the DOI suffix must be percent-encoded.
     fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
-        let path = format!(
-            "/v2/article/{}",
-            percent_encode_path_segment(doi.as_str())
-        );
-        self.base
-            .join(&path)
-            .map_err(|e| FetchError::SourceSchema {
-                hint: format!("tdm-aps URL construction failed: {e}"),
-            })
+        let path = format!("/v2/article/{}", percent_encode_path_segment(doi.as_str()));
+        self.base.join(&path).map_err(|e| FetchError::SourceSchema {
+            hint: format!("tdm-aps URL construction failed: {e}"),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Second Phase-5 / Tier-3 slice. Adds `tdm-aps` — a metadata-only APS Harvest TDM fetcher. Whole module compile-gated by the `tdm-aps` Cargo feature (ADR-0002). Stacks on PR #104 (Slice 17 Springer).

- New `sources/tdm_aps.rs` (`TdmApsSource` Source impl).
- `tier_3_aps_allowlist()` in `http.rs` (`harvest.aps.org` + `*.aps.org`).
- Three-gate activation: Cargo feature + `DOIGET_KEY_APS` + `DOIGET_AGREE_TDM_APS=1`.
- Provenance rows use `Capability::TdmAps`. `FetchResult.pdf_bytes` always `None`.
- 3 wiremock tests (DOI-in-path happy path, no-grant `NotEligible`, non-object `SourceSchema`).

## Known limitation

APS expects `X-API-Key`. `HttpClient` has no per-source header hook yet; this slice does NOT attach the header on the wire. Tests pass with header matching disabled. Wiring will land alongside Slice 19 (Elsevier needs the same hook). TODO documented in `fetch()`.

## Test plan

- [x] `cargo build -p doiget-core` (default `oa-only`).
- [x] `cargo build --features tdm-aps -p doiget-core`.
- [x] `cargo test --features tdm-aps -p doiget-core --lib sources::tdm_aps` — 3 passed.
- [ ] CI green; re-base onto `main` after #104 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)