### PR TITLE
ci(release-plz): use RELEASE_PLZ_TOKEN PAT (fixes stuck release PRs + missing sign/SBOM)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,6 +12,15 @@ name: release-plz
 #      when the push is the merge of a release-PR. On normal pushes it
 #      is a no-op.
 #
+# Token: `secrets.RELEASE_PLZ_TOKEN` (a fine-grained PAT with
+# contents+pull-requests write), NOT the default `GITHUB_TOKEN`.
+# GitHub deliberately does NOT trigger `on: pull_request` /
+# `on: push` workflows for refs created/pushed by `GITHUB_TOKEN`
+# (recursion guard). With `GITHUB_TOKEN`, release-plz's release PR
+# never gets CI (required checks never appear → branch protection
+# blocks the merge forever) and the tag it pushes never triggers
+# `release-sign.yml` / `release-sbom.yml`. The PAT makes both fire.
+#
 # OIDC trusted-publishing — there is NO `CARGO_REGISTRY_TOKEN` secret.
 # The `id-token: write` permission on the `release` job lets it
 # exchange the GitHub OIDC token for a short-lived crates.io token at
@@ -50,7 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -62,7 +71,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
   release-plz-release:
     name: release-plz release
@@ -87,7 +96,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -97,4 +106,4 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
## Problem

Release-plz PRs (e.g. #131 v0.1.2, #133 v0.1.3) are authored by `app/github-actions` via `GITHUB_TOKEN`. GitHub's recursion guard means **no `pull_request` workflow runs for them** → required `test (ubuntu/windows)` checks never appear → branch protection blocks the merge forever (worked around so far by manual close/reopen). The same guard means the **tag** release-plz pushes doesn't trigger `release-sign.yml` / `release-sbom.yml` → cosign signature + SBOM were not produced for automated releases.

## Fix

Both `release-plz-pr` and `release-plz-release` jobs now use `secrets.RELEASE_PLZ_TOKEN` (fine-grained PAT, contents + pull-requests = write) for the `actions/checkout` token and the `release-plz/action` `GITHUB_TOKEN` env. A PAT-authored PR/tag triggers workflows normally. OIDC crates.io publish (`id-token: write`) is untouched.

Secret `RELEASE_PLZ_TOKEN` is already configured on the repo.

## Test plan
- [ ] CI green on this PR (workflow YAML only).
- [ ] After merge: the next release-plz release PR gets CI automatically (no close/reopen) and its tag push triggers sign + SBOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)