### PR TITLE
fix(core): credential hygiene + dry-run robustness (#146 #153 #156)

### DIFF
--- a/crates/doiget-core/src/dry_run.rs
+++ b/crates/doiget-core/src/dry_run.rs
@@ -24,6 +24,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use serde::Serialize;
 
 use crate::http::{oa_publisher_allowlist, tier_1_allowlist, SourceAllowlist};
+use crate::source::FetchError;
 use crate::{RateLimits, Ref};
 
 /// Per-PDF-source row inside [`FetchPlan::pdf_sources`].
@@ -109,19 +110,84 @@ pub fn rate_limit_budget() -> RateLimitBudget {
 /// publisher), reflecting `doiget-cli::commands::fetch::build_http_client`'s
 /// composition.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics with a self-documenting message if the in-crate allowlist
-/// builders ([`oa_publisher_allowlist`] / [`tier_1_allowlist`]) ever stop
-/// returning the source keys this function looks up. That signals an
-/// internal-contract drift bug, not a user error — fail-fast at preview
-/// time is preferable to silently emitting an empty `candidate_hosts`
-/// list. The workspace `clippy::expect_used` lint is `warn`-level
-/// (promoted to `deny` under `-D warnings`); the localized `#[allow]` is
-/// the minimal intervention here, mirroring the pattern in
-/// `crate::http::HttpClient::new_for_tests_allow_http`.
-#[allow(clippy::expect_used)]
+/// This infallible-looking wrapper never returns `Err` — it delegates to
+/// [`try_build_fetch_plan`] and, on the (should-be-impossible) internal
+/// allowlist-contract drift, falls back to an empty `candidate_hosts`
+/// list for the affected PDF source rather than panicking (issue #156 ②:
+/// a stray `.expect()` here crashed `doiget plan` if a source key was
+/// ever renamed). Callers that want to *observe* the invariant violation
+/// as a typed error should call [`try_build_fetch_plan`] directly; this
+/// function's signature is kept infallible because it is `pub` and has
+/// non-`doiget-core` callers (`doiget-mcp`, `doiget-cli`) whose
+/// signatures must not change in this batch.
+///
+/// The empty-`candidate_hosts` fallback is the lesser evil versus a
+/// panic: a preview with an empty allowlist is visibly wrong (and is
+/// what `try_build_fetch_plan` flags as `SourceSchema`), whereas a panic
+/// takes down `doiget plan` entirely. This path is unreachable unless
+/// [`oa_publisher_allowlist`] / [`tier_1_allowlist`] are edited to drop
+/// the `"oa-publisher"` / `"arxiv"` keys, which the in-crate tests pin.
 pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
+    try_build_fetch_plan(ref_, store_root).unwrap_or_else(|_| {
+        // Internal-contract drift (allowlist key renamed): degrade to an
+        // empty `candidate_hosts` instead of panicking `doiget plan`.
+        // `try_build_fetch_plan` is the API that surfaces this as a
+        // typed `FetchError::SourceSchema`.
+        let safekey = ref_.safekey();
+        let target_pdf_path = store_root.join(format!("{}.pdf", safekey.as_str()));
+        let target_metadata_path = store_root
+            .join(".metadata")
+            .join(format!("{}.toml", safekey.as_str()));
+        let (metadata_sources, pdf_key) = match ref_ {
+            Ref::Doi(_) => (
+                vec!["crossref".to_string(), "unpaywall".to_string()],
+                "oa-publisher",
+            ),
+            Ref::Arxiv(_) => (Vec::<String>::new(), "arxiv"),
+        };
+        FetchPlan {
+            metadata_sources,
+            pdf_sources: vec![PdfSourcePlan {
+                key: pdf_key.to_string(),
+                candidate_hosts: Vec::new(),
+            }],
+            redirect_allowlists_loaded: tier_1_allowlist()
+                .iter()
+                .chain(oa_publisher_allowlist().iter())
+                .map(|a| a.source.clone())
+                .collect(),
+            target_pdf_path,
+            target_metadata_path,
+            would_append_provenance: true,
+            candidate_hosts_are_upper_bound: true,
+        }
+    })
+}
+
+/// Fallible builder for the dry-run preview ([`FetchPlan`]).
+///
+/// Identical to [`build_fetch_plan`] on the happy path, but propagates an
+/// internal allowlist-contract drift as a typed
+/// [`FetchError::SourceSchema`] (which maps to
+/// [`crate::ErrorCode::InternalError`] at the public boundary — the
+/// correct closed-set fit for an internal-invariant violation) instead
+/// of panicking. This is the API issue #156 ② asks for; it is added
+/// alongside the existing infallible [`build_fetch_plan`] rather than
+/// replacing it, because `build_fetch_plan` is `pub` and called from
+/// `doiget-mcp` / `doiget-cli`, whose signatures are out of scope for
+/// this change batch.
+///
+/// # Errors
+///
+/// Returns [`FetchError::SourceSchema`] if the in-crate allowlist
+/// builders ([`oa_publisher_allowlist`] / [`tier_1_allowlist`]) stop
+/// returning the `"oa-publisher"` / `"arxiv"` source keys this function
+/// looks up — an internal-contract drift bug, surfaced rather than
+/// panicked (issue #156 ②). The in-crate tests pin the keys so this is
+/// unreachable in a correct build.
+pub fn try_build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> Result<FetchPlan, FetchError> {
     let safekey = ref_.safekey();
     let target_pdf_path = store_root.join(format!("{}.pdf", safekey.as_str()));
     let target_metadata_path = store_root
@@ -131,21 +197,24 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
     let (metadata_sources, pdf_sources) = match ref_ {
         Ref::Doi(_) => {
             // Internal contract: `oa_publisher_allowlist()` MUST always
-            // return an entry whose `.source == "oa-publisher"`. Silent
+            // return an entry whose `.source == "oa-publisher"`. A silent
             // `.unwrap_or_default()` here would mask drift between this
             // function and the allowlist source-of-truth — the resulting
             // empty `candidate_hosts` would mislead an agent into
-            // believing the OA leg has no allowed hosts.
+            // believing the OA leg has no allowed hosts. Issue #156 ②:
+            // surface the drift as a typed error rather than `.expect()`
+            // panicking `doiget plan`.
             let oa_hosts = oa_publisher_allowlist()
                 .into_iter()
                 .find(|a: &SourceAllowlist| a.source == "oa-publisher")
                 .map(|a| a.redirect_hosts)
-                .expect(
-                    "oa-publisher allowlist must exist (see \
-                     crates/doiget-core/src/http.rs::oa_publisher_allowlist); \
-                     if this fires, build_fetch_plan and oa_publisher_allowlist \
-                     have drifted",
-                );
+                .ok_or_else(|| FetchError::SourceSchema {
+                    hint: "internal-contract drift: oa-publisher allowlist \
+                           missing (see crates/doiget-core/src/http.rs::\
+                           oa_publisher_allowlist); build_fetch_plan and \
+                           oa_publisher_allowlist have drifted"
+                        .to_string(),
+                })?;
             (
                 vec!["crossref".to_string(), "unpaywall".to_string()],
                 vec![PdfSourcePlan {
@@ -160,12 +229,13 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
                 .into_iter()
                 .find(|a: &SourceAllowlist| a.source == "arxiv")
                 .map(|a| a.redirect_hosts)
-                .expect(
-                    "tier-1 allowlist must include 'arxiv' (see \
-                     crates/doiget-core/src/http.rs::tier_1_allowlist); \
-                     if this fires, build_fetch_plan and tier_1_allowlist \
-                     have drifted",
-                );
+                .ok_or_else(|| FetchError::SourceSchema {
+                    hint: "internal-contract drift: tier-1 allowlist missing \
+                           'arxiv' (see crates/doiget-core/src/http.rs::\
+                           tier_1_allowlist); build_fetch_plan and \
+                           tier_1_allowlist have drifted"
+                        .to_string(),
+                })?;
             (
                 Vec::<String>::new(),
                 vec![PdfSourcePlan {
@@ -188,7 +258,7 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
         .map(|a| a.source.clone())
         .collect();
 
-    FetchPlan {
+    Ok(FetchPlan {
         metadata_sources,
         pdf_sources,
         redirect_allowlists_loaded,
@@ -201,7 +271,7 @@ pub fn build_fetch_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
         // real fetch would touch. Surfaced on the wire so agents can
         // detect the upper-bound semantics without parsing the spec.
         candidate_hosts_are_upper_bound: true,
-    }
+    })
 }
 
 /// Build the dry-run envelope as a `serde_json::Value`, without writing
@@ -335,6 +405,32 @@ mod tests {
             "plan.candidate_hosts_are_upper_bound must be true on the \
              wire (ADR-0022 §4); got: {env}"
         );
+    }
+
+    #[test]
+    fn try_build_fetch_plan_ok_matches_build_fetch_plan() {
+        // Issue #156 ②: the fallible variant must produce a plan
+        // structurally identical to the infallible wrapper on the happy
+        // path (the allowlist invariant holds in a correct build).
+        for r in [
+            Ref::Doi(Doi("10.1234/example".to_string())),
+            Ref::Arxiv(ArxivId("2401.12345".to_string())),
+        ] {
+            let root = temp_root();
+            let fallible = try_build_fetch_plan(&r, &root).expect("invariant holds");
+            let infallible = build_fetch_plan(&r, &root);
+            assert_eq!(fallible.metadata_sources, infallible.metadata_sources);
+            assert_eq!(fallible.pdf_sources[0].key, infallible.pdf_sources[0].key);
+            assert_eq!(
+                fallible.pdf_sources[0].candidate_hosts,
+                infallible.pdf_sources[0].candidate_hosts
+            );
+            assert!(
+                !fallible.pdf_sources[0].candidate_hosts.is_empty(),
+                "happy-path candidate_hosts must be populated, not the \
+                 degraded empty fallback"
+            );
+        }
     }
 
     #[test]

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -751,7 +751,14 @@ impl HttpClient {
                 }
                 return Err(HttpError::HttpStatus {
                     status: code,
-                    url: final_url.to_string(),
+                    // Issue #146: Springer Nature authenticates via an
+                    // `api_key` URL query parameter (no header path
+                    // upstream). This error string is logged and may
+                    // surface to the user, so strip any `api_key`
+                    // value before it leaves the client. No other
+                    // source puts a secret in the query string, so
+                    // this is a no-op for them.
+                    url: redact_api_key_query(&final_url),
                 });
             }
 
@@ -825,6 +832,37 @@ impl HttpClient {
             return Ok((body, final_url));
         }
     }
+}
+
+/// Return `url` rendered as a string with the value of any `api_key`
+/// query parameter replaced by `REDACTED` (issue #146).
+///
+/// Springer Nature's TDM API authenticates **only** via an `api_key`
+/// query parameter — there is no header-auth path upstream — so the key
+/// is unavoidably in the request URL. This keeps it out of *our* log
+/// and error sinks (the `HttpError::HttpStatus` string in particular,
+/// which is `tracing`-logged and can surface to the user). It is a
+/// structural no-op for every other source, none of which carry a
+/// secret in the query string. Other pairs and their order are
+/// preserved; a URL with no `api_key` pair is rendered unchanged.
+fn redact_api_key_query(url: &url::Url) -> String {
+    const API_KEY_PARAM: &str = "api_key";
+    if url.query_pairs().all(|(k, _)| k != API_KEY_PARAM) {
+        return url.to_string();
+    }
+    let mut redacted = url.clone();
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| {
+            if k == API_KEY_PARAM {
+                (k.into_owned(), "REDACTED".to_string())
+            } else {
+                (k.into_owned(), v.into_owned())
+            }
+        })
+        .collect();
+    redacted.query_pairs_mut().clear().extend_pairs(pairs);
+    redacted.to_string()
 }
 
 /// Test-oriented [`HttpClient`] constructor. Originally `cfg(test)`; now

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -878,7 +878,7 @@ impl RateLimits {
 ///
 /// `docs/CAPABILITY.md` §1 specifies the type as `Secret<String>`; that is
 /// the `secrecy` 0.9 spelling. The workspace pins `secrecy` 0.10, whose
-/// equivalent owned-string secret type is [`secrecy::SecretString`]
+/// equivalent owned-string secret type is `secrecy::SecretString`
 /// (`= SecretBox<str>`). CAPABILITY.md §1 has been updated to match the
 /// 0.10 API. `Debug` redacts the value.
 ///
@@ -890,8 +890,8 @@ impl RateLimits {
 pub struct TdmGrant {
     /// The publisher API key, validated present at startup by
     /// [`CapabilityProfile::from_env`]. Wrapped in
-    /// [`secrecy::SecretString`] so `Debug` never prints it; use
-    /// [`secrecy::ExposeSecret::expose_secret`] at the point of use.
+    /// `secrecy::SecretString` so `Debug` never prints it; use
+    /// `secrecy::ExposeSecret::expose_secret` at the point of use.
     ///
     /// Only present when a `tdm-*` feature is compiled in (see the
     /// type-level docs and ADR-0002).
@@ -1023,7 +1023,7 @@ impl CapabilityProfile {
     /// # Note on `api_key` storage
     ///
     /// When a `tdm-*` feature is compiled in, [`TdmGrant`] carries the
-    /// validated key as [`secrecy::SecretString`] (issue #153). The key is
+    /// validated key as `secrecy::SecretString` (issue #153). The key is
     /// read exactly once here, at startup; TDM sources consume it from the
     /// grant and never re-read the env var at fetch time. This makes the
     /// grant a true startup attestation — an env mutation between startup
@@ -1377,6 +1377,49 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn from_env_agreed_but_empty_key_errs() {
+        // Security-adjacent (PR #161 review): an *empty* key string is
+        // treated as "not set" by `resolve_tdm_grant`. With agree=1 and
+        // DOIGET_KEY_ELSEVIER="" the misconfiguration must surface as
+        // AgreedButNoKey, not silently build a grant around an empty
+        // secret that could never authenticate.
+        let _g = unset_all_capability_env_vars();
+        let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "");
+
+        let result = CapabilityProfile::from_env();
+        match result {
+            Err(CapabilityError::AgreedButNoKey { agree_var, key_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+                assert_eq!(key_var, "DOIGET_KEY_ELSEVIER");
+            }
+            other => panic!("expected AgreedButNoKey for empty key, got {:?}", other),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_env_empty_key_without_agree_is_no_grant() {
+        // Security-adjacent (PR #161 review): an empty key with the
+        // agree var unset is indistinguishable from "no key at all".
+        // It must resolve to Ok(None) (no grant, no error) — an empty
+        // string must NOT trip the KeyButNotAgreed leaked-credential
+        // rule, since there is no credential.
+        let _g = unset_all_capability_env_vars();
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "");
+
+        let p = CapabilityProfile::from_env()
+            .expect("empty key + agree unset must be Ok(None), not an error");
+        assert!(
+            p.tdm_elsevier.is_none(),
+            "empty DOIGET_KEY_ELSEVIER with no agree var must yield no grant"
+        );
+        assert!(p.tdm_aps.is_none());
+        assert!(p.tdm_springer.is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn from_env_key_but_not_agreed_errs() {
         // Rule (CAPABILITY.md §2): key set + agree unset -> KeyButNotAgreed.
         // A leaked DOIGET_KEY_ELSEVIER must not silently enable a source.
@@ -1430,6 +1473,25 @@ mod tests {
                 .as_ref()
                 .expect("feature tdm-elsevier compiled in -> Some(TdmGrant)");
             assert_eq!(grant.agree_env_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            // Issue #153 / PR #161 review: prove the key was actually
+            // threaded into TdmGrant::api_key at startup (not just that
+            // the agree var was recorded). The field is cfg-gated to
+            // the same `tdm-*` set as the assertion below, so gate the
+            // check identically.
+            #[cfg(any(
+                feature = "tdm-elsevier",
+                feature = "tdm-aps",
+                feature = "tdm-springer"
+            ))]
+            {
+                use secrecy::ExposeSecret as _;
+                assert_eq!(
+                    grant.api_key.expose_secret(),
+                    "sk-test",
+                    "the DOIGET_KEY_ELSEVIER value must be threaded into \
+                     TdmGrant::api_key (issue #153)"
+                );
+            }
         } else {
             assert!(
                 p.tdm_elsevier.is_none(),

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -864,19 +864,43 @@ impl RateLimits {
 
 /// A successful TDM grant.
 ///
-/// In Phase 0, the struct does not yet carry the `api_key` field that
-/// `docs/CAPABILITY.md` §1 defines for Phase 1+ — but the type is marked
-/// `#[non_exhaustive]` so adding `api_key: secrecy::Secret<String>` later
-/// is a non-breaking change. Phase 0 callers should not construct this type
-/// directly; use `CapabilityProfile::from_env()` (which today never produces
-/// `Some(TdmGrant)`).
+/// Carries the validated API key (`docs/CAPABILITY.md` §1) so that the key
+/// flows from the startup capability gate into the source, rather than each
+/// TDM source re-reading the env var at fetch time (issue #153 — an env
+/// mutation between startup and fetch is otherwise undetectable).
 ///
-/// Implements `Default` so that in-crate test fixtures using
-/// `TdmGrant { agree_env_var: ..., ..Default::default() }` survive future
-/// field additions (e.g. `api_key` in Phase 1) without source edits.
+/// The `api_key` field exists only when at least one `tdm-*` Cargo feature
+/// is compiled in (the `secrecy` dependency is `optional = true` and gated
+/// on those features per ADR-0002, so default release binaries contain no
+/// TDM code path at all). The struct is `#[non_exhaustive]`; the
+/// `tdm-*`-gated `api_key` field is therefore additive, not breaking, for
+/// builds that toggle the feature set.
+///
+/// `docs/CAPABILITY.md` §1 specifies the type as `Secret<String>`; that is
+/// the `secrecy` 0.9 spelling. The workspace pins `secrecy` 0.10, whose
+/// equivalent owned-string secret type is [`secrecy::SecretString`]
+/// (`= SecretBox<str>`). CAPABILITY.md §1 has been updated to match the
+/// 0.10 API. `Debug` redacts the value.
+///
+/// Implements `Default` so in-crate test fixtures using
+/// `TdmGrant { agree_env_var: ..., ..Default::default() }` keep compiling;
+/// the default `api_key` is an empty secret.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct TdmGrant {
+    /// The publisher API key, validated present at startup by
+    /// [`CapabilityProfile::from_env`]. Wrapped in
+    /// [`secrecy::SecretString`] so `Debug` never prints it; use
+    /// [`secrecy::ExposeSecret::expose_secret`] at the point of use.
+    ///
+    /// Only present when a `tdm-*` feature is compiled in (see the
+    /// type-level docs and ADR-0002).
+    #[cfg(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer"
+    ))]
+    pub api_key: secrecy::SecretString,
     /// Which env var the user used to acknowledge the publisher's ToS.
     pub agree_env_var: String,
     /// When the agreement env var was first observed at startup.
@@ -886,6 +910,12 @@ pub struct TdmGrant {
 impl Default for TdmGrant {
     fn default() -> Self {
         Self {
+            #[cfg(any(
+                feature = "tdm-elsevier",
+                feature = "tdm-aps",
+                feature = "tdm-springer"
+            ))]
+            api_key: secrecy::SecretString::from(String::new()),
             agree_env_var: String::new(),
             agreed_at: chrono::Utc::now(),
         }
@@ -992,18 +1022,19 @@ impl CapabilityProfile {
     ///
     /// # Note on `api_key` storage
     ///
-    /// The [`TdmGrant`] struct does not yet carry an `api_key` field — it is
-    /// a marker that the user agreed and supplied a key, but the key value is
-    /// not threaded through `CapabilityProfile` at this phase. Sources that
-    /// need the key read it from the same env var directly. See the
-    /// [`TdmGrant`] doc-comment for the rationale and roadmap.
+    /// When a `tdm-*` feature is compiled in, [`TdmGrant`] carries the
+    /// validated key as [`secrecy::SecretString`] (issue #153). The key is
+    /// read exactly once here, at startup; TDM sources consume it from the
+    /// grant and never re-read the env var at fetch time. This makes the
+    /// grant a true startup attestation — an env mutation between startup
+    /// and fetch can no longer silently change the credential in flight.
+    /// See the [`TdmGrant`] doc-comment and `docs/CAPABILITY.md` §1/§2.
     pub fn from_env() -> Result<Self, CapabilityError> {
-        // TODO Phase 1+: thread api_key through TdmGrant. The key would be
-        // read here and stored as `secrecy::Secret<String>`; deferred for now
-        // because adding a field to `TdmGrant` requires a coordinated
-        // `secrecy` design (the dep is `optional = true` and only compiled in
-        // under `tdm-*` features). See the `TdmGrant` doc-comment above and
-        // `docs/CAPABILITY.md` §1.
+        // Issue #153: the validated API key is now threaded through
+        // `TdmGrant` (as `secrecy::SecretString`, behind the `tdm-*`
+        // features) by `resolve_tdm_grant` below — sources no longer
+        // re-read the key env var at fetch time. See the `TdmGrant`
+        // doc-comment and `docs/CAPABILITY.md` §1/§2.
 
         // -- Tier 2 metadata -------------------------------------------------
         let metadata = MetadataAccess {
@@ -1104,18 +1135,21 @@ fn resolve_tdm_grant(
     let agree_raw = std::env::var(agree_var).ok();
     let agreed = matches!(agree_raw.as_deref(), Some("1"));
     let agree_present = agree_raw.is_some();
-    // The key value itself is not stored in `TdmGrant` at this phase; we only
-    // care whether it is set. See the TODO in `from_env`.
-    let key_present = std::env::var_os(key_var).is_some();
+    // Read the key value once, at startup, so the validated key flows
+    // through `TdmGrant` and sources never re-read the env (issue #153).
+    // An empty value is treated as "not set" — an empty API key cannot
+    // authenticate, and silently constructing a grant around it would
+    // mask the misconfiguration the AgreedButNoKey rule exists to surface.
+    let key_value = std::env::var(key_var).ok().filter(|v| !v.is_empty());
 
-    match (agreed, agree_present, key_present) {
-        (true, _, true) => {
+    match (agreed, agree_present, key_value) {
+        (true, _, Some(key)) => {
             if feature_enabled {
-                Ok(Some(TdmGrant {
-                    agree_env_var: agree_var.to_string(),
-                    agreed_at: chrono::Utc::now(),
-                }))
+                Ok(Some(build_tdm_grant(agree_var, key)))
             } else {
+                // `key` is dropped here; under no-tdm builds it is the only
+                // consumer of the owned `String`, which is intended.
+                let _ = key;
                 tracing::warn!(
                     env_var = agree_var,
                     feature,
@@ -1126,25 +1160,59 @@ fn resolve_tdm_grant(
                 Ok(None)
             }
         }
-        (true, _, false) => Err(CapabilityError::AgreedButNoKey {
+        (true, _, None) => Err(CapabilityError::AgreedButNoKey {
             agree_var: agree_var.to_string(),
             key_var: key_var.to_string(),
         }),
         // agree set to non-"1", key also set: KeyButNotAgreed (the key would
         // otherwise authorize the source without an explicit agreement).
-        (false, true, true) => Err(CapabilityError::KeyButNotAgreed {
+        (false, true, Some(_)) => Err(CapabilityError::KeyButNotAgreed {
             agree_var: agree_var.to_string(),
         }),
         // agree unset, key set: KeyButNotAgreed (same rule).
-        (false, false, true) => Err(CapabilityError::KeyButNotAgreed {
+        (false, false, Some(_)) => Err(CapabilityError::KeyButNotAgreed {
             agree_var: agree_var.to_string(),
         }),
         // agree set to non-"1" and no key: treat as no-grant. The user
         // expressed something but did not opt in and provided no credential,
         // so silent skip is the safe default (no source enabled).
-        (false, true, false) => Ok(None),
+        (false, true, None) => Ok(None),
         // Neither env var set: no grant, no error.
-        (false, false, false) => Ok(None),
+        (false, false, None) => Ok(None),
+    }
+}
+
+/// Construct a [`TdmGrant`] from the validated agreement var and key value.
+///
+/// Split out so the `tdm-*`-gated `api_key` field is populated in exactly
+/// one place. When no `tdm-*` feature is compiled in the `key` is consumed
+/// (dropped) here — the grant is still produced so that startup attestation
+/// behavior (the warn-and-skip path) does not change shape between feature
+/// sets.
+fn build_tdm_grant(agree_var: &str, key: String) -> TdmGrant {
+    #[cfg(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer"
+    ))]
+    {
+        TdmGrant {
+            api_key: secrecy::SecretString::from(key),
+            agree_env_var: agree_var.to_string(),
+            agreed_at: chrono::Utc::now(),
+        }
+    }
+    #[cfg(not(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer"
+    )))]
+    {
+        let _ = key;
+        TdmGrant {
+            agree_env_var: agree_var.to_string(),
+            agreed_at: chrono::Utc::now(),
+        }
     }
 }
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -17,7 +17,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use chrono::Utc;
 use serde_json::Value;
 
-use crate::dry_run::{build_fetch_plan, FetchPlan};
+use crate::dry_run::{build_fetch_plan, try_build_fetch_plan, FetchPlan};
 use crate::http::HttpError;
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
 use crate::source::{FetchContext, FetchError, FetchResult, Source};
@@ -481,6 +481,21 @@ pub async fn fetch_paper(
 /// tool method does not have to reach across two modules.
 pub fn fetch_paper_plan(ref_: &Ref, store_root: &Utf8Path) -> FetchPlan {
     build_fetch_plan(ref_, store_root)
+}
+
+/// Fallible sibling of [`fetch_paper_plan`] — propagates an internal
+/// allowlist-contract drift as a typed [`FetchError::SourceSchema`]
+/// instead of degrading to an empty `candidate_hosts` list (issue
+/// #156 ②). Thin re-export of [`crate::dry_run::try_build_fetch_plan`].
+/// Added alongside the infallible [`fetch_paper_plan`] rather than
+/// changing its signature, because `fetch_paper_plan` is `pub` and
+/// called from `doiget-mcp`, which is out of scope for this batch.
+///
+/// # Errors
+///
+/// See [`crate::dry_run::try_build_fetch_plan`].
+pub fn try_fetch_paper_plan(ref_: &Ref, store_root: &Utf8Path) -> Result<FetchPlan, FetchError> {
+    try_build_fetch_plan(ref_, store_root)
 }
 
 /// arXiv branch of [`fetch_paper`]. Internal — public callers go
@@ -1071,8 +1086,14 @@ pub async fn batch_fetch(
 /// Dry-run preview for a batch — one [`FetchPlan`] per ref. Enforces
 /// the same [`MAX_BATCH_REFS`] cap [`batch_fetch`] does.
 ///
-/// Returns `Err(FetchError::TooManyRefs)` when over the cap; otherwise
-/// `Ok(Vec<(Ref, FetchPlan)>)` parallel to the input order.
+/// Returns `Err(FetchError::TooManyRefs)` when over the cap, or
+/// `Err(FetchError::SourceSchema)` if the dry-run allowlist invariant
+/// has drifted (issue #156 ②: this now propagates as a typed error via
+/// [`try_build_fetch_plan`] rather than silently emitting an empty
+/// `candidate_hosts` list — the signature already returned `Result`, so
+/// this is an in-crate behavior tightening with no caller-visible type
+/// change). Otherwise `Ok(Vec<(Ref, FetchPlan)>)` parallel to the input
+/// order.
 pub fn batch_fetch_plans(
     refs: &[Ref],
     store_root: &Utf8Path,
@@ -1083,10 +1104,9 @@ pub fn batch_fetch_plans(
             max: MAX_BATCH_REFS,
         });
     }
-    Ok(refs
-        .iter()
-        .map(|r| (r.clone(), build_fetch_plan(r, store_root)))
-        .collect())
+    refs.iter()
+        .map(|r| try_build_fetch_plan(r, store_root).map(|p| (r.clone(), p)))
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -3,8 +3,11 @@
 //! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. Semantic Scholar's Graph
 //! API accepts unauthenticated polite-pool calls; an optional
 //! `x-api-key` header raises rate limits. doiget reads the key from
-//! `DOIGET_S2_API_KEY` at the orchestrator boundary; when absent the
-//! request is sent unauthenticated.
+//! `DOIGET_S2_API_KEY` at the orchestrator boundary; when present it is
+//! sent as the `x-api-key` request header (issue #156 ① — previously
+//! the field was carried but never sent, silently throttling keyed
+//! users to the anonymous tier); when absent the request is sent
+//! unauthenticated.
 //!
 //! ## Capability gate
 //!
@@ -46,10 +49,11 @@ pub struct S2Source {
     /// means the request is sent unauthenticated, which the API
     /// explicitly allows under the public rate-limit ceiling.
     ///
-    /// NOTE: not yet threaded through `HttpClient::fetch_bytes` (which
-    /// has no per-request header hook). Adding the header is a
-    /// follow-up; the field exists to reserve the API surface.
-    #[allow(dead_code)]
+    /// When present it is sent as the `x-api-key` request header via
+    /// [`HttpClient::fetch_bytes_with_headers`] (issue #156 ①),
+    /// mirroring how the APS TDM source attaches `X-API-Key`. The value
+    /// is sent on the wire only — it is never logged, recorded in
+    /// provenance, or echoed back in error strings.
     api_key: Option<String>,
 }
 
@@ -121,7 +125,22 @@ impl Source for S2Source {
         let _permit = ctx.rate_limiter.acquire(self.name()).await;
 
         let url = self.request_url(doi)?;
-        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+        // Issue #156 ①: when an API key is configured, send it as the
+        // `x-api-key` header so S2 applies the keyed rate-limit tier
+        // instead of the anonymous ceiling. Mirrors the APS TDM
+        // source's `X-API-Key` wiring. An empty string is treated as
+        // "no key" (it cannot authenticate and would only add a
+        // useless header). The header value is sent on the wire only —
+        // never logged or echoed.
+        let api_key = self.api_key.as_deref().filter(|k| !k.is_empty());
+        let (body, final_url) = match api_key {
+            Some(key) => {
+                ctx.http
+                    .fetch_bytes_with_headers(self.name(), url, &[("x-api-key", key)])
+                    .await?
+            }
+            None => ctx.http.fetch_bytes(self.name(), url).await?,
+        };
 
         let paper: serde_json::Value =
             serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
@@ -184,7 +203,7 @@ mod tests {
 
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::http::HttpClient;
@@ -260,6 +279,33 @@ mod tests {
         let meta = result.metadata_json.expect("metadata_json present");
         assert_eq!(meta["title"], "Example S2 Paper");
         assert_eq!(meta["references"][0]["paperId"], "abc111");
+    }
+
+    #[tokio::test]
+    async fn fetch_sends_x_api_key_header_when_key_present() {
+        // Issue #156 ①: a configured key must reach the wire as the
+        // `x-api-key` header so S2 applies the keyed rate-limit tier.
+        const S2_KEY: &str = "s2-test-key-abc";
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/graph/v1/paper/DOI:10.1234/example"))
+            .and(header("x-api-key", S2_KEY))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_PAPER))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = S2Source::with_base(
+            Url::parse(&server.uri()).expect("wiremock URI parses"),
+            Some(S2_KEY.to_string()),
+        );
+        let profile = profile_with_s2_enabled();
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
+        assert_eq!(result.source, "semantic_scholar");
+        let meta = result.metadata_json.expect("metadata_json present");
+        assert_eq!(meta["title"], "Example S2 Paper");
     }
 
     #[tokio::test]

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -39,7 +39,17 @@ const DEFAULT_BASE: &str = "https://api.semanticscholar.org";
 const DEFAULT_FIELDS: &str = "title,year,citationCount,references";
 
 /// Semantic Scholar [`Source`] impl — DOI → Graph-API paper record.
-#[derive(Clone, Debug)]
+///
+/// `Debug` is implemented manually (not derived) so the optional
+/// `api_key` is never printed: a derived `Debug` would render the raw
+/// key, contradicting the [`api_key`](Self::api_key) doc contract and
+/// the credential-hygiene posture the TDM sources hold (their keys are
+/// `secrecy::SecretString`). S2 is not behind a `tdm-*` feature and the
+/// `secrecy` dep is `tdm-*`-gated/optional, so wrapping the field in
+/// `SecretString` would force `secrecy` onto default (no-feature)
+/// builds; a redacting manual `Debug` achieves the same hygiene with
+/// no dependency change. See issue #156 ① and #153 (category E).
+#[derive(Clone)]
 pub struct S2Source {
     /// API base URL. Production constructor pins
     /// `https://api.semanticscholar.org`; [`with_base`](Self::with_base)
@@ -55,6 +65,25 @@ pub struct S2Source {
     /// is sent on the wire only — it is never logged, recorded in
     /// provenance, or echoed back in error strings.
     api_key: Option<String>,
+}
+
+impl std::fmt::Debug for S2Source {
+    /// Redacts `api_key`: prints only whether a key is present, never
+    /// the value. Mirrors the `secrecy::SecretString` `Debug` posture of
+    /// the TDM sources (issue #153 category E / #156 ①).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S2Source")
+            .field("base", &self.base)
+            .field(
+                "api_key",
+                if self.api_key.is_some() {
+                    &"Some(REDACTED)"
+                } else {
+                    &"None"
+                },
+            )
+            .finish()
+    }
 }
 
 impl S2Source {

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -23,9 +23,11 @@
 //! `profile.tdm_aps = Some(TdmGrant)`. This source mirrors that
 //! check in [`can_serve`](TdmApsSource::can_serve) and again in
 //! [`fetch`](TdmApsSource::fetch) (defensive). APS expects the key
-//! in the `X-API-Key` header (not a URL parameter, unlike Springer);
-//! `TdmGrant` does not currently store the key, so the source
-//! re-reads `DOIGET_KEY_APS` at fetch time.
+//! in the `X-API-Key` header (not a URL parameter, unlike Springer).
+//! The key is read once at startup and carried in
+//! [`TdmGrant::api_key`](crate::TdmGrant) (issue #153); the source
+//! consumes it from the grant and never re-reads `DOIGET_KEY_APS` at
+//! fetch time.
 //!
 //! ## Metadata-only contract (Phase 5b)
 //!
@@ -38,6 +40,7 @@
 #![cfg(feature = "tdm-aps")]
 
 use async_trait::async_trait;
+use secrecy::ExposeSecret;
 use url::Url;
 
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
@@ -46,12 +49,6 @@ use crate::{CapabilityProfile, Ref};
 
 /// Production APS Harvest API base URL.
 const DEFAULT_BASE: &str = "https://harvest.aps.org";
-
-/// Env var holding the per-tenant API key. Presence is one of the
-/// three activation gates (`docs/CAPABILITY.md` §2); the value is
-/// read at fetch time and sent as the `X-API-Key` header via
-/// [`HttpClient::fetch_bytes_with_headers`].
-const KEY_ENV_VAR: &str = "DOIGET_KEY_APS";
 
 /// APS Harvest [`Source`] impl — DOI → `/v2/article/<DOI>` JSON
 /// record.
@@ -121,19 +118,18 @@ impl Source for TdmApsSource {
             }
         };
 
-        // Defensive gate (1/3): runtime grant must be populated.
-        if profile.tdm_aps.is_none() {
-            return Err(FetchError::NotEligible {
+        // Defensive gate (1/3 + 2/3): the runtime grant must be
+        // populated and now carries the key validated at startup
+        // (issue #153). `CapabilityProfile` is immutable for the
+        // process lifetime (`docs/CAPABILITY.md` §6), so the startup
+        // grant is the single source of truth — no env re-read.
+        let grant = profile
+            .tdm_aps
+            .as_ref()
+            .ok_or_else(|| FetchError::NotEligible {
                 source_key: "tdm-aps".into(),
-            });
-        }
-
-        // Defensive gate (2/3): re-read the key env var. A missing
-        // key here means env changed mid-process — fail-close as
-        // NotEligible so the orchestrator can fall through.
-        let api_key = std::env::var(KEY_ENV_VAR).map_err(|_| FetchError::NotEligible {
-            source_key: "tdm-aps".into(),
-        })?;
+            })?;
+        let api_key = grant.api_key.expose_secret();
         if api_key.is_empty() {
             return Err(FetchError::NotEligible {
                 source_key: "tdm-aps".into(),
@@ -150,7 +146,7 @@ impl Source for TdmApsSource {
         // or echoed back in error messages.
         let (body, final_url) = ctx
             .http
-            .fetch_bytes_with_headers(self.name(), url, &[("X-API-Key", &api_key)])
+            .fetch_bytes_with_headers(self.name(), url, &[("X-API-Key", api_key)])
             .await?;
 
         let envelope: serde_json::Value =
@@ -277,16 +273,18 @@ mod tests {
         (td, ctx)
     }
 
+    const TEST_KEY: &str = "aps-test-key-xyz";
+
     fn profile_with_aps_grant() -> CapabilityProfile {
         let mut p = CapabilityProfile::from_env().expect("clean env never errors");
         p.tdm_aps = Some(TdmGrant {
+            // Issue #153: key flows through the grant, not the env var.
+            api_key: secrecy::SecretString::from(TEST_KEY.to_string()),
             agree_env_var: "DOIGET_AGREE_TDM_APS".to_string(),
             ..Default::default()
         });
         p
     }
-
-    const TEST_KEY: &str = "aps-test-key-xyz";
 
     #[tokio::test]
     #[serial_test::serial]
@@ -306,10 +304,7 @@ mod tests {
         let profile = profile_with_aps_grant();
         let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
 
-        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
-        let result = src.fetch(&ref_, &profile, &ctx).await;
-        std::env::remove_var(KEY_ENV_VAR);
-        let result = result.expect("fetch ok");
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
 
         assert_eq!(result.source, "tdm-aps");
         assert!(result.pdf_bytes.is_none(), "metadata-only contract");
@@ -352,9 +347,7 @@ mod tests {
         let profile = profile_with_aps_grant();
         let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
 
-        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
         let result = src.fetch(&ref_, &profile, &ctx).await;
-        std::env::remove_var(KEY_ENV_VAR);
 
         let err = result.expect_err("non-object response must surface as SourceSchema");
         assert!(matches!(err, FetchError::SourceSchema { .. }));

--- a/crates/doiget-core/src/sources/tdm_elsevier.rs
+++ b/crates/doiget-core/src/sources/tdm_elsevier.rs
@@ -23,9 +23,10 @@
 //! `profile.tdm_elsevier = Some(TdmGrant)`. This source mirrors that
 //! check in [`can_serve`](TdmElsevierSource::can_serve) and again in
 //! [`fetch`](TdmElsevierSource::fetch) (defensive). Elsevier expects
-//! the key in the `X-ELS-APIKey` header. `TdmGrant` does not
-//! currently store the key, so the source re-reads
-//! `DOIGET_KEY_ELSEVIER` at fetch time.
+//! the key in the `X-ELS-APIKey` header. The key is read once at
+//! startup and carried in [`TdmGrant::api_key`](crate::TdmGrant)
+//! (issue #153); the source consumes it from the grant and never
+//! re-reads `DOIGET_KEY_ELSEVIER` at fetch time.
 //!
 //! ## Metadata-only contract (Phase 5c)
 //!
@@ -38,6 +39,7 @@
 #![cfg(feature = "tdm-elsevier")]
 
 use async_trait::async_trait;
+use secrecy::ExposeSecret;
 use url::Url;
 
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
@@ -46,12 +48,6 @@ use crate::{CapabilityProfile, Ref};
 
 /// Production Elsevier ScienceDirect API base URL.
 const DEFAULT_BASE: &str = "https://api.elsevier.com";
-
-/// Env var holding the per-tenant API key. Presence is one of the
-/// three activation gates (`docs/CAPABILITY.md` §2); the value is
-/// read at fetch time and sent as the `X-ELS-APIKey` header via
-/// [`HttpClient::fetch_bytes_with_headers`].
-const KEY_ENV_VAR: &str = "DOIGET_KEY_ELSEVIER";
 
 /// Elsevier ScienceDirect [`Source`] impl — DOI →
 /// `/content/article/doi/<DOI>?httpAccept=application/json` JSON
@@ -135,19 +131,18 @@ impl Source for TdmElsevierSource {
             }
         };
 
-        // Defensive gate (1/3): runtime grant must be populated.
-        if profile.tdm_elsevier.is_none() {
-            return Err(FetchError::NotEligible {
+        // Defensive gate (1/3 + 2/3): the runtime grant must be
+        // populated and now carries the key validated at startup
+        // (issue #153). `CapabilityProfile` is immutable for the
+        // process lifetime (`docs/CAPABILITY.md` §6), so the startup
+        // grant is the single source of truth — no env re-read.
+        let grant = profile
+            .tdm_elsevier
+            .as_ref()
+            .ok_or_else(|| FetchError::NotEligible {
                 source_key: "tdm-elsevier".into(),
-            });
-        }
-
-        // Defensive gate (2/3): re-read the key env var. A missing
-        // key here means env changed mid-process — fail-close as
-        // NotEligible so the orchestrator can fall through.
-        let api_key = std::env::var(KEY_ENV_VAR).map_err(|_| FetchError::NotEligible {
-            source_key: "tdm-elsevier".into(),
-        })?;
+            })?;
+        let api_key = grant.api_key.expose_secret();
         if api_key.is_empty() {
             return Err(FetchError::NotEligible {
                 source_key: "tdm-elsevier".into(),
@@ -162,7 +157,7 @@ impl Source for TdmElsevierSource {
         // the wire only; it is never logged or echoed back.
         let (body, final_url) = ctx
             .http
-            .fetch_bytes_with_headers(self.name(), url, &[("X-ELS-APIKey", &api_key)])
+            .fetch_bytes_with_headers(self.name(), url, &[("X-ELS-APIKey", api_key)])
             .await?;
 
         let envelope: serde_json::Value =
@@ -294,16 +289,18 @@ mod tests {
         (td, ctx)
     }
 
+    const TEST_KEY: &str = "els-test-key-xyz";
+
     fn profile_with_elsevier_grant() -> CapabilityProfile {
         let mut p = CapabilityProfile::from_env().expect("clean env never errors");
         p.tdm_elsevier = Some(TdmGrant {
+            // Issue #153: key flows through the grant, not the env var.
+            api_key: secrecy::SecretString::from(TEST_KEY.to_string()),
             agree_env_var: "DOIGET_AGREE_TDM_ELSEVIER".to_string(),
             ..Default::default()
         });
         p
     }
-
-    const TEST_KEY: &str = "els-test-key-xyz";
 
     #[tokio::test]
     #[serial_test::serial]
@@ -325,10 +322,7 @@ mod tests {
         let profile = profile_with_elsevier_grant();
         let ref_ = Ref::Doi(Doi::parse("10.1016/j.example.2024.001").expect("DOI parses"));
 
-        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
-        let result = src.fetch(&ref_, &profile, &ctx).await;
-        std::env::remove_var(KEY_ENV_VAR);
-        let result = result.expect("fetch ok");
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
 
         assert_eq!(result.source, "tdm-elsevier");
         assert!(result.pdf_bytes.is_none(), "metadata-only contract");
@@ -372,9 +366,7 @@ mod tests {
         let profile = profile_with_elsevier_grant();
         let ref_ = Ref::Doi(Doi::parse("10.1016/j.example.2024.001").expect("DOI parses"));
 
-        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
         let result = src.fetch(&ref_, &profile, &ctx).await;
-        std::env::remove_var(KEY_ENV_VAR);
 
         let err = result.expect_err("missing wrapper must surface as SourceSchema");
         assert!(matches!(err, FetchError::SourceSchema { .. }));

--- a/crates/doiget-core/src/sources/tdm_springer.rs
+++ b/crates/doiget-core/src/sources/tdm_springer.rs
@@ -44,7 +44,7 @@
 //! recorded-provenance sink. The request URL is built with the key,
 //! but every URL this module hands back (the `FetchResult::final_url`
 //! and any error string) is first passed through
-//! [`redact_api_key_in_url`], which replaces the `api_key` value with
+//! `redact_api_key_in_url`, which replaces the `api_key` value with
 //! `REDACTED`. The key still appears on the wire and in Springer's own
 //! server-side / proxy logs — that is inherent to query-param auth and
 //! is documented here and in `docs/CAPABILITY.md` §1 as accepted

--- a/crates/doiget-core/src/sources/tdm_springer.rs
+++ b/crates/doiget-core/src/sources/tdm_springer.rs
@@ -24,10 +24,31 @@
 //! `profile.tdm_springer = Some(TdmGrant)`. This source mirrors that
 //! check in [`can_serve`](TdmSpringerSource::can_serve) and again in
 //! [`fetch`](TdmSpringerSource::fetch) (defensive — the orchestrator
-//! is *supposed* to gate on `can_serve` first). The key value itself
-//! is not currently stored in `TdmGrant` (see the
-//! [`crate::TdmGrant`] doc-comment); this source re-reads
+//! is *supposed* to gate on `can_serve` first). The key value is read
+//! once at startup and carried in
+//! [`TdmGrant::api_key`](crate::TdmGrant) (issue #153); this source
+//! consumes it from the grant and never re-reads
 //! `DOIGET_KEY_SPRINGER` at fetch time.
+//!
+//! ## Credential hygiene — key in the URL (issue #146)
+//!
+//! Unlike Elsevier (`X-ELS-APIKey` header) and APS (`X-API-Key`
+//! header), the Springer Nature API authenticates **only** via an
+//! `api_key` URL query parameter. The official Springer Nature API
+//! client sends it the same way (`params["api_key"] = api_key`); there
+//! is no header-auth path for either the regular or the TDM endpoint.
+//! Moving the key to a header (the preferred #146 fix) is therefore
+//! not possible against this upstream.
+//!
+//! Residual-risk mitigation instead: the key never reaches any log or
+//! recorded-provenance sink. The request URL is built with the key,
+//! but every URL this module hands back (the `FetchResult::final_url`
+//! and any error string) is first passed through
+//! [`redact_api_key_in_url`], which replaces the `api_key` value with
+//! `REDACTED`. The key still appears on the wire and in Springer's own
+//! server-side / proxy logs — that is inherent to query-param auth and
+//! is documented here and in `docs/CAPABILITY.md` §1 as accepted
+//! residual risk.
 //!
 //! ## Metadata-only contract (Phase 5a)
 //!
@@ -40,6 +61,7 @@
 #![cfg(feature = "tdm-springer")]
 
 use async_trait::async_trait;
+use secrecy::ExposeSecret;
 use url::Url;
 
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
@@ -49,10 +71,11 @@ use crate::{CapabilityProfile, Ref};
 /// Production Springer Nature TDM API base URL.
 const DEFAULT_BASE: &str = "https://api.springernature.com";
 
-/// Env var holding the per-tenant API key. The presence of this var
-/// is one of the three activation gates (`docs/CAPABILITY.md` §2);
-/// the value is read at fetch time and appended as `?api_key=...`.
-const KEY_ENV_VAR: &str = "DOIGET_KEY_SPRINGER";
+/// The `api_key` query-parameter name Springer Nature expects, and the
+/// value it is replaced with in any URL that leaves this module bound
+/// for a log or recorded-provenance sink (issue #146).
+const API_KEY_PARAM: &str = "api_key";
+const REDACTED: &str = "REDACTED";
 
 /// Springer Nature OA TDM [`Source`] impl — DOI → first matching
 /// `records[]` entry from `/openaccess/json`.
@@ -93,9 +116,39 @@ impl TdmSpringerSource {
             })?;
         url.query_pairs_mut()
             .append_pair("q", &format!("doi:{}", doi.as_str()))
-            .append_pair("api_key", api_key);
+            .append_pair(API_KEY_PARAM, api_key);
         Ok(url)
     }
+}
+
+/// Return a copy of `url` with the `api_key` query-parameter value
+/// replaced by `REDACTED`, preserving every other pair and ordering.
+///
+/// Springer Nature only supports query-param auth (issue #146), so the
+/// key unavoidably appears on the wire and in Springer's own logs. This
+/// keeps it out of *our* sinks: the `FetchResult::final_url` (which the
+/// orchestrator persists into the metadata TOML `url` field) and any
+/// error string this module produces. If no `api_key` pair is present
+/// the URL is returned structurally unchanged.
+fn redact_api_key_in_url(url: &Url) -> Url {
+    if url.query_pairs().all(|(k, _)| k != API_KEY_PARAM) {
+        return url.clone();
+    }
+    let mut redacted = url.clone();
+    // Re-serialize the pairs, swapping only the api_key value. `clear()`
+    // first so we don't append onto the existing query string.
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| {
+            if k == API_KEY_PARAM {
+                (k.into_owned(), REDACTED.to_string())
+            } else {
+                (k.into_owned(), v.into_owned())
+            }
+        })
+        .collect();
+    redacted.query_pairs_mut().clear().extend_pairs(pairs);
+    redacted
 }
 
 impl Default for TdmSpringerSource {
@@ -129,26 +182,21 @@ impl Source for TdmSpringerSource {
             }
         };
 
-        // Defensive gate (1/3): runtime grant must be populated. The
-        // orchestrator is supposed to call `can_serve` first, but we
-        // re-check here so a misrouted call still fail-closes per
-        // ADR-0019.
-        if profile.tdm_springer.is_none() {
-            return Err(FetchError::NotEligible {
+        // Defensive gate (1/3 + 2/3): the runtime grant must be
+        // populated, and it now carries the key validated at startup
+        // (issue #153). The orchestrator is supposed to call
+        // `can_serve` first, but we re-check here so a misrouted call
+        // still fail-closes per ADR-0019. The key is no longer
+        // re-read from the env at fetch time — `CapabilityProfile` is
+        // immutable for the process lifetime (`docs/CAPABILITY.md`
+        // §6), so the startup grant is the single source of truth.
+        let grant = profile
+            .tdm_springer
+            .as_ref()
+            .ok_or_else(|| FetchError::NotEligible {
                 source_key: "tdm-springer".into(),
-            });
-        }
-
-        // Defensive gate (2/3): the api key env var must still be
-        // present at fetch time. `TdmGrant` does not yet hold the
-        // key value (see the `TdmGrant` doc-comment), so we re-read
-        // here. A missing key at this point indicates the env
-        // changed mid-process — treat it as NotEligible so the
-        // orchestrator falls through to the next source rather than
-        // surfacing a confusing schema error.
-        let api_key = std::env::var(KEY_ENV_VAR).map_err(|_| FetchError::NotEligible {
-            source_key: "tdm-springer".into(),
-        })?;
+            })?;
+        let api_key = grant.api_key.expose_secret();
         if api_key.is_empty() {
             return Err(FetchError::NotEligible {
                 source_key: "tdm-springer".into(),
@@ -157,8 +205,11 @@ impl Source for TdmSpringerSource {
 
         let _permit = ctx.rate_limiter.acquire(self.name()).await;
 
-        let url = self.request_url(doi, &api_key)?;
+        let url = self.request_url(doi, api_key)?;
         let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+        // Issue #146: Springer auth is query-param only; strip the key
+        // from the URL before it can reach the metadata TOML / any log.
+        let final_url = redact_api_key_in_url(&final_url);
 
         let envelope: serde_json::Value =
             serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
@@ -279,19 +330,31 @@ mod tests {
         (td, ctx)
     }
 
+    /// Sentinel test key used in the happy-path wiremock matcher.
+    const TEST_KEY: &str = "test-key-xyz";
+
     fn profile_with_springer_grant() -> CapabilityProfile {
         let mut p = CapabilityProfile::from_env().expect("clean env never errors");
         p.tdm_springer = Some(TdmGrant {
+            // Issue #153: the key now flows through the grant, not the
+            // env var, so the fixture seeds it directly.
+            api_key: secrecy::SecretString::from(TEST_KEY.to_string()),
             agree_env_var: "DOIGET_AGREE_TDM_SPRINGER".to_string(),
             ..Default::default()
         });
         p
     }
 
-    /// Sentinel test key used in the happy-path wiremock matcher. The
-    /// real env var is set/unset around the test body so it does not
-    /// bleed into sibling tests.
-    const TEST_KEY: &str = "test-key-xyz";
+    /// Grant whose key is empty — exercises the fail-closed branch.
+    fn profile_with_empty_key_grant() -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.tdm_springer = Some(TdmGrant {
+            api_key: secrecy::SecretString::from(String::new()),
+            agree_env_var: "DOIGET_AGREE_TDM_SPRINGER".to_string(),
+            ..Default::default()
+        });
+        p
+    }
 
     #[tokio::test]
     #[serial_test::serial]
@@ -311,15 +374,61 @@ mod tests {
         let profile = profile_with_springer_grant();
         let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
 
-        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
-        let result = src.fetch(&ref_, &profile, &ctx).await;
-        std::env::remove_var(KEY_ENV_VAR);
-        let result = result.expect("fetch ok");
+        // Key comes from the grant now — no env var is touched.
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
 
         assert_eq!(result.source, "tdm-springer");
         assert!(result.pdf_bytes.is_none(), "metadata-only contract");
+        // Issue #146: the returned final_url must NOT carry the real key.
+        let final_url = result.final_url.expect("final_url present");
+        assert!(
+            !final_url.as_str().contains(TEST_KEY),
+            "api_key must be redacted out of final_url: {final_url}"
+        );
+        assert!(
+            final_url
+                .query_pairs()
+                .any(|(k, v)| k == "api_key" && v == "REDACTED"),
+            "redacted api_key sentinel must be present: {final_url}"
+        );
         let meta = result.metadata_json.expect("metadata_json present");
         assert_eq!(meta["title"], "Example Springer OA Article");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_with_empty_grant_key_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = TdmSpringerSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
+        let profile = profile_with_empty_key_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("empty grant key must fail-close");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[test]
+    fn redact_api_key_in_url_replaces_only_the_key() {
+        let u = Url::parse(
+            "https://api.springernature.com/openaccess/json?q=doi:10.1/x&api_key=SUPERSECRET",
+        )
+        .expect("parses");
+        let r = redact_api_key_in_url(&u);
+        assert!(!r.as_str().contains("SUPERSECRET"), "key must be gone: {r}");
+        assert!(
+            r.query_pairs().any(|(k, v)| k == "q" && v == "doi:10.1/x"),
+            "other pairs preserved: {r}"
+        );
+        assert!(r
+            .query_pairs()
+            .any(|(k, v)| k == "api_key" && v == "REDACTED"));
+        // No-op when there is no api_key pair.
+        let clean = Url::parse("https://api.springernature.com/openaccess/json?q=doi:10.1/x")
+            .expect("parses");
+        assert_eq!(redact_api_key_in_url(&clean), clean);
     }
 
     #[tokio::test]
@@ -357,9 +466,7 @@ mod tests {
         let profile = profile_with_springer_grant();
         let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
 
-        std::env::set_var(KEY_ENV_VAR, TEST_KEY);
         let result = src.fetch(&ref_, &profile, &ctx).await;
-        std::env::remove_var(KEY_ENV_VAR);
 
         let err = result.expect_err("empty records must surface as SourceSchema");
         assert!(matches!(err, FetchError::SourceSchema { .. }));

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -10,14 +10,16 @@
 ```rust
 // Phase 1+ target module path; Phase 0 ships these types in monolithic lib.rs.
 
-use secrecy::Secret;
+use secrecy::SecretString; // = SecretBox<str>; the `secrecy` 0.10 owned-string secret
 use chrono::{DateTime, Utc};
 
 // All structs below are #[non_exhaustive] in the Rust source. External crates
 // cannot construct them via struct-literal syntax — go through
-// `CapabilityProfile::from_env()` (see §2). The shapes shown are the Phase 1+
-// target; the Phase 0 stub omits `TdmGrant::api_key` (added non-breakingly
-// later via `#[non_exhaustive]`).
+// `CapabilityProfile::from_env()` (see §2). `TdmGrant::api_key` exists only
+// when at least one `tdm-*` Cargo feature is compiled in (the `secrecy` dep is
+// `optional = true` and gated on those features per ADR-0002). The field is
+// additive under `#[non_exhaustive]`; default release binaries — which contain
+// no TDM code at all — do not carry it.
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -44,7 +46,10 @@ pub struct MetadataAccess {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct TdmGrant {
-    pub api_key:       Secret<String>,    // added in Phase 1
+    // Present only under a `tdm-*` feature (see the note above). `secrecy`
+    // 0.10 replaced `Secret<String>` with `SecretString` (= `SecretBox<str>`).
+    #[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps", feature = "tdm-springer"))]
+    pub api_key:       SecretString,
     pub agreed_at:     DateTime<Utc>,
     pub agree_env_var: String,            // e.g. "DOIGET_AGREE_TDM_ELSEVIER"
 }
@@ -87,8 +92,12 @@ Struct-literal construction (`CapabilityProfile { oa: ..., ... }`) is blocked
 outside `doiget-core` by `#[non_exhaustive]`. Tests inside `doiget-core` may
 still construct profiles directly for fixture purposes.
 
-`api_key` is wrapped in `secrecy::Secret<String>` so that `Display` and `Debug` print
-`****`. Logs use a redactor for known sensitive field names.
+`api_key` is wrapped in `secrecy::SecretString` (the `secrecy` 0.10 replacement
+for the 0.9 `Secret<String>`) so that `Debug` prints a redaction placeholder
+rather than the key. Logs additionally use a redactor for known sensitive field
+names, and any URL that carries a key as a query parameter (Springer Nature —
+see §3) is passed through `redact_api_key_in_url` before it is logged or
+recorded in provenance.
 
 ## 2. Resolution algorithm
 
@@ -115,7 +124,11 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
     let key    = env::var(key_var).ok();
     match (agreed, key) {
         (true, Some(k)) => Ok(Some(TdmGrant {
-            api_key:       Secret::new(k),
+            // `secrecy` 0.10: `SecretString::from(String)` replaces the
+            // 0.9 `Secret::new(k)`. Field present only under a `tdm-*`
+            // feature; the actual source splits this into a small
+            // `build_tdm_grant` helper so the cfg lives in one place.
+            api_key:       SecretString::from(k),
             agreed_at:     Utc::now(),
             agree_env_var: agree_var.to_string(),
         })),


### PR DESCRIPTION
## Summary

Review-batch fixes confined to `crates/doiget-core/` (plus the pre-existing `docs/CAPABILITY.md` `secrecy` 0.10 tracking from the prior agent).

### #153 — TdmGrant carries the api_key; sources stop re-reading the env var
`TdmGrant.api_key: secrecy::SecretString` (gated on `any(tdm-elsevier, tdm-aps, tdm-springer)`), populated once at startup by `CapabilityProfile::from_env` / `resolve_tdm_grant` (via `build_tdm_grant`). `tdm_springer.rs` and `tdm_aps.rs` were already converted by the prior agent. **`tdm_elsevier.rs` was the remaining gap** — it still did `std::env::var("DOIGET_KEY_ELSEVIER")` at fetch time. It now consumes `grant.api_key.expose_secret()`, mirroring the exact `tdm_aps.rs` pattern (defensive gate 1/3+2/3 collapsed, `KEY_ENV_VAR` removed, fixture seeds the key into the grant, tests no longer set/remove the env var).

### #146 — Springer key never reaches a log/provenance sink
Already done by the prior agent (`redact_api_key_in_url` in `tdm_springer.rs`, `redact_api_key_query` in `http.rs`). Preserved as-is. Springer auth is query-param only upstream, so the key still appears on the wire / Springer's own logs — documented as accepted residual risk.

### #156 ① — S2 api_key now sent as `x-api-key`
`S2Source` previously carried `api_key` with `#[allow(dead_code)]` and never sent it, silently throttling keyed users to the anonymous tier. It is now sent as the `x-api-key` request header via `fetch_bytes_with_headers` when present and non-empty (mirrors the APS `X-API-Key` wiring); unauthenticated path unchanged when absent. `#[allow(dead_code)]` removed. New wiremock test asserts the header reaches the wire.

### #156 ② — dry-run `.expect()` panics removed
The two `.expect()` calls in `dry_run.rs` (allowlist invariant drift would panic `doiget plan`) are gone. Added `pub fn try_build_fetch_plan` / `try_fetch_paper_plan` returning `Result<FetchPlan, FetchError>`, propagating the invariant violation as `FetchError::SourceSchema` (→ `ErrorCode::InternalError` at the boundary — the idiomatic closed-set fit; the crate has no separate plan-error type). `batch_fetch_plans` (already `-> Result`) now routes through the fallible path so the typed error genuinely propagates.

## Decisions / judgment calls

- **secrecy 0.10 deviation**: `docs/CAPABILITY.md` §1 specified `Secret<String>` (secrecy 0.9); the workspace pins 0.10, whose equivalent is `SecretString` (= `SecretBox<str>`). CAPABILITY.md was updated to the 0.10 API by the prior agent and is kept.
- **tdm_elsevier finding**: confirmed it *was* still re-reading the env var (the #153 gap) and fixed it to mirror `tdm_aps.rs` exactly.
- **#156 ② signature scope (deliberate deviation from the literal issue text)**: `build_fetch_plan` and `fetch_paper_plan` are `pub` and have **non-`doiget-core` callers** (`doiget-mcp` lib.rs:244,487,638; `doiget-cli` fetch.rs:516, batch.rs:96; CLI integration tests). Changing their return type to `Result` would force edits in other crates, which the task explicitly forbids. Resolution: the actual bug (the panic) is fully removed; the requested `Result` API is delivered as new `try_*` siblings; the existing infallible entry points keep their signatures and degrade to an empty `candidate_hosts` list (visibly wrong, but no `doiget plan` crash) instead of panicking. `batch_fetch_plans` already returned `Result`, so it propagates the typed error with no caller-visible type change. No non-core crate was touched.

## Cargo gate (all green, in the worktree)

- `cargo fmt --all` — clean
- `cargo clippy -p doiget-core --all-targets -- -D warnings` — Finished, no warnings
- `cargo test -p doiget-core` — all passed (incl. hermetic `no_outbound_network`)
- `cargo test -p doiget-core --features tdm-springer,tdm-aps,tdm-elsevier` — 219 unit + all integration passed (incl. `no_outbound_network`)
- `cargo clippy -p doiget-core --all-targets --features tdm-springer,tdm-aps,tdm-elsevier -- -D warnings` — Finished, no warnings

Closes #146
Closes #153
Part of #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)