### PR TITLE
fix(mcp): spec conformance + non-goal guard + error observability (#141 #152 #154 #156)

### DIFF
--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1725,7 +1725,18 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
             o.insert("code".into(), json!(code));
             o.insert("message".into(), json!(message));
             if let Some(dc) = denial {
-                o.insert("denial_context".into(), json!(dc));
+                // Route through the logged helper (#154): a bare
+                // `json!(dc)` here would silently coerce a future
+                // serialization failure to `null` inside the
+                // `fetch_paper` SUCCESS envelope with no trace —
+                // exactly the silent-swallow class #154 eliminates.
+                // The other three denial-context sites already use
+                // this helper; keep this consistent. `tracing` is
+                // stderr-only (stdout is the JSON-RPC channel).
+                o.insert(
+                    "denial_context".into(),
+                    denial_context_to_value(dc, "fetch_paper_pdf_leg"),
+                );
             }
             Value::Object(o)
         }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -163,14 +163,16 @@ impl Server {
 
     /// `doiget_capability_profile` — report the runtime capability tiers.
     ///
-    /// Per `docs/MCP_TOOLS.md` §7 ("Capability awareness"), agents call
-    /// this first to plan whether a TDM-class fetch will succeed. The
-    /// output shape is `{ tier_1: [...], tier_2: [...], tier_3: [...] }`
-    /// alongside boolean roll-ups and the (always-5) rate cap.
+    /// Per `docs/MCP_TOOLS.md` §7 ("Capability awareness", NORMATIVE),
+    /// agents call this first to plan whether a TDM-class fetch will
+    /// succeed. The spec'd output shape is
+    /// `{ oa_enabled, metadata_sources: string[], tdm_enabled,
+    /// tdm_elsevier, tdm_aps, tdm_springer, rate_limit_per_sec }`;
+    /// `ok` and `tier_1/2/3` are emitted additively for back-compat.
     #[tool(
         description = "WHEN TO USE: Determine which sources the running doiget instance is allowed to use.\n\
                        INPUTS: none.\n\
-                       OUTPUTS: { ok: true, tier_1, tier_2, tier_3, oa_enabled, tdm_enabled, rate_limit_per_sec }.\n\
+                       OUTPUTS: { oa_enabled, metadata_sources, tdm_enabled, tdm_elsevier, tdm_aps, tdm_springer, rate_limit_per_sec } (plus additive ok, tier_1, tier_2, tier_3).\n\
                        COSTS: <1 ms.\n\
                        SIDE EFFECTS: none.\n\
                        LIMITS: none."
@@ -1240,6 +1242,7 @@ impl Server {
 /// The matching `#[schemars(rename = "ref")]` keeps the generated JSON
 /// schema field name aligned with the wire form.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(deny_unknown_fields)]
 pub struct MetadataOnlyInput {
     /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
@@ -1603,6 +1606,32 @@ fn metadata_only_success_envelope(outcome: &MetadataOnlyOutcome, ref_str: &str) 
     })
 }
 
+/// Serialize a [`DenialContext`] to its wire [`Value`], logging a
+/// `tracing::warn!` on the (today unreachable) serialization-failure
+/// branch instead of silently substituting `null` (#154).
+///
+/// `DenialContext` is a typed `Serialize` struct with only optional
+/// scalar/string/array fields, so `serde_json::to_value` cannot fail in
+/// practice. The fallback exists purely so a future non-serializable
+/// field cannot panic the server — but a silent `null` would strip the
+/// structured recovery payload an agent depends on, with zero trace.
+/// `tracing` writes to stderr only (stdout is the JSON-RPC channel and
+/// `clippy::print_stdout` is denied crate-wide), so this is safe to log.
+fn denial_context_to_value(dc: &DenialContext, surface: &str) -> Value {
+    match serde_json::to_value(dc) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                surface,
+                error = %e,
+                "denial_context serialization failed; emitting null and losing the \
+                 structured ADR-0023 recovery payload for this {surface} error envelope"
+            );
+            Value::Null
+        }
+    }
+}
+
 /// Build the `{ok:false, error:{code, message, denial_context?}}`
 /// envelope for orchestrator failures. Maps the [`FetchError`] to the
 /// closed [`ErrorCode`] set via the existing
