### PR TITLE
Slice 22 — OIDC crates.io trusted-publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,34 +1,37 @@
 name: release-plz
 
-# Phase 6 / Slice 21 — release-plz integration (PR side only).
+# Phase 6 / Slice 22 — release-plz integration with OIDC trusted-publishing.
 #
-# On every push to `main`, this workflow runs `release-plz release-pr`,
-# which inspects the conventional-commit history and opens (or updates)
-# a single "release PR" that:
-#   - bumps the workspace version in `Cargo.toml`
-#   - prepends a new versioned section to `CHANGELOG.md`
+# Two-job pattern (recommended by the release-plz docs):
+#   1. `release-pr` runs on every push to `main`. It walks the
+#      conventional-commit history and opens / updates a single
+#      "release PR" that bumps the workspace version in `Cargo.toml`
+#      and prepends a versioned section to `CHANGELOG.md`.
+#   2. `release` runs on every push to `main` too, but only "fires"
+#      (creates tag + GitHub release + `cargo publish`es each crate)
+#      when the push is the merge of a release-PR. On normal pushes it
+#      is a no-op.
 #
-# Tagging, GitHub-releases, and `cargo publish` are intentionally NOT
-# wired in this slice. They land alongside crates.io trusted-publishing
-# via OIDC in a follow-up Phase 6 slice. See `release-plz.toml`
-# (`git_release_enable = false`, `publish = false`).
-#
-# `workflow_dispatch` is enabled so the workflow can be exercised
-# manually on the slice-21 branch before any push lands on `main`.
+# OIDC trusted-publishing — there is NO `CARGO_REGISTRY_TOKEN` secret.
+# The `id-token: write` permission on the `release` job lets it
+# exchange the GitHub OIDC token for a short-lived crates.io token at
+# publish time (per the release-plz trusted-publishing flow). The
+# three crates MUST be registered as Trusted Publishers on crates.io
+# before the first run; see the Slice 22 PR description for the exact
+# steps.
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-# release-plz needs write access to create / update the release PR.
-# Nothing else in the job writes to the repo or the registry.
+# Workflow-level permissions are intentionally the LEAST common
+# denominator. Per-job permissions narrow further below.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Single global lock — never let two release-plz runs race for the
-# same release PR.
+# same release PR / tag.
 concurrency:
   group: release-plz-${{ github.ref }}
   cancel-in-progress: false
@@ -37,26 +40,61 @@ jobs:
   release-plz-pr:
     name: release-plz release-pr
     runs-on: ubuntu-latest
+    # Only enough to push the release-PR branch and open / update the
+    # PR itself. No `id-token`, no tag-creation rights.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout (full history for release-plz)
-        # release-plz walks conventional-commit history to compute the
-        # next version, so it needs the full git log.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain (stable)
-        # release-plz invokes `cargo` internally to read the workspace.
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
       - name: release-plz release-pr
-        # SHA-pinned to v0.5.129 (released 2026-05-10).
-        uses: MarcoIeni/release-plz-action@064f4d1e36c843611ddf013be726beaa4ad804db
+        # SHA-pinned to v0.5.129 (released 2026-05-10), canonical
+        # repo `release-plz/action`.
+        uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db
         with:
-          # Only open / update the release PR; never tag or publish.
-          # The `release` side stays off until OIDC trusted-publishing
-          # is wired (later Phase 6 slice).
           command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: release-plz release
