### PR TITLE
fix(ci): publish order core→mcp→cli + partial-publish-recovery gate

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -147,14 +147,16 @@ jobs:
         # registered as a Trusted Publisher on crates.io before the first run.
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
         id: auth
-      - name: Publish doiget-core then doiget-cli + doiget-mcp (idempotent)
+      - name: Publish doiget-core, then doiget-mcp, then doiget-cli (idempotent)
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
-          # Per-crate sequential publish in dependency order: core first
-          # (cli + mcp depend on it). --locked: publish exactly the resolved
+          # Per-crate sequential publish in TOPOLOGICAL dependency order:
+          # doiget-core (no internal deps) -> doiget-mcp (depends on core)
+          # -> doiget-cli (depends on BOTH core AND mcp). --locked: publish
+          # exactly the resolved
           # Cargo.lock the gate validated. ADR-0025 D5 idempotency: a re-run
           # that finds a crate ALREADY on crates.io (immutable) must CONTINUE
           # to the next crate, not hard-fail — recovery from a partial publish
@@ -183,8 +185,8 @@ jobs:
             return "$rc"
           }
           publish_one doiget-core
-          publish_one doiget-cli
           publish_one doiget-mcp
+          publish_one doiget-cli
 
   # -------------------------------------------------------------------------
   # d. github-release — create the GitHub Release whose body is EXACTLY the

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -283,3 +283,33 @@ email). This does not weaken the property D1 protects — the tag is still
 cryptographically signed by the maintainer and verified by the gate before any
 publish; only the signature *format* is broadened. Adding/rotating a release
 signer is a one-line reviewed change to `.github/allowed_signers`.
+
+## Amendment — 2026-05-18 (2): publish order + partial-publish-recovery gate
+
+The first real `v0.2.0` cut exposed two implementation bugs (the *design*
+stands; D5 already anticipated partial-publish recovery — the code did not
+implement it correctly):
+
+1. **Publish order was wrong.** D5/the workflow published `doiget-core →
+   doiget-cli → doiget-mcp`, assuming `cli`/`mcp` only depend on `core`. In
+   fact **`doiget-cli` depends on BOTH `doiget-core` AND `doiget-mcp`**, so
+   `cargo publish -p doiget-cli` failed (`failed to select a version for
+   doiget-mcp`) after `core` had already published. The topological order is
+   **`doiget-core → doiget-mcp → doiget-cli`** (cli last). Fixed in
+   `.github/workflows/release-plz.yml`.
+
+2. **G3/G4 blocked the D5 recovery re-run.** G3 hard-failed if *any* crate
+   already published `$TAG_VERSION`. After the partial `v0.2.0`
+   (`doiget-core@0.2.0` live, `cli`/`mcp` not), every re-run aborted at the
+   gate, so D5's idempotent recovery in the publish step was unreachable —
+   directly contradicting D5. G3/G4 are now partial-publish-aware: a crate
+   already at `$TAG_VERSION` is a recovery skip (the publish step idempotently
+   skips it); the gate FAILs only when **all** crates already publish the
+   version (a complete re-release / forgotten bump); 1..n−1 published is a
+   PASS-with-notice recovery. Fixed in `scripts/release-version-gate.sh`.
+
+Recovery for the in-flight `v0.2.0`: with this PR merged, re-run the pipeline
+for the existing tag (`gh workflow run release-plz.yml -f tag=v0.2.0`) — the
+gate now passes as partial-recovery, `doiget-core@0.2.0` idempotently skips,
+and `doiget-mcp@0.2.0` then `doiget-cli@0.2.0` publish. No new tag is minted;
+`doiget-core@0.2.0` (already immutable on crates.io) is reused as-is.

--- a/scripts/release-version-gate.sh
+++ b/scripts/release-version-gate.sh
@@ -231,25 +231,37 @@ else
   if ! command -v curl >/dev/null 2>&1; then
     fail "G3: curl not available and --offline-skip-crates-io not set — cannot verify crates.io publication state"
   fi
+  # ADR-0025 D2-G3/G4 with D5 partial-publish-recovery semantics.
+  # Per crate: if THIS crate already publishes the exact $TAG_VERSION, that is
+  # the idempotent-recovery case (crates.io is immutable; the publish step
+  # skips it) — record it and skip G4 for that crate. Otherwise enforce G4
+  # (strictly SemVer-greater than every published version). AFTER the loop:
+  #   - all crates already at $TAG_VERSION  -> FAIL (complete re-release / a
+  #     forgotten version bump; nothing to do, crates.io is immutable);
+  #   - some (1..n-1) already at it          -> PASS as partial-publish
+  #     recovery (the publish step completes the not-yet-published siblings);
+  #   - none                                 -> normal PASS.
+  published_at_tag=0
   for crate in "${CRATES[@]}"; do
     # crates.io v1 API: 200 + a `versions` array. We grep the raw JSON for the
     # exact "num":"X.Y.Z" pair (no jq, house style). A 404 => crate never
-    # published yet, which is fine for G3 (treated as "not present").
+    # published yet (treated as "not present").
     body="$(curl -fsSL --max-time 30 \
       -H 'User-Agent: doiget-release-version-gate (https://github.com/sotashimozono/doiget)' \
       "https://crates.io/api/v1/crates/${crate}" 2>/dev/null || true)"
     if [ -z "$body" ]; then
