### PR TITLE
Slice 15b — doiget_bibtex_export + doiget_csl_export MCP tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "camino",
+ "chrono",
  "doiget-core",
  "rmcp",
  "serde",

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -1,25 +1,17 @@
 //! `doiget bib <ref>` subcommand — emit a BibTeX entry for a stored entry.
 //!
-//! Phase 2 starter: read the stored [`Metadata`] for a [`Ref`] and write a
-//! minimal BibTeX entry on stdout. The Phase 1 binding fields from
-//! `docs/STORE.md` §2 (title, authors, year, doi, venue, publisher, issn)
-//! are emitted as `@article` for `type = "journal-article"` and `@misc`
-//! otherwise. Richer entry-type mapping (`@inproceedings`, `@book`, custom
-//! note fields) lands in a follow-up.
-//!
-//! Output is a single hand-rolled BibTeX entry — no external bibtex /
-//! biber crate is pulled in for Phase 2. The emitter is intentionally
-//! conservative: any literal `{` / `}` in a field value is stripped (with a
-//! `tracing::warn!`), and missing / empty fields are omitted. Real-world
-//! Crossref / Unpaywall titles rarely contain bare braces, so the
-//! strip-on-encounter policy is safe-by-default and keeps the Phase 2
-//! starter free of a TeX-aware escaper.
+//! Reads the stored [`Metadata`](doiget_core::store::Metadata) for a
+//! [`Ref`] and writes a BibTeX entry on stdout. The actual rendering
+//! lives in [`doiget_core::store::render::to_bibtex`] so the CLI and the
+//! `doiget_bibtex_export` MCP tool share one implementation (Slice 15b).
+//! See that function's docs for the field/entry-type mapping and the
+//! brace-stripping policy.
 
 use std::io::Write;
 
 use anyhow::{bail, Context, Result};
 
-use doiget_core::store::{FsStore, Metadata, Store};
+use doiget_core::store::{render, FsStore, Store};
 use doiget_core::Ref;
 
 use super::resolve_store_root;
@@ -29,7 +21,7 @@ use super::resolve_store_root;
 /// `input` is the user-supplied ref string (e.g. `"10.1234/example"`,
 /// `"arxiv:2401.12345"`, or any of the schemes accepted by [`Ref::parse`]).
 ///