+    runs-on: ubuntu-latest
+    # `contents: write` to push the annotated tag and the GitHub
+    # release. `id-token: write` is the OIDC permission used to mint
+    # the crates.io publish token (no `CARGO_REGISTRY_TOKEN`
+    # required). `pull-requests: read` only because release-plz
+    # reads the merged release-PR description to format the release
+    # body.
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+    # Run AFTER the release-PR job so a single push that creates a
+    # release-PR doesn't simultaneously try to publish off the prior
+    # state. (release-plz's `release` step is idempotent — this is
+    # belt-and-braces.)
+    needs: release-plz-pr
+    steps:
+      - name: Checkout (full history for release-plz)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - name: release-plz release (publish + tag + GH release)
+        uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db
+        with:
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,39 @@ Five tools were wired during Slice 1 / Slice 2 (`doiget_health`,
 out the remaining five (`doiget_resolve_paper`, `doiget_info`,
 `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`).
 
+### Slice 22 — OIDC crates.io trusted-publishing
+
+Phase 6 continuation. Turns on the `release` side of release-plz
+so the workflow now (a) pushes an annotated git tag, (b) opens a
+GitHub release with the CHANGELOG section as the body, and (c)
+publishes each crate to crates.io — using OIDC trusted-publishing
+instead of a long-lived `CARGO_REGISTRY_TOKEN`.
+
+- **`release-plz.toml`**: `publish` and `git_release_enable` flipped
+  to `true`. `publish_no_verify` stays on (CI already builds every
+  commit; the registry-side dry-run is redundant).
+- **`.github/workflows/release-plz.yml`**: split into two jobs.
+  - `release-plz-pr`: unchanged behaviour, narrowed permissions
+    (`contents: write` + `pull-requests: write` only — no
+    `id-token`).
+  - `release-plz-release` (new): runs after the PR job, has
+    `id-token: write` so release-plz can mint a short-lived
+    crates.io token via OIDC. Idempotent — on non-release pushes
+    the step is a no-op.
+  - Both jobs now use the canonical `release-plz/action@SHA` ref
+    (the prior `MarcoIeni/release-plz-action` is a redirect; same
+    SHA, same release).
+  - Workflow-level `permissions: contents: read` is the new least-
+    common-denominator; each job widens only what it needs.
+
+**Prerequisite (manual, one-time, before merge or first release-PR
+merge):** the three crates (`doiget-core`, `doiget-cli`,
+`doiget-mcp`) must be registered as Trusted Publishers on
+crates.io. Without this, the `release` job will fail to publish.
+Per crates.io's policy, the FIRST publish of each new crate has to
+be done manually (Trusted Publishing only works for existing
+crates).
+
 ### Slice 21 — release-plz integration (Phase 6 foundation)
 
 First Phase-6 slice. Wires `release-plz` so every push to `main`

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,15 +12,20 @@
 # Reference: https://release-plz.dev/docs/config
 
 [workspace]
-# Do NOT create GitHub releases yet. The `release` job is not enabled
-# in `.github/workflows/release-plz.yml` either; this is belt-and-braces.
-git_release_enable    = false
-# Do NOT publish to crates.io yet. Crates.io trusted-publishing via OIDC
-# lands in a later slice; until then, leave the registry untouched.
-publish               = false
-# Skip the "is this commit already in the registry?" check while
-# publishing is off — speeds up release-PR generation and avoids
-# spurious network calls.
+# GitHub releases ARE created — each release-PR merge produces an
+# annotated tag + GitHub release page with the CHANGELOG section as
+# the body. Slice 22 (Phase 6) flipped this on alongside crates.io
+# publish via OIDC trusted-publishing.
+git_release_enable    = true
+# Crates.io publish IS enabled. The publish step uses OIDC trusted-
+# publishing — no `CARGO_REGISTRY_TOKEN` is set; release-plz exchanges
+# the workflow's OIDC token for a short-lived crates.io token. Each
+# crate must be registered as a Trusted Publisher on crates.io BEFORE
+# the first run (see PR description for Slice 22).
+publish               = true
+# `cargo publish --no-verify` — skip the dry-run build inside the
+# registry. We rebuild every commit in CI already; the extra verify
+# pass on the release runner just doubles publish time.
 publish_no_verify     = true
 # We maintain ONE workspace-wide CHANGELOG.md at the repo root
 # (already in place; Slices 1-20 entries live there). release-plz will


### PR DESCRIPTION
## Summary

Phase 6 continuation. Turns on the `release` side of release-plz so each merged release-PR now tags, opens a GitHub release, and `cargo publish`es each crate using OIDC trusted-publishing (no `CARGO_REGISTRY_TOKEN`).

- `release-plz.toml`: \`publish = true\`, \`git_release_enable = true\`.
- `release-plz.yml`: split into two jobs.
  - `release-plz-pr` (existing, narrowed perms — \`contents: write\` + \`pull-requests: write\`, no id-token).
  - `release-plz-release` (new — \`id-token: write\` for OIDC, \`contents: write\` to push the tag, \`pull-requests: read\` to read the merged PR body for the release notes). Idempotent: on non-release pushes the step is a no-op.
  - Migrated action ref to canonical \`release-plz/action@SHA\` (same SHA as the legacy \`MarcoIeni/release-plz-action\` redirect; v0.5.129).
- Workflow-level perms tightened to \`contents: read\`; each job widens only what it needs.

## ⚠️ Manual prerequisite — must be done before this PR merges (or before the first release-PR merges)

1. **Initial manual publish of each crate.** crates.io Trusted Publishing **only works for crates that already exist on the registry** — the first version of every new crate has to be published manually. From your workstation, run for each of the three crates while logged in to crates.io:
   \`\`\`
   cargo login            # one-time, paste your interactive token
   cd crates/doiget-core   && cargo publish
   cd ../doiget-cli        && cargo publish
   cd ../doiget-mcp        && cargo publish
   \`\`\`
   (If you'd rather wait and have the workflow attempt the first publish too, that's also OK — it will fail loudly on the first run and you can run the manual publish then merge the release-PR via `workflow_dispatch` re-run.)

2. **Register each crate as a Trusted Publisher on crates.io.** For each crate page (`https://crates.io/crates/doiget-core` etc.) → Settings → Trusted Publishing → Add GitHub Actions, then enter:
   - Repository owner: \`sotashimozono\`
   - Repository name: \`doiget\`
   - Workflow filename: \`release-plz.yml\`
   - (Leave Environment blank — we don't gate on a GH-Environment.)

After both steps are done, the workflow will succeed on subsequent merges.

## Test plan

- [ ] CI green on this branch (this PR only touches workflow YAML + the toml; no Rust code).
- [ ] Manual prerequisites (1) and (2) completed BEFORE merging this PR.
- [ ] After merge, the next release-PR that merges into `main` triggers a successful tag + GitHub release + crates.io publish for all three crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)