### PR TITLE
fix: MVP polish batch — other-union §6 + envelope ref §5 (closes #123)

### DIFF
--- a/crates/doiget-core/src/store/fs_store.rs
+++ b/crates/doiget-core/src/store/fs_store.rs
@@ -472,12 +472,17 @@ fn merge_metadata(existing: Metadata, incoming: Metadata) -> Metadata {
         out.doiget = existing.doiget;
     }
 
-    // `other` (unknown tables / fields): union, prefer incoming on key
-    // collision. This preserves e.g. `[bibliofetch]` across a doiget rewrite
-    // when incoming.other is empty (the common case for a re-fetch).
+    // `other` (unknown tables / fields): union, prefer EXISTING on key
+    // collision (issue #123). STORE.md §6 forbids doiget overwriting a
+    // field/table another tool authored; an unknown key already on disk
+    // (e.g. a `[bibliofetch]` sub-key) must win over whatever doiget
+    // happens to carry in `other`. Doiget normally leaves `other`
+    // empty on a re-fetch, so this only changes behaviour in the
+    // (latent) case where both sides populate the same unknown key —
+    // there, "never overwrite" is the correct §6 resolution.
     let mut merged_other = existing.other;
     for (k, v) in out.other.iter() {
-        merged_other.insert(k.clone(), v.clone());
+        merged_other.entry(k.clone()).or_insert_with(|| v.clone());
     }
     out.other = merged_other;
 
@@ -1134,6 +1139,40 @@ mod tests {
         // STORE.md §7 normalization: trailing newline preserved.
         let raw = std::fs::read_to_string(meta_path.as_std_path()).expect("raw re-read");
         assert!(raw.ends_with('\n'), "missing trailing newline: {raw:?}");
+    }
+
+    /// Issue #123: on an `other`-key collision the EXISTING on-disk
+    /// value must win (STORE.md §6 "never overwrite"). Seeds a
+    /// `zotero_key` "by another tool", then has doiget write an entry
+    /// whose own `other` carries a different `zotero_key`; the disk
+    /// value must survive.
+    #[test]
+    fn other_key_collision_prefers_existing() {
+        let dir = TempDir::new().expect("tmp");
+        let store = fresh_store(&dir);
+        let key = sample_safekey();
+        let meta_path = store.metadata_path(&key).expect("path");
+
+        let body = format!(
+            "schema_version = \"{}\"\ntitle = \"Existing\"\nauthors = [\"Carol\"]\n\
+             zotero_key = \"FROM_BIBLIOFETCH\"\n",
+            SCHEMA_VERSION
+        );
+        std::fs::write(meta_path.as_std_path(), body).expect("seed");
+
+        let mut m = sample_metadata();
+        m.other.insert(
+            "zotero_key".to_string(),
+            toml::Value::String("FROM_DOIGET".to_string()),
+        );
+        store.write(&key, &m, None).expect("write");
+
+        let got = store.read(&key).expect("read").expect("present");
+        assert_eq!(
+            got.other.get("zotero_key").and_then(|v| v.as_str()),
+            Some("FROM_BIBLIOFETCH"),
+            "STORE.md §6: existing `other` value must win on collision"
+        );
     }
 
     #[test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -223,6 +223,7 @@ impl Server {
             Ok(r) => r,
             Err(e) => {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
                     ErrorCode::InvalidRef,
                     &format!("invalid ref: {e}"),
                 )));
@@ -255,6 +256,7 @@ impl Server {
             Ok(c) => c,
             Err(e) => {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
                     ErrorCode::InternalError,
                     &format!("metadata-only context initialization failed: {e}"),
                 )));
@@ -281,6 +283,7 @@ impl Server {
             canonical_digest: None,
         }) {
             return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                Some(&input.ref_),
                 ErrorCode::LogError,
                 &format!("SessionStart append failed: {e}"),
             )));
@@ -365,6 +368,7 @@ impl Server {
             Ok(r) => r,
             Err(e) => {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
                     ErrorCode::InvalidRef,
                     &format!("invalid ref: {e}"),
                 )));
