### PR TITLE
fix(fetch): MVP-core fetch-path hardening — #117 retry, #118 transparency, #120 Crossref non-fatal

### DIFF
--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -48,7 +48,7 @@ use camino::Utf8PathBuf;
 #[cfg(feature = "citation")]
 use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
-use doiget_core::orchestrator::{fetch_paper as core_fetch_paper, FetchPaperOutcome};
+use doiget_core::orchestrator::{fetch_paper as core_fetch_paper, FetchPaperOutcome, PdfLegStatus};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
 use doiget_core::source::FetchContext;
@@ -402,16 +402,50 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
         Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
         Ref::Doi(doi) => format!("doi:{}", doi.as_str()),
     };
-    if outcome.size_bytes == 0 {
-        print_success(format_args!(
-            "fetched {} (metadata-only) -> {}",
-            label, outcome.path
-        ));
-    } else {
-        print_success(format_args!(
-            "fetched {} ({} bytes) -> {}",
-            label, outcome.size_bytes, outcome.path
-        ));
+    match &outcome.pdf_leg {
+        PdfLegStatus::Fetched => {
+            print_success(format_args!(
+                "fetched {} ({} bytes) -> {}",
+                label, outcome.size_bytes, outcome.path
+            ));
+        }
+        PdfLegStatus::NoOaUrl => {
+            print_success(format_args!(
+                "fetched {} (metadata-only: no OA PDF available) -> {}",
+                label, outcome.path
+            ));
+        }
+        // Issue #118: an OA PDF existed but could not be retrieved.
+        // The metadata WAS written, so this is still a (partial)
+        // success — but we MUST tell the user why the PDF is missing
+        // instead of an indistinguishable "metadata-only" line.
+        PdfLegStatus::Blocked { code, message, .. } => {
+            print_success(format_args!(
+                "fetched {} (metadata-only) -> {}",
+                label, outcome.path
+            ));
+            print_success(format_args!(
+                "  note: an OA PDF was found but could not be retrieved [{}]: {}",
+                code.as_wire(),
+                message
+            ));
+        }
+        // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
+        // degrades to the size-based wording rather than failing the
+        // downstream-crate build.
+        _ => {
+            if outcome.size_bytes == 0 {
+                print_success(format_args!(
+                    "fetched {} (metadata-only) -> {}",
+                    label, outcome.path
+                ));
+            } else {
+                print_success(format_args!(
+                    "fetched {} ({} bytes) -> {}",
+                    label, outcome.size_bytes, outcome.path
+                ));
+            }
+        }
     }
 }
 

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -350,3 +350,68 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     drop(env);
     drop(td);
 }
+
+/// Issue #120: a Crossref failure must NOT abort the DOI fetch when
+/// Unpaywall alone can still deliver the OA PDF. Mount Unpaywall +
+/// OA-publisher normally but DO NOT mount `/works/<doi>` (wiremock
+/// 404 → `CrossrefSource` returns `Err`). The PDF must still land on
+/// disk; metadata title falls back to the DOI (Crossref gave nothing).
+#[tokio::test]
+#[serial]
+async fn fetch_doi_crossref_down_unpaywall_oa_still_yields_pdf() {
+    let server = MockServer::start().await;
+    let base_uri = server.uri();
+    let oa_url = format!("{}/oa/file.pdf", base_uri);
+
+    // NO `/works/<doi>` mock — Crossref gets 404 and fails.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(unpaywall_body(&oa_url)))
+        .mount(&server)
+        .await;
+    let pdf_body = b"%PDF-fake-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/oa/file.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(pdf_body.clone()))
+        .mount(&server)
+        .await;
+
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CROSSREF_BASE", &base_uri);
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", base_uri));
+    env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
+
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
+        .await
+        .expect("fetch must succeed via Unpaywall even though Crossref failed");
+
+    let pdf_path = store_root.join("doi_10.1234_test.pdf");
+    assert!(
+        pdf_path.exists(),
+        "PDF must be written even though Crossref failed; tree: {:?}",
+        std::fs::read_dir(temp_root.as_std_path())
+            .map(|d| d.flatten().map(|e| e.path()).collect::<Vec<_>>())
+    );
+    let pdf_bytes = std::fs::read(pdf_path.as_std_path()).expect("read pdf");
+    assert_eq!(pdf_bytes, pdf_body);
+
+    let meta_path = store_root.join(".metadata").join("doi_10.1234_test.toml");
+    let meta_raw = std::fs::read_to_string(meta_path.as_std_path()).expect("read metadata toml");
+    let metadata: Metadata = toml::from_str(&meta_raw).expect("metadata round-trips");
+    let doiget = metadata.doiget.expect("[doiget] table present");
+    assert_eq!(doiget.source, "oa-publisher");
+    // Crossref produced nothing, so the title falls back to the DOI.
+    assert_eq!(metadata.title, TEST_DOI);
+
+    drop(env);
+    drop(td);
+}

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -53,6 +53,68 @@ const READ_TIMEOUT: Duration = Duration::from_secs(60);
 /// Total per-request timeout per `docs/SECURITY.md` §1.2.
 const TOTAL_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Max retry attempts AFTER the first try, for transient failures only
