### PR TITLE
Slice 20 — per-source HTTP header hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,35 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 20 — Per-source HTTP header hook (Phase 5 follow-up)
+
+Closes the Slice 18/19 known-limitation by letting Tier-3 TDM
+sources attach authentication headers on the wire.
+
+- **New API** `HttpClient::fetch_bytes_with_headers(source, url,
+  headers: &[(&str, &str)])` (`crates/doiget-core/src/http.rs`).
+  Header names/values are validated up-front against the
+  visible-ASCII subset (RFC 7230 §3.2); invalid headers return
+  the new `HttpError::InvalidHeader { name, reason }` variant
+  before the request is sent. `fetch_bytes` / `fetch_pdf` keep
+  their existing signatures and pass `&[]` internally — no caller
+  needs to change.
+- **APS source** now sends `X-API-Key: $DOIGET_KEY_APS` on the
+  outgoing GET. Wiremock happy-path test asserts the header is
+  present (`header("x-api-key", TEST_KEY)` matcher); removing the
+  header would now fail the test.
+- **Elsevier source** now sends `X-ELS-APIKey: $DOIGET_KEY_ELSEVIER`
+  on the outgoing GET, with the matching `header("x-els-apikey",
+  TEST_KEY)` wiremock assertion.
+- **`HttpError::InvalidHeader`** is mapped to `None` in the
+  `From<&HttpError> for Option<DenialContext>` table — it is a
+  caller-bug signal, not an ADR-0023 denial, and collapses to
+  `ErrorCode::InternalError` via the existing wildcard arm in
+  `From<HttpError> for ErrorCode`.
+- **Stale notes removed**: the "header not on wire" `NOTE:` blocks
+  inside `tdm_aps.rs` / `tdm_elsevier.rs::fetch` and the
+  `KEY_ENV_VAR` doc-comments now describe the wired behaviour.
+
 ### Slice 19 — Elsevier ScienceDirect TDM source (Phase 5c)
 
 Third Phase-5 / Tier-3 slice — closes the Phase 5a/b/c trio. Adds

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -380,6 +380,21 @@ pub enum HttpError {
         /// The unregistered source key.
         source_key: String,
     },
+    /// A header name or value passed to
+    /// [`HttpClient::fetch_bytes_with_headers`] was not a valid HTTP
+    /// header. The header parser only accepts the visible-ASCII subset
+    /// per RFC 7230 §3.2; control characters and non-ASCII bytes are
+    /// rejected before the request is even built. Surfaces as
+    /// `ErrorCode::InternalError` at the public boundary (callers
+    /// supplying bad headers are responsible for fixing the call site;
+    /// not a denial in the ADR-0023 sense).
+    #[error("invalid HTTP header `{name}`: {reason}")]
+    InvalidHeader {
+        /// The header name as supplied by the caller.
+        name: String,
+        /// `"name"` or `"value"` — which side failed parsing.
+        reason: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -488,8 +503,10 @@ impl From<&HttpError> for Option<crate::DenialContext> {
             }
             // The remaining variants are not "denials" in the ADR-0023
             // sense — HttpStatus/UnknownSource are upstream / programming-
-            // error signals.
-            HttpError::HttpStatus { .. } | HttpError::UnknownSource { .. } => None,
+            // error signals; InvalidHeader is a caller-bug signal.
+            HttpError::HttpStatus { .. }
+            | HttpError::UnknownSource { .. }
+            | HttpError::InvalidHeader { .. } => None,
         }
     }
 }
