### PR TITLE
fix(ci): retain release-plz.yml filename (preserve crates.io Trusted Publisher)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,5 +1,14 @@
 name: release
 
+# FILENAME NOTE (ADR-0025 amendment, 2026-05-18): this workflow is
+# intentionally kept at `.github/workflows/release-plz.yml` even though
+# release-plz itself was removed. The crates.io OIDC Trusted Publisher for
+# doiget-core / doiget-cli / doiget-mcp is bound to (repo, workflow filename)
+# = `release-plz.yml` (it is NOT environment-scoped). Renaming the file would
+# require re-registering the Trusted Publisher for all three crates on
+# crates.io before the next publish. The filename is a deliberate, documented
+# misnomer; the contents are the ADR-0025 tag-driven pipeline below.
+
 # ADR-0025 — tag-driven release pipeline. The ONLY entry point is pushing an
 # annotated, GPG-signed workspace tag `vX.Y.Z` (stable) or `vX.Y.Z-beta.N`
 # (beta). One workspace tag IS the release; the legacy per-crate

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -3,14 +3,14 @@ name: release-sbom
 # Phase 6 / Slice 24 — generate + sign a CycloneDX SBOM per release.
 #
 # ADR-0025 (PR #166): the SBOM logic below is now ALSO folded into
-# release.yml as its `sbom` job, which fires on the single workspace tag
+# release-plz.yml as its `sbom` job, which fires on the single workspace tag
 # `v*`. To avoid double-firing on a tag (and on the now-retired per-crate
 # `doiget-cli-v*` pattern), this workflow's `push: tags: doiget-cli-v*`
 # trigger has been REMOVED — it is `workflow_dispatch`-only and exists solely
 # as a MANUAL re-SBOM escape hatch for an already-released version (generate a
 # CycloneDX SBOM for the `doiget-cli` package — the full transitive dependency
 # graph of the SHIPPED binary — cosign-keyless sign it, upload to the matching
-# GitHub Release). The routine path is release.yml's `sbom` job; reach for
+# GitHub Release). The routine path is release-plz.yml's `sbom` job; reach for
 # this only to regenerate out of band.
 #
 # Uploads (to the Release named by the dispatch `tag` input):
@@ -28,7 +28,7 @@ name: release-sbom
 
 on:
   # push: tags trigger intentionally REMOVED under ADR-0025 (PR #166) — the
-  # routine SBOM generation now happens in release.yml's `sbom` job on the
+  # routine SBOM generation now happens in release-plz.yml's `sbom` job on the
   # single `v*` tag. This workflow is a manual re-SBOM escape hatch only.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -3,14 +3,14 @@ name: release-sign
 # Phase 6 / Slice 23 — sign release binaries with sigstore (cosign keyless).
 #
 # ADR-0025 (PR #166): the binary-signing logic below is now ALSO folded into
-# release.yml as its `sign` job, which fires on the single workspace tag
+# release-plz.yml as its `sign` job, which fires on the single workspace tag
 # `v*`. To avoid double-firing on a tag (and on the now-retired per-crate
 # `doiget-cli-v*` pattern), this workflow's `push: tags: doiget-cli-v*`
 # trigger has been REMOVED — it is `workflow_dispatch`-only and exists solely
 # as a MANUAL re-sign escape hatch for an already-released version (build the
 # `doiget` CLI binary for the three first-class targets, cosign-keyless sign
 # each, upload to the matching GitHub Release). The routine path is
-# release.yml's `sign` job; reach for this only to re-sign out of band.
+# release-plz.yml's `sign` job; reach for this only to re-sign out of band.
 #
 # Uploads (to the Release named by the dispatch `tag` input):
 #   doiget-<os>-<arch>[.exe]
@@ -27,7 +27,7 @@ name: release-sign
 
 on:
   # push: tags trigger intentionally REMOVED under ADR-0025 (PR #166) — the
-  # routine binary signing now happens in release.yml's `sign` job on the
+  # routine binary signing now happens in release-plz.yml's `sign` job on the
   # single `v*` tag. This workflow is a manual re-sign escape hatch only.
   workflow_dispatch:
     inputs:

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -1,7 +1,7 @@
 # 0025 - Tag-driven release with a mandatory version gate and beta/stable lanes
 
 - **Date:** 2026-05-17
