### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.3...doiget-core-v0.1.4) - 2026-05-17
+
+### Fixed
+
+- *(core)* enforce oa-publisher allowlist on discovered OA URL pre-fetch ([#145](https://github.com/sotashimozono/doiget/pull/145))
+
+### Other
+
+- Merge remote-tracking branch 'origin/main' into fix/145-oa-url-allowlist-prefetch
+
 ## [0.1.3](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.2...doiget-core-v0.1.3) - 2026-05-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.1.3"
+version       = "0.1.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.1.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.1.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.1.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.1.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.1.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.1.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION



## 🤖 New release

* `doiget-core`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `doiget-mcp`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `doiget-cli`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `doiget-core`

<blockquote>

## [0.1.4](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.3...doiget-core-v0.1.4) - 2026-05-17

### Fixed

- *(core)* enforce oa-publisher allowlist on discovered OA URL pre-fetch ([#145](https://github.com/sotashimozono/doiget/pull/145))

### Other

- Merge remote-tracking branch 'origin/main' into fix/145-oa-url-allowlist-prefetch
</blockquote>

## `doiget-mcp`

<blockquote>

## [0.1.4](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.3...doiget-core-v0.1.4) - 2026-05-17

### Fixed

- *(core)* enforce oa-publisher allowlist on discovered OA URL pre-fetch ([#145](https://github.com/sotashimozono/doiget/pull/145))

### Other

- Merge remote-tracking branch 'origin/main' into fix/145-oa-url-allowlist-prefetch
</blockquote>

## `doiget-cli`

<blockquote>

## [0.1.4](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.3...doiget-core-v0.1.4) - 2026-05-17

### Fixed

- *(core)* enforce oa-publisher allowlist on discovered OA URL pre-fetch ([#145](https://github.com/sotashimozono/doiget/pull/145))

### Other

- Merge remote-tracking branch 'origin/main' into fix/145-oa-url-allowlist-prefetch
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).