@@ -546,7 +563,28 @@ impl HttpClient {
     ///
     /// Any [`HttpError`] variant.
     pub async fn fetch_bytes(&self, source: &str, url: Url) -> Result<(Bytes, Url), HttpError> {
-        self.fetch_inner(source, url, false).await
+        self.fetch_inner(source, url, &[], false).await
+    }
+
+    /// Like [`Self::fetch_bytes`] but attaches additional request
+    /// headers to the outgoing GET. The headers are validated up-front
+    /// against the visible-ASCII subset (RFC 7230 §3.2); any failure
+    /// returns [`HttpError::InvalidHeader`] before the request is sent.
+    ///
+    /// Used by Tier-3 TDM sources that authenticate via a header
+    /// (APS Harvest `X-API-Key`, Elsevier ScienceDirect `X-ELS-APIKey`).
+    /// Header values appear on the wire only — they are never logged.
+    ///
+    /// # Errors
+    ///
+    /// Any [`HttpError`] variant including [`HttpError::InvalidHeader`].
+    pub async fn fetch_bytes_with_headers(
+        &self,
+        source: &str,
+        url: Url,
+        headers: &[(&str, &str)],
+    ) -> Result<(Bytes, Url), HttpError> {
+        self.fetch_inner(source, url, headers, false).await
     }
 
     /// Fetch a URL expected to be a PDF. Same as [`Self::fetch_bytes`] plus
@@ -558,13 +596,14 @@ impl HttpClient {
     ///
     /// Any [`HttpError`] variant including [`HttpError::NotAPdf`].
     pub async fn fetch_pdf(&self, source: &str, url: Url) -> Result<(Bytes, Url), HttpError> {
-        self.fetch_inner(source, url, true).await
+        self.fetch_inner(source, url, &[], true).await
     }
 
     async fn fetch_inner(
         &self,
         source: &str,
         url: Url,
+        headers: &[(&str, &str)],
         check_pdf_magic: bool,
     ) -> Result<(Bytes, Url), HttpError> {
         let client = self
@@ -574,7 +613,27 @@ impl HttpClient {
                 source_key: source.to_string(),
             })?;
 
-        let response = client.get(url).send().await?;
+        // Parse headers up-front so an invalid name/value fails BEFORE
+        // we touch the network. `HeaderName::from_bytes` / `HeaderValue::from_str`
+        // accept the visible-ASCII subset only (RFC 7230 §3.2).
+        let mut header_map = reqwest::header::HeaderMap::with_capacity(headers.len());
+        for (name, value) in headers {
+            let hn = reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+                HttpError::InvalidHeader {
+                    name: (*name).to_string(),
+                    reason: "name".to_string(),
+                }
+            })?;
+            let hv = reqwest::header::HeaderValue::from_str(value).map_err(|_| {
+                HttpError::InvalidHeader {
+                    name: (*name).to_string(),
+                    reason: "value".to_string(),
+                }
+            })?;
+            header_map.insert(hn, hv);
+        }
+
+        let response = client.get(url).headers(header_map).send().await?;
         let final_url = response.url().clone();
 
         // Status check before body read so we can fail fast.

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -49,9 +49,8 @@ const DEFAULT_BASE: &str = "https://harvest.aps.org";
 
 /// Env var holding the per-tenant API key. Presence is one of the
 /// three activation gates (`docs/CAPABILITY.md` §2); the value is
-/// read at fetch time and would be sent as the `X-API-Key` header
-/// once `HttpClient` grows a per-source header hook (TODO in
-/// `fetch`).
+/// read at fetch time and sent as the `X-API-Key` header via
+/// [`HttpClient::fetch_bytes_with_headers`].
 const KEY_ENV_VAR: &str = "DOIGET_KEY_APS";
 
 /// APS Harvest [`Source`] impl — DOI → `/v2/article/<DOI>` JSON