-/// On success, a BibTeX entry derived from the entry's [`Metadata`] is
+/// On success, a BibTeX entry derived from the entry's `Metadata` is
 /// written to stdout. On a missing entry, the function returns an error
 /// so the CLI exits non-zero.
 pub fn run(input: String) -> Result<()> {
@@ -45,219 +37,18 @@ pub fn run(input: String) -> Result<()> {
 
     match metadata {
         Some(m) => {
+            let bib = render::to_bibtex(safekey.as_str(), &m);
             // Workspace lints deny `print_stdout` (the `print!`/`println!`
             // macros) so JSON-RPC frames never collide with diagnostics.
-            // `writeln!` against an explicit `stdout().lock()` is the
-            // sanctioned escape hatch — the caller chose stdout
-            // explicitly. See `docs/SECURITY.md` §3 / ADR-0001.
+            // `write!` against an explicit `stdout().lock()` is the
+            // sanctioned escape hatch — `to_bibtex` already terminates
+            // the entry with `}\n`, so no extra newline is added.
+            // See `docs/SECURITY.md` §3 / ADR-0001.
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
-            write_bibtex_entry(&mut out, safekey.as_str(), &m)
-                .context("failed to write BibTeX entry to stdout")?;
+            write!(out, "{bib}").context("failed to write BibTeX entry to stdout")?;
             Ok(())
         }
         None => bail!("no entry for {input}"),
-    }
-}
-
-/// Map a Crossref-taxonomy `type` string to a BibTeX entry type.
-///
-/// Phase 2 starter only differentiates `journal-article` (→ `@article`)
-/// from everything else (→ `@misc`). Extending the map to
-/// `@inproceedings` / `@book` / `@techreport` is a Phase 2 follow-up that
-/// requires an explicit list of accepted Crossref types per entry kind.
-fn entry_type_for(type_: Option<&str>) -> &'static str {
-    match type_ {
-        Some("journal-article") => "article",
-        _ => "misc",
-    }
-}
-
-/// Write a single BibTeX entry for `m` keyed by `citation_key`.
-///
-/// Field order matches the spec block: `title`, `author`, `year`, `doi`,
-/// `journal`, `publisher`, `issn`. Any field that resolves to `None` /
-/// empty is omitted entirely.
-fn write_bibtex_entry<W: Write>(
-    out: &mut W,
-    citation_key: &str,
-    m: &Metadata,
-) -> std::io::Result<()> {
-    let entry_type = entry_type_for(m.type_.as_deref());
-    writeln!(out, "@{entry_type}{{{citation_key},")?;
-
-    write_field(out, "title", &m.title)?;
-    if !m.authors.is_empty() {
-        // BibTeX joins multiple authors with the literal token " and ".
-        write_field(out, "author", &m.authors.join(" and "))?;
-    }
-    if let Some(year) = m.year {
-        write_field(out, "year", &year.to_string())?;
-    }
-    if let Some(doi) = &m.doi {
-        write_field(out, "doi", doi.as_str())?;
-    }
-    if let Some(venue) = m.venue.as_deref() {
-        if !venue.is_empty() {
-            write_field(out, "journal", venue)?;
-        }
-    }
-    if let Some(publisher) = m.publisher.as_deref() {
-        if !publisher.is_empty() {
-            write_field(out, "publisher", publisher)?;
-        }
-    }
-    if let Some(issn) = m.issn.as_deref() {
-        if !issn.is_empty() {
-            write_field(out, "issn", issn)?;
-        }
-    }
-
-    writeln!(out, "}}")?;
-    Ok(())
-}
-
-/// Write a single `<key> = {<value>},` line, padded so the `=` columns
-/// line up across the seven-field Phase 2 surface.
-fn write_field<W: Write>(out: &mut W, key: &str, value: &str) -> std::io::Result<()> {
-    let escaped = strip_unsafe(key, value);
-    // Width 10 is wide enough for `publisher` (the longest key in the
-    // Phase 2 set). Future fields longer than 10 chars will reflow the
-    // table; that's an acceptable cost for a hand-rolled emitter.
-    writeln!(out, "  {key:<10} = {{{escaped}}},")
-}
-
-/// Strip BibTeX-unsafe characters from `value`.
-///
-/// Phase 2 starter takes the pragmatic route: any literal `{` or `}`
-/// would unbalance the surrounding braces, and no escaping convention
-/// applies inside a brace-wrapped value without falling back to a full
-/// LaTeX escaper. Real-world titles rarely contain bare braces, so we
-/// strip them and emit a `tracing::warn!` so the dropped chars are
-/// visible in stderr / structured logs.
-fn strip_unsafe(key: &str, value: &str) -> String {
-    let has_braces = value.contains('{') || value.contains('}');
-    if has_braces {
-        tracing::warn!(
-            field = key,
-            "stripping literal '{{'/'}}' from BibTeX field value; \
-             a TeX-aware escaper lands in a Phase 2 follow-up"
-        );
-    }
-    value.chars().filter(|c| !matches!(c, '{' | '}')).collect()
-}
-
-#[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
-mod tests {
-    use std::collections::BTreeMap;
-
-    use chrono::TimeZone;
-
-    use doiget_core::store::{DoigetExtension, Metadata};
-    use doiget_core::{Doi, SCHEMA_VERSION};
-
-    use super::*;
-
-    fn fixture(type_: Option<&str>) -> Metadata {
-        Metadata {
-            schema_version: SCHEMA_VERSION.to_string(),
-            title: "Quantum Stuff".to_string(),
-            authors: vec!["Alice Researcher".to_string(), "Bob Coauthor".to_string()],
-            year: Some(2026),
-            doi: Some(Doi::parse("10.1234/example").expect("valid DOI")),
-            arxiv_id: None,
-            abstract_: None,
-            venue: Some("Phys Rev X".to_string()),
-            publisher: Some("APS".to_string()),
-            issn: Some("2160-3308".to_string()),
-            isbn: None,
-            type_: type_.map(str::to_string),
-            keywords: vec![],
-            url: None,
-            pdf_path: None,
-            doiget: Some(DoigetExtension {
-                fetched_at: chrono::Utc
-                    .with_ymd_and_hms(2026, 5, 6, 12, 0, 0)
-                    .single()
-                    .expect("valid timestamp"),
-                source: "unpaywall".to_string(),
-                license: "CC-BY-4.0".to_string(),
-                size_bytes: 1234,
-                mcp_call_id: None,
-            }),
-            other: BTreeMap::new(),
-        }
-    }
-
-    fn render(citation_key: &str, m: &Metadata) -> String {
-        let mut buf: Vec<u8> = Vec::new();
-        write_bibtex_entry(&mut buf, citation_key, m).expect("write_bibtex_entry");
-        String::from_utf8(buf).expect("UTF-8 BibTeX output")
-    }
-
-    #[test]
-    fn journal_article_renders_as_article() {
-        let m = fixture(Some("journal-article"));
-        let s = render("doi_10.1234_example", &m);
-        assert!(s.starts_with("@article{doi_10.1234_example,\n"), "{s}");
-        assert!(s.contains("title      = {Quantum Stuff},"), "{s}");
-        assert!(
-            s.contains("author     = {Alice Researcher and Bob Coauthor},"),
-            "{s}"
-        );
-        assert!(s.contains("year       = {2026},"), "{s}");
-        assert!(s.contains("doi        = {10.1234/example},"), "{s}");
-        assert!(s.contains("journal    = {Phys Rev X},"), "{s}");
-        assert!(s.contains("publisher  = {APS},"), "{s}");
-        assert!(s.contains("issn       = {2160-3308},"), "{s}");
-        assert!(s.ends_with("}\n"), "{s}");
-    }
-
-    #[test]
-    fn missing_type_renders_as_misc() {
-        let m = fixture(None);
-        let s = render("doi_10.1234_example", &m);
-        assert!(s.starts_with("@misc{doi_10.1234_example,\n"), "{s}");
-    }
-
-    #[test]
-    fn unknown_type_renders_as_misc() {
-        let m = fixture(Some("posted-content"));
-        let s = render("doi_10.1234_example", &m);
-        assert!(s.starts_with("@misc{doi_10.1234_example,\n"), "{s}");
-    }
-
-    #[test]
-    fn empty_optional_fields_are_omitted() {
-        let mut m = fixture(Some("journal-article"));
-        m.venue = None;
-        m.publisher = None;
-        m.issn = None;
-        let s = render("doi_10.1234_example", &m);
-        assert!(!s.contains("journal"), "{s}");
-        assert!(!s.contains("publisher"), "{s}");
-        assert!(!s.contains("issn"), "{s}");
-        // Required-shape fields still emitted.
-        assert!(s.contains("title"));
-        assert!(s.contains("author"));
-        assert!(s.contains("year"));
-        assert!(s.contains("doi"));
-    }
-
-    #[test]
-    fn no_authors_omits_author_line() {
-        let mut m = fixture(Some("journal-article"));
-        m.authors = vec![];
-        let s = render("doi_10.1234_example", &m);
-        assert!(!s.contains("author"), "{s}");
-    }
-
-    #[test]
-    fn braces_in_value_are_stripped() {
-        let mut m = fixture(Some("journal-article"));
-        m.title = "A {curly} Title".to_string();
-        let s = render("doi_10.1234_example", &m);
-        assert!(s.contains("title      = {A curly Title},"), "{s}");
     }
 }

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -1,35 +1,29 @@
 //! `doiget csl <ref>` — emit a CSL JSON 1.0 array for a stored Metadata.
 //!
-//! Phase 1 emits a single-entry array with the binding fields from
-//! [`docs/STORE.md`](../../../../docs/STORE.md) §2 (title, authors, year,
-//! doi, venue, publisher, issn). Richer shapes (abstract, keywords,
-//! container-IDs, page ranges) follow in Phase 2.
+//! Reads the stored [`Metadata`](doiget_core::store::Metadata) for a
+//! [`Ref`] and writes a single-element CSL JSON 1.0 **array** (a drop-in
+//! for citeproc-js / pandoc `--csl-json` consumers that expect a list)
+//! on stdout. Rendering lives in
+//! [`doiget_core::store::render::to_csl_array`] so the CLI and the
+//! `doiget_csl_export` MCP tool share one implementation (Slice 15b).
 //!
