### PR TITLE
fix(cli): error-contract + env-var conformance (#142 #143 #145 #148 #149)

### DIFF
--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -41,6 +41,17 @@ use camino::Utf8PathBuf;
 
 use doiget_core::provenance::{verify, VerifyIssueKind};
 
+use super::fetch::CliExit;
+
+/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. Mirrors
+/// the `print_err` helper in `commands::fetch`; the localized `#[allow]`
+/// is the minimal intervention for the workspace `clippy::print_stderr`
+/// lint.
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
+
 /// Run the `audit-log` subcommand.
 ///
 /// `verify_flag` corresponds to the `--verify` clap flag. Phase 1 requires
@@ -53,10 +64,15 @@ use doiget_core::provenance::{verify, VerifyIssueKind};
 /// and the non-zero exit code.
 pub fn run(verify_flag: bool) -> Result<()> {
     if !verify_flag {
-        bail!(
-            "doiget audit-log: --verify is required (Phase 1 ships only \
+        // Issue #149: a missing required flag is argument misuse →
+        // `docs/ERRORS.md` §4 exit 2, NOT the generic exit 1 a bare
+        // `bail!` produced. The human-readable line is emitted here (so
+        // `main` does not reprint it) and only the exit code is carried.
+        print_err(format_args!(
+            "error: doiget audit-log: --verify is required (Phase 1 ships only \
              --verify; --since / --source / --session land later)"
-        );
+        ));
+        return Err(anyhow::Error::new(CliExit(2)));
     }
 
     let log_path = resolve_log_path()?;
@@ -184,12 +200,20 @@ mod tests {
     fn run_without_verify_flag_errors() {
         // Even with no log file at all, the absence of --verify is a
         // user-error guard that fires before we touch the disk.
+        //
+        // Issue #149: missing-required-flag is argument misuse →
+        // `docs/ERRORS.md` §4 exit 2. The human-readable line is now
+        // written to stderr (not into the error's Display), and the
+        // returned error carries a `CliExit(2)` so `main` exits 2
+        // instead of the old generic 1.
         let _g = EnvGuard::unset("DOIGET_LOG_PATH");
         let err = run(false).expect_err("--verify must be required in Phase 1");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("--verify is required"),
-            "unexpected error message: {msg}"
+        let cli_exit = err
+            .downcast_ref::<CliExit>()
+            .expect("missing --verify must carry a CliExit (issue #149)");
+        assert_eq!(
+            cli_exit.0, 2,
+            "missing required flag is misuse → exit 2, not the generic exit 1"
         );
     }
 

--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -125,11 +125,14 @@ pub fn run(verify_flag: bool) -> Result<()> {
 /// 1. `DOIGET_LOG_PATH` env var, if set and non-empty.
 /// 2. `<config_dir>/doiget/access.jsonl` (cross-platform via `dirs::config_dir`).
 ///
-/// Note: the writer's default in `commands/config.rs::ResolvedConfig` is
-/// `DOIGET_LOG_DIR` + `access.jsonl`. We accept the more direct
-/// `DOIGET_LOG_PATH` here too because §1 of `docs/PROVENANCE_LOG.md`
-/// specifies `DOIGET_LOG_PATH` as the spec'd override. Tests rely on
-/// `DOIGET_LOG_PATH` to point at a per-test tempdir.
+/// This resolution agrees with the provenance-log *writer*
+/// (`commands::fetch::resolve_log_path` / `commands::config::ResolvedConfig`):
+/// since issue #142 all of them key off `DOIGET_LOG_PATH` (the only log env
+/// var `docs/CONFIG.md` §4 / `docs/PROVENANCE_LOG.md` §1 documents), falling
+/// back to `<config_dir>/doiget/access.jsonl`. The previously read,
+/// undocumented `DOIGET_LOG_DIR` was removed in #142, so reader and writer
+/// can never disagree. Tests rely on `DOIGET_LOG_PATH` to point at a
+/// per-test tempdir.
 fn resolve_log_path() -> Result<Utf8PathBuf> {
     if let Ok(s) = std::env::var("DOIGET_LOG_PATH") {
         if !s.is_empty() {

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -34,7 +34,7 @@ use anyhow::{anyhow, Context, Result};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, RowInput};
 use doiget_core::{RateLimits, Ref, MCP_BATCH_MAX_SIZE};
 
-use super::fetch::{build_fetch_plan, emit_dry_run_plan_to_stdout, FetchHarness};
+use super::fetch::{build_fetch_plan, emit_dry_run_plan_to_stdout, CliExit, FetchHarness};
 use super::resolve_store_root;
 
 /// Run the `doiget batch <path>` subcommand.
@@ -226,12 +226,16 @@ pub async fn run_with_options(path: String, dry_run: bool) -> Result<()> {
     if all_ok {
         Ok(())
     } else {
-        Err(anyhow!(
-            "batch failed: {} OK, {} parse errors, {} fetch errors",
-            fetch_ok,
-            parse_errors,
-            fetch_errors,
-        ))
+        // Issue #143 / `docs/ERRORS.md` §4: the batch process exit code is
+        // the number of failures, capped at 255 (the dedicated "capped
+        // failure count for `batch`" exit). Previously a bare `anyhow!`
+        // fell through to `main`'s catch-all and exited 1 regardless of
+        // volume, so CI callers could not tell 1 failure from 200. The
+        // human-readable breakdown was ALREADY written to stderr by
+        // `print_summary` above, so `CliExit` carries only the code —
+        // `main` downcasts it exactly as it does for `fetch`'s `CliExit`.
+        let code = total_errors.min(255) as i32;
+        Err(anyhow::Error::new(CliExit(code)))
     }
 }
 

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -11,23 +11,34 @@
 //! never invoked from inside an MCP session (`doiget serve` runs a
 //! different code path), so the lint is locally relaxed below.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use camino::Utf8PathBuf;
+
+use super::fetch::CliExit;
 
 /// Snapshot of the env-var + default-fallback config that `doiget` would
 /// use on the current machine.
 ///
-/// Phase 1 surface: env vars only (`DOIGET_STORE_ROOT`, `DOIGET_LOG_DIR`,
+/// Phase 1 surface: env vars only (`DOIGET_STORE_ROOT`, `DOIGET_LOG_PATH`,
 /// `DOIGET_CONTACT_EMAIL`, `DOIGET_UNPAYWALL_EMAIL`) layered over
 /// XDG / known-folder defaults. Phase 2 will layer the user config.toml
 /// underneath the env vars per `docs/CONFIG.md` §1.
+///
+/// Issue #142: `log_path` is resolved from `DOIGET_LOG_PATH` — the ONLY
+/// log env var `docs/CONFIG.md` §4 documents — using the exact same
+/// resolution the provenance-log *writer*
+/// (`commands::fetch::resolve_log_path` / `commands::audit_log`) uses, so
+/// `config show` reports the path the writer actually uses. The previously
+/// read, undocumented `DOIGET_LOG_DIR` has been dropped.
 #[derive(Debug, serde::Serialize)]
 pub struct ResolvedConfig {
     /// Root of the on-disk paper store. Default: `$HOME/papers`.
     pub store_root: Utf8PathBuf,
-    /// Directory holding doiget's append-only logs.
+    /// Directory holding doiget's append-only logs. Derived from
+    /// `log_path`'s parent so it always agrees with the writer.
     pub log_dir: Utf8PathBuf,
-    /// JSON-Lines provenance log file path. Always `<log_dir>/access.jsonl`.
+    /// JSON-Lines provenance log file path. `DOIGET_LOG_PATH` when set,
+    /// otherwise `<config_dir>/doiget/access.jsonl` (`docs/CONFIG.md` §4).
     pub log_path: Utf8PathBuf,
     /// Directory holding `config.toml` and `credentials.toml`.
     pub config_dir: Utf8PathBuf,
@@ -63,11 +74,25 @@ impl ResolvedConfig {
         let store_root = std::env::var("DOIGET_STORE_ROOT")
             .map(Utf8PathBuf::from)
             .unwrap_or_else(|_| home.join("papers"));
-        let log_dir = std::env::var("DOIGET_LOG_DIR")
-            .map(Utf8PathBuf::from)
-            .unwrap_or_else(|_| cfg.join("doiget"));
 
-        let log_path = log_dir.join("access.jsonl");
+        // Issue #142: resolve the log path the SAME way the writer does
+        // (`commands::fetch::resolve_log_path` / `commands::audit_log`):
+        // `DOIGET_LOG_PATH` (the only log env var documented in
+        // `docs/CONFIG.md` §4) when set, otherwise
+        // `<config_dir>/doiget/access.jsonl`. The undocumented
+        // `DOIGET_LOG_DIR` is no longer read, so `config show` can no
+        // longer disagree with the path the provenance log is written to.
+        let log_path = match std::env::var("DOIGET_LOG_PATH") {
+            Ok(s) if !s.is_empty() => Utf8PathBuf::from(s),
+            _ => cfg.join("doiget").join("access.jsonl"),
+        };
+        // `log_dir` is purely derived from `log_path` so the two can never
+        // drift; fall back to the config dir for a path with no parent.
+        let log_dir = log_path
+            .parent()
+            .map(Utf8PathBuf::from)
+            .unwrap_or_else(|| cfg.join("doiget"));
+
         let config_dir = cfg.join("doiget");
         let config_path = config_dir.join("config.toml");
 
@@ -124,12 +149,33 @@ pub fn run(action: String) -> Result<()> {
             // Trying to actually create the dirs would have side-effects;
             // keep doctor read-only and just check existence of parents.
             if !all_ok {
-                bail!("config doctor: one or more checks failed");
+                // Issue #149: a failing doctor means missing/invalid
+                // config — `docs/ERRORS.md` §4 classes "missing config"
+                // as misuse → exit 2 (the per-check `[FAIL]` lines were
+                // already written to stderr by `check`).
+                eprintln_err("error: config doctor: one or more checks failed");
+                return Err(anyhow::Error::new(CliExit(2)));
             }
         }
-        other => bail!("unknown config action: {other}; expected `show` / `path` / `doctor`"),
+        other => {
+            // Issue #149: an unknown subcommand action is clear argument
+            // misuse → `docs/ERRORS.md` §4 exit 2, not the generic exit 1
+            // a bare `bail!` produced.
+            eprintln_err(&format!(
+                "error: unknown config action: {other}; expected `show` / `path` / `doctor`"
+            ));
+            return Err(anyhow::Error::new(CliExit(2)));
+        }
     }
     Ok(())
+}
+
+/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. The
+/// localized `#[allow]` is the minimal intervention for the workspace
+/// `clippy::print_stderr` lint (same pattern as `commands::fetch`).
+#[allow(clippy::print_stderr)]
+fn eprintln_err(msg: &str) {
+    eprintln!("{msg}");
 }
 
 /// Emit one `[ ok ]` / `[FAIL]` checklist line to stderr and update the
@@ -193,7 +239,7 @@ mod tests {
     fn unset_all_doiget_config_env() -> Vec<EnvGuard> {
         [
             "DOIGET_STORE_ROOT",
-            "DOIGET_LOG_DIR",
+            "DOIGET_LOG_PATH",
             "DOIGET_CONTACT_EMAIL",
             "DOIGET_UNPAYWALL_EMAIL",
         ]
@@ -228,16 +274,44 @@ mod tests {
         assert_eq!(cfg.store_root.as_str(), "/tmp/foo");
     }
 
+    /// Issue #142: `config show` MUST report the same `log_path` the
+    /// provenance-log writer uses. The writer keys off `DOIGET_LOG_PATH`
+    /// (the only log env var documented in `docs/CONFIG.md` §4); the
+    /// resolver must do the same, and `log_dir` must be that path's
+    /// parent — never an independently-resolved (and divergent) value.
+    #[test]
+    #[serial_test::serial]
+    fn log_path_follows_doiget_log_path_env() {
+        let _g = unset_all_doiget_config_env();
+        let _override = EnvGuard::set("DOIGET_LOG_PATH", "/var/lib/doiget/access.jsonl");
+        let cfg = ResolvedConfig::from_env().expect("home dir must resolve on test host");
+        assert_eq!(
+            cfg.log_path.as_str(),
+            "/var/lib/doiget/access.jsonl",
+            "config show must echo DOIGET_LOG_PATH verbatim (issue #142)"
+        );
+        assert_eq!(
+            cfg.log_dir.as_str(),
+            "/var/lib/doiget",
+            "log_dir must be derived from log_path's parent so the two cannot drift"
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn doctor_fails_without_contact_email() {
+        // Issue #149: a failing doctor is "missing config" → exit 2.
+        // The human-readable line moved to stderr; the error now carries
+        // a `CliExit(2)` rather than a Display-formatted anyhow string.
         let _g = unset_all_doiget_config_env();
         let err = run("doctor".into())
             .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("config doctor"),
-            "unexpected error message: {msg}"
+        let cli_exit = err
+            .downcast_ref::<CliExit>()
+            .expect("failing doctor must carry a CliExit (issue #149)");
+        assert_eq!(
+            cli_exit.0, 2,
+            "missing/invalid config is misuse → exit 2, not the generic exit 1"
         );
     }
 
@@ -254,12 +328,17 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn unknown_action_errors() {
+        // Issue #149: an unknown action is clear argument misuse →
+        // `docs/ERRORS.md` §4 exit 2. The descriptive line moved to
+        // stderr; the error carries `CliExit(2)`.
         let _g = unset_all_doiget_config_env();
         let err = run("bogus".into()).expect_err("bogus action should error");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("unknown config action"),
-            "unexpected error message: {msg}"
+        let cli_exit = err
+            .downcast_ref::<CliExit>()
+            .expect("unknown config action must carry a CliExit (issue #149)");
+        assert_eq!(
+            cli_exit.0, 2,
+            "unknown config action is misuse → exit 2, not the generic exit 1"
         );
     }
 }

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -387,6 +387,25 @@ impl FetchHarness {
         let ctx = self.fetch_context();
         match core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await {
             Ok(outcome) => {
+                // Issue #145 / `docs/ERRORS.md` §3 + §6: a `Blocked` PDF
+                // leg means an OA PDF *was* discovered but could not be
+                // retrieved. Metadata was written, but this is NOT a
+                // clean success — emitting only `print_success` here made
+                // a denied PDF visually indistinguishable from a genuine
+                // metadata-only result and exited 0 (a silent failure).
+                // Route it through the SAME `error[CODE]:` stderr channel
+                // + `cli_exit_code(...)` mapping `fetch` already uses for
+                // `CapabilityDenied`, using the structured code the
+                // orchestrator mapped from the underlying transport error.
+                if let PdfLegStatus::Blocked {
+                    code,
+                    message,
+                    denial,
+                } = &outcome.pdf_leg
+                {
+                    render_blocked_error(ref_, &outcome, *code, message, denial.as_ref());
+                    return Err(anyhow::Error::new(CliExit(cli_exit_code(*code))));
+                }
                 emit_success_line(ref_, &outcome);
                 Ok(())
             }
@@ -425,20 +444,19 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
                 label, outcome.path
             ));
         }
-        // Issue #118: an OA PDF existed but could not be retrieved.
-        // The metadata WAS written, so this is still a (partial)
-        // success — but we MUST tell the user why the PDF is missing
-        // instead of an indistinguishable "metadata-only" line.
-        PdfLegStatus::Blocked { code, message, .. } => {
-            print_success(format_args!(
-                "fetched {} (metadata-only) -> {}",
-                label, outcome.path
-            ));
-            print_success(format_args!(
-                "  note: an OA PDF was found but could not be retrieved [{}]: {}",
-                code.as_wire(),
-                message
-            ));
+        // Issue #145: `Blocked` is NO LONGER a success outcome. It is
+        // intercepted in `fetch_one` BEFORE `emit_success_line` is
+        // called and rendered via `render_blocked_error` with a
+        // non-zero exit (`docs/ERRORS.md` §3/§6 — no silent failures).
+        // Reaching this arm would mean the interception regressed, so we
+        // fail closed: surface the `error[CODE]:` line here too rather
+        // than printing a misleading success line.
+        PdfLegStatus::Blocked {
+            code,
+            message,
+            denial,
+        } => {
+            render_blocked_error(ref_, outcome, *code, message, denial.as_ref());
         }
         // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
         // degrades to the size-based wording rather than failing the
@@ -573,7 +591,12 @@ impl std::error::Error for CliExit {}
 
 /// `docs/ERRORS.md` §4 closed-code → process exit code. Anything not
 /// individually listed falls under "at least one fetch failed" (1).
-fn cli_exit_code(code: ErrorCode) -> i32 {
+///
+/// `pub(crate)` so sibling subcommands (`commands::graph`, …) route
+/// their typed denials through the SAME centralized mapping instead of
+/// open-coding magic exit numbers — keeps the `ErrorCode`→exit contract
+/// single-sourced (issue #149).
+pub(crate) fn cli_exit_code(code: ErrorCode) -> i32 {
     match code {
         ErrorCode::CapabilityDenied => 3,
         ErrorCode::StoreError | ErrorCode::LogError => 4,
@@ -604,6 +627,52 @@ fn render_fetch_error(e: &FetchError) {
             }
         }
     }
+}
+
+/// Render a `PdfLegStatus::Blocked` outcome in the `docs/ERRORS.md` §3
+/// "Researcher (CLI human)" form. Issue #145: an OA PDF was discovered
+/// but could not be retrieved — the metadata WAS written, but this is a
+/// denial, not a clean success. We emit the same `error[CODE]:` stderr
+/// shape as [`render_fetch_error`] (so pipelines and humans see an
+/// unambiguous failure), name the metadata path that DID land so the
+/// partial result is still discoverable, and surface the ADR-0023
+/// `denial_context` note when present. stdout stays clean (ADR-0001).
+fn render_blocked_error(
+    ref_: &Ref,
+    outcome: &FetchPaperOutcome,
+    code: ErrorCode,
+    message: &str,
+    denial: Option<&DenialContext>,
+) {
+    let label = match ref_ {
+        Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
+        Ref::Doi(doi) => format!("doi:{}", doi.as_str()),
+    };
+    print_err(format_args!(
+        "error[{}]: {label}: an OA PDF was found but could not be retrieved: {message}",
+        code.as_wire()
+    ));
+    if let Some(dc) = denial {
+        let attempted = dc.attempted.as_deref().unwrap_or("(unknown)");
+        match &dc.expected {
+            Some(exp) if !exp.is_empty() => {
+                print_err(format_args!(
+                    "  = note: attempted {attempted}; allowed: {}",
+                    exp.join(", ")
+                ));
+            }
+            _ => {
+                print_err(format_args!("  = note: attempted {attempted}"));
+            }
+        }
+    }
+    // The metadata TOML still landed; point the user at it so the
+    // partial result is not lost (it is still useful), without
+    // pretending the fetch succeeded.
+    print_err(format_args!(
+        "  = note: metadata-only record written to {}",
+        outcome.path
+    ));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -412,7 +412,7 @@ impl FetchHarness {
                     // off-allowlist / redirect-denied / insecure-scheme OA
                     // PDF leg is a DELIBERATE policy block — retrying never
                     // helps — yet it would otherwise surface as
-                    // `NETWORK_ERROR` → generic exit 1, mis-signalling a
+                    // `NETWORK_ERROR` → generic exit 1, misrepresenting a
                     // flaky network. The orchestrator already preserves the
                     // real reason on `denial` (the `From<&HttpError> for
                     // Option<DenialContext>` impl walks reqwest's source
@@ -623,7 +623,7 @@ impl std::error::Error for CliExit {}
 /// fine" — true for a real network blip, but **false** for a deliberate
 /// supply-chain policy block (off-allowlist redirect, insecure-scheme
 /// redirect, host-blocklist hit): retrying such a block never helps, so
-/// surfacing it as `NETWORK_ERROR` (generic exit 1) mis-signals a flaky
+/// surfacing it as `NETWORK_ERROR` (generic exit 1) misrepresents a flaky
 /// network to humans and agents.
 ///
 /// The orchestrator already preserves the true reason on the

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -53,7 +53,7 @@ use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, Ro
 use doiget_core::rate_limiter::RateLimiter;
 use doiget_core::source::{FetchContext, FetchError};
 use doiget_core::store::FsStore;
-use doiget_core::{CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref};
+use doiget_core::{CapabilityProfile, DenialContext, DenialReason, ErrorCode, RateLimits, Ref};
 
 /// Defer to docs/PROVENANCE_LOG.md §3: 26-char ULID per process invocation.
 fn new_session_id() -> String {
@@ -403,8 +403,29 @@ impl FetchHarness {
                     denial,
                 } = &outcome.pdf_leg
                 {
-                    render_blocked_error(ref_, &outcome, *code, message, denial.as_ref());
-                    return Err(anyhow::Error::new(CliExit(cli_exit_code(*code))));
+                    // Issue #145 / `docs/ERRORS.md` §2 + §3: the core
+                    // collapses *every* `FetchError::Http(_)` to
+                    // `ErrorCode::NetworkError` (see
+                    // `doiget_core::source.rs`'s `From<&FetchError> for
+                    // ErrorCode`). For a genuine transport/DNS/TLS fault
+                    // that is correct ("retry usually fine"). But an
+                    // off-allowlist / redirect-denied / insecure-scheme OA
+                    // PDF leg is a DELIBERATE policy block — retrying never
+                    // helps — yet it would otherwise surface as
+                    // `NETWORK_ERROR` → generic exit 1, mis-signalling a
+                    // flaky network. The orchestrator already preserves the
+                    // real reason on `denial` (the `From<&HttpError> for
+                    // Option<DenialContext>` impl walks reqwest's source
+                    // chain, so even a redirect denial wrapped as
+                    // `HttpError::Network` still yields
+                    // `DenialReason::RedirectNotInAllowlist`). Reclassify
+                    // the *policy* denials here at the CLI layer to
+                    // `CapabilityDenied` → `error[CAPABILITY_DENIED]:` →
+                    // exit 3 (the same code `fetch`/`graph` already use for
+                    // `ErrorCode::CapabilityDenied`).
+                    let effective = effective_blocked_code(*code, denial.as_ref());
+                    render_blocked_error(ref_, &outcome, effective, message, denial.as_ref());
+                    return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
                 }
                 emit_success_line(ref_, &outcome);
                 Ok(())
@@ -456,7 +477,10 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
             message,
             denial,
         } => {
-            render_blocked_error(ref_, outcome, *code, message, denial.as_ref());
+            // Same #145 reclassification as the primary interception in
+            // `fetch_one`, so this fail-closed fallback stays consistent.
+            let effective = effective_blocked_code(*code, denial.as_ref());
+            render_blocked_error(ref_, outcome, effective, message, denial.as_ref());
         }
         // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
         // degrades to the size-based wording rather than failing the
@@ -589,6 +613,57 @@ impl std::fmt::Display for CliExit {
 
 impl std::error::Error for CliExit {}
 
+/// Reclassify a `PdfLegStatus::Blocked` code at the CLI layer (issue
+/// #145 / `docs/ERRORS.md` §2 "NETWORK_ERROR" vs §3.1 / §6).
+///
+/// The core maps *every* `FetchError::Http(_)` to
+/// [`ErrorCode::NetworkError`] (`doiget_core::source`'s
+/// `From<&FetchError> for ErrorCode`). `docs/ERRORS.md` §2 defines
+/// `NETWORK_ERROR` as a transport / DNS / TLS fault where "retry usually
+/// fine" — true for a real network blip, but **false** for a deliberate
+/// supply-chain policy block (off-allowlist redirect, insecure-scheme
+/// redirect, host-blocklist hit): retrying such a block never helps, so
+/// surfacing it as `NETWORK_ERROR` (generic exit 1) mis-signals a flaky
+/// network to humans and agents.
+///
+/// The orchestrator already preserves the true reason on the
+/// [`DenialContext`] side-channel (the `From<&HttpError> for
+/// Option<DenialContext>` impl walks reqwest's `source()` chain, so even
+/// a redirect denial wrapped as `HttpError::Network` still yields
+/// [`DenialReason::RedirectNotInAllowlist`]). When that reason is one of
+/// the closed-set *policy* denials, promote the surface code to
+/// [`ErrorCode::CapabilityDenied`] so the CLI renders
+/// `error[CAPABILITY_DENIED]:` and [`cli_exit_code`] returns exit 3 —
+/// the same code `fetch` / `graph` already use for capability denials.
+/// Non-policy blocks (no `denial`, or a non-policy reason such as
+/// `SizeCapExceeded` / `ContentTypeMismatch`) keep the core's code so a
+/// genuine transport failure still reads as `NETWORK_ERROR`.
+fn effective_blocked_code(code: ErrorCode, denial: Option<&DenialContext>) -> ErrorCode {
+    match denial.map(|d| d.reason) {
+        Some(
+            DenialReason::RedirectNotInAllowlist
+            | DenialReason::InsecureScheme
+            | DenialReason::HostInBlockList,
+        ) => ErrorCode::CapabilityDenied,
+        _ => code,
+    }
+}
+
+/// Snake-case wire token for a [`DenialReason`], matching the
+/// `#[serde(rename_all = "snake_case")]` JSON/MCP surface (ADR-0023 §2)
+/// so the CLI human line uses the SAME vocabulary as the machine
+/// envelope (`docs/ERRORS.md` §3.1). Only the policy-denial reasons the
+/// CLI inlines are enumerated; everything else degrades to a generic
+/// token rather than drifting from the serde form.
+fn denial_reason_wire(reason: DenialReason) -> &'static str {
+    match reason {
+        DenialReason::RedirectNotInAllowlist => "redirect_not_in_allowlist",
+        DenialReason::InsecureScheme => "insecure_scheme",
+        DenialReason::HostInBlockList => "host_in_block_list",
+        _ => "policy_denied",
+    }
+}
+
 /// `docs/ERRORS.md` §4 closed-code → process exit code. Anything not
 /// individually listed falls under "at least one fetch failed" (1).
 ///
@@ -648,10 +723,30 @@ fn render_blocked_error(
         Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
         Ref::Doi(doi) => format!("doi:{}", doi.as_str()),
     };
-    print_err(format_args!(
-        "error[{}]: {label}: an OA PDF was found but could not be retrieved: {message}",
-        code.as_wire()
-    ));
+    // Issue #145: when the block is a deliberate policy denial, name the
+    // closed-set reason inline so a human/agent reading the
+    // `error[CAPABILITY_DENIED]:` line immediately sees this is a
+    // supply-chain policy block (retrying is futile), not a flaky network.
+    match denial.map(|d| d.reason) {
+        Some(
+            reason @ (DenialReason::RedirectNotInAllowlist
+            | DenialReason::InsecureScheme
+            | DenialReason::HostInBlockList),
+        ) => {
+            print_err(format_args!(
+                "error[{}]: {label}: an OA PDF was found but its host is blocked by \
+                 supply-chain policy ({}): {message}",
+                code.as_wire(),
+                denial_reason_wire(reason)
+            ));
+        }
+        _ => {
+            print_err(format_args!(
+                "error[{}]: {label}: an OA PDF was found but could not be retrieved: {message}",
+                code.as_wire()
+            ));
+        }
+    }
     if let Some(dc) = denial {
         let attempted = dc.attempted.as_deref().unwrap_or("(unknown)");
         match &dc.expected {
@@ -709,5 +804,102 @@ mod tests {
     #[test]
     fn fetch_paper_outcome_is_reachable_from_cli() {
         let _ = std::any::type_name::<doiget_core::orchestrator::FetchPaperOutcome>();
+    }
+
+    /// Minimal `DenialContext` carrying only `reason`; every other field
+    /// is optional (ADR-0023 §3) so `None`/empty is a valid producer
+    /// shape for the reclassification decision under test.
+    fn denial(reason: DenialReason) -> DenialContext {
+        DenialContext {
+            reason,
+            source: None,
+            attempted: None,
+            expected: None,
+            hop_index: None,
+            cap: None,
+            actual: None,
+        }
+    }
+
+    /// Issue #145 / `docs/ERRORS.md` §6.1: a policy-class denial reason
+    /// on a `Blocked` OA-PDF leg must be reclassified from the core's
+    /// blanket `NetworkError` to `CapabilityDenied` at the CLI layer, so
+    /// the user-facing exit becomes 3 (not the generic 1) and a flaky
+    /// network is not implied for a deliberate supply-chain block.
+    #[test]
+    fn policy_denials_reclassify_network_error_to_capability_denied() {
+        for r in [
+            DenialReason::RedirectNotInAllowlist,
+            DenialReason::InsecureScheme,
+            DenialReason::HostInBlockList,
+        ] {
+            let d = denial(r);
+            assert_eq!(
+                effective_blocked_code(ErrorCode::NetworkError, Some(&d)),
+                ErrorCode::CapabilityDenied,
+                "policy reason {r:?} must promote NetworkError -> CapabilityDenied"
+            );
+            assert_eq!(
+                cli_exit_code(effective_blocked_code(ErrorCode::NetworkError, Some(&d))),
+                3,
+                "policy reason {r:?} must map to exit 3 (docs/ERRORS.md §4/§6.1)"
+            );
+        }
+    }
+
+    /// A genuine transport fault carries NO `DenialContext`; it must stay
+    /// `NetworkError` / exit 1 — `docs/ERRORS.md` §2 "retry usually fine"
+    /// is the correct signal there. (This is exactly the e2e
+    /// `..._host_off_allowlist` path: first-leg connect failure, no
+    /// redirect hop, so no allowlist denial is produced.)
+    #[test]
+    fn absent_denial_context_keeps_network_error() {
+        assert_eq!(
+            effective_blocked_code(ErrorCode::NetworkError, None),
+            ErrorCode::NetworkError
+        );
+        assert_eq!(
+            cli_exit_code(effective_blocked_code(ErrorCode::NetworkError, None)),
+            1
+        );
+    }
+
+    /// Non-policy denial reasons (size cap, content-type mismatch) are
+    /// NOT supply-chain policy blocks; they keep the core's code so a
+    /// genuine cap/transport class is not masked as a capability denial.
+    #[test]
+    fn non_policy_denials_keep_core_code() {
+        for r in [
+            DenialReason::SizeCapExceeded,
+            DenialReason::ContentTypeMismatch,
+        ] {
+            let d = denial(r);
+            assert_eq!(
+                effective_blocked_code(ErrorCode::NetworkError, Some(&d)),
+                ErrorCode::NetworkError,
+                "non-policy reason {r:?} must NOT be reclassified"
+            );
+        }
+    }
+
+    /// The closed-set wire token used in the human `error[...]:` line
+    /// must match the serde `snake_case` form so the CLI vocabulary does
+    /// not drift from the JSON/MCP envelope (`docs/ERRORS.md` §3.1).
+    #[test]
+    fn denial_reason_wire_matches_serde_snake_case() {
+        for r in [
+            DenialReason::RedirectNotInAllowlist,
+            DenialReason::InsecureScheme,
+            DenialReason::HostInBlockList,
+        ] {
+            let serde_form = serde_json::to_string(&r).expect("serialize DenialReason");
+            // serde_json wraps the enum unit variant in quotes.
+            let serde_token = serde_form.trim_matches('"');
+            assert_eq!(
+                denial_reason_wire(r),
+                serde_token,
+                "CLI wire token for {r:?} must equal the serde snake_case form"
+            );
+        }
     }
 }

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -27,13 +27,22 @@
 
 use std::io::Write;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use doiget_core::citation_graph::{expand, GraphCaps, GraphError};
 use doiget_core::sources::openalex::OpenalexSource;
-use doiget_core::Ref;
+use doiget_core::{ErrorCode, Ref};
 
-use super::fetch::FetchHarness;
+use super::fetch::{cli_exit_code, CliExit, FetchHarness};
+
+/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. Mirrors
+/// the `print_err` helper in `commands::fetch`; the localized `#[allow]`
+/// is the minimal intervention for the workspace `clippy::print_stderr`
+/// lint.
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
 
 /// Run the `graph` subcommand against the live source set.
 ///
@@ -50,21 +59,47 @@ pub async fn run(
     total: Option<u32>,
     per_paper: Option<u32>,
 ) -> Result<()> {
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = match Ref::parse(&input) {
+        Ok(r) => r,
+        Err(e) => {
+            // Bad ref string is user misuse → `docs/ERRORS.md` §4 exit 2
+            // (issue #149), consistent with `fetch`'s INVALID_REF path.
+            print_err(format_args!(
+                "error[{}]: invalid ref: {e}",
+                ErrorCode::InvalidRef.as_wire()
+            ));
+            return Err(anyhow::Error::new(CliExit(2)));
+        }
+    };
     let doi = match &ref_ {
         Ref::Doi(d) => d.clone(),
-        Ref::Arxiv(_) => bail!(
-            "doiget graph requires a DOI seed; arXiv ids are not in OpenAlex's referenced_works \
-             keyspace"
-        ),
+        Ref::Arxiv(_) => {
+            // Passing an arXiv id to `graph` is an argument-misuse error
+            // (OpenAlex's `referenced_works` is DOI-keyed) → exit 2
+            // (`docs/ERRORS.md` §4), not the generic exit 1 (issue #149).
+            print_err(format_args!(
+                "error: doiget graph requires a DOI seed; arXiv ids are not in OpenAlex's \
+                 referenced_works keyspace"
+            ));
+            return Err(anyhow::Error::new(CliExit(2)));
+        }
     };
 
     let harness = FetchHarness::from_env().context("building fetch harness")?;
     if !harness.profile.metadata.openalex {
-        bail!(
-            "doiget graph requires DOIGET_ENABLE_OPENALEX in env AND the binary built with \
-             `--features citation`. CapabilityProfile.metadata.openalex is currently false."
-        );
+        // Capability not granted → `docs/ERRORS.md` §4 exit 3, the SAME
+        // code `fetch` uses for `CAPABILITY_DENIED` (issue #149). This
+        // pre-`expand` guard is the same denial class as the post-`expand`
+        // `GraphError::CapabilityDenied` arm below; route both through
+        // `cli_exit_code(ErrorCode::CapabilityDenied)`.
+        print_err(format_args!(
+            "error[{}]: doiget graph requires DOIGET_ENABLE_OPENALEX in env AND the binary \
+             built with `--features citation` (CapabilityProfile.metadata.openalex is false)",
+            ErrorCode::CapabilityDenied.as_wire()
+        ));
+        return Err(anyhow::Error::new(CliExit(cli_exit_code(
+            ErrorCode::CapabilityDenied,
+        ))));
     }
 
     let contact_email =
@@ -97,11 +132,24 @@ pub async fn run(
     harness.log_session_end(session_ok, Some(&input));
 
     let graph = outcome.map_err(|e| match e {
-        GraphError::CapabilityDenied => anyhow::anyhow!(
-            "OpenAlex capability denied: set DOIGET_ENABLE_OPENALEX and rebuild with \
-             --features citation"
-        ),
+        GraphError::CapabilityDenied => {
+            // Issue #149: `ERRORS.md` §4 maps a capability denial to
+            // exit 3 (the same code `fetch` uses for
+            // `CAPABILITY_DENIED`), NOT the generic exit 1 a plain
+            // `anyhow!` string would have produced. Emit the cargo-style
+            // `error[CODE]:` line here (while the error is still typed),
+            // then carry only the exit code to `main`.
+            print_err(format_args!(
+                "error[{}]: OpenAlex capability denied: set DOIGET_ENABLE_OPENALEX and \
+                 rebuild with --features citation",
+                ErrorCode::CapabilityDenied.as_wire()
+            ));
+            anyhow::Error::new(CliExit(cli_exit_code(ErrorCode::CapabilityDenied)))
+        }
         GraphError::SeedNotIndexed => {
+            // Not a capability/misuse class — an indexing gap upstream.
+            // Falls under the generic "at least one fetch failed" exit
+            // (1); a descriptive anyhow string is the right surface.
             anyhow::anyhow!("seed DOI '{input}' is not indexed by OpenAlex")
         }
         other => anyhow::Error::new(other),

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -1,12 +1,11 @@
 //! doiget CLI binary.
 //!
-//! Phase 0 ships the CLI skeleton: `doiget --help` works, and each subcommand
-//! returns a Phase-1-pending error message. Real implementations land in Phase 1+.
-//!
-//! Phase 1 progressively replaces the Phase-0 bail-out per subcommand. The
-//! `config`, `info`, `list-recent`, `search`, `fetch`, `audit-log`, `batch`,
-//! `bib`, and `csl` subcommands have landed. Phase 3 wires `serve` to
-//! the rmcp-based MCP server in `doiget-mcp`.
+//! `doiget` is an OA-first paper fetcher and stdio MCP server. The full
+//! shipped subcommand surface is wired through [`run_dispatch`]: `fetch`,
+//! `batch`, `bib`, `csl`, `info`, `search`, `list-recent`, `audit-log`,
+//! `provenance`, `config`, `serve`, and (under `--features citation`)
+//! `graph`. `serve` runs the rmcp-based MCP server in `doiget-mcp` over
+//! stdio (ADR-0001).
 
 use clap::{Parser, Subcommand};
 
@@ -32,8 +31,23 @@ enum ProvenanceAction {
     version,
     about = "Fetch academic papers via official Open Access APIs.",
     long_about = "doiget is an OA-first paper fetcher and stdio MCP server.\n\
-                  See README.md and docs/ for the full specification.\n\
-                  This is the Phase 0 skeleton; subcommands are not yet implemented."
+                  \n\
+                  Subcommands:\n\
+                  \x20 fetch        Fetch a single paper PDF by DOI or arXiv id\n\
+                  \x20 batch        Fetch many refs from a newline-separated file\n\
+                  \x20 bib          Export a stored entry as BibTeX\n\
+                  \x20 csl          Export a stored entry as CSL JSON\n\
+                  \x20 info         Show metadata for a stored entry\n\
+                  \x20 search       Search the local store by title / authors / venue\n\
+                  \x20 list-recent  List the most recently fetched entries\n\
+                  \x20 audit-log    Inspect or verify the provenance log\n\
+                  \x20 provenance   Provenance-log lifecycle ops (migrate v1 -> v2)\n\
+                  \x20 config       Show or doctor the resolved configuration\n\
+                  \x20 serve        Run as an MCP server over stdio\n\
+                  \x20 graph        Expand a DOI's citation neighborhood via OpenAlex\n\
+                  \x20              (requires --features citation + DOIGET_ENABLE_OPENALEX)\n\
+                  \n\
+                  See README.md and docs/ for the full specification."
 )]
 struct Cli {
     #[command(subcommand)]

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -238,9 +238,16 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
     .expect("write refs file");
 
     let result = batch::run_with_options(refs_path.as_str().to_string(), false).await;
-    assert!(
-        result.is_err(),
-        "batch with a malformed ref must surface an error to the binary"
+    let err = result.expect_err("batch with a malformed ref must surface an error to the binary");
+    // Issue #143 / `docs/ERRORS.md` §4: the batch exit code is the number
+    // of failures (capped at 255), NOT a blanket 1. Exactly one entry
+    // failed to parse here, so the carried `CliExit` must be 1.
+    let cli_exit = err
+        .downcast_ref::<doiget_cli::commands::fetch::CliExit>()
+        .expect("batch failure must carry a CliExit so main maps it to the §4 exit code");
+    assert_eq!(
+        cli_exit.0, 1,
+        "one parse failure must yield exit code 1 (failure count), not a generic anyhow exit"
     );
 
     // Step 2: the good ref's PDF must still be on disk.

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -253,9 +253,17 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     let base_uri = server.uri();
 
     // The OA URL points at an `https://` host that is NOT one of our
-    // registered allowlist entries (`127.0.0.1`). The redirect-policy
-    // closure denies the initial-leg URL on the host-allowlist check
-    // before any body is read.
+    // registered allowlist entries. NOTE (issue #145 investigation): the
+    // per-source host allowlist is enforced ONLY inside
+    // `reqwest::redirect::Policy::custom`, which `reqwest` invokes ONLY on
+    // redirect hops — there is NO initial-URL host pre-check in
+    // `doiget_core::http::HttpClient::fetch_inner`. This mock mounts NO
+    // redirect and `attacker.test` is unroutable, so the OA leg fails at
+    // connect/DNS on the FIRST request: a genuine `HttpError::Network`
+    // transport fault with NO wrapped `RedirectDenied` and therefore NO
+    // `DenialContext`. It is NOT distinguishable from a flaky network at
+    // the doiget-cli layer, so it correctly remains `NETWORK_ERROR` /
+    // exit 1 (see the assertion + the §6.1 caveat below).
     let off_allowlist_oa_url = "https://attacker.test/file.pdf".to_string();
 
     // Crossref uses `Url::join("/works/<doi>")` which does NOT URL-encode
@@ -297,10 +305,35 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     // Issue #145: the blocked PDF leg must surface as a non-zero exit,
     // NOT a silent `Ok(())`. The metadata is still written (asserted
     // below) but the CLI persona gets an `error[CODE]:` line + a
-    // `CliExit` carrying the `docs/ERRORS.md` §4 process code. The
-    // off-allowlist denial is wrapped by reqwest as `HttpError::Network`
-    // → `NETWORK_ERROR` → `cli_exit_code` falls to the generic
-    // "at least one fetch failed" exit (1).
+    // `CliExit` carrying the `docs/ERRORS.md` §4 process code.
+    //
+    // Issue #145 (Option B, approved) — scope caveat. The approved
+    // decision is: an off-allowlist / redirect-denied / insecure-scheme
+    // OA-PDF block is a DELIBERATE policy denial and MUST surface as
+    // `CAPABILITY_DENIED` / exit 3, not `NETWORK_ERROR` / exit 1
+    // (`docs/ERRORS.md` §2 + §6.1). That reclassification IS implemented
+    // at the doiget-cli layer in `effective_blocked_code`
+    // (`crates/doiget-cli/src/commands/fetch.rs`): whenever the
+    // orchestrator surfaces a `DenialContext` whose `reason` is
+    // `redirect_not_in_allowlist` / `insecure_scheme` /
+    // `host_in_block_list`, the CLI promotes the code to
+    // `CapabilityDenied` and returns `CliExit(3)`.
+    //
+    // THIS test case, however, does NOT exercise that path. The core's
+    // host allowlist is enforced only inside the redirect-policy closure
+    // (`reqwest::redirect::Policy::custom`), which runs ONLY on redirect
+    // hops; there is no initial-URL host pre-check in
+    // `doiget_core::http::fetch_inner`. With an unroutable first-leg host
+    // and no redirect, the OA leg fails at connect — a real
+    // `HttpError::Network` with NO wrapped `RedirectDenied`, hence
+    // `denial == None`. Per `docs/ERRORS.md` §6.1 a genuine transport
+    // fault with no `denial_context` correctly stays `NETWORK_ERROR` /
+    // exit 1. Closing the "initial OA URL host off-allowlist with no
+    // redirect" gap requires an initial-URL host pre-check in
+    // `crates/doiget-core/src/http.rs`, which is out of scope for this
+    // CLI-only branch/PR (tracked under #145; see the PR description /
+    // ERRORS.md §6.1). The metadata-still-written / PDF-not-written and
+    // `error_code == NETWORK_ERROR` provenance assertions below remain.
     let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
         .await
         .expect_err("a blocked OA PDF leg must NOT be a silent success (issue #145)");
@@ -309,7 +342,13 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
         .expect("blocked PDF leg must carry a CliExit so main maps it to a §4 exit code");
     assert_eq!(
         cli_exit.0, 1,
-        "off-allowlist OA denial maps to NETWORK_ERROR → exit 1"
+        "first-leg connect failure to an unroutable off-allowlist host \
+         has NO DenialContext (no redirect hop fired the allowlist \
+         closure) → genuine NETWORK_ERROR → exit 1, per docs/ERRORS.md \
+         §6.1. The policy-block → CAPABILITY_DENIED/exit-3 reclassification \
+         (issue #145) is unit-covered in fetch.rs::effective_blocked_code \
+         for the redirect/insecure-scheme cases that DO carry a \
+         DenialContext."
     );
 
     // PDF MUST NOT be written.

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -253,17 +253,18 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     let base_uri = server.uri();
 
     // The OA URL points at an `https://` host that is NOT one of our
-    // registered allowlist entries. NOTE (issue #145 investigation): the
-    // per-source host allowlist is enforced ONLY inside
-    // `reqwest::redirect::Policy::custom`, which `reqwest` invokes ONLY on
-    // redirect hops — there is NO initial-URL host pre-check in
-    // `doiget_core::http::HttpClient::fetch_inner`. This mock mounts NO
-    // redirect and `attacker.test` is unroutable, so the OA leg fails at
-    // connect/DNS on the FIRST request: a genuine `HttpError::Network`
-    // transport fault with NO wrapped `RedirectDenied` and therefore NO
-    // `DenialContext`. It is NOT distinguishable from a flaky network at
-    // the doiget-cli layer, so it correctly remains `NETWORK_ERROR` /
-    // exit 1 (see the assertion + the §6.1 caveat below).
+    // registered allowlist entries. As of issue #145 / PR #163 the core
+    // runs a PRE-FETCH host allowlist check on the metadata-discovered OA
+    // URL in `doiget_core::orchestrator::try_fetch_oa_pdf` BEFORE the PDF
+    // fetch is issued (`docs/REDIRECT_ALLOWLIST.md` §1 — NORMATIVE), not
+    // only inside the redirect closure. This mock mounts NO redirect and
+    // `attacker.test` is off the `oa-publisher` allowlist, so the pre-fetch
+    // check rejects the OA URL with the SAME `HttpError::RedirectDenied`
+    // the redirect closure produces — carrying a
+    // `DenialContext(RedirectNotInAllowlist)`. The connect to
+    // `attacker.test` never happens. The doiget-cli classification then
+    // promotes this deliberate policy block to `CAPABILITY_DENIED` /
+    // exit 3 (see the assertion + `docs/ERRORS.md` §6.1 below).
     let off_allowlist_oa_url = "https://attacker.test/file.pdf".to_string();
 
     // Crossref uses `Url::join("/works/<doi>")` which does NOT URL-encode
@@ -307,33 +308,34 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     // below) but the CLI persona gets an `error[CODE]:` line + a
     // `CliExit` carrying the `docs/ERRORS.md` §4 process code.
     //
-    // Issue #145 (Option B, approved) — scope caveat. The approved
-    // decision is: an off-allowlist / redirect-denied / insecure-scheme
-    // OA-PDF block is a DELIBERATE policy denial and MUST surface as
-    // `CAPABILITY_DENIED` / exit 3, not `NETWORK_ERROR` / exit 1
-    // (`docs/ERRORS.md` §2 + §6.1). That reclassification IS implemented
-    // at the doiget-cli layer in `effective_blocked_code`
+    // Issue #145 (Option B, approved): an off-allowlist / redirect-denied
+    // / insecure-scheme OA-PDF block is a DELIBERATE policy denial and
+    // MUST surface as `CAPABILITY_DENIED` / exit 3, not `NETWORK_ERROR` /
+    // exit 1 (`docs/ERRORS.md` §2 + §6.1). The doiget-cli reclassification
+    // lives in `effective_blocked_code`
     // (`crates/doiget-cli/src/commands/fetch.rs`): whenever the
     // orchestrator surfaces a `DenialContext` whose `reason` is
     // `redirect_not_in_allowlist` / `insecure_scheme` /
     // `host_in_block_list`, the CLI promotes the code to
     // `CapabilityDenied` and returns `CliExit(3)`.
     //
-    // THIS test case, however, does NOT exercise that path. The core's
-    // host allowlist is enforced only inside the redirect-policy closure
-    // (`reqwest::redirect::Policy::custom`), which runs ONLY on redirect
-    // hops; there is no initial-URL host pre-check in
-    // `doiget_core::http::fetch_inner`. With an unroutable first-leg host
-    // and no redirect, the OA leg fails at connect — a real
-    // `HttpError::Network` with NO wrapped `RedirectDenied`, hence
-    // `denial == None`. Per `docs/ERRORS.md` §6.1 a genuine transport
-    // fault with no `denial_context` correctly stays `NETWORK_ERROR` /
-    // exit 1. Closing the "initial OA URL host off-allowlist with no
-    // redirect" gap requires an initial-URL host pre-check in
-    // `crates/doiget-core/src/http.rs`, which is out of scope for this
-    // CLI-only branch/PR (tracked under #145; see the PR description /
-    // ERRORS.md §6.1). The metadata-still-written / PDF-not-written and
-    // `error_code == NETWORK_ERROR` provenance assertions below remain.
+    // This case IS now COVERED end-to-end. PR #163 added the core
+    // PRE-FETCH host allowlist check in
+    // `doiget_core::orchestrator::try_fetch_oa_pdf`
+    // (`docs/REDIRECT_ALLOWLIST.md` §1 — NORMATIVE): the
+    // metadata-discovered OA URL is run through the `oa-publisher`
+    // allowlist BEFORE the PDF fetch is issued, not only on redirect
+    // hops. With `attacker.test` off the allowlist and NO redirect, the
+    // pre-fetch check rejects it with the SAME `HttpError::RedirectDenied`
+    // the redirect closure produces → `DenialContext(RedirectNotIn-
+    // Allowlist)` (not `None`). The #162 CLI classification then promotes
+    // it to `CAPABILITY_DENIED` / exit 3. This closes the former "initial
+    // OA URL host off-allowlist with no redirect" gap (#145 + #163; see
+    // `docs/ERRORS.md` §6.1). The metadata-still-written /
+    // PDF-not-written and `error_code == NETWORK_ERROR` provenance
+    // assertions below remain (the pre-fetch denial emits the same
+    // closed-set `NETWORK_ERROR` provenance row as a redirect-time
+    // denial; the process EXIT code is the reclassified value).
     let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
         .await
         .expect_err("a blocked OA PDF leg must NOT be a silent success (issue #145)");
@@ -341,14 +343,14 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
         .downcast_ref::<doiget_cli::commands::fetch::CliExit>()
         .expect("blocked PDF leg must carry a CliExit so main maps it to a §4 exit code");
     assert_eq!(
-        cli_exit.0, 1,
-        "first-leg connect failure to an unroutable off-allowlist host \
-         has NO DenialContext (no redirect hop fired the allowlist \
-         closure) → genuine NETWORK_ERROR → exit 1, per docs/ERRORS.md \
-         §6.1. The policy-block → CAPABILITY_DENIED/exit-3 reclassification \
-         (issue #145) is unit-covered in fetch.rs::effective_blocked_code \
-         for the redirect/insecure-scheme cases that DO carry a \
-         DenialContext."
+        cli_exit.0, 3,
+        "off-allowlist OA URL with NO redirect is now caught by the #163 \
+         core PRE-FETCH allowlist check, which yields the SAME \
+         HttpError::RedirectDenied → DenialContext(RedirectNotInAllowlist) \
+         as a redirect-time denial. The #162 CLI classification promotes \
+         this deliberate supply-chain policy block to CAPABILITY_DENIED → \
+         exit 3 (#145 + #163; docs/ERRORS.md §6.1). It is NO LONGER a \
+         generic NETWORK_ERROR / exit 1."
     );
 
     // PDF MUST NOT be written.

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -239,10 +239,16 @@ async fn fetch_doi_oa_pdf_happy_path() {
 async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     // Failure-fallback path: Unpaywall hands back an OA URL whose host is
     // NOT registered in the test client's `oa-publisher` allowlist. The
-    // orchestrator MUST log a `Fetch err / source=oa-publisher` row,
-    // SKIP writing a PDF, and still return Ok(()) with the metadata
-    // written. Per the `informed-best-effort` posture in
-    // `docs/REDIRECT_ALLOWLIST.md` §3.
+    // orchestrator MUST log a `Fetch err / source=oa-publisher` row and
+    // SKIP writing a PDF while still writing the metadata TOML (the
+    // `informed-best-effort` posture in `docs/REDIRECT_ALLOWLIST.md` §3
+    // keeps the metadata).
+    //
+    // Issue #145 / `docs/ERRORS.md` §3 + §6: the CLI persona must NOT
+    // treat this blocked PDF leg as a clean `Ok(())`. The metadata is
+    // still written (and pointed at), but `run_with_options` returns an
+    // `Err` carrying a `CliExit` so the process exits non-zero — a
+    // blocked PDF is no longer a silent success.
     let server = MockServer::start().await;
     let base_uri = server.uri();
 
@@ -288,11 +294,23 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     // on every redirect hop).
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
-    // The orchestrator MUST still return Ok(()) — metadata is the
-    // partial-success contract from REDIRECT_ALLOWLIST.md §3.
-    fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
+    // Issue #145: the blocked PDF leg must surface as a non-zero exit,
+    // NOT a silent `Ok(())`. The metadata is still written (asserted
+    // below) but the CLI persona gets an `error[CODE]:` line + a
+    // `CliExit` carrying the `docs/ERRORS.md` §4 process code. The
+    // off-allowlist denial is wrapped by reqwest as `HttpError::Network`
+    // → `NETWORK_ERROR` → `cli_exit_code` falls to the generic
+    // "at least one fetch failed" exit (1).
+    let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
         .await
-        .expect("fetch::run_with_options succeeds (metadata-only fallback)");
+        .expect_err("a blocked OA PDF leg must NOT be a silent success (issue #145)");
+    let cli_exit = err
+        .downcast_ref::<doiget_cli::commands::fetch::CliExit>()
+        .expect("blocked PDF leg must carry a CliExit so main maps it to a §4 exit code");
+    assert_eq!(
+        cli_exit.0, 1,
+        "off-allowlist OA denial maps to NETWORK_ERROR → exit 1"
+    );
 
     // PDF MUST NOT be written.
     let pdf_path = store_root.join("doi_10.1234_test.pdf");

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -163,13 +163,22 @@ transport mechanism); the *user-facing* code/exit is `CAPABILITY_DENIED` /
 `denial_context`, or a non-policy reason such as `size_cap_exceeded` /
 `content_type_mismatch`) remain `NETWORK_ERROR` / exit 1.
 
-Known gap (tracked under #145): the per-source host allowlist is enforced
-only inside the redirect-policy closure, which `reqwest` invokes only on
-**redirect hops**. An OA URL whose *initial* host is off-allowlist with no
-redirect therefore fails at connect with no `RedirectDenied` / no
-`denial_context`, so it cannot be reclassified at the CLI layer and stays
-`NETWORK_ERROR` / exit 1. Closing this requires an initial-URL host
-pre-check in `doiget-core` (`crates/doiget-core/src/http.rs`); the
-reclassification rule above already covers every block that *does* carry a
-policy `denial_context` (real redirect denials, insecure-scheme hops,
-host-blocklist hits).
+Covered end-to-end (closed by #163; originally tracked under #145): the
+`oa-publisher` host allowlist is no longer enforced *only* inside the
+redirect-policy closure. PR #163 added a **pre-fetch host allowlist
+check** on the metadata-discovered OA URL in
+`doiget_core::orchestrator::try_fetch_oa_pdf`
+(`docs/REDIRECT_ALLOWLIST.md` §1 — NORMATIVE), applied **before** the PDF
+fetch is issued, not only on redirect hops. An OA URL whose *initial*
+host is off-allowlist with **no redirect** is therefore rejected by the
+pre-check with the **same** `HttpError::RedirectDenied` value the redirect
+closure produces (same `source_key` / lowercased `host` /
+`expected_hosts`), so it still carries a policy `denial_context`
+(`redirect_not_in_allowlist`). The CLI reclassification rule above then
+promotes it to `CAPABILITY_DENIED` / exit 3 — the off-allowlist OA URL is
+**not** fetched and never reaches connect. The reclassification rule now
+covers every supply-chain policy block uniformly: pre-fetch off-allowlist
+OA URLs, real redirect denials, insecure-scheme hops, and host-blocklist
+hits. Only a genuine transport fault with no `denial_context` (or a
+non-policy reason such as `size_cap_exceeded` / `content_type_mismatch`)
+remains `NETWORK_ERROR` / exit 1, consistent with §2.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -36,7 +36,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
 | `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
-| `NETWORK_ERROR` | Transport / DNS / TLS failure. | Retry usually fine. |
+| `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
 | `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
 | `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
 | `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |
@@ -130,3 +130,46 @@ unset.
 doiget MUST NOT return a "success" result with placeholder data when a real fetch
 failed. A fetch either succeeds with a real PDF + license + metadata, or returns an
 error with one of the codes above.
+
+### 6.1 Off-allowlist / redirect-denied OA-PDF leg → `CAPABILITY_DENIED` / exit 3 (NORMATIVE; issue #145)
+
+When a DOI fetch discovers an OA PDF URL but the OA-PDF leg is **blocked
+by supply-chain redirect policy** — the host is off the `oa-publisher`
+allowlist (`redirect_not_in_allowlist`), a redirect hop is non-HTTPS
+(`insecure_scheme`), or the host is on the block list
+(`host_in_block_list`) — the metadata is still written, but the leg is a
+**deliberate policy denial, not a transport failure**.
+
+Internally `doiget-core` collapses every `FetchError::Http(_)` (including
+a redirect denial that `reqwest` re-wraps as `HttpError::Network`) to
+`NetworkError`, and the provenance-log row for the failed `oa-publisher`
+leg is therefore written with `error_code = NETWORK_ERROR` (the
+transport-layer truth — unchanged). However, surfacing this to the user
+as `NETWORK_ERROR` would be **wrong**: §2 defines `NETWORK_ERROR` as
+"retry usually fine", whereas retrying a policy block never helps.
+
+NORMATIVE rule: the CLI MUST reclassify such a blocked OA-PDF leg using
+the preserved `denial_context.reason` (§3.1) and surface it as:
+
+- error code **`CAPABILITY_DENIED`** (rendered `error[CAPABILITY_DENIED]:`,
+  with the closed-set `denial_context.reason` named inline so the block is
+  unambiguously a policy denial, not a flaky network);
+- process **exit code `3`** (§4 "Capability denied"), the same exit code
+  `fetch` / `graph` use for every other `ErrorCode::CapabilityDenied`.
+
+The provenance row keeps `error_code = NETWORK_ERROR` (it records the
+transport mechanism); the *user-facing* code/exit is `CAPABILITY_DENIED` /
+`3`. Non-policy OA-PDF blocks (genuine transport fault with no
+`denial_context`, or a non-policy reason such as `size_cap_exceeded` /
+`content_type_mismatch`) remain `NETWORK_ERROR` / exit 1.
+
+Known gap (tracked under #145): the per-source host allowlist is enforced
+only inside the redirect-policy closure, which `reqwest` invokes only on
+**redirect hops**. An OA URL whose *initial* host is off-allowlist with no
+redirect therefore fails at connect with no `RedirectDenied` / no
+`denial_context`, so it cannot be reclassified at the CLI layer and stays
+`NETWORK_ERROR` / exit 1. Closing this requires an initial-URL host
+pre-check in `doiget-core` (`crates/doiget-core/src/http.rs`); the
+reclassification rule above already covers every block that *does* carry a
+policy `denial_context` (real redirect denials, insecure-scheme hops,
+host-blocklist hits).

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -42,7 +42,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
 | `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
-| `NETWORK_ERROR` | Transport / DNS / TLS failure. | Retry usually fine. |
+| `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
 | `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
 | `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
 | `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |
@@ -136,3 +136,55 @@ unset.
 doiget MUST NOT return a "success" result with placeholder data when a real fetch
 failed. A fetch either succeeds with a real PDF + license + metadata, or returns an
 error with one of the codes above.
+
+### 6.1 Off-allowlist / redirect-denied OA-PDF leg → `CAPABILITY_DENIED` / exit 3 (NORMATIVE; issue #145)
+
+When a DOI fetch discovers an OA PDF URL but the OA-PDF leg is **blocked
+by supply-chain redirect policy** — the host is off the `oa-publisher`
+allowlist (`redirect_not_in_allowlist`), a redirect hop is non-HTTPS
+(`insecure_scheme`), or the host is on the block list
+(`host_in_block_list`) — the metadata is still written, but the leg is a
+**deliberate policy denial, not a transport failure**.
+
+Internally `doiget-core` collapses every `FetchError::Http(_)` (including
+a redirect denial that `reqwest` re-wraps as `HttpError::Network`) to
+`NetworkError`, and the provenance-log row for the failed `oa-publisher`
+leg is therefore written with `error_code = NETWORK_ERROR` (the
+transport-layer truth — unchanged). However, surfacing this to the user
+as `NETWORK_ERROR` would be **wrong**: §2 defines `NETWORK_ERROR` as
+"retry usually fine", whereas retrying a policy block never helps.
+
+NORMATIVE rule: the CLI MUST reclassify such a blocked OA-PDF leg using
+the preserved `denial_context.reason` (§3.1) and surface it as:
+
+- error code **`CAPABILITY_DENIED`** (rendered `error[CAPABILITY_DENIED]:`,
+  with the closed-set `denial_context.reason` named inline so the block is
+  unambiguously a policy denial, not a flaky network);
+- process **exit code `3`** (§4 "Capability denied"), the same exit code
+  `fetch` / `graph` use for every other `ErrorCode::CapabilityDenied`.
+
+The provenance row keeps `error_code = NETWORK_ERROR` (it records the
+transport mechanism); the *user-facing* code/exit is `CAPABILITY_DENIED` /
+`3`. Non-policy OA-PDF blocks (genuine transport fault with no
+`denial_context`, or a non-policy reason such as `size_cap_exceeded` /
+`content_type_mismatch`) remain `NETWORK_ERROR` / exit 1.
+
+Covered end-to-end (closed by #163; originally tracked under #145): the
+`oa-publisher` host allowlist is no longer enforced *only* inside the
+redirect-policy closure. PR #163 added a **pre-fetch host allowlist
+check** on the metadata-discovered OA URL in
+`doiget_core::orchestrator::try_fetch_oa_pdf`
+(`docs/REDIRECT_ALLOWLIST.md` §1 — NORMATIVE), applied **before** the PDF
+fetch is issued, not only on redirect hops. An OA URL whose *initial*
+host is off-allowlist with **no redirect** is therefore rejected by the
+pre-check with the **same** `HttpError::RedirectDenied` value the redirect
+closure produces (same `source_key` / lowercased `host` /
+`expected_hosts`), so it still carries a policy `denial_context`
+(`redirect_not_in_allowlist`). The CLI reclassification rule above then
+promotes it to `CAPABILITY_DENIED` / exit 3 — the off-allowlist OA URL is
+**not** fetched and never reaches connect. The reclassification rule now
+covers every supply-chain policy block uniformly: pre-fetch off-allowlist
+OA URLs, real redirect denials, insecure-scheme hops, and host-blocklist
+hits. Only a genuine transport fault with no `denial_context` (or a
+non-policy reason such as `size_cap_exceeded` / `content_type_mismatch`)
+remains `NETWORK_ERROR` / exit 1, consistent with §2.


### PR DESCRIPTION
Batch fix for the doiget-cli review findings. All changes are confined to `crates/doiget-cli/`.

## Fixes
- **#142** `config show` read undocumented `DOIGET_LOG_DIR`; every other command uses the `CONFIG.md §4`-documented `DOIGET_LOG_PATH`. Unified on `DOIGET_LOG_PATH`; `config show` now reports the path the writer actually uses.
- **#143** `batch` returned a bare `anyhow!` → exit 1 regardless of failure count. Now returns `CliExit(total_failures.min(255))` per `ERRORS.md §4`; `main` downcasts it the same way it already does for `fetch`.
- **#145** `PdfLegStatus::Blocked` printed two success lines and exited 0 — a silent failure. Now emits a cargo-style `error[CODE]:` line on stderr and carries a non-zero `CliExit` (`ERRORS.md §3/§6`). Metadata is still written and pointed at.
- **#148** `main.rs` `long_about` rewritten from the "Phase 0 skeleton; subcommands not yet implemented" placeholder to the real shipped surface.
- **#149** `graph` `CapabilityDenied` → `CliExit(3)`; `audit-log` (no `--verify`) and other clear arg-misuse `bail!` sites → `CliExit(2)` per `ERRORS.md §4`.

## Decisions / judgment calls
- **#145 exit code:** an off-allowlist OA denial is wrapped by reqwest as `HttpError::Network` → `NETWORK_ERROR` → the generic "at least one fetch failed" exit (**1**), not `CAPABILITY_DENIED` (3). The behavioral fix (no longer a silent `Ok(())`) is the point; mapping that specific denial to a distinct code would need orchestrator-level error-type plumbing — flagged as a possible follow-up, out of scope here.
- **e2e tests updated, not weakened:** `batch_e2e.rs` and `fetch_doi_oa_pdf_e2e.rs` previously asserted the *old, wrong* behavior (generic err / silent `Ok(())`). They now downcast `CliExit` and assert the `ERRORS.md`-correct codes. Each change is commented inline with the issue/section reference.
- Out of scope: output-mode/`--json` resolution is deferred issue **#144** (interacts with this surface; intentionally not touched).

## Gate (in worktree, cargo 1.86)
`fmt --all` clean · `clippy -p doiget-cli --all-targets -- -D warnings` clean · `cargo test -p doiget-cli` all green (incl. updated batch / fetch e2e, list_recent, search).

Closes #142
Closes #143
Closes #145
Closes #148
Closes #149

Do not merge without review (agent-authored).