+/// (connect/timeout/mid-stream network errors and the transient HTTP
+/// status set). 3 retries → up to 4 total attempts. See issue #117.
+const MAX_FETCH_RETRIES: u32 = 3;
+
+/// Base delay for the exponential backoff (`base * 2^attempt`, jittered).
+const RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
+
+/// Hard ceiling on any single backoff / `Retry-After` sleep. Keeps the
+/// worst-case retry chain comfortably inside [`TOTAL_TIMEOUT`].
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
+
+/// HTTP status codes worth retrying: request timeout, rate-limited, and
+/// the transient 5xx family. A plain 500 is included because upstreams
+/// (Crossref/Unpaywall) intermittently 500 under load. 4xx other than
+/// 408/429 are caller/permanent and never retried.
+fn is_transient_status(code: u16) -> bool {
+    matches!(code, 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// A `reqwest::Error` is transient iff it is a connect or timeout
+/// failure or a mid-body transfer error. Redirect-policy aborts
+/// (allowlist denial), builder errors, and decode errors are NOT
+/// transient — retrying them cannot help and would mask a real denial.
+fn reqwest_is_transient(e: &reqwest::Error) -> bool {
+    (e.is_timeout() || e.is_connect() || e.is_body()) && !e.is_redirect()
+}
+
+/// Parse a `Retry-After` header expressed as integer seconds (the
+/// HTTP-date form is accepted by the RFC but rare for these APIs and
+/// deliberately ignored for the MVP — we fall back to exponential
+/// backoff in that case). Capped at [`RETRY_MAX_DELAY`].
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let secs: u64 = headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    Some(Duration::from_secs(secs).min(RETRY_MAX_DELAY))
+}
+
+/// Exponential backoff with decorrelated jitter. `RETRY_BASE_DELAY *
+/// 2^attempt`, capped at [`RETRY_MAX_DELAY`], plus 0..base jitter so a
+/// fleet of clients does not thunder back in lockstep. Jitter is derived
+/// from the wall-clock subsec nanos rather than pulling in an RNG
+/// dependency — adequate decorrelation for backoff, not a security
+/// primitive.
+fn backoff_delay(attempt: u32) -> Duration {
+    let factor = 1u64 << attempt.min(20);
+    let base_ms = RETRY_BASE_DELAY.as_millis() as u64;
+    let capped_ms = base_ms
+        .saturating_mul(factor)
+        .min(RETRY_MAX_DELAY.as_millis() as u64);
+    let jitter_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| (d.subsec_nanos() as u64) % base_ms.max(1))
+        .unwrap_or(0);
+    Duration::from_millis(capped_ms.saturating_add(jitter_ms))
+}
+
 // ---------------------------------------------------------------------------
 // SourceAllowlist
 // ---------------------------------------------------------------------------
@@ -633,61 +695,135 @@ impl HttpClient {
             header_map.insert(hn, hv);
         }
 
