### PR TITLE
fix(ci): release-sign/sbom portable sha256 + cyclonedx invocation

### DIFF
--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -71,13 +71,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # SBOM of the shipped binary's full transitive graph. `oa-only`
-          # matches the feature surface release-sign.yml builds + CI gates.
-          cargo cyclonedx -p doiget-cli --format json \
-            --no-default-features --features oa-only
-          # cargo-cyclonedx writes the bom next to the crate manifest;
-          # the exact filename has drifted across versions, so locate it
-          # defensively rather than hard-coding.
+          # cargo-cyclonedx has no `-p` / `--features` flags (it derives
+          # the graph from `cargo metadata` over the whole workspace);
+          # passing them fails with "unexpected argument". Run it bare
+          # at the workspace root — it emits one `<crate>.cdx.json` per
+          # member — then select doiget-cli's bom below (it transitively
+          # includes doiget-core + doiget-mcp + all deps anyway).
+          cargo cyclonedx --format json
+          # cargo-cyclonedx writes the bom next to each crate manifest;
+          # the exact filename has drifted across versions, so locate
+          # doiget-cli's defensively rather than hard-coding.
           src="$(find . -name '*.cdx.json' -path '*doiget-cli*' | head -n1)"
           if [ -z "$src" ]; then
             src="$(find . -name '*.cdx.json' | head -n1)"
@@ -88,7 +91,10 @@ jobs:
           fi
           out="doiget-sbom-${TAG}.cdx.json"
           cp "$src" "$out"
-          shasum -a 256 "$out" > "$out.sha256"
+          # `shasum` is absent on the Windows Git-bash runner and
+          # `sha256sum` is absent on macOS; `openssl dgst` is present
+          # on all three. `-r` gives a `<hash> *<file>` line.
+          openssl dgst -sha256 -r "$out" > "$out.sha256"
           echo "SBOM=$out" >> "$GITHUB_ENV"
 
       - name: cosign sign-blob (keyless)

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -96,7 +96,10 @@ jobs:
           src="target/release/doiget${{ matrix.ext }}"
           out="${{ matrix.artifact }}${{ matrix.ext }}"
           cp "$src" "$out"
-          shasum -a 256 "$out" > "$out.sha256"
+          # `shasum` is absent on the Windows Git-bash runner and
+          # `sha256sum` is absent on macOS; `openssl dgst` is present
+          # on all three. `-r` gives a `<hash> *<file>` line.
+          openssl dgst -sha256 -r "$out" > "$out.sha256"
           echo "ARTIFACT=$out" >> "$GITHUB_ENV"
 
       - name: cosign sign-blob (keyless)


### PR DESCRIPTION
First real run of the Slice 23/24 workflows (v0.1.2 backfill via workflow_dispatch) exposed two bugs:

1. **`shasum` not found on Windows Git-bash** (exit 127) — and `sha256sum` is absent on macOS. → both workflows now use `openssl dgst -sha256 -r` (present on ubuntu/macOS/windows-git-bash).
2. **`cargo cyclonedx -p doiget-cli --format json --no-default-features --features oa-only`** → `error: unexpected argument '-p'` (cargo-cyclonedx has no `-p`/`--features`). → run bare at workspace root; the existing defensive `find` selects doiget-cli's bom (transitively includes core+mcp+all deps).

Linux + macOS cosign bundles for v0.1.2 already uploaded fine; this fixes the Windows leg and the SBOM job. Post-merge I'll re-dispatch both for `doiget-cli-v0.1.2` to finish the backfill; v0.1.3 (#136) will exercise the fixed workflows via its (now PAT-authored, #135) tag push.

## Test plan
- [ ] CI green (workflow YAML only)
- [ ] Post-merge: re-dispatch release-sign + release-sbom for doiget-cli-v0.1.2 → all 3 binaries + bundles + signed SBOM attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)