### PR TITLE
fix(site): resync docs->site projection so build (zola) passes

### DIFF
--- a/site/content/contribute/phases.md
+++ b/site/content/contribute/phases.md
@@ -27,14 +27,46 @@ weight = 110
 | 6 | Release: OIDC + sigstore + SBOM + landing page polish + auto-tag (`release-plz`) | 1 week |
 | 7 | Optional features (`vault`, `obsidian`) | per feature |
 
-> **Phase 6 auto-tag note.** Version bumps and tags are deferred to Phase 6 via
-> [`release-plz`](https://release-plz.dev) — Conventional Commits drive a
-> Cargo.toml version bump PR, which when merged tags and (with OIDC trusted
-> publishing) ships to crates.io. Phase 0 carries no `release-plz.toml` yet;
-> until Phase 6 the version stays `0.0.0` and tags are not minted.
+> **Phase 6 auto-tag note (live as of 2026-05-17).** Phase 6 has landed.
+> [`release-plz`](https://release-plz.dev) is wired (Slice 21) and trusted
+> publishing is on (Slice 22): every push to `main` opens/updates a release PR
+> that bumps the shared workspace version and prepends a versioned `CHANGELOG.md`
+> section; merging it pushes annotated `doiget-{core,cli,mcp}-vX.Y.Z` tags,
+> opens a GitHub release, and publishes to crates.io via OIDC. The workspace is
+> **no longer `0.0.0`** — `Cargo.toml` is `0.1.3` and the `v0.1.0`–`v0.1.3`
+> tag triplets exist. See [`CHANGELOG.md`](../CHANGELOG.md) for the released
+> versions and [`release-plz.toml`](../release-plz.toml) for the configuration.
 
 **Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
-Phase 0–4 production usage and any publisher-side correspondence.
+Phase 0–4 production usage and any publisher-side correspondence. *(Not skipped: all
+three TDM sub-phases shipped — see status table below.)*
+
+### Per-phase completion status
+
+Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings and
+the slice entries within them, with the annotated `doiget-{core,cli,mcp}-v0.1.x`
+git tags backing the `0.1.1`–`0.1.3` lines. No dates are invented: the `0.0.0`
+cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
+`v0.0.0` tag — while the `0.1.1`–`0.1.3` tags are dated 2026-05-17. The TDM work
+(Slices 17–19) is recorded under the `## [0.0.0]` CHANGELOG section, i.e. the
+2026-05-15 dev cut, not the later `0.1.x` tags.
+
+| Phase | Status | Evidence (CHANGELOG slice / version) |
+|---|---|---|
+| **0** | Complete (2026-05-15) | Phase-0 skeleton + normative specs + ADRs + 9 CI workflows; `0.0.0` section |
+| **1** | Complete (2026-05-15) | Core resolver, Tier 1 Crossref/Unpaywall/arXiv, `fetch`/`batch`/audit-log (#64–#78); Slices 1–6 |
+| **2** | Complete (2026-05-17) | Store + metadata read path; `bib`/`csl` exports via Slice 15b (`0.1.1`); BiblioFetch round-trip (#121, `0.1.2`) |
+| **3** | Complete (2026-05-17) | MCP server + 10-tool baseline (Slices 7–9); strict stdio (Slice 9 `stdout-purity`) |
+| **4** | Complete | Tier 2 OpenAlex/S2/DOAJ + citation graph (Slices 10–16, ADR-0010) |
+| **5a** | Complete | Springer Nature OA TDM (Slice 17) |
+| **5b** | Complete | APS Harvest TDM (Slice 18) |
+| **5c** | Complete | Elsevier ScienceDirect TDM (Slice 19) + per-source header hook (Slice 20) |
+| **6** | Complete (live) | `release-plz` PR flow (Slice 21) + OIDC trusted publishing (Slice 22); `0.1.0`–`0.1.3` released |
+| **7** | Not started | Optional `vault`/`obsidian` crate is `exclude`d in `Cargo.toml` (ADR-0008) |
+
+The Phase-0 checklist in §2 below is retained as the historical deliverable record;
+its boxes reflect what was committed. Per-version release dates live in
+[`CHANGELOG.md`](../CHANGELOG.md).
 
 ## 2. Phase 0 deliverable checklist
 
@@ -99,9 +131,14 @@ Phase 0 is complete when **all** of the following are committed.
 ### Repo-level settings (manual; cannot be committed)
 
 - [ ] Branch protection on `main`: required PR review, required status checks, signed
-      commits.
+      commits. *(unverified: repo-settings/external — not observable from the tree.)*
 - [ ] 2FA mandatory on the maintainer account.
+      *(unverified: repo-settings/external.)*
 - [ ] Default branch protection includes Action SHA pinning policy.
+      *(unverified: repo-settings/external — note: the workflow actions themselves
+      are SHA-pinned in-tree, e.g. `.github/workflows/release-plz.yml`
+      `actions/checkout@de0fac2…`, `release-plz/action@064f4d1…`; the branch-level
+      enforcement *policy* is still a repo-settings claim.)*
 
 ### Test fixtures
 
@@ -110,11 +147,23 @@ Phase 0 is complete when **all** of the following are committed.
 
 ### Pre-flight items (must be confirmed before Phase 0 begins)
 
-- [ ] Confirm BiblioFetch.jl's current safekey algorithm matches
+- [x] Confirm BiblioFetch.jl's current safekey algorithm matches
       [`SAFEKEY.md`](SAFEKEY.md) §3, or arrange a coordinated bump.
-- [ ] Confirm BiblioFetch.jl's current TOML `schema_version`.
+      *(verified: the 100-vector NORMATIVE parity set landed in Slice 3 and the
+      cross-tool store round-trip — typed `[bibliofetch]` table + unknown scalar
+      preservation — landed in CHANGELOG `0.1.2` / issue #121, exercised in
+      `crates/doiget-core/src/store/metadata.rs`.)*
+- [x] Confirm BiblioFetch.jl's current TOML `schema_version`.
+      *(verified: `schema_version = "1.0"` is the binding value in
+      [`STORE.md`](STORE.md) §; the round-trip test asserts unknown/foreign
+      tables survive read-modify-write, so a BiblioFetch-written schema is
+      preserved.)*
 - [ ] Verify maintainer's `crates.io` account is set up for trusted publishing (OIDC).
+      *(partial — the OIDC release job is wired in-tree (Slice 22,
+      `.github/workflows/release-plz.yml`), but the one-time crates.io Trusted
+      Publisher registration is unverified: repo-settings/external.)*
 - [ ] Verify GitHub Environment is configurable for the release workflow.
+      *(unverified: repo-settings/external.)*
 
 ## 3. Phase 0 working principles
 
@@ -139,9 +188,15 @@ have been confirmed. Phase 1's success criterion is:
 
 Phase progress is tracked through:
 
-- This file's checklist.
-- `CHANGELOG.md` `[Unreleased]` section.
-- GitHub issues labeled `phase-0`, `phase-1`, etc.
+- The **per-phase completion status table** in §1 above (the authoritative
+  current-state view).
+- `CHANGELOG.md` — each unit of work lands as a numbered **Slice** entry tagging
+  its phase (e.g. *"Slice 14 — Citation graph BFS expansion (ADR-0010, Phase 4)"*);
+  released versions carry their date in the `## [X.Y.Z] - YYYY-MM-DD` heading.
+  This is the real tracking mechanism — there are **no** `phase-N` GitHub issue
+  labels (the original plan to use them was never adopted).
+- `git log` / git tags (`doiget-{core,cli,mcp}-vX.Y.Z`) for release dates.
 
-When a Phase completes, this document gets updated with the completion date and a brief
-summary, and the next Phase's checklist becomes active.
+When a Phase completes, the §1 status table is updated with the completion date
+(derived from the CHANGELOG slice / tag, never invented) and a one-line evidence
+pointer; the next Phase's slices then begin landing in `CHANGELOG.md`.

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -16,14 +16,16 @@ weight = 110
 ```rust
 // Phase 1+ target module path; Phase 0 ships these types in monolithic lib.rs.
 
-use secrecy::Secret;
+use secrecy::SecretString; // = SecretBox<str>; the `secrecy` 0.10 owned-string secret
 use chrono::{DateTime, Utc};
 
 // All structs below are #[non_exhaustive] in the Rust source. External crates
 // cannot construct them via struct-literal syntax — go through
-// `CapabilityProfile::from_env()` (see §2). The shapes shown are the Phase 1+
-// target; the Phase 0 stub omits `TdmGrant::api_key` (added non-breakingly
-// later via `#[non_exhaustive]`).
+// `CapabilityProfile::from_env()` (see §2). `TdmGrant::api_key` exists only
+// when at least one `tdm-*` Cargo feature is compiled in (the `secrecy` dep is
+// `optional = true` and gated on those features per ADR-0002). The field is
+// additive under `#[non_exhaustive]`; default release binaries — which contain
+// no TDM code at all — do not carry it.
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -50,7 +52,10 @@ pub struct MetadataAccess {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct TdmGrant {
-    pub api_key:       Secret<String>,    // added in Phase 1
+    // Present only under a `tdm-*` feature (see the note above). `secrecy`
+    // 0.10 replaced `Secret<String>` with `SecretString` (= `SecretBox<str>`).
+    #[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps", feature = "tdm-springer"))]
+    pub api_key:       SecretString,
     pub agreed_at:     DateTime<Utc>,
     pub agree_env_var: String,            // e.g. "DOIGET_AGREE_TDM_ELSEVIER"
 }
@@ -93,8 +98,12 @@ Struct-literal construction (`CapabilityProfile { oa: ..., ... }`) is blocked
 outside `doiget-core` by `#[non_exhaustive]`. Tests inside `doiget-core` may
 still construct profiles directly for fixture purposes.
 
-`api_key` is wrapped in `secrecy::Secret<String>` so that `Display` and `Debug` print
-`****`. Logs use a redactor for known sensitive field names.
+`api_key` is wrapped in `secrecy::SecretString` (the `secrecy` 0.10 replacement
+for the 0.9 `Secret<String>`) so that `Debug` prints a redaction placeholder
+rather than the key. Logs additionally use a redactor for known sensitive field
+names, and any URL that carries a key as a query parameter (Springer Nature —
+see §3) is passed through `redact_api_key_in_url` before it is logged or
+recorded in provenance.
 
 ## 2. Resolution algorithm
 
@@ -121,7 +130,11 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
     let key    = env::var(key_var).ok();
     match (agreed, key) {
         (true, Some(k)) => Ok(Some(TdmGrant {
-            api_key:       Secret::new(k),
+            // `secrecy` 0.10: `SecretString::from(String)` replaces the
+            // 0.9 `Secret::new(k)`. Field present only under a `tdm-*`
+            // feature; the actual source splits this into a small
+            // `build_tdm_grant` helper so the cfg lives in one place.
+            api_key:       SecretString::from(k),
             agreed_at:     Utc::now(),
             agree_env_var: agree_var.to_string(),
         })),

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -128,6 +128,35 @@ is the optional structured-recovery payload defined in
 [ADR-0023](DECISIONS/0023-denial-context-structured.md). `FetchPlan` is the
 dry-run preview shape — see §10 below.
 
+### 5.1 `denial_context` presence: single-paper vs batch (NORMATIVE)
+
+There is an **intentional, normative asymmetry** in how the optional
+`denial_context` field is represented on an `ok:false` error:
+
+- **Single-paper tools** (`doiget_fetch_paper`, `doiget_metadata_only`,
+  `doiget_resolve_paper`): the `denial_context` key is **omit-when-None**.
+  When the error *does* carry a structured recovery channel (e.g. a
+  `CAPABILITY_DENIED` allowlist/scheme denial), the key **is present**
+  with the `DenialContext` payload; when there is no denial channel for
+  the error (e.g. a `NETWORK_ERROR`), the key is **omitted** entirely.
+  `doiget_resolve_paper` follows this exact same contract as the other
+  two single-paper tools — it is *not* a tool that can never carry a
+  denial context; the key is simply absent rather than `null` when there
+  is nothing to report. Agents MUST treat absence and `null` as
+  equivalent ("no structured recovery payload").
+- **`doiget_batch_fetch`** per-ref error entries: the `denial_context`
+  key is **always present**, set to `null` when there is no denial
+  channel. Per-ref rows are uniform table rows in the agent's view, so
+  the explicit `null` lets an agent index every row's
+  `error.denial_context` without a presence test.
+
+An agent that wants to work across both surfaces should read
+`error.denial_context` and treat both *missing* and `null` as "none".
+A serialization failure of a non-`null` `DenialContext` (today
+unreachable — the type is a typed `Serialize` struct) emits `null` **and
+a `tracing::warn!` on stderr** so the swallow is observable; it is never
+silent (see #154 / ADR-0023 §4).
+
 ## 6. Excluded tools (permanent)
 
 The following are intentionally **not** offered as MCP tools and will not be added.

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -171,11 +171,18 @@ Notes:
   authoring; they have NOT all been validated against real fetch traces. Each
   entry below is `(unverified)` for Phase 1 and MUST be either confirmed or
   removed before Phase 1 closes.
-- **Partial-success semantics.** When the OA URL host is NOT on this list, the
-  redirect is denied at the closure boundary (`HttpError::RedirectDenied`) and
-  the orchestrator falls back to metadata-only success — the metadata is still
-  useful. The PDF outcome is logged as a distinct `Fetch` provenance row with
-  `source = "oa-publisher"` and `result = err` /
+- **Partial-success semantics.** When the OA URL host is NOT on this list,
+  the denial is raised as `HttpError::RedirectDenied` — at the **pre-fetch
+  check** on the metadata-discovered OA URL per §1 (the host is rejected
+  before the PDF fetch is issued, even when no redirect hop occurs) and,
+  for hosts that pass the pre-check but redirect off-list mid-fetch, again
+  at the redirect-closure boundary. Both raise the *same*
+  `HttpError::RedirectDenied` value, so the downstream shape (the
+  structured `DenialContext` with `reason = redirect_not_in_allowlist`)
+  is identical regardless of which guard fires. In either case the
+  orchestrator falls back to metadata-only success — the metadata is still
+  useful. The PDF outcome is logged as a distinct `Fetch` provenance row
+  with `source = "oa-publisher"` and `result = err` /
   `error_code = "NETWORK_ERROR"`.
 - **Host families** (each `(unverified)`):
   - Springer Nature OA imprints: `*.springer.com`, `*.springeropen.com`,

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -57,7 +57,7 @@ cargo install doiget --features metadata,tdm-aps
 cargo install doiget --features metadata,tdm-elsevier
 ```
 
-There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 16).
+There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 ## 4. Source-specific notes
 

--- a/site/content/use/scope.md
+++ b/site/content/use/scope.md
@@ -29,7 +29,9 @@ explicitly out of scope below or requires a new ADR.
 
 ## Two classes of non-goal
 
-doiget's non-goals split into two classes:
+doiget enumerates **19 non-goals total**, continuously numbered 1–19 (a stable
+`§non-goal N` reference scheme), split into two classes — **14 permanent**
+(items 1–14) and **5 current design choices** (items 15–19):
 
 - **Permanent non-goals.** Reversing one would weaken the
   [`LEGAL.md`](LEGAL.md) posture, the [`SECURITY.md`](SECURITY.md) threat
@@ -51,7 +53,7 @@ A future ADR may freely move an item from "Current design choices" to
 scope-reopening Discussion. Moving the other way (Permanent → Current →
 Removed) requires the full meta-rule.
 
-## Permanent non-goals (14)
+## Permanent non-goals (14 — items 1–14 of 19)
 
 ### Content / processing
 
@@ -119,7 +121,7 @@ Removed) requires the full meta-rule.
     explicitly in scope and is **not** governed by item #1 above. This is the
     same boundary [`LEGAL.md`](LEGAL.md) §3 documents.
 
-## Current design choices (5)
+## Current design choices (5 — items 15–19 of 19)
 
 These are out of scope **today** because the maintainer judges them more
 trouble than they're worth at the current Phase, but they do not threaten the


### PR DESCRIPTION
## Problem
`build (zola)` has failed on **every** PR and on `main`. Root cause: the job runs `scripts/sync_docs_to_site.sh` then `git diff --exit-code site/content/` ("Verify projection is up-to-date"). PRs #159/#160/#161/#163 edited canonical `docs/*.md` (MCP_TOOLS, SCOPE, SOURCES, PHASES, CAPABILITY, REDIRECT_ALLOWLIST) but did not regenerate the git-managed `site/content/*` projection, so the check failed.

This was non-required (hence PRs showed UNSTABLE, not BLOCKED) which is why it slipped through, but it left `build (zola)` red repo-wide.

## Fix
Ran `scripts/sync_docs_to_site.sh` off current `main` and committed the regenerated projection. **No hand edits** — pure script output. 6 pages resynced: `contribute/phases.md`, `developer/{capability,mcp-tools,redirect-allowlist,sources}.md`, `use/scope.md`.

## Verification
- `git diff --exit-code site/content/` is clean post-commit → the CI "Verify projection is up-to-date" step will pass.
- Full `build (zola)` (projection check + `zola build`) confirmed by this PR's own CI run.

## Follow-up
Consider making `build (zola)` a required check (or adding a lightweight pre-commit/CI guard) so a stale projection blocks merge instead of silently accumulating.

Do not merge without review (agent-authored).