-        let response = client.get(url).headers(header_map).send().await?;
-        let final_url = response.url().clone();
+        // Bounded retry loop (issue #117). Only transient classes are
+        // retried — connect/timeout/mid-stream network errors and the
+        // transient HTTP status set. Allowlist denials, NotAPdf,
+        // OversizedBody, 4xx (non-408/429) are deterministic and return
+        // on the first occurrence. GET is idempotent so a retried
+        // attempt re-streams the body from scratch.
+        let mut attempt: u32 = 0;
+        loop {
+            let send_result = client
+                .get(url.clone())
+                .headers(header_map.clone())
+                .send()
+                .await;
+            let response = match send_result {
+                Ok(r) => r,
+                Err(e) => {
+                    if attempt < MAX_FETCH_RETRIES && reqwest_is_transient(&e) {
+                        let d = backoff_delay(attempt);
+                        tracing::warn!(
+                            source,
+                            attempt,
+                            delay_ms = d.as_millis() as u64,
+                            error = %e,
+                            "transient send failure; retrying"
+                        );
+                        tokio::time::sleep(d).await;
+                        attempt += 1;
+                        continue;
+                    }
+                    return Err(HttpError::Network(e));
+                }
+            };
+            let final_url = response.url().clone();
 
-        // Status check before body read so we can fail fast.
-        let status = response.status();
-        if !status.is_success() {
-            return Err(HttpError::HttpStatus {
-                status: status.as_u16(),
-                url: final_url.to_string(),
-            });
-        }
+            // Status check before body read so we can fail fast.
+            let status = response.status();
+            if !status.is_success() {
+                let code = status.as_u16();
+                if attempt < MAX_FETCH_RETRIES && is_transient_status(code) {
+                    // Prefer the server's `Retry-After` over our backoff
+                    // when present (429/503 commonly carry it).
+                    let d = parse_retry_after(response.headers())
+                        .unwrap_or_else(|| backoff_delay(attempt));
+                    tracing::warn!(
+                        source,
+                        attempt,
+                        status = code,
+                        delay_ms = d.as_millis() as u64,
+                        "transient HTTP status; retrying"
+                    );
+                    tokio::time::sleep(d).await;
+                    attempt += 1;
+                    continue;
+                }
+                return Err(HttpError::HttpStatus {
+                    status: code,
+                    url: final_url.to_string(),
+                });
+            }
 
-        // Content-Length fast-path: if header is present and exceeds the
-        // cap, fail without reading any body. Per `docs/SECURITY.md` §1.2.
-        if let Some(len) = response.content_length() {
-            if len > PDF_MAX_BYTES {
+            // Content-Length fast-path: if header is present and exceeds
+            // the cap, fail without reading any body (deterministic — not
+            // retried). Per `docs/SECURITY.md` §1.2.
+            if let Some(len) = response.content_length() {
+                if len > PDF_MAX_BYTES {
+                    return Err(HttpError::OversizedBody {
+                        actual: len,
+                        cap: PDF_MAX_BYTES,
+                    });
+                }
+            }
+
+            // Stream body and enforce the cap as bytes accumulate. A
+            // mid-stream transport error is transient (retry); an
+            // oversized body is deterministic (return).
+            let mut buf = BytesMut::new();
+            let mut stream = response.bytes_stream();
+            let mut oversized_at: Option<u64> = None;
+            let mut stream_err: Option<reqwest::Error> = None;
+            while let Some(chunk) = stream.next().await {
+                let chunk = match chunk {
+                    Ok(c) => c,
+                    Err(e) => {
+                        stream_err = Some(e);
+                        break;
+                    }
+                };
+                let projected = (buf.len() as u64).saturating_add(chunk.len() as u64);
+                if projected > PDF_MAX_BYTES {
+                    oversized_at = Some(projected);
+                    break;
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            if let Some(actual) = oversized_at {
                 return Err(HttpError::OversizedBody {
-                    actual: len,
+                    actual,
                     cap: PDF_MAX_BYTES,
                 });
             }
-        }
-
-        // Stream body and enforce the cap as bytes accumulate. We use
-        // `bytes_stream` rather than `.bytes()` so that an oversized body
-        // is rejected after at most one chunk past the cap, not after the
-        // entire transfer completes.
-        let mut buf = BytesMut::new();
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
-            // Saturating-add into a u64 for the error report; the actual
-            // accumulator never grows past the cap because we abort as
-            // soon as we cross it.
-            let projected = (buf.len() as u64).saturating_add(chunk.len() as u64);
-            if projected > PDF_MAX_BYTES {
-                return Err(HttpError::OversizedBody {
-                    actual: projected,
-                    cap: PDF_MAX_BYTES,
-                });
+            if let Some(e) = stream_err {
+                if attempt < MAX_FETCH_RETRIES && reqwest_is_transient(&e) {
+                    let d = backoff_delay(attempt);
+                    tracing::warn!(
+                        source,
+                        attempt,
+                        delay_ms = d.as_millis() as u64,
+                        error = %e,
+                        "transient mid-stream failure; retrying"
+                    );
+                    tokio::time::sleep(d).await;
+                    attempt += 1;
+                    continue;
+                }
+                return Err(HttpError::Network(e));
             }
-            buf.extend_from_slice(&chunk);
-        }
-        let body = buf.freeze();
+            let body = buf.freeze();
 
-        if check_pdf_magic {
-            let mut got = [0u8; 5];
-            let n = body.len().min(5);
-            got[..n].copy_from_slice(&body[..n]);
-            if got != PDF_MAGIC {
-                return Err(HttpError::NotAPdf { got });
+            if check_pdf_magic {
+                let mut got = [0u8; 5];
+                let n = body.len().min(5);
+                got[..n].copy_from_slice(&body[..n]);
+                if got != PDF_MAGIC {
+                    return Err(HttpError::NotAPdf { got });
+                }
             }
-        }
 
-        Ok((body, final_url))
+            return Ok((body, final_url));
+        }
     }
 }
 
@@ -1423,5 +1559,123 @@ mod tests {
             dc.is_none(),
             "UnknownSource must not produce a DenialContext"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #117 — transient retry / backoff. Real time: wiremock
+    // serves over real localhost IO and tokio `start_paused` is
+    // incompatible with that (it auto-advances past reqwest's
+    // timeout). Backoff is small enough that the slowest case
+    // (persistent 503, 3 retries ≈ 3.5s) stays within the suite budget.
+    // ---------------------------------------------------------------
+
+    fn host_of(server: &MockServer) -> String {
+        server
+            .uri()
+            .parse::<Url>()
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn transient_503_then_200_succeeds() {
+        let server = MockServer::start().await;
+        // Catch-all 200 mounted first (lowest precedence); the
+        // single-shot 503 mounted last takes precedence for the first
+        // request only, then falls through to the 200.
+        Mock::given(method("GET"))
+            .and(path("/p"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":1}"#))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/p"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client_for_http("crossref", &host_of(&server));
+        let url: Url = format!("{}/p", server.uri()).parse().unwrap();
+        let (body, _) = client
+            .fetch_bytes("crossref", url)
+            .await
+            .expect("503-then-200 must succeed after one retry");
+        assert_eq!(&body[..], br#"{"ok":1}"#);
+    }
+
+    #[tokio::test]
+    async fn persistent_503_exhausts_and_returns_httpstatus() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/p"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let client = build_test_client_for_http("crossref", &host_of(&server));
+        let url: Url = format!("{}/p", server.uri()).parse().unwrap();
+        let err = client
+            .fetch_bytes("crossref", url)
+            .await
+            .expect_err("persistent 503 must exhaust retries");
+        match err {
+            HttpError::HttpStatus { status, .. } => assert_eq!(status, 503),
+            other => panic!("expected HttpStatus 503, got {other:?}"),
+        }
+        // First attempt + MAX_FETCH_RETRIES retries.
+        let reqs = server
+            .received_requests()
+            .await
+            .expect("wiremock records requests");
+        assert_eq!(reqs.len(), (MAX_FETCH_RETRIES + 1) as usize);
+    }
+
+    #[tokio::test]
+    async fn retry_after_429_then_200_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/p"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/p"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "1"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client_for_http("crossref", &host_of(&server));
+        let url: Url = format!("{}/p", server.uri()).parse().unwrap();
+        let (body, _) = client
+            .fetch_bytes("crossref", url)
+            .await
+            .expect("429+Retry-After then 200 must succeed");
+        assert_eq!(&body[..], b"ok");
+    }
+
+    #[tokio::test]
+    async fn permanent_404_is_not_retried() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/p"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = build_test_client_for_http("crossref", &host_of(&server));
+        let url: Url = format!("{}/p", server.uri()).parse().unwrap();
+        let _ = client
+            .fetch_bytes("crossref", url)
+            .await
+            .expect_err("404 must fail");
+        let reqs = server
+            .received_requests()
+            .await
+            .expect("wiremock records requests");
+        assert_eq!(reqs.len(), 1, "4xx (non-408/429) must NOT be retried");
     }
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -647,6 +647,33 @@ pub enum ErrorCode {
     NotImplemented,
 }
 
+impl ErrorCode {
+    /// The `SCREAMING_SNAKE_CASE` wire token for this code, as a
+    /// `&'static str`. Identical to the serde representation but
+    /// allocation-free and usable where a borrowed string with a
+    /// `'static` lifetime is required — notably the provenance log
+    /// `error_code` column (`docs/PROVENANCE_LOG.md` §3), so a failure
+    /// row records the *actual* mapped code instead of a hand-written
+    /// literal that can drift from this enum (issue #118).
+    #[must_use]
+    pub fn as_wire(&self) -> &'static str {
+        match self {
+            ErrorCode::InvalidRef => "INVALID_REF",
+            ErrorCode::NoOaAvailable => "NO_OA_AVAILABLE",
+            ErrorCode::RateLimited => "RATE_LIMITED",
+            ErrorCode::NetworkError => "NETWORK_ERROR",
+            ErrorCode::StoreError => "STORE_ERROR",
+            ErrorCode::LogError => "LOG_ERROR",
+            ErrorCode::CapabilityDenied => "CAPABILITY_DENIED",
+            ErrorCode::FetchTimeout => "FETCH_TIMEOUT",
+            ErrorCode::SchemaTooNew => "SCHEMA_TOO_NEW",
+            ErrorCode::LockTimeout => "LOCK_TIMEOUT",
+            ErrorCode::InternalError => "INTERNAL_ERROR",
+            ErrorCode::NotImplemented => "NOT_IMPLEMENTED",
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // DenialReason / DenialContext (ADR-0023)
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -342,6 +342,47 @@ fn extract_unpaywall_oa_url(meta: &Value) -> Option<String> {
 /// host off the `oa-publisher` allowlist, or PDF leg failed for another
 /// transport reason — `docs/REDIRECT_ALLOWLIST.md` §3 informed-best-
 /// effort posture) this is `<root>/.metadata/<safekey>.toml`.
+/// Outcome of the DOI OA-PDF leg, carried on [`FetchPaperOutcome`] so a
+/// caller can NEVER silently report a blocked PDF as a plain
+/// "metadata-only" success (issue #118). The product promise is
+/// "immediately explain WHY a paper can't be fetched" — the distinction
+/// between "there was no OA PDF to fetch" and "an OA PDF existed but we
+/// were blocked, and here is the reason" is exactly that explanation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum PdfLegStatus {
+    /// A PDF was fetched and written to disk (arXiv always; DOI when
+    /// the OA-publisher leg succeeded).
+    Fetched,
+    /// No OA URL was discovered (Unpaywall reported no
+    /// `best_oa_location`). Metadata-only is the correct, expected
+    /// result here — not a failure.
+    NoOaUrl,
+    /// An OA URL *was* discovered but the PDF could not be retrieved
+    /// (host outside the oa-publisher allowlist, not-a-PDF body,
+    /// transport failure, …). Metadata was still written, but the
+    /// caller MUST surface this reason rather than pretending the
+    /// fetch was a clean metadata-only success.
+    Blocked {
+        /// Closed-set code, mapped from the underlying transport error
+        /// via the canonical `From<FetchError> for ErrorCode`.
+        code: crate::ErrorCode,
+        /// Human-readable one-line reason (the `FetchError` display).
+        message: String,
+        /// Structured denial side-channel (ADR-0023) when the failure
+        /// was an allowlist / scheme denial; `None` otherwise.
+        denial: Option<crate::DenialContext>,
+    },
+}
+
+/// What `fetch_paper` wrote to disk and how.
+///
+/// `path` is the PDF (`<root>/<safekey>.pdf`) on a successful PDF
+/// fetch, or the metadata TOML (`<root>/.metadata/<safekey>.toml`)
+/// when the DOI path fell back to metadata-only. [`Self::pdf_leg`]
+/// disambiguates *why* there is no PDF (genuinely none available vs.
+/// available-but-blocked) so callers never report a blocked PDF as a
+/// silent success (issue #118).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct FetchPaperOutcome {
@@ -374,6 +415,11 @@ pub struct FetchPaperOutcome {
     /// The schema version of the metadata TOML written
     /// (always [`crate::SCHEMA_VERSION`] for this build).
     pub schema_version: String,
+    /// What happened on the PDF leg (issue #118). `Fetched` /
+    /// `NoOaUrl` are clean outcomes; `Blocked` carries the structured
+    /// reason an OA PDF existed but could not be retrieved, so the
+    /// CLI / MCP surface it instead of a silent metadata-only success.
+    pub pdf_leg: PdfLegStatus,
 }
 
 /// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it
@@ -513,6 +559,9 @@ async fn fetch_paper_arxiv(
         path,
         size_bytes,
         schema_version: SCHEMA_VERSION.to_string(),
+        // arXiv always delivers the PDF (or the whole fn already
+        // returned Err above) — there is no metadata-only fallback.
+        pdf_leg: PdfLegStatus::Fetched,
     })
 }
 
@@ -562,16 +611,35 @@ async fn fetch_paper_doi(
 
     // OA PDF leg. Try the URL Unpaywall returned via the `oa-publisher`
     // source allowlist. Magic-byte check is enforced inside
-    // `HttpClient::fetch_pdf`. Any failure here is logged as a distinct
-    // `Fetch err` row and falls through to metadata-only success.
-    let pdf_outcome = if let Some(url) = oa_url {
-        try_fetch_oa_pdf(doi, &url, ctx).await
-    } else {
-        None
+    // `HttpClient::fetch_pdf`. Issue #118: a failure here is NEVER
+    // silently turned into a clean metadata-only success — the
+    // structured reason is carried out on `PdfLegStatus::Blocked` so
+    // the CLI / MCP can explain WHY the PDF could not be fetched.
+    let (pdf_leg, pdf_bytes) = match oa_url {
+        None => (PdfLegStatus::NoOaUrl, None),
+        Some(url) => match try_fetch_oa_pdf(doi, &url, ctx).await {
+            Ok((bytes, _final_url)) => (PdfLegStatus::Fetched, Some(bytes)),
+            Err(e) => {
+                // Borrow for the denial side-channel + human message,
+                // then consume into the closed ErrorCode last.
+                let fe = FetchError::Http(e);
+                let denial: Option<crate::DenialContext> = (&fe).into();
+                let message = fe.to_string();
+                let code: crate::ErrorCode = fe.into();
+                (
+                    PdfLegStatus::Blocked {
+                        code,
+                        message,
+                        denial,
+                    },
+                    None,
+                )
+            }
+        },
     };
 
-    let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_outcome {
-        Some((bytes, _final_url)) => {
+    let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_bytes {
+        Some(bytes) => {
             let staged = stage_pdf_to_tempfile(bytes)?;
             (
                 "oa-publisher".to_string(),
@@ -615,7 +683,7 @@ async fn fetch_paper_doi(
     write_metadata_and_pdf(store, safekey, &metadata, pdf_src_path.as_deref(), ctx)?;
     drop(pdf_staged);
 
-    let path = if pdf_outcome.is_some() {
+    let path = if pdf_bytes.is_some() {
         store_root.join(format!("{}.pdf", safekey.as_str()))
     } else {
         store_root
@@ -629,6 +697,7 @@ async fn fetch_paper_doi(
         path,
         size_bytes,
         schema_version: SCHEMA_VERSION.to_string(),
+        pdf_leg,
     })
 }
 
@@ -731,7 +800,7 @@ async fn try_fetch_oa_pdf(
     doi: &Doi,
     url: &url::Url,
     ctx: &FetchContext,
-) -> Option<(Vec<u8>, url::Url)> {
+) -> Result<(Vec<u8>, url::Url), HttpError> {
     const SOURCE: &str = "oa-publisher";
     let _permit = ctx.rate_limiter.acquire(SOURCE).await;
     // ADR-0021 §1: the oa-publisher PDF leg is a DISTINCT audit
@@ -758,7 +827,7 @@ async fn try_fetch_oa_pdf(
             }) {
                 tracing::warn!(error = %e, "appending oa-publisher Fetch ok row failed");
             }
-            Some((body.to_vec(), final_url))
+            Ok((body.to_vec(), final_url))
         }
         Err(e) => {
             match &e {
@@ -766,36 +835,47 @@ async fn try_fetch_oa_pdf(
                     tracing::info!(
                         oa_url = %url,
                         denied_host = %host,
-                        "OA URL host outside oa-publisher allowlist; metadata-only fallback"
+                        "OA URL host outside oa-publisher allowlist"
                     );
                 }
                 HttpError::NotAPdf { .. } => {
                     tracing::info!(
                         oa_url = %url,
-                        "OA URL did not return a PDF magic byte; metadata-only fallback"
+                        "OA URL did not return a PDF magic byte"
                     );
                 }
                 other => {
                     tracing::warn!(
                         oa_url = %url,
                         error = %other,
-                        "OA PDF fetch failed; metadata-only fallback"
+                        "OA PDF fetch failed"
                     );
                 }
             }
+            // Provenance `error_code` is the CLOSED-set code. Every
+            // `HttpError` collapses to `NETWORK_ERROR` through the
+            // canonical `From<FetchError> for ErrorCode` (the closed
+            // set has no finer transport code by design) — so this is
+            // the correct mapped value, not the misattribution the
+            // previous hardcode implied. The *fine* reason
+            // (RedirectDenied vs NotAPdf vs …) is preserved for the
+            // user via `PdfLegStatus::Blocked.denial` / `.message`
+            // built by the caller from the returned `HttpError`
+            // (issue #118). Rendered via `ErrorCode::as_wire` so the
+            // token can never drift from the enum.
             let _ = ctx.log.append(RowInput {
                 event: LogEvent::Fetch,
                 result: LogResult::Err,
                 capability: Capability::Oa,
                 ref_: Some(doi.as_str()),
                 source: Some(SOURCE),
-                error_code: Some("NETWORK_ERROR"),
+                error_code: Some(crate::ErrorCode::NetworkError.as_wire()),
                 size_bytes: None,
                 license: None,
                 store_path: None,
                 canonical_digest: Some(&canonical),
             });
-            None
+            Err(e)
         }
     }
 }
@@ -1226,6 +1306,59 @@ mod tests {
                 assert_eq!(max, MAX_BATCH_REFS);
             }
             other => panic!("expected TooManyRefs, got: {other:?}"),
+        }
+    }
+
+    // Issue #118: a non-PDF OA body must surface as `Err(HttpError)`
+    // from `try_fetch_oa_pdf` (previously silently flattened to
+    // `None`, which `fetch_paper_doi` then reported as a clean
+    // metadata-only success). The compiler-checked `Err(e) =>
+    // PdfLegStatus::Blocked` arm in `fetch_paper_doi` does the rest.
+    #[tokio::test]
+    async fn try_fetch_oa_pdf_non_pdf_body_is_err_not_silent_none() {
+        use crate::http::HttpClient;
+        use crate::provenance::ProvenanceLog;
+        use crate::rate_limiter::RateLimiter;
+        use crate::{Doi, RateLimits};
+        use std::sync::Arc;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(b"<html>not a pdf</html>".to_vec()),
+            )
+            .mount(&server)
+            .await;
+        let host = server
+            .uri()
+            .parse::<url::Url>()
+            .expect("uri")
+            .host_str()
+            .expect("host")
+            .to_string();
+
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let log_path = Utf8Path::from_path(td.path())
+            .expect("utf-8")
+            .join("log.jsonl");
+        let ctx = FetchContext {
+            http: Arc::new(HttpClient::new_for_tests_allow_http("oa-publisher", &host)),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log: Arc::new(
+                ProvenanceLog::open(log_path, "01J0000000000000000000TEST".into())
+                    .expect("provenance log"),
+            ),
+            session_id: "01J0000000000000000000TEST".into(),
+        };
+
+        let doi = Doi("10.1234/example".to_string());
+        let url: url::Url = format!("{}/oa.pdf", server.uri()).parse().expect("url");
+        let res = try_fetch_oa_pdf(&doi, &url, &ctx).await;
+        match res {
+            Err(HttpError::NotAPdf { .. }) => {}
+            other => panic!("expected Err(NotAPdf), got: {other:?}"),
         }
     }
 }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -581,8 +581,24 @@ async fn fetch_paper_doi(
     let contact = contact_email_from_env();
     let unpaywall_contact = unpaywall_email_from_env(&contact);
     let crossref = crossref_source_from_env(&contact);
-    let cross = crossref.fetch(ref_, profile, ctx).await?;
-    let crossref_meta = cross.metadata_json.unwrap_or(Value::Null);
+    // Issue #120: Crossref is NON-fatal. A transient Crossref failure
+    // must not abort the whole DOI fetch when Unpaywall alone can
+    // still deliver the OA PDF. We keep the error and only surface it
+    // if nothing usable comes back (see the both-failed guard below).
+    let (cross, crossref_err) = match crossref.fetch(ref_, profile, ctx).await {
+        Ok(r) => (Some(r), None),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "crossref fetch failed; continuing with unpaywall-only metadata + OA leg"
+            );
+            (None, Some(e))
+        }
+    };
+    let crossref_meta = cross
+        .as_ref()
+        .and_then(|c| c.metadata_json.clone())
+        .unwrap_or(Value::Null);
     let extracted = extract_crossref_fields(&crossref_meta);
 
     // Unpaywall second — license enrichment + OA URL discovery. A
@@ -638,6 +654,16 @@ async fn fetch_paper_doi(
         },
     };
 
+    // Issue #120: Crossref is non-fatal, but if it failed AND the OA
+    // PDF leg produced nothing, writing a DOI-only stub entry would
+    // mask a total failure and violate the "explain why" promise.
+    // Surface the Crossref error so the caller reports a real reason.
+    if let Some(e) = crossref_err {
+        if pdf_bytes.is_none() {
+            return Err(e);
+        }
+    }
+
     let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_bytes {
         Some(bytes) => {
             let staged = stage_pdf_to_tempfile(bytes)?;
@@ -665,7 +691,10 @@ async fn fetch_paper_doi(
         isbn: None,
         type_: extracted.type_,
         keywords: Vec::new(),
-        url: cross.final_url.as_ref().map(|u| u.to_string()),
+        url: cross
+            .as_ref()
+            .and_then(|c| c.final_url.as_ref())
+            .map(|u| u.to_string()),
         pdf_path: pdf_path_relative,
         doiget: Some(DoigetExtension {
             fetched_at: Utc::now(),

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -48,6 +48,7 @@ use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, tier_2_allowli
 use doiget_core::orchestrator::{
     batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
     metadata_only, resolve_only as core_resolve_only, FetchPaperOutcome, MetadataOnlyOutcome,
+    PdfLegStatus,
 };
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
@@ -1661,6 +1662,36 @@ pub struct FetchPaperInput {
 
 /// Build the `{ok:true, ref, source, path, ...}` success envelope per
 /// `docs/MCP_TOOLS.md` §5 `FetchResult`.
+/// Render [`PdfLegStatus`] for the wire. `Blocked` carries the
+/// closed-set `code`, a human `message`, and (when the failure was an
+/// allowlist / scheme denial) the structured ADR-0023 `denial_context`
+/// so an agent can act on WHY the PDF was not retrieved instead of
+/// seeing an indistinguishable "metadata-only" success (issue #118).
+fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
+    match leg {
+        PdfLegStatus::Fetched => json!({ "status": "fetched" }),
+        PdfLegStatus::NoOaUrl => json!({ "status": "no_oa_url" }),
+        PdfLegStatus::Blocked {
+            code,
+            message,
+            denial,
+        } => {
+            let mut o = serde_json::Map::new();
+            o.insert("status".into(), json!("blocked"));
+            o.insert("code".into(), json!(code));
+            o.insert("message".into(), json!(message));
+            if let Some(dc) = denial {
+                o.insert("denial_context".into(), json!(dc));
+            }
+            Value::Object(o)
+        }
+        // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
+        // surfaces as a forward-compatible neutral status rather than
+        // failing the build in this downstream crate.
+        _ => json!({ "status": "unknown" }),
+    }
+}
+
 fn fetch_paper_success_envelope(outcome: &FetchPaperOutcome, ref_str: &str) -> Value {
     json!({
         "ok": true,
@@ -1673,6 +1704,8 @@ fn fetch_paper_success_envelope(outcome: &FetchPaperOutcome, ref_str: &str) -> V
         "path": outcome.path,
         "size_bytes": outcome.size_bytes,
         "schema_version": outcome.schema_version,
+        // Issue #118: never a silent metadata-only success.
+        "pdf": pdf_leg_json(&outcome.pdf_leg),
     })
 }
 
@@ -1765,6 +1798,7 @@ fn batch_fetch_success_envelope(
                 "path": outcome.path,
                 "size_bytes": outcome.size_bytes,
                 "schema_version": outcome.schema_version,
+                "pdf": pdf_leg_json(&outcome.pdf_leg),
             }),
             Err(err) => {
                 let code: ErrorCode = match err {


### PR DESCRIPTION
Three MVP-core fetch-path fixes from the /code-review punch list. Same branch because all three are the same `fetch_paper_doi`/HTTP surface and a reviewer evaluates them together; no file conflicts.

Closes #117. Closes #118. Closes #120.

## #117 — bounded retry + backoff (取得成功率)
`HttpClient::fetch_inner` retries transient classes only (connect/timeout/mid-stream; HTTP 408/429/500/502/503/504). Exp backoff 500ms*2^n cap 30s + jitter (no new dep), ≤3 retries, inside the 300s budget. `Retry-After` honored on 429/503. Deterministic failures not retried. 4 wiremock tests.

## #118 — blocked OA-PDF surfaced, never silent (失敗透明性)
`try_fetch_oa_pdf` → `Result`; new `PdfLegStatus` (`Fetched`/`NoOaUrl`/`Blocked{code,message,denial}`) on `FetchPaperOutcome`. CLI prints a distinct line + `note:` on blocked; MCP envelopes gain a `pdf` object (status + code/message/denial_context). Provenance `error_code` via new drift-free `ErrorCode::as_wire()`. Orchestrator unit test: non-PDF OA body ⇒ `Err(NotAPdf)` (was silent `None`).

## #120 — Crossref non-fatal (取得成功率)
`fetch_paper_doi` no longer aborts on a Crossref failure; Unpaywall + OA leg still run and can deliver the PDF. If Crossref fails AND no PDF ⇒ surface the Crossref error (no DOI-only stub). New e2e: Crossref 404 + Unpaywall/OA ⇒ PDF still written.

## Test plan
- [x] `cargo test --workspace --all-targets --no-default-features --features oa-only` — 0 failed
- [x] new: 4 retry (http) + 1 blocked-OA (orchestrator) + 1 crossref-down (cli e2e); existing OA/fetch/batch e2e still green
- [x] `cargo fmt -- --check` + `clippy … -D warnings` clean
- [ ] CI green

Remaining MVP punch list (separate PRs): #119 CLI error/exit-code mapping, #121 BiblioFetch round-trip test, #122 torn-write, #123 LOW batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)