### PR TITLE
chore: bump workspace 0.0.0 → 0.1.0 (initial crates.io release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.0.0"
+version       = "0.1.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.0.0" }
-doiget-cli  = { path = "crates/doiget-cli",  version = "0.0.0" }
-doiget-mcp  = { path = "crates/doiget-mcp",  version = "0.0.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.1.0" }
+doiget-cli  = { path = "crates/doiget-cli",  version = "0.1.0" }
+doiget-mcp  = { path = "crates/doiget-mcp",  version = "0.1.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
## Summary

Bootstrap version bump for the initial crates.io release. All three crates were just published manually at **v0.1.0** (Trusted Publishing requires a pre-existing crate, so the first publish is by hand):

- `doiget-core` v0.1.0 — published ✅
- `doiget-mcp` v0.1.0 — published ✅
- `doiget-cli` v0.1.0 — published ✅

Bumps `[workspace.package].version` and the 3 `[workspace.dependencies]` pins `0.0.0 → 0.1.0`.

## Why merge this

main must match what's on the registry (`0.1.0`). Once merged, the release-plz `release` job sees `0.1.0` already published → **skips publish**, and just creates the `v0.1.0` git tag + GitHub release (`git_release_enable = true`). No failed runs. From `0.2.0` on, release-plz + OIDC is fully automated.

## Follow-up (manual, yours)

Register each crate as a Trusted Publisher on crates.io so future automated releases work:
- https://crates.io/crates/doiget-core/settings → Trusted Publishing → Add GitHub Actions
- same for `doiget-mcp`, `doiget-cli`
- Owner `sotashimozono`, repo `doiget`, workflow `release-plz.yml`, Environment blank

## Test plan

- [x] `cargo metadata` shows all 3 crates at 0.1.0
- [x] `cargo publish --dry-run` (core) clean
- [x] All 3 published & visible on crates.io at 0.1.0
- [ ] After merge: release-plz tags `v0.1.0` + GitHub release, publish step is a skip (not a failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)