### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.2...doiget-core-v0.1.3) - 2026-05-17
+
+### Fixed
+
+- MVP polish batch (closes #123)
+- *(store)* write PDF before metadata for crash-consistency (closes #122)
+
+### Other
+
+- Merge branch 'main' into fix/122-torn-write-ordering-r2
+
 ## [0.1.2](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.1...doiget-core-v0.1.2) - 2026-05-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.1.2"
+version       = "0.1.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.1.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.1.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.1.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.1.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.1.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.1.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION



## 🤖 New release

* `doiget-core`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `doiget-mcp`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `doiget-cli`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `doiget-core`

<blockquote>

## [0.1.3](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.2...doiget-core-v0.1.3) - 2026-05-17

### Fixed

- MVP polish batch (closes #123)
- *(store)* write PDF before metadata for crash-consistency (closes #122)

### Other

- Merge branch 'main' into fix/122-torn-write-ordering-r2
</blockquote>

## `doiget-mcp`

<blockquote>

## [0.1.3](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.2...doiget-core-v0.1.3) - 2026-05-17

### Fixed

- MVP polish batch (closes #123)
- *(store)* write PDF before metadata for crash-consistency (closes #122)

### Other

- Merge branch 'main' into fix/122-torn-write-ordering-r2
</blockquote>

## `doiget-cli`

<blockquote>

## [0.1.3](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.2...doiget-core-v0.1.3) - 2026-05-17

### Fixed

- MVP polish batch (closes #123)
- *(store)* write PDF before metadata for crash-consistency (closes #122)

### Other

- Merge branch 'main' into fix/122-torn-write-ordering-r2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).