### PR TITLE
fix(core): allowlist the discovered OA URL before the PDF fetch, not just redirect hops (#145)

### DIFF
--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -588,6 +588,20 @@ pub struct HttpClient {
     /// policy that captures only that source's allowlist. `Arc` so cloning
     /// is cheap.
     clients: Arc<HashMap<String, Client>>,
+    /// The exact [`SourceAllowlist`] each per-source client was built from,
+    /// keyed by source. The redirect closure inside each `reqwest::Client`
+    /// captures its allowlist *by move*, so it cannot be read back from the
+    /// client itself. This map keeps the identical `SourceAllowlist`
+    /// available to callers that must perform a *pre-fetch* host check on a
+    /// metadata-discovered URL (issue #145 / `docs/REDIRECT_ALLOWLIST.md`
+    /// §1: the allowlist is consulted "on the OA URL discovered through
+    /// metadata sources before the actual PDF fetch is issued", not only on
+    /// redirect hops). Storing the same value here — rather than re-deriving
+    /// it from [`oa_publisher_allowlist`] at the call site — guarantees the
+    /// pre-check and the redirect closure can never drift, and that the
+    /// check works under the test constructors too (which register a
+    /// wiremock host as the allowlist).
+    allowlists: Arc<HashMap<String, SourceAllowlist>>,
 }
 
 impl HttpClient {
@@ -604,14 +618,37 @@ impl HttpClient {
     /// fails (typically a TLS-backend init failure).
     pub fn new(allowlists: Vec<SourceAllowlist>) -> Result<Self, reqwest::Error> {
         let mut clients = HashMap::with_capacity(allowlists.len());
+        let mut allowlist_map = HashMap::with_capacity(allowlists.len());
         for entry in allowlists {
             let source = entry.source.clone();
+            // Keep the *same* allowlist value both inside the redirect
+            // closure (via `build_client`) and queryable on the client
+            // (issue #145 pre-fetch check). `build_client` takes the
+            // allowlist by value, so clone once for the side table first.
+            allowlist_map.insert(source.clone(), entry.clone());
             let client = build_client(entry)?;
             clients.insert(source, client);
         }
         Ok(Self {
             clients: Arc::new(clients),
+            allowlists: Arc::new(allowlist_map),
         })
+    }
+
+    /// The [`SourceAllowlist`] this client was built with for `source`, or
+    /// `None` if `source` was not registered.
+    ///
+    /// This is the *identical* value captured by the per-source redirect
+    /// closure (see [`HttpClient`]'s `allowlists` field doc). It exists so
+    /// the orchestrator can apply the `docs/REDIRECT_ALLOWLIST.md` §1
+    /// pre-fetch host check on a metadata-discovered OA URL — the URL that
+    /// is fetched *without* necessarily passing through a redirect hop —
+    /// using the same source of truth the redirect closure uses, so the two
+    /// can never disagree. Callers MUST use this for the `"oa-publisher"`
+    /// leg only; the initial template-constructed URL is exempt per
+    /// `docs/REDIRECT_ALLOWLIST.md` §6.
+    pub fn source_allowlist(&self, source: &str) -> Option<&SourceAllowlist> {
+        self.allowlists.get(source)
     }
 
     /// Fetch a URL, treating it as a JSON or text body. Caps at
@@ -849,9 +886,12 @@ impl HttpClient {
         let allowlist = SourceAllowlist::new(source, vec![allowlist_host.to_string()]);
         let client = build_client_allow_http(allowlist.clone()).expect("test client builds");
         let mut map = HashMap::new();
+        let mut allowlist_map = HashMap::new();
+        allowlist_map.insert(allowlist.source.clone(), allowlist.clone());
         map.insert(allowlist.source.clone(), client);
         Self {
             clients: Arc::new(map),
+            allowlists: Arc::new(allowlist_map),
         }
     }
 
@@ -865,13 +905,16 @@ impl HttpClient {
     /// [`tier_1_allowlist`].
     pub fn new_for_tests_allow_http_multi(entries: &[(&str, &str)]) -> Self {
         let mut map = HashMap::with_capacity(entries.len());
+        let mut allowlist_map = HashMap::with_capacity(entries.len());
         for (source, host) in entries {
             let allowlist = SourceAllowlist::new(*source, vec![host.to_string()]);
             let client = build_client_allow_http(allowlist.clone()).expect("test client builds");
+            allowlist_map.insert(allowlist.source.clone(), allowlist.clone());
             map.insert(allowlist.source.clone(), client);
         }
         Self {
             clients: Arc::new(map),
+            allowlists: Arc::new(allowlist_map),
         }
     }
 }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -839,6 +839,70 @@ async fn try_fetch_oa_pdf(
     // both the ok and err row variants below.
     let canonical =
         crate::CanonicalRef::new(crate::SourceType::Doi, doi.as_str(), SOURCE, None).digest_hex();
+
+    // Pre-fetch host allowlist check on the metadata-discovered OA URL
+    // (issue #145; `docs/REDIRECT_ALLOWLIST.md` §1 — NORMATIVE). The
+    // per-source `redirect_hosts` allowlist is, by §1, consulted "on the
+    // OA URL discovered through metadata sources before the actual PDF
+    // fetch is issued", not only on redirect hops. The redirect closure in
+    // `crate::http` only fires when an *actual redirect* occurs; an OA URL
+    // whose host is off the `oa-publisher` allowlist that resolves WITHOUT
+    // a redirect would otherwise reach connect and be misclassified as a
+    // transport error, violating §1. This is scoped strictly to the
+    // `"oa-publisher"` PDF leg — §6 explicitly exempts the initial
+    // template-constructed URL, and `fetch_bytes`/metadata-only/resolve-
+    // only paths (which never follow the OA URL) are deliberately NOT
+    // touched. On a host MISS we return the *same* `HttpError::RedirectDenied`
+    // value the redirect closure produces (same `source_key`, lowercased
+    // `host`, and `expected_hosts` snapshot), reusing the identical
+    // allowlist the closure captured (queried via `source_allowlist`, not
+    // re-derived) so the single source of truth cannot drift. Returning
+    // that exact variant means the existing `Err(e)` arm below, the
+    // `From<&HttpError> for Option<DenialContext>` mapping
+    // (`DenialReason::RedirectNotInAllowlist`), the `PdfLegStatus::Blocked`
+    // construction in the caller, and PR #162's CLI classification all see
+    // a byte-identical downstream shape with no new code path.
+    if let Some(allowlist) = ctx.http.source_allowlist(SOURCE) {
+        // `Url::host_str()` is `None` for hostless URLs (e.g. `data:`);
+        // treat that exactly as the redirect closure does (an allowlist
+        // miss with an empty host string).
+        let host = url
+            .host_str()
+            .map(|h| h.to_ascii_lowercase())
+            .unwrap_or_default();
+        if !allowlist.matches(&host) {
+            let e = HttpError::RedirectDenied {
+                source_key: SOURCE.to_string(),
+                host: host.clone(),
+                expected_hosts: allowlist.redirect_hosts.clone(),
+            };
+            tracing::info!(
+                oa_url = %url,
+                denied_host = %host,
+                "OA URL host outside oa-publisher allowlist (pre-fetch check, \
+                 docs/REDIRECT_ALLOWLIST.md §1 / issue #145)"
+            );
+            // Emit the SAME provenance row the post-fetch redirect-denied
+            // path emits: a `Fetch` `Err` row under the `oa-publisher`
+            // source key with the closed-set `NETWORK_ERROR` code and the
+            // same canonical digest. Mirrors the `Err(e)` arm below so the
+            // audit trail is indistinguishable from a redirect-time denial.
+            let _ = ctx.log.append(RowInput {
+                event: LogEvent::Fetch,
+                result: LogResult::Err,
+                capability: Capability::Oa,
+                ref_: Some(doi.as_str()),
+                source: Some(SOURCE),
+                error_code: Some(crate::ErrorCode::NetworkError.as_wire()),
+                size_bytes: None,
+                license: None,
+                store_path: None,
+                canonical_digest: Some(&canonical),
+            });
+            return Err(e);
+        }
+    }
+
     match ctx.http.fetch_pdf(SOURCE, url.clone()).await {
         Ok((body, final_url)) => {
             let size_bytes = body.len() as u64;
@@ -1389,5 +1453,246 @@ mod tests {
             Err(HttpError::NotAPdf { .. }) => {}
             other => panic!("expected Err(NotAPdf), got: {other:?}"),
         }
+    }
+
+    // Issue #145 / `docs/REDIRECT_ALLOWLIST.md` §1: the `oa-publisher`
+    // host allowlist MUST be consulted on the metadata-discovered OA URL
+    // *before the actual PDF fetch is issued*, not only on redirect hops.
+    // An OA URL whose host is OFF the allowlist and that resolves WITHOUT
+    // a redirect previously slipped past the redirect closure entirely and
+    // was misclassified as a transport error. This test pins the fix: the
+    // pre-fetch check rejects it with the SAME `HttpError::RedirectDenied`
+    // the redirect closure produces, the OA fetch is NEVER issued (the
+    // wiremock origin records ZERO requests, proving no PDF bytes were
+    // requested / written), and the provenance trail is the byte-identical
+    // `Fetch`/`err`/`oa-publisher`/`NETWORK_ERROR` row the redirect-denied
+    // path emits.
+    #[tokio::test]
+    async fn try_fetch_oa_pdf_off_allowlist_host_no_redirect_is_redirect_denied_145() {
+        use crate::http::HttpClient;
+        use crate::provenance::ProvenanceLog;
+        use crate::rate_limiter::RateLimiter;
+        use crate::{DenialContext, DenialReason, Doi, RateLimits};
+        use std::sync::Arc;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // The wiremock origin would serve a valid PDF with NO redirect —
+        // if the pre-check were absent the fetch would *succeed* against
+        // an off-allowlist host, which is exactly the §1 violation.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.7 real pdf".to_vec()))
+            .mount(&server)
+            .await;
+
+        // Register a DIFFERENT host as the `oa-publisher` allowlist so the
+        // wiremock origin (127.0.0.1) is OFF it. `evil.example.com` is a
+        // valid host string the allowlist will not match.
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let log_path = Utf8Path::from_path(td.path())
+            .expect("utf-8")
+            .join("log.jsonl");
+        let ctx = FetchContext {
+            http: Arc::new(HttpClient::new_for_tests_allow_http(
+                "oa-publisher",
+                "allowed-publisher.example.com",
+            )),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log: Arc::new(
+                ProvenanceLog::open(log_path.clone(), "01J0000000000000000000TEST".into())
+                    .expect("provenance log"),
+            ),
+            session_id: "01J0000000000000000000TEST".into(),
+        };
+
+        let doi = Doi("10.1234/example".to_string());
+        // The OA URL Unpaywall handed back resolves to the wiremock host,
+        // which is OFF the `oa-publisher` allowlist.
+        let off_host_url: url::Url = format!("{}/oa.pdf", server.uri()).parse().expect("url");
+        let res = try_fetch_oa_pdf(&doi, &off_host_url, &ctx).await;
+
+        // 1. Same error variant the redirect closure produces.
+        let err = match res {
+            Err(e @ HttpError::RedirectDenied { .. }) => e,
+            other => {
+                panic!("expected Err(RedirectDenied) from the pre-fetch check, got: {other:?}")
+            }
+        };
+        match &err {
+            HttpError::RedirectDenied {
+                source_key,
+                host,
+                expected_hosts,
+            } => {
+                assert_eq!(source_key, "oa-publisher");
+                // The host is lowercased, exactly as the redirect closure
+                // would record it.
+                assert_eq!(
+                    host,
+                    off_host_url
+                        .host_str()
+                        .expect("wiremock host")
+                        .to_ascii_lowercase()
+                        .as_str()
+                );
+                assert_eq!(
+                    expected_hosts,
+                    &vec!["allowed-publisher.example.com".to_string()]
+                );
+            }
+            _ => unreachable!(),
+        }
+
+        // 2. The OA fetch was NEVER issued — the wiremock origin saw zero
+        //    requests, so no PDF bytes were requested or written.
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty(),
+            "the off-allowlist OA URL must NOT be fetched: the pre-check \
+             (REDIRECT_ALLOWLIST.md §1) rejects it before any request is \
+             issued; wiremock recorded request(s)",
+        );
+
+        // 3. The structured denial side-channel is byte-identical to the
+        //    redirect-closure path: `RedirectNotInAllowlist`, source key,
+        //    attempted host, expected allowlist snapshot.
+        let dc: Option<DenialContext> = (&err).into();
+        let dc = dc.expect("pre-fetch RedirectDenied -> Some(DenialContext)");
+        assert_eq!(dc.reason, DenialReason::RedirectNotInAllowlist);
+        assert_eq!(dc.source.as_deref(), Some("oa-publisher"));
+        assert_eq!(
+            dc.attempted,
+            Some(off_host_url.host_str().expect("host").to_ascii_lowercase()),
+            "attempted host must be the rejected OA URL host, lowercased — \
+             identical to what the redirect closure records",
+        );
+        assert_eq!(
+            dc.expected,
+            Some(vec!["allowed-publisher.example.com".to_string()]),
+        );
+
+        // 4. Provenance: exactly the `Fetch`/`err`/`oa-publisher`/
+        //    `NETWORK_ERROR` row the post-fetch redirect-denied arm emits
+        //    (same row kind + source key + closed-set code).
+        let log_txt = std::fs::read_to_string(&log_path).expect("read provenance log");
+        let fetch_err_row = log_txt
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .find(|v| {
+                v.get("event").and_then(|e| e.as_str()) == Some("fetch")
+                    && v.get("result").and_then(|r| r.as_str()) == Some("err")
+            })
+            .expect("a Fetch/err provenance row was written");
+        assert_eq!(
+            fetch_err_row.get("source").and_then(|s| s.as_str()),
+            Some("oa-publisher"),
+        );
+        assert_eq!(
+            fetch_err_row.get("error_code").and_then(|c| c.as_str()),
+            Some("NETWORK_ERROR"),
+        );
+        assert_eq!(
+            fetch_err_row.get("ref").and_then(|r| r.as_str()),
+            Some("10.1234/example"),
+        );
+    }
+
+    // Issue #145 positive / no-regression: an ON-allowlist OA URL still
+    // fetches the PDF normally. The pre-fetch check must be a pure gate —
+    // it must not perturb the happy path.
+    #[tokio::test]
+    async fn try_fetch_oa_pdf_on_allowlist_host_still_fetches_pdf_no_regression_145() {
+        use crate::http::HttpClient;
+        use crate::provenance::ProvenanceLog;
+        use crate::rate_limiter::RateLimiter;
+        use crate::{Doi, RateLimits};
+        use std::sync::Arc;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let body = b"%PDF-1.7\nhello pdf".to_vec();
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+        // The wiremock host IS the registered `oa-publisher` allowlist, so
+        // the pre-check passes and the fetch proceeds as before.
+        let host = server
+            .uri()
+            .parse::<url::Url>()
+            .expect("uri")
+            .host_str()
+            .expect("host")
+            .to_string();
+
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let log_path = Utf8Path::from_path(td.path())
+            .expect("utf-8")
+            .join("log.jsonl");
+        let ctx = FetchContext {
+            http: Arc::new(HttpClient::new_for_tests_allow_http("oa-publisher", &host)),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log: Arc::new(
+                ProvenanceLog::open(log_path, "01J0000000000000000000TEST".into())
+                    .expect("provenance log"),
+            ),
+            session_id: "01J0000000000000000000TEST".into(),
+        };
+
+        let doi = Doi("10.1234/example".to_string());
+        let url: url::Url = format!("{}/oa.pdf", server.uri()).parse().expect("url");
+        let (bytes, _final_url) = try_fetch_oa_pdf(&doi, &url, &ctx)
+            .await
+            .expect("on-allowlist OA URL still fetches the PDF");
+        assert_eq!(bytes, body, "PDF bytes must be returned unchanged");
+    }
+
+    // Issue #145: the pre-fetch denial and the redirect-closure denial
+    // MUST produce a byte-identical `DenialContext` so PR #162's CLI
+    // classification (CAPABILITY_DENIED / exit 3) handles both unchanged.
+    // This pins the equivalence at the value level: the same source key +
+    // host + allowlist snapshot map through the SAME
+    // `From<&HttpError> for Option<DenialContext>` impl to equal structs.
+    #[test]
+    fn pre_fetch_denial_produces_byte_identical_denial_context_as_redirect_denied_145() {
+        use crate::{DenialContext, DenialReason};
+
+        // Shape produced by the pre-fetch check in `try_fetch_oa_pdf`.
+        let pre_fetch = HttpError::RedirectDenied {
+            source_key: "oa-publisher".to_string(),
+            host: "attacker.test".to_string(),
+            expected_hosts: vec!["*.springer.com".to_string(), "*.plos.org".to_string()],
+        };
+        // Shape produced by the redirect closure in `crate::http` for the
+        // identical inputs.
+        let redirect_closure = HttpError::RedirectDenied {
+            source_key: "oa-publisher".to_string(),
+            host: "attacker.test".to_string(),
+            expected_hosts: vec!["*.springer.com".to_string(), "*.plos.org".to_string()],
+        };
+
+        let dc_pre: Option<DenialContext> = (&pre_fetch).into();
+        let dc_red: Option<DenialContext> = (&redirect_closure).into();
+        let dc_pre = dc_pre.expect("pre-fetch -> Some");
+        let dc_red = dc_red.expect("redirect -> Some");
+
+        // Byte-identical: same reason, same source, same attempted host,
+        // same expected snapshot, all auxiliary channels None.
+        assert_eq!(dc_pre, dc_red);
+        assert_eq!(dc_pre.reason, DenialReason::RedirectNotInAllowlist);
+        assert_eq!(dc_pre.source.as_deref(), Some("oa-publisher"));
+        assert_eq!(dc_pre.attempted.as_deref(), Some("attacker.test"));
+        assert_eq!(
+            dc_pre.expected,
+            Some(vec!["*.springer.com".to_string(), "*.plos.org".to_string()]),
+        );
+        assert_eq!(dc_pre.hop_index, None);
+        assert_eq!(dc_pre.cap, None);
+        assert_eq!(dc_pre.actual, None);
     }
 }

--- a/crates/doiget-core/src/sources/unpaywall.rs
+++ b/crates/doiget-core/src/sources/unpaywall.rs
@@ -128,10 +128,15 @@ impl Source for UnpaywallSource {
             canonical_digest: Some(&canonical),
         })?;
 
-        // Note: Phase 1 returns metadata only; the actual PDF fetch from the
-        // OA URL is the orchestrator's job (a follow-up PR — `doiget fetch`
-        // CLI subcommand calls Unpaywall, then HttpClient::fetch_pdf on the
-        // discovered URL via a per-publisher allowlist). See ARCHITECTURE.md §6.
+        // Note: this source returns metadata only; the actual PDF fetch
+        // from the discovered OA URL is the orchestrator's job
+        // (`crate::orchestrator::try_fetch_oa_pdf`, called from
+        // `fetch_paper_doi`). That leg runs the OA URL through the
+        // `oa-publisher` per-publisher allowlist BOTH as a pre-fetch host
+        // check (issue #145; `docs/REDIRECT_ALLOWLIST.md` §1 — applied to
+        // the metadata-discovered URL before the fetch is issued) and on
+        // every redirect hop via the per-source redirect closure in
+        // `crate::http`. See ARCHITECTURE.md §6.
         Ok(FetchResult {
             source: self.name().to_string(),
             license,

--- a/docs/REDIRECT_ALLOWLIST.md
+++ b/docs/REDIRECT_ALLOWLIST.md
@@ -165,11 +165,18 @@ Notes:
   authoring; they have NOT all been validated against real fetch traces. Each
   entry below is `(unverified)` for Phase 1 and MUST be either confirmed or
   removed before Phase 1 closes.
-- **Partial-success semantics.** When the OA URL host is NOT on this list, the
-  redirect is denied at the closure boundary (`HttpError::RedirectDenied`) and
-  the orchestrator falls back to metadata-only success — the metadata is still
-  useful. The PDF outcome is logged as a distinct `Fetch` provenance row with
-  `source = "oa-publisher"` and `result = err` /
+- **Partial-success semantics.** When the OA URL host is NOT on this list,
+  the denial is raised as `HttpError::RedirectDenied` — at the **pre-fetch
+  check** on the metadata-discovered OA URL per §1 (the host is rejected
+  before the PDF fetch is issued, even when no redirect hop occurs) and,
+  for hosts that pass the pre-check but redirect off-list mid-fetch, again
+  at the redirect-closure boundary. Both raise the *same*
+  `HttpError::RedirectDenied` value, so the downstream shape (the
+  structured `DenialContext` with `reason = redirect_not_in_allowlist`)
+  is identical regardless of which guard fires. In either case the
+  orchestrator falls back to metadata-only success — the metadata is still
+  useful. The PDF outcome is logged as a distinct `Fetch` provenance row
+  with `source = "oa-publisher"` and `result = err` /
   `error_code = "NETWORK_ERROR"`.
 - **Host families** (each `(unverified)`):
   - Springer Nature OA imprints: `*.springer.com`, `*.springeropen.com`,


### PR DESCRIPTION
## The mandate (§1 vs §6)

`docs/REDIRECT_ALLOWLIST.md` is **NORMATIVE**. §1 requires the per-source
host allowlist to be consulted "on **every** redirect hop, **and on the OA
URL discovered through metadata sources before the actual PDF fetch is
issued**". §6 Non-goals explicitly **exempts** "the initial fetch URL …
constructed from validated identifiers via source-side URL templates".

Before this PR the `oa-publisher` allowlist was enforced *only* inside the
`reqwest::redirect::Policy::custom` closure in `crates/doiget-core/src/http.rs`
— i.e. only when an actual redirect hop occurred. When Unpaywall handed back
an OA PDF URL whose host is off the `oa-publisher` allowlist and the fetch
reached it **without a redirect**, the allowlist was never consulted; the
request failed at connect and was misclassified as a transport error. That
violated §1. (`unpaywall.rs` even carried a comment deferring this to "a
follow-up PR" — this is that PR.)

## Scope (oa-publisher leg only — surgical)

A pre-fetch host allowlist check is added **only** to the `"oa-publisher"`
PDF leg in `orchestrator::try_fetch_oa_pdf`, immediately before
`HttpClient::fetch_pdf` is issued. It is NOT added to generic
`HttpClient::fetch_bytes`, nor to any template-constructed URL (§6 exempt),
nor to metadata-only / resolve-only paths (which never follow the OA URL) —
the check is gated strictly inside the actual PDF-fetch leg.

## Reusing the existing machinery (identical downstream shape)

- `HttpClient` now stores the exact `SourceAllowlist` each per-source client
  was built from and exposes it via a new `HttpClient::source_allowlist`
  accessor. The redirect closure captures its allowlist by move and cannot
  be read back; storing the *same* value (not re-deriving from
  `oa_publisher_allowlist()`) guarantees the pre-check and the redirect
  closure can never drift, and that the check works under the test
  constructors too.
- On a host miss the pre-check returns the **same `HttpError::RedirectDenied`
  value** (same `source_key`, lowercased `host`, `expected_hosts` snapshot)
  the redirect closure produces. That single fact makes every downstream
  consumer byte-identical with **no new code path**:
  - the existing `Err(e)` arm in `try_fetch_oa_pdf` (logging + the
    `Fetch`/`err`/`oa-publisher`/`NETWORK_ERROR` provenance row),
  - `From<&HttpError> for Option<DenialContext>` →
    `DenialReason::RedirectNotInAllowlist` (closed enum; **no new variant**),
  - the `PdfLegStatus::Blocked { code, message, denial }` construction in
    `fetch_paper_doi` (metadata still written, PDF not),
  - **PR #162's already-merged CLI classification handles it unchanged**
    (promotes to CAPABILITY_DENIED / exit 3).

## Core tests (hermetic, wiremock)

- `try_fetch_oa_pdf_off_allowlist_host_no_redirect_is_redirect_denied_145`
  — off-allowlist host, server issues NO redirect → `Err(RedirectDenied)`,
  the OA fetch is never issued (wiremock records **zero** requests, proving
  no PDF bytes), `DenialContext.reason == redirect_not_in_allowlist`, and the
  byte-identical `Fetch`/`err`/`oa-publisher`/`NETWORK_ERROR` provenance row.
- `try_fetch_oa_pdf_on_allowlist_host_still_fetches_pdf_no_regression_145`
  — positive: on-allowlist OA URL still fetches the PDF normally.
- `pre_fetch_denial_produces_byte_identical_denial_context_as_redirect_denied_145`
  — pins value-level equivalence: identical inputs map through the same
  `From` impl to equal `DenialContext` structs.

## Gate (all green, in worktree)

- `cargo fmt --all` — clean
- `cargo clippy -p doiget-core --all-targets -- -D warnings` — no warnings
- `cargo test -p doiget-core` — 210 unit + all integration tests pass;
  the hermetic `no_outbound_network` test stays green;
  `redirect_denied_denial_context_e2e` unaffected.

## Docs

- Updated the stale `unpaywall.rs` follow-up-PR comment.
- Tightened `REDIRECT_ALLOWLIST.md` §3.4 prose so it no longer implies
  redirect-only enforcement (§1 already mandated the pre-fetch check; the
  spec is **not** weakened). `ARCHITECTURE.md §6` is only a sequence diagram
  with no deferred/unimplemented claim, so it needed no correction.

## Post-merge follow-up (out of scope here, to keep PRs decoupled)

Once this merges, PR #162's e2e off-allowlist case should flip exit 1 → 3,
and `ERRORS.md` §6.1 can be upgraded from "known gap" to "covered". Those
files belong to other open PRs and are intentionally **not** touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)