@@ -377,6 +381,7 @@ impl Server {
             Ok(c) => c,
             Err(e) => {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
                     ErrorCode::InternalError,
                     &format!("resolve-paper context initialization failed: {e}"),
                 )));
@@ -402,6 +407,7 @@ impl Server {
             canonical_digest: None,
         }) {
             return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                Some(&input.ref_),
                 ErrorCode::LogError,
                 &format!("SessionStart append failed: {e}"),
             )));
@@ -1556,9 +1562,14 @@ fn read_path_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &st
 /// I6 lesson from PR #84's multi-agent review: free-form string codes
 /// can drift from `ErrorCode`'s SCREAMING_SNAKE_CASE rendering without
 /// the compiler noticing.
-fn metadata_only_error_envelope(code: ErrorCode, message: &str) -> Value {
+fn metadata_only_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &str) -> Value {
     json!({
         "ok": false,
+        // Issue #123: docs/MCP_TOOLS.md §5 mandates `ref` on every
+        // ok:false envelope. Emitted always (null when there is no
+        // ref to surface) for shape-symmetry with the success
+        // envelopes and `read_path_error_envelope`.
+        "ref": ref_str.map(Value::from).unwrap_or(Value::Null),
         "error": {
             "code": code,
             "message": message,

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -238,6 +238,14 @@ async fn doiget_metadata_only_invalid_ref_returns_invalid_ref_envelope() -> anyh
         serde_json::json!("INVALID_REF"),
         "envelope: {structured:?}"
     );
+    // Issue #123: docs/MCP_TOOLS.md §5 mandates `ref` on every
+    // ok:false envelope (was previously omitted by
+    // metadata_only_error_envelope).
+    assert_eq!(
+        structured["ref"],
+        serde_json::json!("not a doi"),
+        "ok:false envelope must carry the request ref (§5); got: {structured:?}"
+    );
     assert!(
         structured["error"]["message"]
             .as_str()

--- a/docs/STORE.md
+++ b/docs/STORE.md
@@ -140,7 +140,18 @@ When doiget writes to a `<safekey>.toml` that already exists (e.g., a re-fetch):
 - Exception: `schema_version` may be bumped on a coordinated minor revision.
 
 This rule prevents a user who runs both BiblioFetch.jl and doiget against the same store
-from losing BiblioFetch-authored fields.
+from losing BiblioFetch-authored fields. Unknown keys inside `other` (e.g. an unknown
+top-level scalar or a `[bibliofetch]` sub-key) follow the same rule: on a re-write, an
+existing on-disk value WINS over whatever doiget carries (issue #123).
+
+> **Re-fetch downgrade behaviour (issue #123).** A doiget re-fetch of an entry that
+> previously had a PDF but is now metadata-only (e.g. the OA host went off-allowlist)
+> rewrites the `[doiget]` table (`source`, `size_bytes`, …) in place. The PDF blob is
+> immutable-after-write (§1) so the existing `.pdf` file is **not** deleted, but the
+> entry's recorded state changes. This is intentional, not silent: as of issue #118 the
+> blocked-PDF reason is surfaced to the caller (CLI `note:` line / MCP `pdf.status`),
+> so the operator always learns the entry was downgraded and why. A guard that refuses
+> to downgrade is deferred (post-MVP) — it is a policy choice, not a correctness bug.
 
 ## 7. TOML normalization
 
@@ -171,6 +182,18 @@ Both implementations MUST refuse:
 
 - Missing `schema_version`, `title`, `authors`, or year-equivalent.
 - Future major `schema_version` for write operations.
+
+> **Known doiget limitation (issue #123).** doiget reads any unknown table
+> into an opaque `other` map and preserves *flat* unknown tables (e.g.
+> `[bibliofetch]` with scalar/array sub-keys) losslessly across a
+> read→write→read cycle (proven by
+> `bibliofetch_typed_table_and_unknown_scalar_survive_roundtrip`). It does
+> **not** yet round-trip a *nested* unknown sub-table such as
+> `[bibliofetch.history]`: doiget's TOML normalizer rejects a nested table
+> inside `other`, so a doiget rewrite of an entry containing one returns
+> `StoreError::Serialize` rather than silently dropping data (fail-loud,
+> not data loss). BiblioFetch.jl should keep its tool table flat until
+> this is lifted; tracked for a post-MVP normalizer pass.
 
 ## 9. Round-trip CI test
 

--- a/site/content/developer/store.md
+++ b/site/content/developer/store.md
@@ -146,7 +146,18 @@ When doiget writes to a `<safekey>.toml` that already exists (e.g., a re-fetch):
 - Exception: `schema_version` may be bumped on a coordinated minor revision.
 
 This rule prevents a user who runs both BiblioFetch.jl and doiget against the same store
-from losing BiblioFetch-authored fields.
+from losing BiblioFetch-authored fields. Unknown keys inside `other` (e.g. an unknown
+top-level scalar or a `[bibliofetch]` sub-key) follow the same rule: on a re-write, an
+existing on-disk value WINS over whatever doiget carries (issue #123).
+
+> **Re-fetch downgrade behaviour (issue #123).** A doiget re-fetch of an entry that
+> previously had a PDF but is now metadata-only (e.g. the OA host went off-allowlist)
+> rewrites the `[doiget]` table (`source`, `size_bytes`, …) in place. The PDF blob is
+> immutable-after-write (§1) so the existing `.pdf` file is **not** deleted, but the
+> entry's recorded state changes. This is intentional, not silent: as of issue #118 the
+> blocked-PDF reason is surfaced to the caller (CLI `note:` line / MCP `pdf.status`),
+> so the operator always learns the entry was downgraded and why. A guard that refuses
+> to downgrade is deferred (post-MVP) — it is a policy choice, not a correctness bug.
 
 ## 7. TOML normalization
 
@@ -177,6 +188,18 @@ Both implementations MUST refuse:
 
 - Missing `schema_version`, `title`, `authors`, or year-equivalent.
 - Future major `schema_version` for write operations.
+
+> **Known doiget limitation (issue #123).** doiget reads any unknown table
+> into an opaque `other` map and preserves *flat* unknown tables (e.g.
+> `[bibliofetch]` with scalar/array sub-keys) losslessly across a
+> read→write→read cycle (proven by
+> `bibliofetch_typed_table_and_unknown_scalar_survive_roundtrip`). It does
+> **not** yet round-trip a *nested* unknown sub-table such as
+> `[bibliofetch.history]`: doiget's TOML normalizer rejects a nested table
+> inside `other`, so a doiget rewrite of an entry containing one returns
+> `StoreError::Serialize` rather than silently dropping data (fail-loud,
+> not data loss). BiblioFetch.jl should keep its tool table flat until
+> this is lifted; tracked for a post-MVP normalizer pass.
 
 ## 9. Round-trip CI test
 


### PR DESCRIPTION
Closes #123. Rebased clean onto current `main` (post #129/#130). Supersedes #132 (which was BEHIND under strict branch-protection and needed a rebase; force-push blocked by a local guard, so re-pushed as a fresh branch — same verified content).

Content integrity verified post-rebase: 0 conflict markers; **both** store tests present (`bibliofetch_typed_table_and_unknown_scalar_survive_roundtrip` from #121 + `other_key_collision_prefers_existing` from #123); STORE.md carries **both** the §5 cross-file-ordering note (#122) and the §6/§8 #123 notes; `site/content/developer/store.md` projection synced. `cargo test -p doiget-core --lib store::fs_store` = 13 passed; fmt clean.

## Fixed
- `other`-union prefers EXISTING on collision (STORE.md §6) + unit test.
- `metadata_only_error_envelope` emits the §5-mandated `ref` (6 callers updated; e2e asserts it).

## Documented (post-MVP)
- Nested unknown sub-table fail-loud; flat tables round-trip (§8). Re-fetch downgrade rewrites `[doiget]` in place, non-silent via #118 (§6).

Completes the /code-review MVP punch list (#117–#123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)