### PR TITLE
Slice 21 — release-plz integration (Phase 6 foundation)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,62 @@
+name: release-plz
+
+# Phase 6 / Slice 21 — release-plz integration (PR side only).
+#
+# On every push to `main`, this workflow runs `release-plz release-pr`,
+# which inspects the conventional-commit history and opens (or updates)
+# a single "release PR" that:
+#   - bumps the workspace version in `Cargo.toml`
+#   - prepends a new versioned section to `CHANGELOG.md`
+#
+# Tagging, GitHub-releases, and `cargo publish` are intentionally NOT
+# wired in this slice. They land alongside crates.io trusted-publishing
+# via OIDC in a follow-up Phase 6 slice. See `release-plz.toml`
+# (`git_release_enable = false`, `publish = false`).
+#
+# `workflow_dispatch` is enabled so the workflow can be exercised
+# manually on the slice-21 branch before any push lands on `main`.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# release-plz needs write access to create / update the release PR.
+# Nothing else in the job writes to the repo or the registry.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Single global lock — never let two release-plz runs race for the
+# same release PR.
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-plz-pr:
+    name: release-plz release-pr
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for release-plz)
+        # release-plz walks conventional-commit history to compute the
+        # next version, so it needs the full git log.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust toolchain (stable)
+        # release-plz invokes `cargo` internally to read the workspace.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - name: release-plz release-pr
+        # SHA-pinned to v0.5.129 (released 2026-05-10).
+        uses: MarcoIeni/release-plz-action@064f4d1e36c843611ddf013be726beaa4ad804db
+        with:
+          # Only open / update the release PR; never tag or publish.
+          # The `release` side stays off until OIDC trusted-publishing
+          # is wired (later Phase 6 slice).
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,34 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 21 — release-plz integration (Phase 6 foundation)
+
+First Phase-6 slice. Wires `release-plz` so every push to `main`
+opens or updates a single "release PR" that bumps the workspace
+version (currently `0.0.0`) and prepends a versioned section to
+`CHANGELOG.md`. Tagging, GitHub releases, and `cargo publish` are
+intentionally NOT enabled in this slice — those land alongside
+OIDC trusted-publishing and sigstore signing in subsequent Phase 6
+slices.
+
+- **New** `release-plz.toml` at the repo root. `git_release_enable
+  = false`, `publish = false`, `publish_no_verify = true`,
+  `changelog_path = "CHANGELOG.md"`. Lists `doiget-core` /
+  `doiget-cli` / `doiget-mcp` as managed packages (they share a
+  single workspace version).
+- **New** `.github/workflows/release-plz.yml`. Triggers on `push:
+  main` and `workflow_dispatch`. Permissions: `contents: write` +
+  `pull-requests: write` (only enough to open / update the release
+  PR). Concurrency group `release-plz-${{ github.ref }}` prevents
+  duplicate runs. SHA-pinned actions:
+  - `actions/checkout@de0fac2e…` (v6.0.2) with `fetch-depth: 0`
+    so release-plz can walk the full conventional-commit history.
+  - `dtolnay/rust-toolchain@29eef336…` (stable, for the workspace
+    `cargo` invocation release-plz makes internally).
+  - `MarcoIeni/release-plz-action@064f4d1e…` (v0.5.129) with
+    `command: release-pr` — never `release`, so it cannot tag or
+    publish.
+
 ### Slice 20 — Per-source HTTP header hook (Phase 5 follow-up)
 
 Closes the Slice 18/19 known-limitation by letting Tier-3 TDM

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,46 @@
+# release-plz workspace config — Phase 6 / Slice 21.
+#
+# This slice ships ONLY the release-PR side of release-plz:
+#   - On every push to `main`, release-plz inspects conventional-commit
+#     messages and opens (or updates) a single "release PR" that bumps
+#     the workspace version and updates CHANGELOG.md.
+#   - The `release` side of release-plz (which tags, GitHub-releases,
+#     and `cargo publish`es each crate) is intentionally DISABLED here.
+#     Tag + GitHub-release + crates.io publish wiring lands with the
+#     Phase 6 OIDC / sigstore / SBOM follow-up slices.
+#
+# Reference: https://release-plz.dev/docs/config
+
+[workspace]
+# Do NOT create GitHub releases yet. The `release` job is not enabled
+# in `.github/workflows/release-plz.yml` either; this is belt-and-braces.
+git_release_enable    = false
+# Do NOT publish to crates.io yet. Crates.io trusted-publishing via OIDC
+# lands in a later slice; until then, leave the registry untouched.
+publish               = false
+# Skip the "is this commit already in the registry?" check while
+# publishing is off — speeds up release-PR generation and avoids
+# spurious network calls.
+publish_no_verify     = true
+# We maintain ONE workspace-wide CHANGELOG.md at the repo root
+# (already in place; Slices 1-20 entries live there). release-plz will
+# append new sections to it on each release PR.
+changelog_update      = true
+changelog_path        = "CHANGELOG.md"
+# Group all workspace crates' bumps into a single release PR. Per-crate
+# split adds churn without value while we have just three crates.
+release_always        = false
+
+# Per-crate entries. The three published crates share a single workspace
+# version (via `version.workspace = true`) so per-crate version pinning
+# is unnecessary — listing them here only declares which crates
+# release-plz manages.
+
+[[package]]
+name                  = "doiget-core"
+
+[[package]]
+name                  = "doiget-cli"
+
+[[package]]
+name                  = "doiget-mcp"


### PR DESCRIPTION
## Summary

First Phase-6 slice. Adds `release-plz` so every push to `main` opens (or updates) a single release-PR that bumps the workspace version and prepends a CHANGELOG section. Tagging, GitHub-releases, and `cargo publish` stay **off** — those land in the OIDC / sigstore / SBOM slices on top of this foundation.

- `release-plz.toml`: `git_release_enable=false`, `publish=false`, `changelog_path="CHANGELOG.md"`, lists `doiget-core` / `doiget-cli` / `doiget-mcp`.
- `.github/workflows/release-plz.yml`: `push: main` + `workflow_dispatch`, minimum-permissions, concurrency-gated, SHA-pinned actions, `command: release-pr` only.

## Test plan

- [ ] CI green (no new checks expected from this slice — release-plz runs only on `main`).
- [ ] After merge: workflow appears in the Actions tab and the first `main` push triggers a release-PR proposing the initial version bump.
- [ ] If release-plz proposes an unexpected version (e.g. due to historical commits not following conventional-commit), close the PR and decide whether to fast-forward CHANGELOG manually or adjust `release-plz.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)