@@ -132,15 +131,6 @@ impl Source for TdmApsSource {
         // Defensive gate (2/3): re-read the key env var. A missing
         // key here means env changed mid-process — fail-close as
         // NotEligible so the orchestrator can fall through.
-        //
-        // NOTE: Phase 5b relies on the shared `FetchContext.http`
-        // for the GET, which does not yet surface a per-source
-        // header hook. The `X-API-Key` header is therefore NOT
-        // attached on the wire in this slice; the call would 401 in
-        // production until the HttpClient is extended (the same
-        // hook Slice 19 / Elsevier needs). The wiremock test below
-        // exercises the path with header matching disabled. See
-        // `docs/SOURCES.md` §4 "TDM sources (Phase 5)" follow-up.
         let api_key = std::env::var(KEY_ENV_VAR).map_err(|_| FetchError::NotEligible {
             source_key: "tdm-aps".into(),
         })?;
@@ -153,7 +143,15 @@ impl Source for TdmApsSource {
         let _permit = ctx.rate_limiter.acquire(self.name()).await;
 
         let url = self.request_url(doi)?;
-        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+        // APS Harvest authenticates via the `X-API-Key` request
+        // header. Slice 20 wired `fetch_bytes_with_headers` into
+        // `HttpClient` for this and Elsevier's `X-ELS-APIKey`. The
+        // header value is sent on the wire only; it is never logged
+        // or echoed back in error messages.
+        let (body, final_url) = ctx
+            .http
+            .fetch_bytes_with_headers(self.name(), url, &[("X-API-Key", &api_key)])
+            .await?;
 
         let envelope: serde_json::Value =
             serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
@@ -238,7 +236,7 @@ mod tests {
 
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::http::HttpClient;
@@ -297,6 +295,8 @@ mod tests {
         Mock::given(method("GET"))
             // APS path with percent-encoded DOI (`/` → `%2F`).
             .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            // Slice 20: X-API-Key header MUST be present on the wire.
+            .and(header("x-api-key", TEST_KEY))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ARTICLE_HIT))
             .mount(&server)
             .await;

--- a/crates/doiget-core/src/sources/tdm_elsevier.rs
+++ b/crates/doiget-core/src/sources/tdm_elsevier.rs
@@ -49,9 +49,8 @@ const DEFAULT_BASE: &str = "https://api.elsevier.com";
 
 /// Env var holding the per-tenant API key. Presence is one of the
 /// three activation gates (`docs/CAPABILITY.md` §2); the value is
-/// read at fetch time and would be sent as the `X-ELS-APIKey`
-/// header once `HttpClient` grows a per-source header hook (TODO
-/// in `fetch`).
+/// read at fetch time and sent as the `X-ELS-APIKey` header via
+/// [`HttpClient::fetch_bytes_with_headers`].
 const KEY_ENV_VAR: &str = "DOIGET_KEY_ELSEVIER";
 
 /// Elsevier ScienceDirect [`Source`] impl — DOI →
@@ -146,15 +145,6 @@ impl Source for TdmElsevierSource {
         // Defensive gate (2/3): re-read the key env var. A missing
         // key here means env changed mid-process — fail-close as
         // NotEligible so the orchestrator can fall through.
-        //
-        // NOTE: Phase 5c relies on the shared `FetchContext.http`
-        // for the GET, which does not yet surface a per-source
-        // header hook. The `X-ELS-APIKey` header is therefore NOT
-        // attached on the wire in this slice; the call would 401 in
-        // production until the HttpClient is extended (the same
-        // hook Slice 18 / APS needs). The wiremock test below
-        // exercises the path with header matching disabled. See
-        // `docs/SOURCES.md` §4 "TDM sources (Phase 5)" follow-up.
         let api_key = std::env::var(KEY_ENV_VAR).map_err(|_| FetchError::NotEligible {
             source_key: "tdm-elsevier".into(),
         })?;
@@ -167,7 +157,13 @@ impl Source for TdmElsevierSource {
         let _permit = ctx.rate_limiter.acquire(self.name()).await;
 
         let url = self.request_url(doi)?;
-        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+        // Elsevier authenticates via the `X-ELS-APIKey` request
+        // header (Slice 20 wiring). The header value is sent on
+        // the wire only; it is never logged or echoed back.
+        let (body, final_url) = ctx
+            .http
+            .fetch_bytes_with_headers(self.name(), url, &[("X-ELS-APIKey", &api_key)])
+            .await?;
 
         let envelope: serde_json::Value =
             serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
@@ -254,7 +250,7 @@ mod tests {
 
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::http::HttpClient;
@@ -317,6 +313,8 @@ mod tests {
             // Elsevier path with percent-encoded DOI (`/` → `%2F`).
             .and(path("/content/article/doi/10.1016%2Fj.example.2024.001"))
             .and(query_param("httpAccept", "application/json"))
+            // Slice 20: X-ELS-APIKey header MUST be present on the wire.
+            .and(header("x-els-apikey", TEST_KEY))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ARTICLE_HIT))
             .mount(&server)
             .await;


### PR DESCRIPTION
## Summary

Closes the Slice 18/19 known limitation (auth headers were validated at fetch-time but never put on the wire). Adds `HttpClient::fetch_bytes_with_headers(source, url, headers: &[(&str, &str)])` and wires APS + Elsevier through it.

- **New API**: `fetch_bytes_with_headers` on `HttpClient`. Header names/values validated up-front against the RFC 7230 §3.2 visible-ASCII subset; bad headers return new `HttpError::InvalidHeader { name, reason }` before the request is built.
- **No caller migration**: `fetch_bytes` / `fetch_pdf` keep their signatures and delegate to the inner with `&[]`.
- **APS** now sends `X-API-Key: $DOIGET_KEY_APS` on the GET. Test asserts the header via wiremock's `header()` matcher.
- **Elsevier** now sends `X-ELS-APIKey: $DOIGET_KEY_ELSEVIER` on the GET, same matching assertion.
- **Mappings**: `InvalidHeader` → `None` in the `DenialContext` table (caller-bug, not an ADR-0023 denial). Collapses to `ErrorCode::InternalError` via the existing wildcard in `From<HttpError> for ErrorCode`.

## Test plan

- [x] `cargo check -p doiget-core` (default oa-only) — green.
- [x] `cargo test -p doiget-core --no-default-features --features oa-only --lib` — 192/192 pass.
- [x] `cargo test --features 'tdm-springer,tdm-aps,tdm-elsevier' -p doiget-core --lib 'sources::tdm_' -- --test-threads=1` — 9/9 pass (new header assertions included).
- [x] `cargo fmt -- --check` — clean.
- [ ] CI green on `feat/slice-20-http-headers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)