-- **Status:** Accepted — implemented by PR #166 (`.github/workflows/release.yml` + `scripts/release-version-gate.sh` + `cliff.toml`/`scripts/release-changelog.sh`; `release-plz.{toml,yml}` removed; `release-sign.yml`/`release-sbom.yml` demoted to `workflow_dispatch`-only and folded into `release.yml`). `0013`'s release portion is `Superseded by 0025` (its CI-baseline / posture-lint / SHA-pin / Dependabot decisions stand).
+- **Status:** Accepted — implemented by PR #166; amended 2026-05-18 (see Amendment) so the workflow filename stays `.github/workflows/release-plz.yml` (tag-driven pipeline contents + `scripts/release-version-gate.sh` + `cliff.toml`/`scripts/release-changelog.sh`; only `release-plz.toml` removed; `release-sign.yml`/`release-sbom.yml` demoted to `workflow_dispatch`-only and folded in). `0013`'s release portion is `Superseded by 0025` (its CI-baseline / posture-lint / SHA-pin / Dependabot decisions stand).
 - **Supersedes:** 0013 (release portion only — the CI baseline / posture-lint / SHA-pin / Dependabot decisions of 0013 stand)
 - **Source:** Maintainer release-workflow review, 2026-05-17 (release-plz `release-PR` model rejected after the v0.1.4 `#164` changelog defect)
 
@@ -67,14 +67,19 @@ flowchart LR
   end
 ```
 
-- New workflow `.github/workflows/release.yml`, `on: push: tags: ['v*']`.
+- The release workflow lives at `.github/workflows/release-plz.yml`,
+  `on: push: tags: ['v*']`. **The filename `release-plz.yml` is retained
+  deliberately** (see the Amendment below): the crates.io OIDC Trusted
+  Publisher binding is `(repo, workflow filename)`-scoped, so keeping the name
+  avoids re-registering it. The file no longer runs release-plz; its contents
+  are this tag-driven pipeline.
 - **One** workspace tag `vX.Y.Z` (or `vX.Y.Z-beta.N`). The per-crate
   `doiget-<crate>-v*` tag scheme is retired. `release-sign.yml` /
-  `release-sbom.yml` are re-pointed from `doiget-cli-v*` to `v*` (or folded
-  into `release.yml` as jobs).
-- `release-plz.yml` and `release-plz.toml` are **removed**. Version bump +
-  `CHANGELOG.md` editing become an explicit pre-tag step (script-assisted, see
-  D4), not an auto-PR.
+  `release-sbom.yml` are folded into the pipeline as `sign` / `sbom` jobs
+  (their standalone files demoted to `workflow_dispatch`-only escape hatches).
+- `release-plz.toml` is **removed** and the `release-plz` action is no longer
+  invoked. Version bump + `CHANGELOG.md` editing become an explicit pre-tag
+  step (script-assisted, see D4), not an auto-PR.
 - Tags MUST be annotated and GPG-signed (`git tag -s`); the gate verifies this.
 
 ### D2 — Mandatory version gate (runs first; abort on any failure)
@@ -244,3 +249,24 @@ flip this to `Accepted` (note the PR), flip `0013` `Status:` to
 `DECISIONS/INDEX.md`, and update any NORMATIVE doc that references the
 release process. To revise this decision, write a new ADR with
 `Supersedes: 0025` per `CONTRIBUTING.md`.
+
+## Amendment — 2026-05-18: retain the `release-plz.yml` filename
+
+D1 originally specified a new file `.github/workflows/release.yml` with
+`release-plz.yml` removed. PR #166 implemented it that way. This amendment
+(separate follow-up PR) **renames the pipeline back to
+`.github/workflows/release-plz.yml`** (only `release-plz.toml` stays removed).
+
+**Why:** the crates.io OIDC Trusted Publisher for `doiget-core`/`-cli`/`-mcp`
+is bound to `(repo, workflow filename)` and is **not** environment-scoped
+(verified against the pre-#166 `release-plz.yml`: no `environment:` key).
+Keeping the filename means the existing Trusted Publisher continues to
+authorize the publish job with **zero crates.io reconfiguration**; renaming
+would have required re-registering all three crates before the next publish.
+
+**Scope of the amendment:** filename + internal references only. No change to
+the decision, the version gate (D2), lanes (D3), changelog strategy (D4),
+pipeline order (D5), branch model (D6), or `#164` disposition (D7). The
+filename is a deliberate, documented misnomer (header note in the workflow).
+This is recorded as an in-place amendment rather than a superseding ADR
+because no decision changed — only an implementation detail was corrected.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -103,7 +103,7 @@ malicious PDFs because doiget does not interact with their content.
 | Malicious release artifact swap | Sigstore keyless signing of release binaries; verifiable with `cosign verify-blob`. |
 | `cargo publish` token leak | Use crates.io trusted publishing (OIDC) — no long-lived token in repo. |
 | 3rd-party Action injection | All Actions pinned by SHA, not floating tag; Dependabot updates SHAs. |
