### PR TITLE
fix(ci): accept SSH-signed release tags (G7 + .github/allowed_signers)

### DIFF
--- a/.github/allowed_signers
+++ b/.github/allowed_signers
@@ -1,0 +1,13 @@
+# SSH allowed-signers for release-tag verification (ADR-0025 D2 G7).
+#
+# The version gate (`scripts/release-version-gate.sh`) verifies the release
+# tag with `git -c gpg.ssh.allowedSignersFile=.github/allowed_signers
+# verify-tag`. The principal is the tag's tagger email; it MUST match the
+# maintainer's `git config user.email`. `namespaces="git"` scopes the key to
+# git object signing only.
+#
+# These are PUBLIC keys (already published on the maintainer's GitHub account)
+# — committing them here is the standard, intended allowed-signers mechanism.
+# Adding a new release signer = add a line; rotation = replace the line (a
+# normal reviewed PR).
+shimozono-sota631@g.ecc.u-tokyo.ac.jp namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAMITHD4rPVQdh+7X/GG8/0Xv9RyWZhCiBVz/RiAXY4S

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,7 +10,7 @@ name: release
 # misnomer; the contents are the ADR-0025 tag-driven pipeline below.
 
 # ADR-0025 — tag-driven release pipeline. The ONLY entry point is pushing an
-# annotated, GPG-signed workspace tag `vX.Y.Z` (stable) or `vX.Y.Z-beta.N`
+# annotated, signed (GPG or SSH) workspace tag `vX.Y.Z` (stable) or `vX.Y.Z-beta.N`
 # (beta). One workspace tag IS the release; the legacy per-crate
 # `doiget-<crate>-v*` tag scheme (release-plz) is retired.
 #

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -80,7 +80,10 @@ flowchart LR
 - `release-plz.toml` is **removed** and the `release-plz` action is no longer
   invoked. Version bump + `CHANGELOG.md` editing become an explicit pre-tag
   step (script-assisted, see D4), not an auto-PR.
-- Tags MUST be annotated and GPG-signed (`git tag -s`); the gate verifies this.
+- Tags MUST be annotated and signed — **GPG or SSH** (`git tag -s` with
+  `gpg.format` set to `openpgp` or `ssh`). G7 verifies the signature; SSH
+  signatures are checked against the committed `.github/allowed_signers`
+  (principal = tagger email). See the Amendment.
 
 ### D2 — Mandatory version gate (runs first; abort on any failure)
 
@@ -270,3 +273,13 @@ pipeline order (D5), branch model (D6), or `#164` disposition (D7). The
 filename is a deliberate, documented misnomer (header note in the workflow).
 This is recorded as an in-place amendment rather than a superseding ADR
 because no decision changed — only an implementation detail was corrected.
+
+**Signing mechanism (same amendment):** D1 originally said "GPG-signed". The
+maintainer's environment has no GPG secret key but does have an SSH key
+already trusted by GitHub for auth. Tag signing therefore accepts **GPG *or*
+SSH** (`git tag -s` with `gpg.format=ssh`). G7 verifies SSH signatures against
+the repo-committed `.github/allowed_signers` (public keys; principal = tagger
+email). This does not weaken the property D1 protects — the tag is still
+cryptographically signed by the maintainer and verified by the gate before any
+publish; only the signature *format* is broadened. Adding/rotating a release
+signer is a one-line reviewed change to `.github/allowed_signers`.

--- a/scripts/release-version-gate.sh
+++ b/scripts/release-version-gate.sh
@@ -281,8 +281,15 @@ else
   if [ "$OBJ_TYPE" != "tag" ]; then
     fail "G7: tag '$TAG' is a lightweight tag (object type '$OBJ_TYPE'), not an annotated tag. ADR-0025 D1 requires 'git tag -s' (annotated + signed)."
   fi
-  if ! git -C "$REPO_ROOT" verify-tag "$TAG" >/dev/null 2>&1; then
-    fail "G7: tag '$TAG' is not GPG-verifiable ('git verify-tag' failed). ADR-0025 D1 requires a signed tag."
+  # ADR-0025 D1: GPG- OR SSH-signed. `git verify-tag` auto-detects the
+  # signature type; SSH signatures additionally need an allowed-signers file.
+  # Passing it via `-c` is harmless for GPG-signed tags (ignored) and enables
+  # SSH verification against the committed `.github/allowed_signers` (whose
+  # principal is the tagger email).
+  ALLOWED_SIGNERS="$REPO_ROOT/.github/allowed_signers"
+  if ! git -C "$REPO_ROOT" -c gpg.ssh.allowedSignersFile="$ALLOWED_SIGNERS" \
+        verify-tag "$TAG" >/dev/null 2>&1; then
+    fail "G7: tag '$TAG' is not signature-verifiable ('git verify-tag' failed). ADR-0025 D1 requires a GPG- or SSH-signed tag; an SSH signer must be listed in .github/allowed_signers with a principal matching the tagger email."
   fi
   if [ "$LANE" = "beta" ]; then
     LANE_BRANCH="next"


### PR DESCRIPTION
Follow-up enabling the ADR-0025 release pipeline to actually be cut on the maintainer's machine. **No decision change** — ADR-0025 Amendment (signing-mechanism clause).

## Why
ADR-0025 D1 originally required a **GPG**-signed tag. The maintainer's environment has no GPG secret key (`git tag -s` → `gpg: No secret key`) but already has an SSH key trusted by GitHub for auth. Forcing GPG would mean standing up GPG key management for no security gain.

## Change
- `.github/allowed_signers` (new): the maintainer's **public** SSH key, principal = git tagger email, `namespaces="git"`. Public keys are safe/standard to commit; this is the git allowed-signers mechanism.
- `scripts/release-version-gate.sh` G7: verify via `git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag` — auto-detects GPG **or** SSH; harmless for GPG, enables SSH verification in CI.
- ADR-0025: D1 reworded ("GPG or SSH"), Amendment extended with the signing-mechanism rationale (the property D1 protects is unchanged — the tag is still cryptographically signed by the maintainer and gate-verified before any publish; only the signature *format* is broadened).
- Workflow header comment: "GPG-signed" → "signed (GPG or SSH)".

## Validation
`bash -n` clean; YAML parses; `release-version-gate.sh v0.2.0 --offline-skip-crates-io` PASSes (G7 skipped pre-tag as designed; it runs for real on the pushed tag in CI).

## Maintainer steps after this merges (one-time SSH-signing setup, then release)
```
git config --global gpg.format ssh
git config --global user.signingkey ~/.ssh/id_ed25519.pub
# GitHub → Settings → SSH and GPG keys → New SSH key → type "Signing Key"
#   (paste the SAME ~/.ssh/id_ed25519.pub; it is currently only an Auth key)
git switch main && git pull --ff-only
git tag -s v0.2.0 -m "doiget v0.2.0" && git push origin v0.2.0
```

Agent-authored; do not merge without review. No tag pushed.