### PR TITLE
docs: reconcile planning artifacts with shipped reality (#147 #150 #151 #155 #158)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,28 @@ When proposing a binding decision:
 Do not edit accepted ADRs in place. To revise a decision, write a new ADR that supersedes
 the old one (the old ADR's `Status:` becomes `Superseded by NNNN`).
 
+### ADR acceptance closes the source Discussion
+
+An ADR flips from `Proposed` to `Accepted` when its decision is merged (the
+implementing slice/PR is recorded in the ADR `Status:` line and in
+`docs/DECISIONS/INDEX.md`). When that happens, the **source GitHub Discussion**
+(the `Source Discussion` column in `INDEX.md`) is **locked** and a closing
+comment links the superseding ADR, e.g.:
+
+> Resolved by [ADR-0010](docs/DECISIONS/0010-citation-graph-hard-cap.md)
+> (Accepted, Slice 14). Binding decision now lives in the ADR; this thread is
+> locked for history.
+
+This keeps the binding decision in the source tree (per the ADR rationale —
+Discussions may be deleted) and prevents a resolved Discussion from looking
+like an open question. Locking is a deliberate human action via the GitHub UI
+/ `gh`; it is **not** automated by CI.
+
+> **Follow-up (noted, not done here):** the 19 design Discussions whose ADRs
+> were reconciled to `Accepted` in issue #150 still need this lock + closing
+> comment back-filled. That is tracked separately and is out of scope for the
+> docs-reconciliation PR that introduced this rule.
+
 ## Posture lint
 
 A CI workflow (`.github/workflows/posture-lint.yml`) scans the repository for:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 > A single-binary CLI + stdio MCP server that turns DOIs and arXiv ids into local PDFs through official, OA-first APIs.
 > Designed as the **agent-facing companion** to [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl).
 
-**Status:** Design phase complete (v1.0 spec, 2026-05-05). Phase 0 implementation pending.
-See [docs/PHASES.md](docs/PHASES.md) for the implementation plan.
+**Status:** Shipping — **v0.1.3** on a live `release-plz` pipeline. Tier 1 + Tier 2
+sources, the stdio MCP server, citation-graph expansion, gated TDM sources, and
+OIDC/sigstore release automation are all implemented. See [CHANGELOG.md](CHANGELOG.md)
+for the per-slice history and [docs/PHASES.md](docs/PHASES.md) for the phase plan.
 
 ## Posture
 

--- a/docs/DECISIONS/0002-tdm-feature-gated.md
+++ b/docs/DECISIONS/0002-tdm-feature-gated.md
@@ -1,7 +1,7 @@
 # 0002 - TDM sources are compile-time feature-gated
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; Slices 17/18/19 (Springer / APS / Elsevier TDM sources, each individually `--features tdm-<publisher>` gated; no umbrella flag, enforced by `docs/SCOPE.md` #12/#13 + posture-lint)
 - **Supersedes:** -
 - **Source:** Discussion #5
 

--- a/docs/DECISIONS/0003-pdf-content-out-of-scope.md
+++ b/docs/DECISIONS/0003-pdf-content-out-of-scope.md
@@ -1,7 +1,7 @@
 # 0003 - PDF content processing is permanently out of scope
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — standing policy, enforced; `docs/SCOPE.md` permanent non-goal #1 + posture-lint; no PDF-content code path exists in any shipped slice
 - **Supersedes:** -
 - **Source:** Discussion #9
 

--- a/docs/DECISIONS/0004-bibliofetch-coexistence.md
+++ b/docs/DECISIONS/0004-bibliofetch-coexistence.md
@@ -1,7 +1,7 @@
 # 0004 - BiblioFetch.jl coexistence — shared store contract
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; Store contract in `doiget-core/src/store/` (Phase 1) + BiblioFetch round-trip preservation test (CHANGELOG `0.1.2`, issue #121)
 - **Supersedes:** -
 - **Source:** Discussion #1 / #2
 

--- a/docs/DECISIONS/0005-capability-profile-type-gate.md
+++ b/docs/DECISIONS/0005-capability-profile-type-gate.md
@@ -1,7 +1,7 @@
 # 0005 - CapabilityProfile gates source invocation at the type level
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; `Source` trait + `CapabilityProfile::from_env` (PR #64/#65, Phase 1); Tier 2 / TDM sources gate on `profile.*` flags (Slices 11–19)
 - **Supersedes:** -
 - **Source:** Discussion #16 / #17
 

--- a/docs/DECISIONS/0006-provenance-log-fail-closed.md
+++ b/docs/DECISIONS/0006-provenance-log-fail-closed.md
@@ -1,7 +1,7 @@
 # 0006 - Provenance log is JSON Lines + SHA-256 hash chain (fail-closed)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; provenance writer (JSON Lines + SHA-256 chain, PR #61) + v1→v2 fail-closed migration (Slice 4 / ADR-0024); citation-graph fail-closed on log error (Slice 14)
 - **Supersedes:** -
 - **Source:** Discussion #12 / #17
 

--- a/docs/DECISIONS/0007-safekey-algorithm.md
+++ b/docs/DECISIONS/0007-safekey-algorithm.md
@@ -1,7 +1,7 @@
 # 0007 - safekey algorithm with reference test vectors
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; `Ref::safekey()` (PR #39) + 100-vector NORMATIVE parity set (Slice 3) gated by `.github/workflows/safekey-vectors.yml`
 - **Supersedes:** -
 - **Source:** Discussion #1 §Contract 4 / #17
 

--- a/docs/DECISIONS/0008-crate-decomposition.md
+++ b/docs/DECISIONS/0008-crate-decomposition.md
@@ -1,7 +1,7 @@
 # 0008 - Workspace is split into doiget-core / -cli / -mcp (+ -obsidian opt)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; Cargo workspace with `doiget-core` / `doiget-cli` / `doiget-mcp` members (Phase 0); optional `doiget-obsidian` remains `exclude`d (Phase 7, not yet built)
 - **Supersedes:** -
 - **Source:** Discussion #14 / #18
 

--- a/docs/DECISIONS/0009-mvp-tier-1-only.md
+++ b/docs/DECISIONS/0009-mvp-tier-1-only.md
@@ -1,7 +1,7 @@
 # 0009 - MVP source list is Tier 1 only (Crossref / Unpaywall / arXiv)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; default `oa-only` build ships Tier 1 (Crossref / Unpaywall / arXiv) only (PR #67/#68/#69, Phase 1); Tier 2 is feature-gated and off by default (Slices 10–13)
 - **Supersedes:** -
 - **Source:** Discussion #3
 

--- a/docs/DECISIONS/0010-citation-graph-hard-cap.md
+++ b/docs/DECISIONS/0010-citation-graph-hard-cap.md
@@ -1,7 +1,7 @@
 # 0010 - Citation graph hard-cap (depth=3, total=100, per-paper=20)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; `GraphCaps::clamped` enforces MAX_DEPTH=3 / MAX_TOTAL=100 / MAX_PER_PAPER=20 with cycle detection and no TDM use (Slice 14; exposed via Slice 15 MCP tool + Slice 16 CLI)
 - **Supersedes:** -
 - **Source:** Discussion #6
 

--- a/docs/DECISIONS/0011-phase-plan-v1.md
+++ b/docs/DECISIONS/0011-phase-plan-v1.md
@@ -1,7 +1,7 @@
 # 0011 - Phase plan v1 — MVP at 5 weeks, Phase 5 deferred-by-default
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — realized; the phase plan was executed through Phase 6 (see `docs/PHASES.md` §1 per-phase status table). Phase 5 was *not* deferred — all three TDM sub-phases shipped (Slices 17–19)
 - **Supersedes:** -
 - **Source:** Discussion #7
 

--- a/docs/DECISIONS/0012-mcp-tool-naming.md
+++ b/docs/DECISIONS/0012-mcp-tool-naming.md
@@ -1,7 +1,7 @@
 # 0012 - MCP tool naming + structured ok-false errors
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; the `doiget_*` tool surface + structured `ok:false` envelopes are wired across Slices 1/2/7/8/15 (10-tool Phase-3 baseline + Phase-4 citation tool)
 - **Supersedes:** -
 - **Source:** Discussion #8
 

--- a/docs/DECISIONS/0013-ci-baseline.md
+++ b/docs/DECISIONS/0013-ci-baseline.md
@@ -1,7 +1,7 @@
 # 0013 - CI baseline (workflows, OIDC publish, sigstore signing)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; Phase-0 9-workflow CI baseline + Slice 9 real MCP smoke gate + OIDC publish (Slice 22) + release-sign/SBOM workflow (commit `5a108dd`, v0.1.3)
 - **Supersedes:** -
 - **Source:** Discussion #10
 

--- a/docs/DECISIONS/0014-docs-class-system.md
+++ b/docs/DECISIONS/0014-docs-class-system.md
@@ -1,7 +1,7 @@
 # 0014 - Docs split into NORMATIVE / INFORMATIVE with ADR change-control
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; every doc carries a `Status: NORMATIVE`/`INFORMATIVE` banner, ADRs live in `docs/DECISIONS/` (Nygard format), and NORMATIVE changes require an ADR (CODEOWNERS-gated). In force since Phase 0
 - **Supersedes:** -
 - **Source:** Discussion #11
 

--- a/docs/DECISIONS/0015-no-telemetry.md
+++ b/docs/DECISIONS/0015-no-telemetry.md
@@ -1,7 +1,7 @@
 # 0015 - No telemetry / phone-home / self-update
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — standing policy, enforced; `docs/SCOPE.md` non-goals #10/#11 + `.github/workflows/posture-lint.yml` (telemetry/self-update crate + endpoint guard); no phone-home path in any shipped slice
 - **Supersedes:** -
 - **Source:** Discussion #12
 

--- a/docs/DECISIONS/0016-foundation-crates.md
+++ b/docs/DECISIONS/0016-foundation-crates.md
@@ -1,7 +1,7 @@
 # 0016 - Common foundation crates + deny list
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented; shared `Cargo.toml` workspace deps + root `deny.toml` ban list (bans `openssl`/`native-tls`) in force since Phase 0, gated by `.github/workflows/audit.yml`
 - **Supersedes:** -
 - **Source:** Discussion #13
 

--- a/docs/DECISIONS/0017-output-mode-resolution.md
+++ b/docs/DECISIONS/0017-output-mode-resolution.md
@@ -1,7 +1,7 @@
 # 0017 - Output mode resolution (flag > env > implicit > TTY > quiet)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — implemented (load-bearing invariant); MCP mode forbids non-JSON stdout and tracing is redirected to stderr — enforced by the Slice 9 `stdout-purity` CI job + Slice 1 `metadata_only` wiring. *(Judgment call: the full `--mode`/`DOIGET_MODE`/TTY resolution ladder has no dedicated CHANGELOG slice; the security-critical half of the decision is verifiably shipped, so this is Accepted rather than Proposed.)*
 - **Supersedes:** -
 - **Source:** Discussion #14
 

--- a/docs/DECISIONS/0018-obsidian-one-direction.md
+++ b/docs/DECISIONS/0018-obsidian-one-direction.md
@@ -1,7 +1,7 @@
 # 0018 - Obsidian export is one-direction, optional Phase 7
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Proposed — *intentionally not yet Accepted*; the decision is genuinely unrealized. `doiget-obsidian` is a Phase 7 default-OFF crate still `exclude`d in `Cargo.toml`; no store→vault sync code has shipped (no CHANGELOG slice). Flips to Accepted only once the Phase 7 crate lands
 - **Supersedes:** -
 - **Source:** Discussion #15
 

--- a/docs/DECISIONS/0019-eight-safeguards.md
+++ b/docs/DECISIONS/0019-eight-safeguards.md
@@ -1,7 +1,7 @@
 # 0019 - Eight-safeguard legal posture (5 social + 3 technical)
 
 - **Date:** 2026-05-05
-- **Status:** Proposed
+- **Status:** Accepted — standing posture, enforced; the 5 social + 3 technical safeguards are realized across `docs/LEGAL.md`/`SCOPE.md` + posture-lint + the capability-gate / redirect-allowlist / provenance-log technical controls (Phase 1 onward)
 - **Supersedes:** -
 - **Source:** Discussion #16
 

--- a/docs/DECISIONS/0020-reqwest-tls-feature-stack.md
+++ b/docs/DECISIONS/0020-reqwest-tls-feature-stack.md
@@ -1,7 +1,7 @@
 # 0020 - reqwest TLS feature stack (rustls-only, webpki bundled)
 
 - **Date:** 2026-05-06
-- **Status:** Proposed
+- **Status:** Accepted — implemented; `reqwest` on the rustls + bundled-webpki-roots stack (PR #30, refined PR #49); `openssl`/`native-tls` banned by `deny.toml`
 - **Supersedes:** -
 - **Source:** PR #30, PR #49
 

--- a/docs/DECISIONS/0022-dry-run-mode.md
+++ b/docs/DECISIONS/0022-dry-run-mode.md
@@ -1,7 +1,7 @@
 # 0022 - Dry-run mode for fetch operations
 
 - **Date:** 2026-05-12
-- **Status:** Proposed
+- **Status:** Accepted — implemented; `dry_run` returns a `FetchPlan` without touching network/store on `doiget_fetch_paper`/`doiget_batch_fetch` + CLI `fetch`/`batch` (Slice 2; option bundle simplified in Slice 5)
 - **Supersedes:** -
 - **Source:** Discussion #12 (musaabhasan, 2026-05-08)
 

--- a/docs/DECISIONS/0023-denial-context-structured.md
+++ b/docs/DECISIONS/0023-denial-context-structured.md
@@ -1,7 +1,7 @@
 # 0023 - Structured `denial_context` on error envelopes
 
 - **Date:** 2026-05-12
-- **Status:** Proposed
+- **Status:** Accepted — implemented; failure envelopes carry the structured `denial_context` channel for denial-class errors on the metadata/fetch/batch paths (Slices 1/2; docstring §-refs tightened in Slice 5 A7/A8)
 - **Supersedes:** -
 - **Source:** Discussion #12 (musaabhasan, 2026-05-09)
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -12,38 +12,45 @@ See [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) §"ADR workflow".
 
 ## Index
 
-| # | Title | Status | Source Discussion |
-|---|---|---|---|
-| 0001 | MCP transport is stdio only | Accepted | #4 |
-| 0002 | TDM sources are compile-time feature-gated | Proposed | #5 |
-| 0003 | PDF content processing is permanently out of scope | Proposed | #9 |
-| 0004 | BiblioFetch.jl coexistence — shared store contract | Proposed | #1 / #2 |
-| 0005 | CapabilityProfile gates source invocation at the type level | Proposed | #16 / #17 |
-| 0006 | Provenance log is JSON Lines + SHA-256 hash chain (fail-closed) | Proposed | #12 / #17 |
-| 0007 | safekey algorithm with 100 reference test vectors | Proposed | #1 §Contract 4 / #17 |
-| 0008 | Workspace is split into doiget-core / -cli / -mcp (+ -obsidian opt) | Proposed | #14 / #18 |
-| 0009 | MVP source list is Tier 1 only (Crossref / Unpaywall / arXiv) | Proposed | #3 |
-| 0010 | Citation graph hard-cap (depth=3, total=100, per-paper=20) | Proposed | #6 |
-| 0011 | Phase plan v1 — MVP at 5 weeks, Phase 5 deferred-by-default | Proposed | #7 |
-| 0012 | MCP tool naming + structured ok-false errors | Proposed | #8 |
-| 0013 | CI baseline (9 workflows, OIDC publish, sigstore signing) | Proposed | #10 |
-| 0014 | Docs split into NORMATIVE / INFORMATIVE with ADR change-control | Proposed | #11 |
-| 0015 | No telemetry / phone-home / self-update | Proposed | #12 |
-| 0016 | Common foundation crates + deny list | Proposed | #13 |
-| 0017 | Output mode resolution (flag > env > implicit > TTY > quiet) | Proposed | #14 |
-| 0018 | Obsidian export is one-direction, optional Phase 7 | Proposed | #15 |
-| 0019 | Eight-safeguard legal posture (5 social + 3 technical) | Proposed | #16 |
-| 0020 | reqwest TLS feature stack (rustls-only, webpki bundled) | Proposed | PR #30 / PR #49 |
-| 0021 | Canonical-tuple identity for fetched papers (spec-only) | Superseded by 0024 (impl); §1–§4 NORMATIVE remains binding | #12 |
-| 0022 | Dry-run mode for fetch operations | Proposed | #12 |
-| 0023 | Structured `denial_context` on error envelopes | Proposed | #12 |
-| 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 |
+Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
+"Accepted" rows note the implementing slice/PR in the ADR file's `Status:` line.
+
+| # | Title | Status | Implemented by | Source Discussion |
+|---|---|---|---|---|
+| 0001 | MCP transport is stdio only | Accepted | posture-lint + Slice 9 stdout-purity | #4 |
+| 0002 | TDM sources are compile-time feature-gated | Accepted | Slices 17/18/19 | #5 |
+| 0003 | PDF content processing is permanently out of scope | Accepted | standing policy (SCOPE.md #1 + posture-lint) | #9 |
+| 0004 | BiblioFetch.jl coexistence — shared store contract | Accepted | Phase 1 store + #121 (`0.1.2`) | #1 / #2 |
+| 0005 | CapabilityProfile gates source invocation at the type level | Accepted | PR #64/#65 (Phase 1) | #16 / #17 |
+| 0006 | Provenance log is JSON Lines + SHA-256 hash chain (fail-closed) | Accepted | PR #61 + Slice 4 | #12 / #17 |
+| 0007 | safekey algorithm with 100 reference test vectors | Accepted | PR #39 + Slice 3 | #1 §Contract 4 / #17 |
+| 0008 | Workspace is split into doiget-core / -cli / -mcp (+ -obsidian opt) | Accepted | Phase 0 workspace | #14 / #18 |
+| 0009 | MVP source list is Tier 1 only (Crossref / Unpaywall / arXiv) | Accepted | PR #67/#68/#69 (Phase 1) | #3 |
+| 0010 | Citation graph hard-cap (depth=3, total=100, per-paper=20) | Accepted | Slice 14 | #6 |
+| 0011 | Phase plan v1 — MVP at 5 weeks, Phase 5 deferred-by-default | Accepted | executed through Phase 6 | #7 |
+| 0012 | MCP tool naming + structured ok-false errors | Accepted | Slices 1/2/7/8/15 | #8 |
+| 0013 | CI baseline (9 workflows, OIDC publish, sigstore signing) | Accepted | Phase 0 + Slices 9/22 + `5a108dd` | #10 |
+| 0014 | Docs split into NORMATIVE / INFORMATIVE with ADR change-control | Accepted | Phase 0 (in force) | #11 |
+| 0015 | No telemetry / phone-home / self-update | Accepted | standing policy (SCOPE.md #10/#11 + posture-lint) | #12 |
+| 0016 | Common foundation crates + deny list | Accepted | Phase 0 (deny.toml) | #13 |
+| 0017 | Output mode resolution (flag > env > implicit > TTY > quiet) | Accepted | Slice 9 stdout-purity + Slice 1 (see ADR note) | #14 |
+| 0018 | Obsidian export is one-direction, optional Phase 7 | Proposed (Phase 7, unshipped) | — | #15 |
+| 0019 | Eight-safeguard legal posture (5 social + 3 technical) | Accepted | standing posture (Phase 1 onward) | #16 |
+| 0020 | reqwest TLS feature stack (rustls-only, webpki bundled) | Accepted | PR #30 / PR #49 | PR #30 / PR #49 |
+| 0021 | Canonical-tuple identity for fetched papers (spec-only) | Superseded by 0024 (impl); §1–§4 NORMATIVE remains binding | Slice 4 (via 0024) | #12 |
+| 0022 | Dry-run mode for fetch operations | Accepted | Slice 2 | #12 |
+| 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |
+| 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
 
 ## Conventions
 
 - Filename: `NNNN-<short-slug>.md` (e.g. `0001-stdio-only.md`).
 - All ADRs reference relevant NORMATIVE docs (`../LEGAL.md`, etc.).
 - An ADR is created **before** any code change that locks the decision.
+- **An ADR flips from `Proposed` to `Accepted` when its decision is merged**
+  (the implementing slice/PR is noted in the ADR's `Status:` line and in the
+  "Implemented by" column above). An ADR whose decision is not yet realized
+  stays `Proposed`.
 - Once accepted, an ADR is never edited in place. To change a decision, write a new
   ADR with `Supersedes: NNNN` and update the old ADR's `Status:` to
   `Superseded by NNNN`.

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -37,9 +37,13 @@ three TDM sub-phases shipped — see status table below.)*
 
 ### Per-phase completion status
 
-Status is derived from [`CHANGELOG.md`](../CHANGELOG.md) slices and `git log` tag
-dates only (no dates are invented; `0.0.0` cut = 2026-05-15, the `0.1.x` line =
-2026-05-17).
+Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings and
+the slice entries within them, with the annotated `doiget-{core,cli,mcp}-v0.1.x`
+git tags backing the `0.1.1`–`0.1.3` lines. No dates are invented: the `0.0.0`
+cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
+`v0.0.0` tag — while the `0.1.1`–`0.1.3` tags are dated 2026-05-17. The TDM work
+(Slices 17–19) is recorded under the `## [0.0.0]` CHANGELOG section, i.e. the
+2026-05-15 dev cut, not the later `0.1.x` tags.
 
 | Phase | Status | Evidence (CHANGELOG slice / version) |
 |---|---|---|

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -21,14 +21,42 @@
 | 6 | Release: OIDC + sigstore + SBOM + landing page polish + auto-tag (`release-plz`) | 1 week |
 | 7 | Optional features (`vault`, `obsidian`) | per feature |
 
-> **Phase 6 auto-tag note.** Version bumps and tags are deferred to Phase 6 via
-> [`release-plz`](https://release-plz.dev) — Conventional Commits drive a
-> Cargo.toml version bump PR, which when merged tags and (with OIDC trusted
-> publishing) ships to crates.io. Phase 0 carries no `release-plz.toml` yet;
-> until Phase 6 the version stays `0.0.0` and tags are not minted.
+> **Phase 6 auto-tag note (live as of 2026-05-17).** Phase 6 has landed.
+> [`release-plz`](https://release-plz.dev) is wired (Slice 21) and trusted
+> publishing is on (Slice 22): every push to `main` opens/updates a release PR
+> that bumps the shared workspace version and prepends a versioned `CHANGELOG.md`
+> section; merging it pushes annotated `doiget-{core,cli,mcp}-vX.Y.Z` tags,
+> opens a GitHub release, and publishes to crates.io via OIDC. The workspace is
+> **no longer `0.0.0`** — `Cargo.toml` is `0.1.3` and the `v0.1.0`–`v0.1.3`
+> tag triplets exist. See [`CHANGELOG.md`](../CHANGELOG.md) for the released
+> versions and [`release-plz.toml`](../release-plz.toml) for the configuration.
 
 **Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
-Phase 0–4 production usage and any publisher-side correspondence.
+Phase 0–4 production usage and any publisher-side correspondence. *(Not skipped: all
+three TDM sub-phases shipped — see status table below.)*
+
+### Per-phase completion status
+
+Status is derived from [`CHANGELOG.md`](../CHANGELOG.md) slices and `git log` tag
+dates only (no dates are invented; `0.0.0` cut = 2026-05-15, the `0.1.x` line =
+2026-05-17).
+
+| Phase | Status | Evidence (CHANGELOG slice / version) |
+|---|---|---|
+| **0** | Complete (2026-05-15) | Phase-0 skeleton + normative specs + ADRs + 9 CI workflows; `0.0.0` section |
+| **1** | Complete (2026-05-15) | Core resolver, Tier 1 Crossref/Unpaywall/arXiv, `fetch`/`batch`/audit-log (#64–#78); Slices 1–6 |
+| **2** | Complete (2026-05-17) | Store + metadata read path; `bib`/`csl` exports via Slice 15b (`0.1.1`); BiblioFetch round-trip (#121, `0.1.2`) |
+| **3** | Complete (2026-05-17) | MCP server + 10-tool baseline (Slices 7–9); strict stdio (Slice 9 `stdout-purity`) |
+| **4** | Complete | Tier 2 OpenAlex/S2/DOAJ + citation graph (Slices 10–16, ADR-0010) |
+| **5a** | Complete | Springer Nature OA TDM (Slice 17) |
+| **5b** | Complete | APS Harvest TDM (Slice 18) |
+| **5c** | Complete | Elsevier ScienceDirect TDM (Slice 19) + per-source header hook (Slice 20) |
+| **6** | Complete (live) | `release-plz` PR flow (Slice 21) + OIDC trusted publishing (Slice 22); `0.1.0`–`0.1.3` released |
+| **7** | Not started | Optional `vault`/`obsidian` crate is `exclude`d in `Cargo.toml` (ADR-0008) |
+
+The Phase-0 checklist in §2 below is retained as the historical deliverable record;
+its boxes reflect what was committed. Per-version release dates live in
+[`CHANGELOG.md`](../CHANGELOG.md).
 
 ## 2. Phase 0 deliverable checklist
 
@@ -93,9 +121,14 @@ Phase 0 is complete when **all** of the following are committed.
 ### Repo-level settings (manual; cannot be committed)
 
 - [ ] Branch protection on `main`: required PR review, required status checks, signed
-      commits.
+      commits. *(unverified: repo-settings/external — not observable from the tree.)*
 - [ ] 2FA mandatory on the maintainer account.
+      *(unverified: repo-settings/external.)*
 - [ ] Default branch protection includes Action SHA pinning policy.
+      *(unverified: repo-settings/external — note: the workflow actions themselves
+      are SHA-pinned in-tree, e.g. `.github/workflows/release-plz.yml`
+      `actions/checkout@de0fac2…`, `release-plz/action@064f4d1…`; the branch-level
+      enforcement *policy* is still a repo-settings claim.)*
 
 ### Test fixtures
 
@@ -104,11 +137,23 @@ Phase 0 is complete when **all** of the following are committed.
 
 ### Pre-flight items (must be confirmed before Phase 0 begins)
 
-- [ ] Confirm BiblioFetch.jl's current safekey algorithm matches
+- [x] Confirm BiblioFetch.jl's current safekey algorithm matches
       [`SAFEKEY.md`](SAFEKEY.md) §3, or arrange a coordinated bump.
-- [ ] Confirm BiblioFetch.jl's current TOML `schema_version`.
+      *(verified: the 100-vector NORMATIVE parity set landed in Slice 3 and the
+      cross-tool store round-trip — typed `[bibliofetch]` table + unknown scalar
+      preservation — landed in CHANGELOG `0.1.2` / issue #121, exercised in
+      `crates/doiget-core/src/store/metadata.rs`.)*
+- [x] Confirm BiblioFetch.jl's current TOML `schema_version`.
+      *(verified: `schema_version = "1.0"` is the binding value in
+      [`STORE.md`](STORE.md) §; the round-trip test asserts unknown/foreign
+      tables survive read-modify-write, so a BiblioFetch-written schema is
+      preserved.)*
 - [ ] Verify maintainer's `crates.io` account is set up for trusted publishing (OIDC).
+      *(partial — the OIDC release job is wired in-tree (Slice 22,
+      `.github/workflows/release-plz.yml`), but the one-time crates.io Trusted
+      Publisher registration is unverified: repo-settings/external.)*
 - [ ] Verify GitHub Environment is configurable for the release workflow.
+      *(unverified: repo-settings/external.)*
 
 ## 3. Phase 0 working principles
 
@@ -133,9 +178,15 @@ have been confirmed. Phase 1's success criterion is:
 
 Phase progress is tracked through:
 
-- This file's checklist.
-- `CHANGELOG.md` `[Unreleased]` section.
-- GitHub issues labeled `phase-0`, `phase-1`, etc.
+- The **per-phase completion status table** in §1 above (the authoritative
+  current-state view).
+- `CHANGELOG.md` — each unit of work lands as a numbered **Slice** entry tagging
+  its phase (e.g. *"Slice 14 — Citation graph BFS expansion (ADR-0010, Phase 4)"*);
+  released versions carry their date in the `## [X.Y.Z] - YYYY-MM-DD` heading.
+  This is the real tracking mechanism — there are **no** `phase-N` GitHub issue
+  labels (the original plan to use them was never adopted).
+- `git log` / git tags (`doiget-{core,cli,mcp}-vX.Y.Z`) for release dates.
 
-When a Phase completes, this document gets updated with the completion date and a brief
-summary, and the next Phase's checklist becomes active.
+When a Phase completes, the §1 status table is updated with the completion date
+(derived from the CHANGELOG slice / tag, never invented) and a one-line evidence
+pointer; the next Phase's slices then begin landing in `CHANGELOG.md`.

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -23,7 +23,9 @@ explicitly out of scope below or requires a new ADR.
 
 ## Two classes of non-goal
 
-doiget's non-goals split into two classes:
+doiget enumerates **19 non-goals total**, continuously numbered 1–19 (a stable
+`§non-goal N` reference scheme), split into two classes — **14 permanent**
+(items 1–14) and **5 current design choices** (items 15–19):
 
 - **Permanent non-goals.** Reversing one would weaken the
   [`LEGAL.md`](LEGAL.md) posture, the [`SECURITY.md`](SECURITY.md) threat
@@ -45,7 +47,7 @@ A future ADR may freely move an item from "Current design choices" to
 scope-reopening Discussion. Moving the other way (Permanent → Current →
 Removed) requires the full meta-rule.
 
-## Permanent non-goals (14)
+## Permanent non-goals (14 — items 1–14 of 19)
 
 ### Content / processing
 
@@ -113,7 +115,7 @@ Removed) requires the full meta-rule.
     explicitly in scope and is **not** governed by item #1 above. This is the
     same boundary [`LEGAL.md`](LEGAL.md) §3 documents.
 
-## Current design choices (5)
+## Current design choices (5 — items 15–19 of 19)
 
 These are out of scope **today** because the maintainer judges them more
 trouble than they're worth at the current Phase, but they do not threaten the

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -51,7 +51,7 @@ cargo install doiget --features metadata,tdm-aps
 cargo install doiget --features metadata,tdm-elsevier
 ```
 
-There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 16).
+There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 ## 4. Source-specific notes
 


### PR DESCRIPTION
## Summary

The planning artifacts were frozen at the 2026-05-05 Phase-0 snapshot while
Phases 1–6 actually shipped (CHANGELOG slices, `release-plz` live, current
workspace version **v0.1.3**). This PR makes the docs true. Markdown only — no
Rust/code touched. Dates derived strictly from `CHANGELOG.md` / `git log`
(`0.0.0` cut = 2026-05-15; the `0.1.x` line = 2026-05-17); no dates invented.

- **#147** — `docs/PHASES.md`: rewrote the Phase-6 auto-tag note (release-plz +
  OIDC live; workspace is `0.1.3`, not `0.0.0`); replaced §5 "Tracking" (the
  non-existent `phase-0`/`phase-1` GitHub labels → the real mechanism: numbered
  CHANGELOG **Slice** entries + git tags); added a per-phase completion status
  table with evidence pointers.
- **#150** — flipped ADR-0002–0023 `Status:` to `Accepted` with the implementing
  slice/PR noted in each file; reconciled `docs/DECISIONS/INDEX.md` (new
  "Implemented by" column); added the governance rule "an ADR flips to Accepted
  when its decision is merged". **ADR-0018 (Obsidian) kept `Proposed`** — its
  Phase-7 `doiget-obsidian` crate is still `exclude`d in `Cargo.toml` and no
  store→vault code shipped; the ADR now says so explicitly. (0001/0024 were
  already Accepted; 0021 stays Superseded-by-0024.)
- **#151** — added a `CONTRIBUTING.md` rule under §"ADR workflow": an Accepted
  ADR's source Discussion is locked + linked to the superseding ADR. Documented
  only — no Discussions were locked/closed via `gh`; backfilling the 19 is noted
  as an explicit out-of-scope follow-up.
- **#155** — checked off only repo-verifiable PHASES.md pre-flight items
  (BiblioFetch round-trip / `schema_version` — issue #121, CHANGELOG `0.1.2`,
  `crates/doiget-core/src/store/metadata.rs`). Branch protection / 2FA / crates.io
  Trusted Publisher / GH Environment left `[ ]` with an
  "(unverified: repo-settings/external)" note. crates.io OIDC marked partial
  (job wired in-tree, registration external).
- **#158** — rewrote `README.md` `**Status:**` from "Phase 0 implementation
  pending" to the v0.1.3 shipped reality, pointing to `CHANGELOG.md`.
- **Part of #156** (item ④ only) — `docs/SCOPE.md`: fixed the
  count/grouping. The two per-class counts (14 + 5) were already individually
  correct; the defect was the continuous 1–19 numbering making
  "Permanent non-goals (14)" read as a 19-item list. Headings/intro now state
  **19 total = 14 permanent (1–14) + 5 current (15–19)**. Items ①②③ of #156 are
  handled in other PRs.

## Decisions / judgment calls

- **Version is v0.1.3, not v0.1.2.** The task brief referenced v0.1.2, but
  `Cargo.toml`, the git tags, and `chore: release v0.1.3` in `git log` show the
  tree is at **0.1.3** (v0.1.0=2026-05-15; v0.1.1/0.1.2/0.1.3=2026-05-17). Per
  "make content true", the docs use the verifiable real state (0.1.3).
- **ADR-0017 → Accepted (not Proposed).** The full `--mode`/`DOIGET_MODE`/TTY
  ladder has no dedicated CHANGELOG slice, but the security-load-bearing half
  (MCP forbids non-JSON stdout; tracing→stderr) is verifiably shipped via the
  Slice 9 `stdout-purity` CI gate + Slice 1 wiring. Marked Accepted with this
  caveat recorded in the ADR's Status line.
- **SCOPE.md numbering preserved.** `§non-goal N` is a referenced scheme
  (`docs/SOURCES.md`, `docs/MCP_TOOLS.md`, ADR-0001). Renumbering would break
  those refs, so the fix clarifies headings/intro without renumbering 1–19.
- **SCOPE.md numbering preserved exposes a pre-existing unrelated bug:**
  `docs/SOURCES.md:54` cites "`SCOPE.md` §non-goal 16" for the `tdm-all` rule,
  but `tdm-all` is non-goal **#12** (#16 is "no generic shell/exec tool").
  Out of scope for #156 ④ — flagged here as a discovered follow-up, not fixed.

## Follow-ups discovered

- Back-fill the 19 source Discussions with the lock + closing ADR link (the new
  CONTRIBUTING.md rule; human/`gh` action, intentionally not done here).
- Fix the stale `docs/SOURCES.md:54` `§non-goal 16` → `§non-goal 12` cross-ref.

Closes #147
Closes #150
Closes #151
Closes #155
Closes #158
Part of #156

DO NOT merge / no automerge — review & manual merge by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)