-      echo "note: crates.io returned no body for '$crate' (likely never published yet) — G3 OK for this crate"
+      echo "note: crates.io returned no body for '$crate' (likely never published yet) — new publish, G3/G4 OK for this crate"
       continue
     fi
-    # G3: exact version must NOT already exist.
     if printf '%s' "$body" | grep -Eq "\"num\"[[:space:]]*:[[:space:]]*\"${TAG_VERSION//./\\.}\""; then
-      fail "G3: $crate $TAG_VERSION is ALREADY published on crates.io — crates.io versions are immutable. Bump to a new patch version (ADR-0025 D5: recovery is a new tag, never a force-overwrite)."
+      published_at_tag=$((published_at_tag + 1))
+      echo "::notice::G3/G4: $crate $TAG_VERSION already on crates.io (immutable) — partial-publish recovery; the publish step idempotently skips it (ADR-0025 D5)"
+      continue
     fi
-    # G4: TAG_VERSION must be strictly greater than every published num.
-    # semver_cmp orders a pre-release below its matching normal version, so a
-    # plain strict-greater check is correct for both lanes (ADR-0025 D2-G4
-    # "monotonic within lane"; a stable X.Y.Z is > X.Y.Z-beta.N).
+    # Not yet published for this crate — G4: TAG_VERSION must be strictly
+    # greater than every published num. semver_cmp orders a pre-release below
+    # its matching normal version, so a plain strict-greater check is correct
+    # for both lanes (ADR-0025 D2-G4 "monotonic within lane").
     while IFS= read -r pub; do
       [ -z "$pub" ] && continue
       cmp="$(semver_cmp "$TAG_VERSION" "$pub")"
@@ -262,8 +274,14 @@ else
     done < <(printf '%s' "$body" | grep -Eo '"num"[[:space:]]*:[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)"$/\1/')
     pass "G3/G4: $crate — $TAG_VERSION unpublished and strictly greater than all published"
   done
-  pass "G3: $TAG_VERSION unpublished on crates.io for all 3 crates"
-  pass "G4: $TAG_VERSION strictly SemVer-greater than latest published in lane"
+  if [ "$published_at_tag" -eq "${#CRATES[@]}" ]; then
+    fail "G3: ALL ${#CRATES[@]} crates already publish $TAG_VERSION — this version is fully released; nothing to do. Recovery from a *partial* publish is allowed, but a *complete* re-release is not (crates.io is immutable). Did you forget to bump the version?"
+  elif [ "$published_at_tag" -gt 0 ]; then
+    pass "G3/G4: PARTIAL-PUBLISH RECOVERY — $published_at_tag/${#CRATES[@]} crate(s) already at $TAG_VERSION; the publish step idempotently skips them and completes the rest (ADR-0025 D5)"
+  else
+    pass "G3: $TAG_VERSION unpublished on crates.io for all ${#CRATES[@]} crates"
+    pass "G4: $TAG_VERSION strictly SemVer-greater than latest published in lane"
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Recovers the failed `v0.2.0` release. Two implementation bugs (ADR-0025 design stands; D5 already anticipated this — the code didn't implement it correctly). ADR-0025 Amendment 2026-05-18 (2).

## What happened
`v0.2.0` ran: version-gate PASSED, then **`cargo publish` FAILED**. Result: **`doiget-core@0.2.0` is live on crates.io (immutable); `doiget-cli@0.2.0` / `doiget-mcp@0.2.0` are NOT**.

## Root causes
1. **Wrong publish order.** Pipeline did `core → cli → mcp`. But `doiget-cli` depends on **both** `doiget-core` **and** `doiget-mcp`, so `cargo publish -p doiget-cli` failed: `failed to select a version for doiget-mcp ^0.2.0`. Correct topological order: **`core → mcp → cli`**.
2. **Gate blocked recovery.** G3 hard-failed if *any* crate already published the version. Post-partial-publish, every re-run aborted at the gate → D5's idempotent publish-step recovery was unreachable (contradicts D5).

## Fix
- `release-plz.yml`: publish order → `doiget-core → doiget-mcp → doiget-cli`.
- `release-version-gate.sh`: G3/G4 partial-publish-recovery aware — per-crate already-at-version = recovery skip; FAIL only if **all 3** already published (complete re-release / forgotten bump); 1..2 = PASS-with-`::notice::` recovery.
- ADR-0025: Amendment 2026-05-18 (2).

## Validated against LIVE crates.io
`bash scripts/release-version-gate.sh v0.2.0` →
`::notice:: doiget-core 0.2.0 already on crates.io … recovery` ·
`PASS doiget-cli/doiget-mcp unpublished` ·
`PASS PARTIAL-PUBLISH RECOVERY — 1/3` · `PASS G7` · **version gate PASSED**.

## Recovery runbook (after this merges) — no new tag
```
gh workflow run release-plz.yml -f tag=v0.2.0 --repo sotashimozono/doiget
# gate: partial-recovery PASS → publish: core idempotent-skip,
# mcp publishes, cli publishes → sign/sbom/GitHub Release
```
`doiget-core@0.2.0` (already immutable) is reused as-is; v0.2.0 completes.

Agent-authored; do not merge without review. No tag/publish performed.