-//! The output is human-readable pretty-printed JSON, deliberately a JSON
-//! ARRAY (not a bare object) so it is a drop-in for citeproc-js / pandoc
-//! `--csl-json` consumers that expect an array of items.
-//!
-//! Reads go through [`Store::read`] per [`docs/PUBLIC_API.md`](../../../../docs/PUBLIC_API.md)
-//! §2. Network access is never required.
+//! Reads go through [`Store::read`]; network access is never required.
 
 use std::io::Write;
 
 use anyhow::{bail, Context, Result};
-use serde::Serialize;
 
-use doiget_core::store::{FsStore, Metadata, Store};
+use doiget_core::store::{render, FsStore, Store};
 use doiget_core::Ref;
 
 use super::resolve_store_root;
 
 /// Run the `csl` subcommand against the configured store.
 ///
-/// `input` is the user-supplied ref string (e.g. `"10.1234/example"` or
-/// `"arxiv:2401.12345"` — anything accepted by [`Ref::parse`]).
-///
-/// On success, a single-element CSL JSON 1.0 array is written to stdout.
-/// On a missing entry, the function returns an error so the CLI exits
-/// non-zero — pipelines can distinguish "not in store" from "empty entry".
+/// `input` is the user-supplied ref string (anything accepted by
+/// [`Ref::parse`]). On success a single-element CSL JSON 1.0 array is
+/// written to stdout; a missing entry returns an error so the CLI exits
+/// non-zero (pipelines can distinguish "not in store" from "empty").
 pub fn run(input: String) -> Result<()> {
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
@@ -46,126 +40,16 @@ pub fn run(input: String) -> Result<()> {
         None => bail!("no entry for {input}"),
     };
 
-    let item = build_csl_item(safekey.as_str(), &metadata);
-    let array = vec![item];
+    let array = render::to_csl_array(safekey.as_str(), &metadata);
     let json =
         serde_json::to_string_pretty(&array).context("failed to serialize CSL JSON for stdout")?;
 
-    // Workspace lints deny `print_stdout` (`println!`/`print!`) so the
+    // Workspace lints deny `print_stdout` (`println!`/`print!`); the
     // sanctioned escape hatch is `writeln!(stdout().lock(), ...)`.
-    // See `docs/SECURITY.md` §3 / ADR-0001 — this guarantees JSON-RPC
-    // frames never collide with diagnostics.
+    // See `docs/SECURITY.md` §3 / ADR-0001 — guarantees JSON-RPC frames
+    // never collide with diagnostics.
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     writeln!(out, "{json}").context("failed to write CSL JSON to stdout")?;
     Ok(())
-}
-
-/// One CSL JSON 1.0 item, scoped to the binding fields the local
-/// `Metadata` schema can populate.
-///
-/// Field order is the citeproc-js conventional order (id, type, title,
-/// author, issued, identifiers, container, publisher) so a human
-/// diffing two outputs sees a stable column layout.
-#[derive(Debug, Serialize)]
-struct CslItem<'a> {
-    id: &'a str,
-    #[serde(rename = "type")]
-    type_: &'static str,
-    title: &'a str,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    author: Vec<CslName>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    issued: Option<CslIssued>,
-    #[serde(rename = "DOI", skip_serializing_if = "Option::is_none")]
-    doi: Option<&'a str>,
-    #[serde(rename = "container-title", skip_serializing_if = "Option::is_none")]
-    container_title: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    publisher: Option<&'a str>,
-    #[serde(rename = "ISSN", skip_serializing_if = "Option::is_none")]
-    issn: Option<&'a str>,
-}
-
-/// CSL name-variable shape: `{ "family": "...", "given": "..." }`.
-///
-/// Empty halves are omitted so a single-token name like `"Plato"` lands
-/// as `{"family": "Plato"}` rather than `{"family": "Plato", "given": ""}`,
-/// which citeproc-js renders with a stray comma.
-#[derive(Debug, Serialize)]
-struct CslName {
-    #[serde(skip_serializing_if = "String::is_empty")]
-    family: String,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    given: String,
-}
-
-/// CSL date-variable shape, year-only for Phase 1.
-///
-/// `date-parts` is a list-of-lists: outer list holds 1 or 2 entries
-/// (single date or range), inner list is `[year, month?, day?]`. We only
-/// know the year, so the inner list is `[<year>]`.
-#[derive(Debug, Serialize)]
-struct CslIssued {
-    #[serde(rename = "date-parts")]
-    date_parts: Vec<Vec<i32>>,
-}
-
-/// Build a [`CslItem`] from a stored [`Metadata`].
-///
-/// Type mapping is intentionally narrow: Crossref's `journal-article`
-/// becomes CSL's `article-journal`. Everything else falls back to
-/// `manuscript`, which citeproc-js renders sensibly without forcing
-/// a container. Phase 2 will expand the table to cover `book-chapter`,
-/// `proceedings-article`, etc.
-fn build_csl_item<'a>(citation_key: &'a str, m: &'a Metadata) -> CslItem<'a> {
-    CslItem {
-        id: citation_key,
-        type_: match m.type_.as_deref() {
-            Some("journal-article") => "article-journal",
-            _ => "manuscript",
-        },
-        title: &m.title,
-        author: m.authors.iter().map(|s| parse_author(s)).collect(),
-        issued: m.year.map(|y| CslIssued {
-            date_parts: vec![vec![y]],
-        }),
-        doi: m.doi.as_ref().map(|d| d.as_str()),
-        container_title: m.venue.as_deref(),
-        publisher: m.publisher.as_deref(),
-        issn: m.issn.as_deref(),
-    }
-}
-
-/// Split a free-form name string into CSL `family` / `given` halves.
-///
-/// Heuristic, Phase 1:
-///
-/// - If the name contains a comma, it is `Family, Given` form: split on
-///   the first comma; left side is family, right side is given.
-/// - Otherwise, split on the LAST whitespace: left is given, right is
-///   family. (`"Alice Researcher"` → family `"Researcher"`,
-///   given `"Alice"`.) This is the convention citeproc-js itself uses
-///   for unparsed string names.
-/// - If neither rule applies (single token), the whole string is the
-///   family name and `given` is empty.
-fn parse_author(name: &str) -> CslName {
-    let trimmed = name.trim();
-    if let Some((family, given)) = trimmed.split_once(',') {
-        CslName {
-            family: family.trim().to_string(),
-            given: given.trim().to_string(),
-        }
-    } else if let Some(idx) = trimmed.rfind(char::is_whitespace) {
-        let (given, family) = trimmed.split_at(idx);
-        CslName {
-            family: family.trim().to_string(),
-            given: given.trim().to_string(),
-        }
-    } else {
-        CslName {
-            family: trimmed.to_string(),
-            given: String::new(),
-        }
-    }
 }