@@ -1636,12 +1665,15 @@ fn metadata_only_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value 
     error_obj.insert("message".into(), json!(message));
     if let Some(dc) = denial {
         // `DenialContext` is `Serialize` (`#[serde(deny_unknown_fields)]`,
-        // optional fields). `serde_json::to_value` cannot fail on a
-        // typed struct; the `unwrap_or` defensively returns `null` if a
-        // future field becomes non-serializable (defensive only).
+        // optional fields) and `serde_json::to_value` cannot fail on a
+        // typed struct today. The fallback to `null` is defensive only
+        // (a future non-serializable field), but a silent swallow loses
+        // the structured recovery payload with no trace — so log it on
+        // stderr (#154). stdout is the JSON-RPC channel; `tracing` is
+        // stderr-only.
         error_obj.insert(
             "denial_context".into(),
-            serde_json::to_value(&dc).unwrap_or(Value::Null),
+            denial_context_to_value(&dc, "metadata_only"),
         );
     }
     json!({
@@ -1658,6 +1690,7 @@ fn metadata_only_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value 
 /// JSON-schema-derived input for `doiget_fetch_paper`. Same wire shape
 /// as `MetadataOnlyInput` — just a different orchestrator target.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(deny_unknown_fields)]
 pub struct FetchPaperInput {
     /// DOI or arXiv id; validated via `Ref::parse`.
@@ -1758,7 +1791,7 @@ fn fetch_paper_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value {
     if let Some(dc) = denial {
         error_obj.insert(
             "denial_context".into(),
-            serde_json::to_value(&dc).unwrap_or(Value::Null),
+            denial_context_to_value(&dc, "fetch_paper"),
         );
     }
     json!({
@@ -1829,17 +1862,19 @@ fn batch_fetch_success_envelope(
                 if let Some(dc) = denial {
                     error_obj.insert(
                         "denial_context".into(),
-                        serde_json::to_value(&dc).unwrap_or(Value::Null),
+                        denial_context_to_value(&dc, "batch_fetch"),
                     );
                 } else {
                     // Per the Slice 2 spec: transport (NETWORK_ERROR)
                     // entries carry `denial_context: null` so an agent
                     // can pattern-match on the field's presence rather
                     // than tolerating absence. This deliberately
-                    // differs from the metadata-only envelope where
-                    // the field is omitted entirely; the batch surface
-                    // makes the null explicit because per-ref entries
-                    // are uniform table rows in the agent's view.
+                    // differs from the single-paper envelopes
+                    // (`doiget_fetch_paper` / `doiget_metadata_only`)
+                    // where the field is OMITTED entirely when `None`.
+                    // The asymmetry is intentional and documented in
+                    // `docs/MCP_TOOLS.md` §5; `tests/fetch_paper_e2e.rs`
+                    // pins the explicit-null batch shape (#154).
                     error_obj.insert("denial_context".into(), Value::Null);
                 }
                 json!({
@@ -2088,25 +2123,40 @@ fn probe_store_writable(path: &camino::Utf8Path) -> bool {
 }
 
 /// Serialize a [`CapabilityProfile`] to the JSON surface defined by
-/// `docs/MCP_TOOLS.md` §7.
+/// `docs/MCP_TOOLS.md` §7 (NORMATIVE).
 ///
+/// The §7 contract requires
+/// `{ oa_enabled, metadata_sources: string[], tdm_enabled, tdm_elsevier,
+/// tdm_aps, tdm_springer, rate_limit_per_sec }`. We emit exactly those
+/// fields and additionally retain `ok` and `tier_1/2/3` as **additive**
+/// fields — the e2e handshake test and pre-#141 agents rely on them and
+/// §7 (a TypeScript object type, structurally open) does not forbid
+/// extra keys. `metadata_sources` is the spec-canonical view of the
+/// enabled Tier-2 metadata sources.
+///
+/// - `metadata_sources` reflects the `MetadataAccess` booleans (the
+///   enabled Tier-2 source names; always-on Tier-1 sources are reported
+///   separately via the additive `tier_1` field).
 /// - Tier 1 is always `["arxiv", "crossref", "unpaywall"]` (sorted for
 ///   deterministic output).
-/// - Tier 2 reflects the `MetadataAccess` booleans.
 /// - Tier 3 reflects which `tdm_*` slots are `Some(...)`.
 fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
     let tier_1 = vec!["arxiv", "crossref", "unpaywall"];
 
-    let mut tier_2: Vec<&str> = Vec::new();
+    // `metadata_sources` (spec §7) == the enabled Tier-2 metadata
+    // sources. Order is deterministic (declaration order).
+    let mut metadata_sources: Vec<&str> = Vec::new();
     if profile.metadata.openalex {
-        tier_2.push("openalex");
+        metadata_sources.push("openalex");
     }
     if profile.metadata.semantic_scholar {
-        tier_2.push("semantic_scholar");
+        metadata_sources.push("semantic_scholar");
     }
     if profile.metadata.doaj {
-        tier_2.push("doaj");
+        metadata_sources.push("doaj");
     }
+    // Additive alias kept for back-compat with pre-#141 consumers.
+    let tier_2 = metadata_sources.clone();
 
     let mut tier_3: Vec<&str> = Vec::new();
     if profile.tdm_elsevier.is_some() {
@@ -2122,16 +2172,19 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
     let tdm_enabled = !tier_3.is_empty();
 
     json!({
-        "ok": true,
-        "tier_1": tier_1,
-        "tier_2": tier_2,
-        "tier_3": tier_3,
+        // -- NORMATIVE §7 contract fields --
         "oa_enabled": true,
+        "metadata_sources": metadata_sources,
         "tdm_enabled": tdm_enabled,
         "tdm_elsevier": profile.tdm_elsevier.is_some(),
         "tdm_aps": profile.tdm_aps.is_some(),
         "tdm_springer": profile.tdm_springer.is_some(),
         "rate_limit_per_sec": profile.rate_limits.max_fetches_per_second(),
+        // -- additive (back-compat; not part of the §7 contract) --
+        "ok": true,
+        "tier_1": tier_1,
+        "tier_2": tier_2,
+        "tier_3": tier_3,
     })
 }
 
@@ -2148,10 +2201,20 @@ mod tests {
         // and assert the always-true invariants.
         let profile = CapabilityProfile::from_env().expect("clean env never errors");
         let v = capability_profile_to_json(&profile);
+        // NORMATIVE §7 contract fields.
+        assert_eq!(v["oa_enabled"], true);
+        assert!(
+            v["metadata_sources"].is_array(),
+            "§7 requires metadata_sources: string[]; got: {v:?}"
+        );
+        assert_eq!(v["tdm_enabled"], json!(false));
+        assert_eq!(v["tdm_elsevier"], json!(false));
+        assert_eq!(v["tdm_aps"], json!(false));
+        assert_eq!(v["tdm_springer"], json!(false));
+        assert_eq!(v["rate_limit_per_sec"], 5.0);
+        // Additive back-compat fields.
         assert_eq!(v["ok"], true);
         assert_eq!(v["tier_1"], json!(["arxiv", "crossref", "unpaywall"]));
-        assert_eq!(v["oa_enabled"], true);
-        assert_eq!(v["rate_limit_per_sec"], 5.0);
     }
 
     #[test]

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -137,6 +137,16 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         "tools/list must include doiget_csl_export; got: {names:?}"
     );
 
+    // -- 2b. negative scope guard (#152) -------------------------------
+    //
+    // `docs/SCOPE.md` permanent non-goals: these tool names must NEVER
+    // be advertised. A future refactor that reintroduces one (e.g. an
+    // SSRF-prone `doiget_fetch_url`, a credential sink, a destructive
+    // store op, or a generic shell/exec escape) must fail here rather
+    // than ship silently. See also the dedicated
+    // `tools_list_excludes_scope_nongoals` test below.
+    assert_forbidden_tools_absent(&names);
+
     // -- 3. tools/call doiget_health -----------------------------------
     let health = client
         .peer()
@@ -171,13 +181,29 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         .structured_content
         .as_ref()
         .expect("doiget_capability_profile uses CallToolResult::structured");
-    assert_eq!(cap_struct["ok"], serde_json::json!(true));
+    // NORMATIVE `docs/MCP_TOOLS.md` §7 contract fields (#141).
     assert_eq!(cap_struct["oa_enabled"], serde_json::json!(true));
+    assert!(
+        cap_struct["metadata_sources"].is_array(),
+        "§7 requires metadata_sources: string[]; got: {cap_struct:?}"
+    );
+    // Clean (Tier-1-only) env: no Tier-2 metadata sources enabled.
+    assert_eq!(
+        cap_struct["metadata_sources"],
+        serde_json::json!([]),
+        "clean env must report empty metadata_sources; got: {cap_struct:?}"
+    );
+    assert_eq!(cap_struct["tdm_enabled"], serde_json::json!(false));
+    assert_eq!(cap_struct["tdm_elsevier"], serde_json::json!(false));
+    assert_eq!(cap_struct["tdm_aps"], serde_json::json!(false));
+    assert_eq!(cap_struct["tdm_springer"], serde_json::json!(false));
+    assert_eq!(cap_struct["rate_limit_per_sec"], serde_json::json!(5.0));
+    // Additive back-compat fields (not part of the §7 contract).
+    assert_eq!(cap_struct["ok"], serde_json::json!(true));
     assert_eq!(
         cap_struct["tier_1"],
         serde_json::json!(["arxiv", "crossref", "unpaywall"])
     );
-    assert_eq!(cap_struct["rate_limit_per_sec"], serde_json::json!(5.0));
 
     // -- Shutdown -------------------------------------------------------
     //
@@ -211,6 +237,68 @@ async fn boot_in_memory_server() -> anyhow::Result<(
     });
     let client = ().serve(client_transport).await?;
     Ok((client, server_handle))
+}
+
+/// `docs/SCOPE.md` permanent non-goals (#152). Any tool name in this set
+/// — or any name that *looks* like a generic shell / exec / eval escape
+/// — must never appear in `tools/list`. Reintroducing one (even behind a
+/// feature flag) is a hard scope violation, not a regression to triage.
+const FORBIDDEN_TOOL_NAMES: &[&str] = &[
+    "doiget_fetch_url",
+    "doiget_set_credentials",
+    "doiget_delete_paper",
+];
+
+/// Substrings that betray a generic command/eval escape hatch. Matched
+/// case-insensitively against each advertised tool name so a future
+/// `doiget_run_shell`, `doiget_exec`, `doiget_eval`, `doiget_system`,
+/// etc. trips the guard without needing an exact-name entry.
+const FORBIDDEN_TOOL_SUBSTRINGS: &[&str] = &[
+    "shell",
+    "exec",
+    "eval",
+    "spawn",
+    "system",
+    "command",
+    "subprocess",
+];
+
+/// Assert no `docs/SCOPE.md` non-goal tool is advertised. Shared by the
+/// roundtrip smoke test and the dedicated negative test below.
+fn assert_forbidden_tools_absent(names: &[&str]) {
+    for forbidden in FORBIDDEN_TOOL_NAMES {
+        assert!(
+            !names.contains(forbidden),
+            "SCOPE.md non-goal tool `{forbidden}` must NEVER be in tools/list; got: {names:?}"
+        );
+    }
+    for name in names {
+        let lower = name.to_ascii_lowercase();
+        for needle in FORBIDDEN_TOOL_SUBSTRINGS {
+            assert!(
+                !lower.contains(needle),
+                "tool `{name}` matches forbidden generic-escape substring `{needle}` \
+                 (SCOPE.md non-goal); got: {names:?}"
+            );
+        }
+    }
+}
+
+/// #152: dedicated negative scope guard. The roundtrip test also calls
+/// `assert_forbidden_tools_absent`, but this standalone test localises a
+/// scope-violation failure cleanly and documents the invariant on its
+/// own.
+#[tokio::test]
+async fn tools_list_excludes_scope_nongoals() -> anyhow::Result<()> {
+    let (client, server_handle) = boot_in_memory_server().await?;
+    let tools = client.peer().list_all_tools().await?;
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+
+    assert_forbidden_tools_absent(&names);
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
 }
 
 #[tokio::test]

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -122,6 +122,29 @@ is the optional structured-recovery payload defined in
 [ADR-0023](DECISIONS/0023-denial-context-structured.md). `FetchPlan` is the
 dry-run preview shape — see §10 below.
 
+### 5.1 `denial_context` presence: single-paper vs batch (NORMATIVE)
+
+There is an **intentional, normative asymmetry** in how the optional
+`denial_context` field is represented on an `ok:false` error:
+
+- **Single-paper tools** (`doiget_fetch_paper`, `doiget_metadata_only`,
+  `doiget_resolve_paper`): when there is no denial channel for the error
+  (e.g. a `NETWORK_ERROR`), the `denial_context` key is **omitted**
+  entirely. Agents MUST treat absence and `null` as equivalent ("no
+  structured recovery payload").
+- **`doiget_batch_fetch`** per-ref error entries: the `denial_context`
+  key is **always present**, set to `null` when there is no denial
+  channel. Per-ref rows are uniform table rows in the agent's view, so
+  the explicit `null` lets an agent index every row's
+  `error.denial_context` without a presence test.
+
+An agent that wants to work across both surfaces should read
+`error.denial_context` and treat both *missing* and `null` as "none".
+A serialization failure of a non-`null` `DenialContext` (today
+unreachable — the type is a typed `Serialize` struct) emits `null` **and
+a `tracing::warn!` on stderr** so the swallow is observable; it is never
+silent (see #154 / ADR-0023 §4).
+
 ## 6. Excluded tools (permanent)
 
 The following are intentionally **not** offered as MCP tools and will not be added.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -128,10 +128,16 @@ There is an **intentional, normative asymmetry** in how the optional
 `denial_context` field is represented on an `ok:false` error:
 
 - **Single-paper tools** (`doiget_fetch_paper`, `doiget_metadata_only`,
-  `doiget_resolve_paper`): when there is no denial channel for the error
-  (e.g. a `NETWORK_ERROR`), the `denial_context` key is **omitted**
-  entirely. Agents MUST treat absence and `null` as equivalent ("no
-  structured recovery payload").
+  `doiget_resolve_paper`): the `denial_context` key is **omit-when-None**.
+  When the error *does* carry a structured recovery channel (e.g. a
+  `CAPABILITY_DENIED` allowlist/scheme denial), the key **is present**
+  with the `DenialContext` payload; when there is no denial channel for
+  the error (e.g. a `NETWORK_ERROR`), the key is **omitted** entirely.
+  `doiget_resolve_paper` follows this exact same contract as the other
+  two single-paper tools — it is *not* a tool that can never carry a
+  denial context; the key is simply absent rather than `null` when there
+  is nothing to report. Agents MUST treat absence and `null` as
+  equivalent ("no structured recovery payload").
 - **`doiget_batch_fetch`** per-ref error entries: the `denial_context`
   key is **always present**, set to `null` when there is no denial
   channel. Per-ref rows are uniform table rows in the agent's view, so


### PR DESCRIPTION
## Summary

Review-batch fix for `doiget-mcp`. Scope: only `crates/doiget-mcp/` + `docs/MCP_TOOLS.md` (doc-side reconciliation for #154).

- **#141** `doiget_capability_profile` now emits the NORMATIVE `docs/MCP_TOOLS.md` §7 contract: `{ oa_enabled, metadata_sources: string[], tdm_enabled, tdm_elsevier, tdm_aps, tdm_springer, rate_limit_per_sec }`. `metadata_sources` is the enabled Tier-2 source list. `ok` and `tier_1/2/3` are retained as **additive** back-compat keys (the §7 TS object type is structurally open; the e2e handshake test + pre-#141 agents rely on them). Unit test `capability_profile_to_json_clean_env_shape` and the e2e handshake test updated to assert the spec'd shape.
- **#152** Added a dedicated negative test `tools_list_excludes_scope_nongoals` plus a shared `assert_forbidden_tools_absent` helper (also invoked from the roundtrip smoke test). It asserts `tools/list` never contains `doiget_fetch_url`, `doiget_set_credentials`, `doiget_delete_paper`, and never any name containing `shell`/`exec`/`eval`/`spawn`/`system`/`command`/`subprocess` (defence-in-depth against a future generic-escape tool).
- **#154** All three swallowed `serde_json::to_value(&dc)` sites (metadata_only / fetch_paper / batch_fetch envelopes) now route through a shared `denial_context_to_value(dc, surface)` that emits `tracing::warn!` (stderr) on the `Err` branch instead of a silent `null`. The batch-vs-single `denial_context` presence asymmetry is **documented as NORMATIVE in `docs/MCP_TOOLS.md` §5.1** rather than normalized — see decision below.
- **#156 item ③** Added `#[serde(deny_unknown_fields)]` to `FetchPaperInput` and `MetadataOnlyInput` to match `ResolvePaperInput` (schema advertised strict, deserializer was permissive). Items ①②④ are other PRs.

## Decisions / judgment calls

- **#141 — doc vs code**: the NORMATIVE §7 doc was already correct and stayed unchanged; code was reconciled to it. `ok`/`tier_1/2/3` kept as additive (not spec, not forbidden) so no existing consumer/test breaks. No `docs/MCP_TOOLS.md` §7 edit needed.
- **#154 — asymmetry kept, not normalized**: `tests/fetch_paper_e2e.rs:454-463` asserts the batch per-ref error `denial_context` is *present* AND `null`. Per the issue's explicit instruction ("unless an existing test depends on the null — if so, document the asymmetry"), I documented it in `docs/MCP_TOOLS.md` §5.1 (NORMATIVE) instead of changing the wire shape. The issue also listed `lib.rs:1875`; that line is a `rate_limit_budget` (`to_value(budget)`) fallback over a static always-`Ok` value, not a `denial_context` swallow, so it is intentionally out of scope for this `denial_context` fix (noted here for the reviewer).

## Cargo gate (worktree, all green)

- `cargo fmt --all` — clean
- `cargo clippy -p doiget-mcp --all-targets -- -D warnings` — 0 warnings
- `cargo test -p doiget-mcp` — all suites pass (lib 8, initialize_handshake 7 incl. new negative test, fetch_paper_e2e 8, read_path 7, resolve_paper 4, bibtex_csl 3, doctest 1)

## Follow-ups

- #156 items ① (s2 dead `api_key`), ② (`dry_run.rs` `.expect()` → `Result`), ④ (SCOPE.md count) are doiget-core/docs and out of this crate's scope — separate PRs.
- Optional defence-in-depth from #152: a repo-level posture-lint grep for forbidden tool names in source (beyond the runtime tools/list test).

Closes #141
Closes #152
Closes #154
Part of #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)