### PR TITLE
Slice 24 — CycloneDX SBOM generation + signing per release

### DIFF
--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -1,0 +1,130 @@
+name: release-sbom
+
+# Phase 6 / Slice 24 — generate + sign a CycloneDX SBOM per release.
+#
+# Companion to release-sign.yml (Slice 23). Fires once per version on
+# the `doiget-cli-v*` tag release-plz pushes (or manual dispatch),
+# generates a CycloneDX SBOM for the `doiget-cli` package — i.e. the
+# full transitive dependency graph of the SHIPPED binary — signs it
+# with cosign keyless (Fulcio cert from the GitHub OIDC token; no
+# long-lived key, no stored secret), and uploads to the matching
+# `doiget-cli-v<version>` GitHub Release:
+#
+#   doiget-sbom-<tag>.cdx.json
+#   doiget-sbom-<tag>.cdx.json.sha256
+#   doiget-sbom-<tag>.cdx.json.cosign.bundle
+#
+# Verify with:
+#   cosign verify-blob \
+#     --bundle doiget-sbom-<tag>.cdx.json.cosign.bundle \
+#     --certificate-identity-regexp \
+#       'https://github.com/sotashimozono/doiget/.github/workflows/release-sbom.yml@.*' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     doiget-sbom-<tag>.cdx.json
+
+on:
+  push:
+    tags:
+      - 'doiget-cli-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing doiget-cli-v* tag to (re)generate the SBOM for'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-sbom-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  sbom:
+    name: cyclonedx SBOM + cosign sign
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # upload the SBOM to the GitHub Release
+      id-token: write   # cosign keyless: mint Fulcio cert from OIDC token
+    env:
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Install cargo-cyclonedx
+        shell: bash
+        run: cargo install cargo-cyclonedx --locked
+
+      - name: Generate CycloneDX SBOM for doiget-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          # SBOM of the shipped binary's full transitive graph. `oa-only`
+          # matches the feature surface release-sign.yml builds + CI gates.
+          cargo cyclonedx -p doiget-cli --format json \
+            --no-default-features --features oa-only
+          # cargo-cyclonedx writes the bom next to the crate manifest;
+          # the exact filename has drifted across versions, so locate it
+          # defensively rather than hard-coding.
+          src="$(find . -name '*.cdx.json' -path '*doiget-cli*' | head -n1)"
+          if [ -z "$src" ]; then
+            src="$(find . -name '*.cdx.json' | head -n1)"
+          fi
+          if [ -z "$src" ]; then
+            echo "::error::no .cdx.json produced by cargo-cyclonedx" >&2
+            exit 1
+          fi
+          out="doiget-sbom-${TAG}.cdx.json"
+          cp "$src" "$out"
+          shasum -a 256 "$out" > "$out.sha256"
+          echo "SBOM=$out" >> "$GITHUB_ENV"
+
+      - name: cosign sign-blob (keyless)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cosign sign-blob --yes \
+            --bundle "${SBOM}.cosign.bundle" \
+            "${SBOM}"
+
+      - name: Wait for the GitHub Release to exist
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # release-plz creates the `doiget-cli-v<version>` Release on the
+          # same tag push that triggered this workflow — short race.
+          for i in $(seq 1 20); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "release $TAG present"; exit 0
+            fi
+            echo "release $TAG not yet present (attempt $i/20); waiting 15s"
+            sleep 15
+          done
+          echo "::error::GitHub Release $TAG never appeared after ~5min" >&2
+          exit 1
+
+      - name: Upload signed SBOM to the Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            "${SBOM}" \
+            "${SBOM}.sha256" \
+            "${SBOM}.cosign.bundle" \
+            --clobber


### PR DESCRIPTION
## Summary

Phase 6 final plumbing slice. Adds `.github/workflows/release-sbom.yml` (companion to `release-sign.yml`). On the `doiget-cli-v*` tag release-plz pushes (or manual dispatch):

1. `cargo cyclonedx -p doiget-cli --no-default-features --features oa-only` → CycloneDX JSON SBOM of the shipped binary's full transitive dependency graph.
2. cosign **keyless** signs it (Fulcio cert from the GitHub OIDC token — no long-lived key, no stored secret).
3. Uploads `doiget-sbom-<tag>.cdx.json` + `.sha256` + `.cosign.bundle` to the matching `doiget-cli-v<version>` GitHub Release.

## Design notes

- Per-job `id-token: write`; workflow default `contents: read`.
- `cargo-cyclonedx` via `cargo install --locked`; output located defensively (filename drifts across tool versions).
- Bounded poll for the release-plz-created Release before upload (same-tag-push race).
- SHA-pinned: `actions/checkout` v6.0.2, `dtolnay/rust-toolchain` stable, `sigstore/cosign-installer` v4.1.2 — identical pins to Slice 23.
- Verify recipe in the workflow header.

## Scope

- SBOM scoped to `doiget-cli` (the released binary) — its graph transitively includes `doiget-core` + `doiget-mcp` + all deps.
- First SBOM ships with the next automated release (`doiget-cli-v0.2.0`); 0.1.0 not back-filled.
- CHANGELOG is release-plz-generated from conventional commits — no manual edit.

This completes the Phase 6 release plumbing: **release-plz + OIDC trusted-publishing + sigstore signing + SBOM**.

## Test plan

- [ ] CI green (YAML only; no Rust changes).
- [ ] On `doiget-cli-v0.2.0`: workflow runs, signed SBOM appears on the Release, `cosign verify-blob --bundle … --certificate-oidc-issuer https://token.actions.githubusercontent.com doiget-sbom-….cdx.json` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)