-| Reproducible builds | `Cargo.lock` committed; `rust-toolchain.toml` pins rustc; `RUSTFLAGS` fixed in release.yml. |
+| Reproducible builds | `Cargo.lock` committed; `rust-toolchain.toml` pins rustc; `RUSTFLAGS` fixed in release-plz.yml. |
 
 ### 1.10 Network side channel
 

--- a/scripts/release-version-gate.sh
+++ b/scripts/release-version-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # release-version-gate.sh — the mandatory, abort-safe pre-publish gate for the
-# tag-driven release pipeline (ADR-0025 D2). It runs FIRST in release.yml; if
+# tag-driven release pipeline (ADR-0025 D2). It runs FIRST in release-plz.yml; if
 # any check fails NOTHING external (cargo publish / GitHub Release) runs, so
 # every irreversible step is preceded by this entirely reversible gate.
 #
@@ -16,7 +16,7 @@
 # availability so a local dry-run still exercises the structural checks.
 #
 # `--offline-skip-crates-io` skips ONLY G3/G4 (the crates.io reachability
-# checks) for a local dry-run. It MUST NOT be passed in CI — release.yml calls
+# checks) for a local dry-run. It MUST NOT be passed in CI — release-plz.yml calls
 # this script with no skip flag so the network checks always run for a real
 # release.
 #
@@ -184,7 +184,7 @@ pass "G6: prerelease consistent (tag/manifest/lane all '$LANE')"
 # G3 — X.Y.Z not already published on crates.io for ALL of the 3 crates.
 # G4 — version is strictly SemVer-greater than the latest published in lane.
 # Both query crates.io; skipped only with --offline-skip-crates-io (local
-# dry-run). They ALWAYS run in CI (release.yml passes no skip flag).
+# dry-run). They ALWAYS run in CI (release-plz.yml passes no skip flag).
 # ---------------------------------------------------------------------------
 # SemVer compare: returns 0 if $1 > $2, 1 if $1 == $2, 2 if $1 < $2.
 # Pre-release ordering per SemVer §11: a pre-release has LOWER precedence than

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -109,7 +109,7 @@ malicious PDFs because doiget does not interact with their content.
 | Malicious release artifact swap | Sigstore keyless signing of release binaries; verifiable with `cosign verify-blob`. |
 | `cargo publish` token leak | Use crates.io trusted publishing (OIDC) — no long-lived token in repo. |
 | 3rd-party Action injection | All Actions pinned by SHA, not floating tag; Dependabot updates SHAs. |
-| Reproducible builds | `Cargo.lock` committed; `rust-toolchain.toml` pins rustc; `RUSTFLAGS` fixed in release.yml. |
+| Reproducible builds | `Cargo.lock` committed; `rust-toolchain.toml` pins rustc; `RUSTFLAGS` fixed in release-plz.yml. |
 
 ### 1.10 Network side channel
 


### PR DESCRIPTION
Follow-up to #166. **No decision change** — implementation-detail correction (ADR-0025 Amendment 2026-05-18).

## Why
#166 named the ADR-0025 tag-driven pipeline `.github/workflows/release.yml`. The crates.io OIDC **Trusted Publisher** for `doiget-core` / `doiget-cli` / `doiget-mcp` is bound to **(repo, workflow filename)** and is **not** environment-scoped — verified against the pre-#166 `release-plz.yml` (no `environment:` key). Keeping the original filename means the existing Trusted Publisher keeps authorizing the publish job with **zero crates.io reconfiguration**; renaming would have forced re-registering all three crates before the next publish.

## Changes
- `git mv release.yml → release-plz.yml` + a `FILENAME NOTE` header documenting the deliberate misnomer.
- Swap `release.yml` → `release-plz.yml` references in `release-sign.yml`, `release-sbom.yml`, `docs/SECURITY.md`, `scripts/release-version-gate.sh`.
- ADR-0025: correct D1 + Status line; append a `## Amendment — 2026-05-18` (filename + refs only; D2–D7 unchanged).
- Resync `site/content/developer/security.md` (SECURITY.md is site-projected — keeps `build (zola)` green, the #165 lesson).

## Validation
YAML parses; `release-version-gate.sh v0.2.0` PASSes; only remaining `release.yml` string is the Amendment's accurate "D1 originally specified…" history.

## Effect on the release blockers
- ❌→✅ crates.io Trusted Publisher reconfiguration **no longer needed**.
- Still inherent (by design): the maintainer pushes the **GPG-signed** `v0.2.0` tag (gate G7); `#166` already merged so the pipeline is on `main`.

Agent-authored; do not merge without review. No tag pushed.