### PR TITLE
fix(store): write PDF before metadata for crash-consistency (closes #122)

### DIFF
--- a/crates/doiget-core/src/store/fs_store.rs
+++ b/crates/doiget-core/src/store/fs_store.rs
@@ -14,7 +14,12 @@
 //! - **§5 Atomic write:** write `<safekey>.toml.tmp` → `sync_all` → `rename`
 //!   → fsync parent dir (POSIX). On Windows `std::fs::rename` invokes
 //!   `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`,
-//!   so no extra parent-fsync syscall is required.
+//!   so no extra parent-fsync syscall is required. Each file is atomic
+//!   individually; there is no cross-file transaction. The PDF is
+//!   therefore written BEFORE the metadata that references it (issue
+//!   #122), so a crash between the two renames can only leave an orphan
+//!   PDF or the prior consistent entry — never metadata pointing at a
+//!   missing PDF.
 //! - **§6 Coexistence with BiblioFetch.jl:** when re-writing an existing
 //!   entry, reserved top-level fields previously present are NOT overwritten
 //!   if the new value differs. Only the `[doiget]` table and `other` are
@@ -171,17 +176,30 @@ impl Store for FsStore {
         // key order within tables and a trailing `\n`.
         let normalized = normalize_toml(&merged)?;
 
-        // Atomic write per §5: tmp → fsync → rename → fsync parent.
-        atomic_write(&meta_path, normalized.as_bytes())?;
-
-        // PDF copy (optional). Same atomic dance, but byte-by-byte rather
-        // than text-with-newline-canonicalization.
+        // Issue #122 — crash-consistent ordering: the PDF is written
+        // BEFORE the metadata that references it. A crash between the
+        // two atomic renames then leaves either the previous
+        // consistent entry or no metadata at all — NEVER metadata
+        // whose `pdf_path` points at a `.pdf` that does not exist
+        // yet. (The reverse order could publish a dangling pointer.)
+        // Worst case under the new order is an orphan `<safekey>.pdf`
+        // with stale/absent metadata, which list/search ignore (they
+        // key off metadata) and a re-fetch overwrites — strictly
+        // safer than a torn pointer. There is still no cross-file
+        // transaction; this ordering is the bounded MVP guarantee
+        // (documented in STORE.md §5).
         if let Some(pdf_src) = pdf {
             let pdf_dst = self.pdf_path(key)?;
             let mut bytes = Vec::new();
             File::open(pdf_src.as_std_path())?.read_to_end(&mut bytes)?;
+            // Same atomic dance as the metadata, byte-by-byte.
             atomic_write(&pdf_dst, &bytes)?;
         }
+
+        // Atomic write per §5: tmp → fsync → rename → fsync parent.
+        // Done LAST so the metadata only becomes visible once its PDF
+        // (if any) is already durably on disk.
+        atomic_write(&meta_path, normalized.as_bytes())?;
 
         let _ = <File as FileExt>::unlock(&lock_file);
         Ok(())

--- a/docs/STORE.md
+++ b/docs/STORE.md
@@ -115,6 +115,20 @@ A crash mid-write leaves either:
 It never leaves a partially-visible new file. The lone `.tmp` artifact may be reaped at
 startup.
 
+**Cross-file ordering (issue #122).** Each file is atomic *individually*; there is no
+cross-file transaction across the metadata TOML and its PDF. The writer therefore renames
+the **PDF first**, then the metadata that references it. Consequences of a crash *between*
+the two renames:
+
+- before the PDF rename → the previous consistent entry (or no entry) — unchanged;
+- after the PDF rename, before the metadata rename → an **orphan `<safekey>.pdf`** plus
+  the prior/absent metadata. `list_recent` / `search` key off metadata and ignore the
+  orphan; a subsequent re-fetch overwrites it.
+
+What is **guaranteed not to happen**: metadata becoming visible while its `pdf_path`
+points at a `.pdf` that is absent or stale. A full two-file transaction is out of scope
+for the MVP; this ordering is the bounded guarantee.
+
 ## 6. doiget-side write discipline
 
 When doiget writes to a `<safekey>.toml` that already exists (e.g., a re-fetch):

--- a/site/content/developer/store.md
+++ b/site/content/developer/store.md
@@ -121,6 +121,20 @@ A crash mid-write leaves either:
 It never leaves a partially-visible new file. The lone `.tmp` artifact may be reaped at
 startup.
 
+**Cross-file ordering (issue #122).** Each file is atomic *individually*; there is no
+cross-file transaction across the metadata TOML and its PDF. The writer therefore renames
+the **PDF first**, then the metadata that references it. Consequences of a crash *between*
+the two renames:
+
+- before the PDF rename → the previous consistent entry (or no entry) — unchanged;
+- after the PDF rename, before the metadata rename → an **orphan `<safekey>.pdf`** plus
+  the prior/absent metadata. `list_recent` / `search` key off metadata and ignore the
+  orphan; a subsequent re-fetch overwrites it.
+
+What is **guaranteed not to happen**: metadata becoming visible while its `pdf_path`
+points at a `.pdf` that is absent or stale. A full two-file transaction is out of scope
+for the MVP; this ordering is the bounded guarantee.
+
 ## 6. doiget-side write discipline
 
 When doiget writes to a `<safekey>.toml` that already exists (e.g., a re-fetch):


### PR DESCRIPTION
Closes #122. Re-opened against `main` — original PR #127 was auto-closed when its stacked base `test/121` was deleted on #126's merge. Rebased onto main (clean #122-only diff) + the `site/content` projection of the STORE.md edit (CI verifies docs↔site sync).

`FsStore::write` renamed metadata first, then the PDF — a crash between left metadata `pdf_path`→missing PDF. Now PDF is renamed **first**, then metadata. Crash-between can only leave the prior consistent entry or an orphan PDF (ignored by list/search, overwritten by re-fetch) — never metadata→missing-PDF. Documented as the bounded MVP guarantee in STORE.md §5 + fs_store module header.

## Test plan
- [x] `cargo test -p doiget-core --lib store::fs_store` — green
- [x] fmt + clippy `-D warnings` clean
- [x] site/content projection synced (zola check)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)