--- a/crates/doiget-core/src/store/mod.rs
+++ b/crates/doiget-core/src/store/mod.rs
@@ -21,9 +21,11 @@
 
 mod fs_store;
 pub mod metadata;
+pub mod render;
 
 pub use fs_store::FsStore;
 pub use metadata::{DoigetExtension, Metadata};
+pub use render::{to_bibtex, to_csl_array};
 
 use camino::Utf8Path;
 use thiserror::Error;

--- a/crates/doiget-core/src/store/render.rs
+++ b/crates/doiget-core/src/store/render.rs
@@ -1,0 +1,353 @@
+//! Citation renderers for stored [`Metadata`] — BibTeX and CSL JSON 1.0.
+//!
+//! Phase 2 / Slice 15b. The rendering logic originally lived in the
+//! `doiget-cli` `bib` / `csl` subcommands; it is hoisted here so the
+//! `doiget-mcp` `doiget_bibtex_export` / `doiget_csl_export` tools and
+//! the CLI share a single implementation (`docs/MCP_TOOLS.md` §1 rows
+//! `doiget_bibtex_export` / `doiget_csl_export`).
+//!
+//! Both renderers are pure functions of a [`Metadata`] plus a citation
+//! key (the entry's safekey). No I/O, no network. They emit the Phase 1
+//! binding fields from `docs/STORE.md` §2 (title, authors, year, doi,
+//! venue, publisher, issn); richer entry-type / field mapping is a
+//! Phase 2 follow-up.
+
+use serde::Serialize;
+
+use super::Metadata;
+
+// ---------------------------------------------------------------------------
+// BibTeX
+// ---------------------------------------------------------------------------
+
+/// Render a single BibTeX entry for `m`, keyed by `citation_key`.
+///
+/// `journal-article` → `@article`; everything else → `@misc` (Phase 2
+/// starter — `@inproceedings` / `@book` mapping is a follow-up). Field
+/// order: `title`, `author`, `year`, `doi`, `journal`, `publisher`,
+/// `issn`; any empty / `None` field is omitted. The returned string is a
+/// complete entry terminated by `}\n`.
+///
+/// Literal `{` / `}` in a field value would unbalance the surrounding
+/// braces; they are stripped (with a `tracing::warn!`) rather than
+/// TeX-escaped — real-world Crossref / Unpaywall titles rarely contain
+/// bare braces, so this is safe-by-default for the Phase 2 starter.
+#[must_use]
+pub fn to_bibtex(citation_key: &str, m: &Metadata) -> String {
+    let mut out = String::new();
+    let entry_type = bibtex_entry_type(m.type_.as_deref());
+    out.push_str(&format!("@{entry_type}{{{citation_key},\n"));
+
+    push_field(&mut out, "title", &m.title);
+    if !m.authors.is_empty() {
+        // BibTeX joins multiple authors with the literal token " and ".
+        push_field(&mut out, "author", &m.authors.join(" and "));
+    }
+    if let Some(year) = m.year {
+        push_field(&mut out, "year", &year.to_string());
+    }
+    if let Some(doi) = &m.doi {
+        push_field(&mut out, "doi", doi.as_str());
+    }
+    if let Some(venue) = m.venue.as_deref() {
+        if !venue.is_empty() {
+            push_field(&mut out, "journal", venue);
+        }
+    }
+    if let Some(publisher) = m.publisher.as_deref() {
+        if !publisher.is_empty() {
+            push_field(&mut out, "publisher", publisher);
+        }
+    }
+    if let Some(issn) = m.issn.as_deref() {
+        if !issn.is_empty() {
+            push_field(&mut out, "issn", issn);
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Map a Crossref-taxonomy `type` string to a BibTeX entry type.
+///
+/// Phase 2 starter only differentiates `journal-article` (→ `article`)
+/// from everything else (→ `misc`).
+fn bibtex_entry_type(type_: Option<&str>) -> &'static str {
+    match type_ {
+        Some("journal-article") => "article",
+        _ => "misc",
+    }
+}
+
+/// Append a single `  <key>      = {<value>},\n` line, padded so the `=`
+/// columns line up across the seven-field Phase 2 surface (width 10 is
+/// wide enough for `publisher`, the longest key).
+fn push_field(out: &mut String, key: &str, value: &str) {
+    let escaped = strip_bibtex_unsafe(key, value);
+    out.push_str(&format!("  {key:<10} = {{{escaped}}},\n"));
+}
+
+/// Strip BibTeX-unsafe `{` / `}` from `value`, warning once per field so
+/// the dropped characters are visible in stderr / structured logs.
+fn strip_bibtex_unsafe(key: &str, value: &str) -> String {
+    if value.contains('{') || value.contains('}') {
+        tracing::warn!(
+            field = key,
+            "stripping literal '{{'/'}}' from BibTeX field value; \
+             a TeX-aware escaper lands in a Phase 2 follow-up"
+        );
+    }
+    value.chars().filter(|c| !matches!(c, '{' | '}')).collect()
+}
+
+// ---------------------------------------------------------------------------
+// CSL JSON 1.0
+// ---------------------------------------------------------------------------
+
+/// Render `m` as a CSL JSON 1.0 **array** (a single-element array, so it
+/// is a drop-in for citeproc-js / pandoc `--csl-json` consumers that
+/// expect a list of items), keyed by `citation_key`.
+///
+/// `journal-article` → CSL `article-journal`; everything else →
+/// `manuscript` (citeproc-js renders that without forcing a container).
+/// Empty optional fields are omitted from the JSON.
+#[must_use]
+pub fn to_csl_array(citation_key: &str, m: &Metadata) -> serde_json::Value {
+    let item = build_csl_item(citation_key, m);
+    // `CslItem` is all-`Serialize` over owned/borrowed primitives, so
+    // `to_value` cannot fail; fall back to an empty array rather than
+    // panicking if a future field breaks that invariant.
+    serde_json::to_value([item]).unwrap_or_else(|_| serde_json::Value::Array(Vec::new()))
+}
+
+/// One CSL JSON 1.0 item, scoped to the binding fields the local
+/// `Metadata` schema can populate. Field order is the citeproc-js
+/// conventional order so a human diffing two outputs sees a stable
+/// column layout.
+#[derive(Debug, Serialize)]
+struct CslItem<'a> {
+    id: &'a str,
+    #[serde(rename = "type")]
+    type_: &'static str,
+    title: &'a str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    author: Vec<CslName>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issued: Option<CslIssued>,
+    #[serde(rename = "DOI", skip_serializing_if = "Option::is_none")]
+    doi: Option<&'a str>,
+    #[serde(rename = "container-title", skip_serializing_if = "Option::is_none")]
+    container_title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    publisher: Option<&'a str>,
+    #[serde(rename = "ISSN", skip_serializing_if = "Option::is_none")]
+    issn: Option<&'a str>,
+}
+
+/// CSL name-variable shape. Empty halves are omitted so a single-token
+/// name lands as `{"family": "Plato"}` rather than with a stray `given`.
+#[derive(Debug, Serialize)]
+struct CslName {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    family: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    given: String,
+}
+
+/// CSL date-variable shape, year-only for Phase 1. `date-parts` is a
+/// list-of-lists; we only know the year so the inner list is `[<year>]`.
+#[derive(Debug, Serialize)]
+struct CslIssued {
+    #[serde(rename = "date-parts")]
+    date_parts: Vec<Vec<i32>>,
+}
+
+fn build_csl_item<'a>(citation_key: &'a str, m: &'a Metadata) -> CslItem<'a> {
+    CslItem {
+        id: citation_key,
+        type_: match m.type_.as_deref() {
+            Some("journal-article") => "article-journal",
+            _ => "manuscript",
+        },
+        title: &m.title,
+        author: m.authors.iter().map(|s| parse_author(s)).collect(),
+        issued: m.year.map(|y| CslIssued {
+            date_parts: vec![vec![y]],
+        }),
+        doi: m.doi.as_ref().map(|d| d.as_str()),
+        container_title: m.venue.as_deref(),
+        publisher: m.publisher.as_deref(),
+        issn: m.issn.as_deref(),
+    }
+}
+
+/// Split a free-form name string into CSL `family` / `given` halves.
+///
+/// - `Family, Given` (comma present): split on the first comma.
+/// - Otherwise split on the LAST whitespace: left is given, right is
+///   family (`"Alice Researcher"` → family `"Researcher"`, given
+///   `"Alice"`) — the convention citeproc-js uses for string names.
+/// - Single token: whole string is the family, `given` empty.
+fn parse_author(name: &str) -> CslName {
+    let trimmed = name.trim();
+    if let Some((family, given)) = trimmed.split_once(',') {
+        CslName {
+            family: family.trim().to_string(),
+            given: given.trim().to_string(),
+        }
+    } else if let Some(idx) = trimmed.rfind(char::is_whitespace) {
+        let (given, family) = trimmed.split_at(idx);
+        CslName {
+            family: family.trim().to_string(),
+            given: given.trim().to_string(),
+        }
+    } else {
+        CslName {
+            family: trimmed.to_string(),
+            given: String::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::store::{DoigetExtension, Metadata};
+    use crate::{Doi, SCHEMA_VERSION};
+
+    fn fixture(type_: Option<&str>) -> Metadata {
+        Metadata {
+            schema_version: SCHEMA_VERSION.to_string(),
+            title: "Quantum Stuff".to_string(),
+            authors: vec!["Alice Researcher".to_string(), "Bob Coauthor".to_string()],
+            year: Some(2026),
+            doi: Some(Doi::parse("10.1234/example").expect("valid DOI")),
+            arxiv_id: None,
+            abstract_: None,
+            venue: Some("Phys Rev X".to_string()),
+            publisher: Some("APS".to_string()),
+            issn: Some("2160-3308".to_string()),
+            isbn: None,
+            type_: type_.map(str::to_string),
+            keywords: vec![],
+            url: None,
+            pdf_path: None,
+            doiget: Some(DoigetExtension {
+                fetched_at: chrono::Utc
+                    .with_ymd_and_hms(2026, 5, 6, 12, 0, 0)
+                    .single()
+                    .expect("valid timestamp"),
+                source: "unpaywall".to_string(),
+                license: "CC-BY-4.0".to_string(),
+                size_bytes: 1234,
+                mcp_call_id: None,
+            }),
+            other: BTreeMap::new(),
+        }
+    }
+
+    // ---- BibTeX ----
+
+    #[test]
+    fn bibtex_journal_article_renders_as_article() {
+        let s = to_bibtex("doi_10.1234_example", &fixture(Some("journal-article")));
+        assert!(s.starts_with("@article{doi_10.1234_example,\n"), "{s}");
+        assert!(s.contains("title      = {Quantum Stuff},"), "{s}");
+        assert!(
+            s.contains("author     = {Alice Researcher and Bob Coauthor},"),
+            "{s}"
+        );
+        assert!(s.contains("year       = {2026},"), "{s}");
+        assert!(s.contains("doi        = {10.1234/example},"), "{s}");
+        assert!(s.contains("journal    = {Phys Rev X},"), "{s}");
+        assert!(s.contains("publisher  = {APS},"), "{s}");
+        assert!(s.contains("issn       = {2160-3308},"), "{s}");
+        assert!(s.ends_with("}\n"), "{s}");
+    }
+
+    #[test]
+    fn bibtex_missing_and_unknown_type_render_as_misc() {
+        assert!(to_bibtex("k", &fixture(None)).starts_with("@misc{k,\n"));
+        assert!(to_bibtex("k", &fixture(Some("posted-content"))).starts_with("@misc{k,\n"));
+    }
+
+    #[test]
+    fn bibtex_empty_optionals_omitted() {
+        let mut m = fixture(Some("journal-article"));
+        m.venue = None;
+        m.publisher = None;
+        m.issn = None;
+        let s = to_bibtex("k", &m);
+        assert!(!s.contains("journal"), "{s}");
+        assert!(!s.contains("publisher"), "{s}");
+        assert!(!s.contains("issn"), "{s}");
+        assert!(s.contains("title") && s.contains("author") && s.contains("year"));
+    }
+
+    #[test]
+    fn bibtex_no_authors_omits_author_line() {
+        let mut m = fixture(Some("journal-article"));
+        m.authors = vec![];
+        assert!(!to_bibtex("k", &m).contains("author"));
+    }
+
+    #[test]
+    fn bibtex_braces_stripped() {
+        let mut m = fixture(Some("journal-article"));
+        m.title = "A {curly} Title".to_string();
+        assert!(to_bibtex("k", &m).contains("title      = {A curly Title},"));
+    }
+
+    // ---- CSL ----
+
+    #[test]
+    fn csl_array_shape_and_fields() {
+        let v = to_csl_array("doi_10.1234_example", &fixture(Some("journal-article")));
+        let arr = v.as_array().expect("CSL output is an array");
+        assert_eq!(arr.len(), 1);
+        let it = &arr[0];
+        assert_eq!(it["id"], "doi_10.1234_example");
+        assert_eq!(it["type"], "article-journal");
+        assert_eq!(it["title"], "Quantum Stuff");
+        assert_eq!(it["DOI"], "10.1234/example");
+        assert_eq!(it["container-title"], "Phys Rev X");
+        assert_eq!(it["ISSN"], "2160-3308");
+        assert_eq!(it["issued"]["date-parts"][0][0], 2026);
+        assert_eq!(it["author"][0]["family"], "Researcher");
+        assert_eq!(it["author"][0]["given"], "Alice");
+    }
+
+    #[test]
+    fn csl_unknown_type_is_manuscript() {
+        let v = to_csl_array("k", &fixture(None));
+        assert_eq!(v.as_array().unwrap()[0]["type"], "manuscript");
+    }
+
+    #[test]
+    fn csl_comma_name_split() {
+        let mut m = fixture(Some("journal-article"));
+        m.authors = vec!["Curie, Marie".to_string(), "Plato".to_string()];
+        let v = to_csl_array("k", &m);
+        let authors = v.as_array().unwrap()[0]["author"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(authors[0]["family"], "Curie");
+        assert_eq!(authors[0]["given"], "Marie");
+        assert_eq!(authors[1]["family"], "Plato");
+        assert!(
+            authors[1].get("given").is_none(),
+            "single-token name has no given"
+        );
+    }
+}

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -66,3 +66,6 @@ serde_json  = { workspace = true }
 serial_test = "3"
 wiremock    = { workspace = true }
 tempfile    = { workspace = true }
+# Slice 15b bibtex/csl export e2e seeds a Metadata fixture whose
+# `[doiget].fetched_at` is a `chrono::DateTime<Utc>`.
+chrono      = { workspace = true }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1395,7 +1395,7 @@ impl Server {
     /// Opens the store once, then resolves each ref independently:
     /// a found entry yields `{ ref, safekey, <payload> }`, a missing
     /// one `{ ref, safekey, <payload>: null }` (NOT an error — same
-    /// convention as `doiget_info`), an unparseable ref or a store
+    /// convention as `doiget_info`), an unparsable ref or a store
     /// read failure a per-ref `{ ref, error }` element. A failure to
     /// resolve / open the store at all is a single `ok:false`
     /// envelope. Read-only; emits no provenance row.

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1177,6 +1177,48 @@ impl Server {
             }
         }
     }
+
+    /// `doiget_bibtex_export` — render stored entries as BibTeX.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1. Read-only, no network, no
+    /// provenance row (local inspection, same posture as
+    /// `doiget_info`). Accepts one or many refs; each is resolved
+    /// independently so a bad ref in the batch does not fail the
+    /// others.
+    #[tool(
+        description = "WHEN TO USE: Export already-fetched entries as BibTeX (one or many).\n\
+                       INPUTS: refs (array of DOI / arXiv id strings, 1..=200).\n\
+                       OUTPUTS: { ok: true, entries: [{ ref, safekey, bibtex }] } — bibtex is null when the entry is not in the store; a per-ref { ref, error } element is emitted for an invalid ref or a store read error. OR { ok:false, error } for a store-open failure.\n\
+                       COSTS: <10 ms per entry, local read.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Entry must already have been fetched (bibtex:null otherwise — NOT an error). At most 200 refs per call."
+    )]
+    async fn doiget_bibtex_export(
+        &self,
+        Parameters(input): Parameters<BibtexExportInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(self.export_citations(&input.refs, CiteFmt::Bibtex))
+    }
+
+    /// `doiget_csl_export` — render stored entries as CSL JSON 1.0.
+    ///
+    /// Per `docs/MCP_TOOLS.md` §1. Read-only, no network, no
+    /// provenance row. Each found entry's payload is a single-element
+    /// CSL JSON 1.0 array (drop-in for citeproc-js / pandoc).
+    #[tool(
+        description = "WHEN TO USE: Export already-fetched entries as CSL JSON 1.0 (one or many).\n\
+                       INPUTS: refs (array of DOI / arXiv id strings, 1..=200).\n\
+                       OUTPUTS: { ok: true, entries: [{ ref, safekey, csl }] } — csl is a 1-element CSL JSON array, or null when the entry is not in the store; a per-ref { ref, error } element is emitted for an invalid ref or a store read error. OR { ok:false, error } for a store-open failure.\n\
+                       COSTS: <10 ms per entry, local read.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Entry must already have been fetched (csl:null otherwise — NOT an error). At most 200 refs per call."
+    )]
+    async fn doiget_csl_export(
+        &self,
+        Parameters(input): Parameters<CslExportInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(self.export_citations(&input.refs, CiteFmt::Csl))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1311,6 +1353,137 @@ pub struct ExpandCitationGraphInput {
     /// ADR-0010 maximum (20).
     #[serde(default)]
     pub per_paper: Option<u32>,
+}
+
+/// JSON-schema-derived input for the `doiget_bibtex_export` MCP tool.
+/// One or many refs (`docs/MCP_TOOLS.md` §1 row `doiget_bibtex_export`);
+/// each is resolved independently.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct BibtexExportInput {
+    /// DOIs / arXiv ids to render. 1..=200; each validated via
+    /// `Ref::parse` with per-ref error reporting.
+    pub refs: Vec<String>,
+}
+
+/// JSON-schema-derived input for the `doiget_csl_export` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct CslExportInput {
+    /// DOIs / arXiv ids to render. 1..=200; each validated via
+    /// `Ref::parse` with per-ref error reporting.
+    pub refs: Vec<String>,
+}
+
+/// Hard cap on refs accepted by a single `doiget_bibtex_export` /
+/// `doiget_csl_export` call. Mirrors the 200-entry ceiling used by the
+/// read-path list tools.
+const MAX_EXPORT_REFS: usize = 200;
+
+/// Which citation format [`Server::export_citations`] renders.
+#[derive(Debug, Clone, Copy)]
+enum CiteFmt {
+    Bibtex,
+    Csl,
+}
+
+impl Server {
+    /// Shared body for `doiget_bibtex_export` / `doiget_csl_export`.
+    ///
+    /// Opens the store once, then resolves each ref independently:
+    /// a found entry yields `{ ref, safekey, <payload> }`, a missing
+    /// one `{ ref, safekey, <payload>: null }` (NOT an error — same
+    /// convention as `doiget_info`), an unparseable ref or a store
+    /// read failure a per-ref `{ ref, error }` element. A failure to
+    /// resolve / open the store at all is a single `ok:false`
+    /// envelope. Read-only; emits no provenance row.
+    fn export_citations(&self, refs: &[String], fmt: CiteFmt) -> CallToolResult {
+        if refs.len() > MAX_EXPORT_REFS {
+            return CallToolResult::structured(read_path_error_envelope(
+                None,
+                ErrorCode::InvalidRef,
+                &format!("too many refs: got {}, max {MAX_EXPORT_REFS}", refs.len()),
+            ));
+        }
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return CallToolResult::structured(read_path_error_envelope(
+                    None,
+                    ErrorCode::InternalError,
+                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                ));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return CallToolResult::structured(read_path_error_envelope(
+                    None,
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                ));
+            }
+        };
+
+        let payload_key = match fmt {
+            CiteFmt::Bibtex => "bibtex",
+            CiteFmt::Csl => "csl",
+        };
+        let mut entries: Vec<Value> = Vec::with_capacity(refs.len());
+        for r in refs {
+            let ref_ = match Ref::parse(r) {
+                Ok(v) => v,
+                Err(e) => {
+                    entries.push(json!({
+                        "ref": r,
+                        "error": { "code": ErrorCode::InvalidRef, "message": format!("invalid ref: {e}") },
+                    }));
+                    continue;
+                }
+            };
+            let safekey = ref_.safekey();
+            match store.read(&safekey) {
+                Ok(Some(m)) => {
+                    let payload = match fmt {
+                        CiteFmt::Bibtex => {
+                            Value::from(doiget_core::store::render::to_bibtex(safekey.as_str(), &m))
+                        }
+                        CiteFmt::Csl => {
+                            doiget_core::store::render::to_csl_array(safekey.as_str(), &m)
+                        }
+                    };
+                    // `json!` requires literal keys; the payload key is
+                    // format-dependent, so build the object explicitly.
+                    let mut obj = serde_json::Map::with_capacity(3);
+                    obj.insert("ref".to_string(), Value::from(r.clone()));
+                    obj.insert("safekey".to_string(), Value::from(safekey.as_str()));
+                    obj.insert(payload_key.to_string(), payload);
+                    entries.push(Value::Object(obj));
+                }
+                Ok(None) => {
+                    // Not in store is NOT an error (closed ErrorCode set
+                    // has no NotFound). Surface null payload, same as
+                    // doiget_info's `metadata: null`.
+                    let mut obj = serde_json::Map::with_capacity(3);
+                    obj.insert("ref".to_string(), Value::from(r.clone()));
+                    obj.insert("safekey".to_string(), Value::from(safekey.as_str()));
+                    obj.insert(payload_key.to_string(), Value::Null);
+                    entries.push(Value::Object(obj));
+                }
+                Err(e) => {
+                    entries.push(json!({
+                        "ref": r,
+                        "error": { "code": ErrorCode::StoreError, "message": format!("store read failed: {e}") },
+                    }));
+                }
+            }
+        }
+
+        CallToolResult::structured(json!({ "ok": true, "entries": entries }))
+    }
 }
 
 /// Default + max clamp for the `limit` field on `doiget_search_local`

