### PR TITLE
fix(cli): cargo-style error + ERRORS.md exit codes (closes #119)

### DIFF
--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -51,9 +51,9 @@ use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, HttpClient};
 use doiget_core::orchestrator::{fetch_paper as core_fetch_paper, FetchPaperOutcome, PdfLegStatus};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
-use doiget_core::source::FetchContext;
+use doiget_core::source::{FetchContext, FetchError};
 use doiget_core::store::FsStore;
-use doiget_core::{CapabilityProfile, RateLimits, Ref};
+use doiget_core::{CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref};
 
 /// Defer to docs/PROVENANCE_LOG.md §3: 26-char ULID per process invocation.
 fn new_session_id() -> String {
@@ -385,10 +385,20 @@ impl FetchHarness {
     /// CLI-only stderr success-line print.
     pub(crate) async fn fetch_one(&self, ref_: &Ref) -> Result<()> {
         let ctx = self.fetch_context();
-        let outcome =
-            core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await?;
-        emit_success_line(ref_, &outcome);
-        Ok(())
+        match core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await {
+            Ok(outcome) => {
+                emit_success_line(ref_, &outcome);
+                Ok(())
+            }
+            Err(e) => {
+                // Issue #119: render the cargo-style `error[CODE]:`
+                // line + denial note HERE (while the error is still
+                // typed), then carry only the exit code to `main`.
+                render_fetch_error(&e);
+                let code: ErrorCode = (&e).into();
+                Err(anyhow::Error::new(CliExit(cli_exit_code(code))))
+            }
+        }
     }
 }
 
@@ -477,9 +487,22 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
 /// shape was YAGNI, and the wrapper only existed to spare integration
 /// tests a `FetchOptions::default()` literal.
 pub async fn run_with_options(input: String, dry_run: bool) -> Result<()> {
-    // Step 1: parse + safekey. Granular `RefParseError` collapses to anyhow
-    // via `?`; the higher-level CLI binary maps the error to its exit code.
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    // Step 1: parse + safekey. Issue #119: render the cargo-style
+    // `error[INVALID_REF]:` line + carry the exit code, rather than
+    // letting the granular `RefParseError` fall out as an opaque
+    // anyhow `{:?}` dump.
+    let ref_ = match Ref::parse(&input) {
+        Ok(r) => r,
+        Err(e) => {
+            print_err(format_args!(
+                "error[{}]: invalid ref: {e}",
+                ErrorCode::InvalidRef.as_wire()
+            ));
+            return Err(anyhow::Error::new(CliExit(cli_exit_code(
+                ErrorCode::InvalidRef,
+            ))));
+        }
+    };
 
     // Dry-run branch: build the plan and emit it. NO harness, NO network,
     // NO store write, NO provenance row. Posture-lint ADR-0022 §5 will
@@ -521,6 +544,66 @@ pub async fn run_with_options(input: String, dry_run: bool) -> Result<()> {
 #[allow(clippy::print_stderr)]
 fn print_success(args: std::fmt::Arguments<'_>) {
     eprintln!("{args}");
+}
+
+/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. Mirrors
+/// [`print_success`]; the localized `#[allow]` is the minimal
+/// intervention for the workspace `clippy::print_stderr` lint.
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
+
+/// Carries a `docs/ERRORS.md` §4 process exit code out of a CLI
+/// command to `main`, which owns the actual `std::process::exit`
+/// (calling it inside `run_with_options` would kill in-process
+/// integration tests). The human-readable `error[CODE]: …` line has
+/// ALREADY been written to stderr by [`render_fetch_error`] before
+/// this is constructed, so `main` must NOT print it again. Issue #119.
+#[derive(Debug)]
+pub struct CliExit(pub i32);
+
+impl std::fmt::Display for CliExit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "exiting with status {}", self.0)
+    }
+}
+
+impl std::error::Error for CliExit {}
+
+/// `docs/ERRORS.md` §4 closed-code → process exit code. Anything not
+/// individually listed falls under "at least one fetch failed" (1).
+fn cli_exit_code(code: ErrorCode) -> i32 {
+    match code {
+        ErrorCode::CapabilityDenied => 3,
+        ErrorCode::StoreError | ErrorCode::LogError => 4,
+        ErrorCode::FetchTimeout => 124,
+        _ => 1,
+    }
+}
+
+/// Render a terminal [`FetchError`] in the `docs/ERRORS.md` §3
+/// "Researcher (CLI human)" form: `error[CODE]: message` on stderr,
+/// plus an actionable `= note:` line carrying the ADR-0023
+/// `denial_context` (attempted / expected hosts) when the failure was
+/// a denial class. stdout stays clean (ADR-0001).
+fn render_fetch_error(e: &FetchError) {
+    let code: ErrorCode = e.into();
+    print_err(format_args!("error[{}]: {}", code.as_wire(), e));
+    if let Some(dc) = Option::<DenialContext>::from(e) {
+        let attempted = dc.attempted.as_deref().unwrap_or("(unknown)");
+        match &dc.expected {
+            Some(exp) if !exp.is_empty() => {
+                print_err(format_args!(
+                    "  = note: attempted {attempted}; allowed: {}",
+                    exp.join(", ")
+                ));
+            }
+            _ => {
+                print_err(format_args!("  = note: attempted {attempted}"));
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -558,7 +558,7 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 /// command to `main`, which owns the actual `std::process::exit`
 /// (calling it inside `run_with_options` would kill in-process
 /// integration tests). The human-readable `error[CODE]: …` line has
-/// ALREADY been written to stderr by [`render_fetch_error`] before
+/// ALREADY been written to stderr by `render_fetch_error` before
 /// this is constructed, so `main` must NOT print it again. Issue #119.
 #[derive(Debug)]
 pub struct CliExit(pub i32);

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -140,6 +140,26 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
+    let result: anyhow::Result<()> = run_dispatch(cli).await;
+
+    // Issue #119: a `CliExit` carries a `docs/ERRORS.md` §4 process
+    // exit code and means the human-readable `error[CODE]:` line was
+    // ALREADY printed to stderr by the command. `main` owns the actual
+    // process exit (doing it inside the command would kill in-process
+    // integration tests). Every other error keeps the default anyhow
+    // behaviour (Debug chain to stderr, exit 1).
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) => match err.downcast_ref::<doiget_cli::commands::fetch::CliExit>() {
+            Some(doiget_cli::commands::fetch::CliExit(code)) => {
+                std::process::exit(*code);
+            }
+            None => Err(err),
+        },
+    }
+}
+
+async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         None => {
             anyhow::bail!("no subcommand. Run `doiget --help` for available commands.");

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -1,0 +1,31 @@
+//! Issue #119 — the `doiget fetch` human persona gets a
+//! `docs/ERRORS.md` §3 cargo-style `error[CODE]:` line on stderr and
+//! the §4 process exit code, instead of an opaque anyhow `{:?}` dump.
+//!
+//! Network-free: an invalid ref fails at `Ref::parse` before any
+//! harness / store / network work, so this is a deterministic unit of
+//! the §3/§4 wiring (the same `render_fetch_error` path handles every
+//! `FetchError` variant — type-checked).
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
+    let td = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        // Hygiene only — the invalid ref fails before the store is
+        // ever opened.
+        .env("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8"))
+        .env("DOIGET_LOG_PATH", "")
+        .args(["fetch", "not a doi"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("error[INVALID_REF]: invalid ref"))
+        // stdout MUST stay clean (ADR-0001 stdio rule).
+        .stdout(predicate::str::is_empty());
+}

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -134,6 +134,17 @@ pub enum FetchError {
 /// `From<RefParseError> for ErrorCode` collapse from PR #55.
 impl From<FetchError> for crate::ErrorCode {
     fn from(e: FetchError) -> crate::ErrorCode {
+        crate::ErrorCode::from(&e)
+    }
+}
+
+/// Borrow-form of the collapse above, so a caller that still needs the
+/// error for its `Display` message / `denial_context` side-channel
+/// (notably the CLI human-persona renderer, issue #119) can obtain the
+/// closed code without consuming it. The owned impl delegates here so
+/// the mapping table lives in exactly one place.
+impl From<&FetchError> for crate::ErrorCode {
+    fn from(e: &FetchError) -> crate::ErrorCode {
         match e {
             FetchError::NotEligible { .. } => crate::ErrorCode::CapabilityDenied,
             FetchError::NoOaAvailable => crate::ErrorCode::NoOaAvailable,


### PR DESCRIPTION
Closes #119. Stacked on PR #124 (it uses the #118 error machinery + `ErrorCode::as_wire`). Rebase onto main after #124 merges.

## What

The `doiget fetch` human persona got an opaque `anyhow {:?}` dump + exit 1 for everything. Now it follows `docs/ERRORS.md` §3/§4:

- `error[CODE]: message` on stderr (CODE = closed `ErrorCode` wire token), plus a `= note: attempted X; allowed: [...]` line from the ADR-0023 `denial_context` for denial-class failures. stdout stays clean (ADR-0001).
- Process exit codes per §4: CapabilityDenied→3, Store/Log→4, FetchTimeout→124, else 1. `main` owns `process::exit` (via a `CliExit` carrier) so in-process integration tests aren't killed.
- New `From<&FetchError> for ErrorCode` (borrow form; owned impl delegates — single-source mapping).
- Invalid-ref path now renders `error[INVALID_REF]: …` instead of the anyhow dump.

## Test plan

- [x] new `fetch_error_mapping_e2e`: `doiget fetch "not a doi"` ⇒ exit 1, stderr `error[INVALID_REF]: invalid ref`, empty stdout
- [x] `cargo fmt -- --check` + `clippy --no-default-features --features oa-only -D warnings` clean
- [x] `cargo test --workspace --all-targets --no-default-features --features oa-only` — 0 failed
- [ ] CI green (after #124 merges + rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)