--- a/crates/doiget-mcp/tests/bibtex_csl_export_e2e.rs
+++ b/crates/doiget-mcp/tests/bibtex_csl_export_e2e.rs
@@ -1,0 +1,202 @@
+//! Slice 15b — end-to-end coverage for `doiget_bibtex_export` /
+//! `doiget_csl_export`.
+//!
+//! These tools are 100% local: no network, no provenance row, reads
+//! through the `Store` trait + the shared `doiget_core::store::render`
+//! helpers. Each test seeds a `FsStore` rooted at a per-test
+//! `tempfile::TempDir`, points `DOIGET_STORE_ROOT` at it, then drives
+//! the in-memory MCP server.
+//!
+//! ## Network purity
+//!
+//! No `reqwest::*` items are imported; no HTTP traffic of any kind.
+// allow: outbound-network
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+use chrono::TimeZone;
+use doiget_core::store::{DoigetExtension, FsStore, Metadata, Store};
+use doiget_core::{CapabilityProfile, Doi, Ref, SCHEMA_VERSION};
+use doiget_mcp::Server;
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+
+struct EnvGuard;
+impl EnvGuard {
+    fn new() -> Self {
+        std::env::remove_var("DOIGET_STORE_ROOT");
+        Self
+    }
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        std::env::remove_var("DOIGET_STORE_ROOT");
+    }
+}
+
+async fn boot() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+    Ok((client, handle))
+}
+
+fn seed_store() -> (tempfile::TempDir, camino::Utf8PathBuf) {
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    std::fs::create_dir_all(root.join(".metadata")).expect("create .metadata");
+
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+    let ref_ = Ref::parse("10.1234/example").expect("valid DOI ref");
+    let m = Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title: "Quantum Stuff".to_string(),
+        authors: vec!["Alice Researcher".to_string(), "Bob Coauthor".to_string()],
+        year: Some(2026),
+        doi: Some(Doi::parse("10.1234/example").expect("valid DOI")),
+        arxiv_id: None,
+        abstract_: None,
+        venue: Some("Phys Rev X".to_string()),
+        publisher: Some("APS".to_string()),
+        issn: Some("2160-3308".to_string()),
+        isbn: None,
+        type_: Some("journal-article".to_string()),
+        keywords: vec![],
+        url: None,
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: chrono::Utc
+                .with_ymd_and_hms(2026, 5, 6, 12, 0, 0)
+                .single()
+                .expect("valid timestamp"),
+            source: "unpaywall".to_string(),
+            license: "CC-BY-4.0".to_string(),
+            size_bytes: 1234,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    };
+    store
+        .write(&ref_.safekey(), &m, None)
+        .expect("seed store entry");
+    (td, root)
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn bibtex_export_mixed_batch() -> anyhow::Result<()> {
+    let _g = EnvGuard::new();
+    let (_td, root) = seed_store();
+    std::env::set_var("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, handle) = boot().await?;
+    let mut args = serde_json::Map::new();
+    args.insert(
+        "refs".to_string(),
+        serde_json::json!(["10.1234/example", "10.9999/missing", "not a doi"]),
+    );
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_bibtex_export").with_arguments(args))
+        .await?;
+    let s = result
+        .structured_content
+        .expect("doiget_bibtex_export uses CallToolResult::structured");
+
+    assert_eq!(s["ok"], serde_json::json!(true));
+    let entries = s["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 3, "{s:?}");
+
+    // [0] seeded -> BibTeX string.
+    assert_eq!(entries[0]["ref"], "10.1234/example");
+    let bib = entries[0]["bibtex"].as_str().expect("bibtex string");
+    assert!(bib.starts_with("@article{"), "{bib}");
+    assert!(bib.contains("title      = {Quantum Stuff},"), "{bib}");
+
+    // [1] missing -> null payload, NOT an error.
+    assert_eq!(entries[1]["ref"], "10.9999/missing");
+    assert_eq!(entries[1]["bibtex"], serde_json::Value::Null);
+    assert!(entries[1].get("error").is_none(), "{s:?}");
+
+    // [2] invalid ref -> per-entry error.
+    assert_eq!(entries[2]["ref"], "not a doi");
+    assert_eq!(entries[2]["error"]["code"], "INVALID_REF");
+
+    client.cancel().await?;
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn csl_export_found_and_missing() -> anyhow::Result<()> {
+    let _g = EnvGuard::new();
+    let (_td, root) = seed_store();
+    std::env::set_var("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, handle) = boot().await?;
+    let mut args = serde_json::Map::new();
+    args.insert(
+        "refs".to_string(),
+        serde_json::json!(["10.1234/example", "10.9999/missing"]),
+    );
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_csl_export").with_arguments(args))
+        .await?;
+    let s = result
+        .structured_content
+        .expect("doiget_csl_export uses CallToolResult::structured");
+
+    assert_eq!(s["ok"], serde_json::json!(true));
+    let entries = s["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 2);
+
+    let csl = entries[0]["csl"].as_array().expect("csl is an array");
+    assert_eq!(csl.len(), 1, "single-element CSL array");
+    assert_eq!(csl[0]["type"], "article-journal");
+    assert_eq!(csl[0]["title"], "Quantum Stuff");
+    assert_eq!(csl[0]["DOI"], "10.1234/example");
+
+    assert_eq!(entries[1]["csl"], serde_json::Value::Null);
+
+    client.cancel().await?;
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn bibtex_export_too_many_refs_is_invalid_ref() -> anyhow::Result<()> {
+    let _g = EnvGuard::new();
+    let (_td, root) = seed_store();
+    std::env::set_var("DOIGET_STORE_ROOT", root.as_str());
+
+    let (client, handle) = boot().await?;
+    let refs: Vec<String> = (0..201).map(|i| format!("10.1234/n{i}")).collect();
+    let mut args = serde_json::Map::new();
+    args.insert("refs".to_string(), serde_json::json!(refs));
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_bibtex_export").with_arguments(args))
+        .await?;
+    let s = result.structured_content.expect("structured envelope");
+    assert_eq!(s["ok"], serde_json::json!(false));
+    assert_eq!(s["error"]["code"], "INVALID_REF");
+
+    client.cancel().await?;
+    handle.abort();
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -127,6 +127,15 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_expand_citation_graph"),
         "tools/list must include doiget_expand_citation_graph; got: {names:?}"
     );
+    // Slice 15b: BibTeX / CSL export tools.
+    assert!(
+        names.contains(&"doiget_bibtex_export"),
+        "tools/list must include doiget_bibtex_export; got: {names:?}"
+    );
+    assert!(
+        names.contains(&"doiget_csl_export"),
+        "tools/list must include doiget_csl_export; got: {names:?}"
+    );
 
     // -- 3. tools/call doiget_health -----------------------------------
     let health = client


### PR DESCRIPTION
## Summary

Implements the two citation-export MCP tools that `docs/MCP_TOOLS.md` §1 already advertised (rows `doiget_bibtex_export` / `doiget_csl_export`).

- **New `doiget_core::store::render`** — pure `to_bibtex(&str, &Metadata) -> String` and `to_csl_array(&str, &Metadata) -> serde_json::Value` (single-element CSL JSON 1.0 array). Rendering logic hoisted verbatim from the CLI `bib`/`csl` modules; brace-stripping + citeproc name-splitting preserved. Unit tests moved into the core module.
- **CLI `bib`/`csl`** now delegate to the shared core renderers — no behaviour change (`bib_e2e`/`csl_e2e` pass unmodified).
- **`doiget-mcp`** gains `doiget_bibtex_export` / `doiget_csl_export`. Input `refs: Vec<String>` (one or many, max 200), each resolved independently:
  - found → `{ ref, safekey, bibtex|csl }`
  - missing → payload `null` (NOT an error — mirrors `doiget_info`)
  - invalid ref / store read error → per-ref `{ ref, error }`
  - store-open failure or >200 refs → single `ok:false` envelope
  - read-only, no network, no provenance row
- `initialize_handshake` asserts both tools are advertised; new `bibtex_csl_export_e2e` (mixed batch, found+missing, >200 cap).
- `chrono` added to `doiget-mcp` `[dev-dependencies]` (fixture only).

## Test plan

- [x] `cargo test -p doiget-core --lib store::render` (8/8)
- [x] `cargo test -p doiget-cli --test bib_e2e --test csl_e2e` (7/7, unchanged output)
- [x] `cargo test -p doiget-mcp --test bibtex_csl_export_e2e --test initialize_handshake` (9/9)
- [x] `cargo test --workspace --all-targets --no-default-features --features oa-only` — all suites ok, 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --no-default-features --features oa-only -- -D warnings` clean
- [ ] CI green on the branch

CHANGELOG is release-plz-generated from conventional commits — no manual edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)