### PR TITLE
fix(ci): drop invalid --target from gh release create (HTTP 422)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -254,7 +254,11 @@ jobs:
           # `gh release create` is idempotent-friendly: if the Release already
           # exists (re-run / dispatch), fall back to `edit`. --verify-tag: the
           # Release must point at the pushed signed tag, not create a new
-          # lightweight one.
+          # lightweight one. NOTE: do NOT pass `--target` — `target_commitish`
+          # must be a branch name or commit SHA, never a tag name. The tag is
+          # always pre-created and pushed (ADR-0025 tag-driven model), so
+          # `--verify-tag` alone is correct; passing `--target "$TAG"` made
+          # GitHub reject the create with HTTP 422 "target_commitish invalid".
           if [ "$PRERELEASE" = "true" ]; then
             echo "tag $TAG carries a SemVer pre-release identifier -> prerelease=true (not latest)"
           else
@@ -270,10 +274,10 @@ jobs:
           else
             if [ "$PRERELEASE" = "true" ]; then
               gh release create "$TAG" --title "$TAG" --notes-file release-body.md \
-                --verify-tag --target "$TAG" --prerelease
+                --verify-tag --prerelease
             else
               gh release create "$TAG" --title "$TAG" --notes-file release-body.md \
-                --verify-tag --target "$TAG" --latest
+                --verify-tag --latest
             fi
           fi
 


### PR DESCRIPTION
The final blocker for v0.2.0. **crates.io is already complete** — doiget-core/-mcp/-cli are all published at 0.2.0 (the partial-publish recovery from #169 worked). Only the `create GitHub Release` job failed.

## Root cause
```
gh release create "$TAG" --title "$TAG" --notes-file release-body.md --verify-tag --target "$TAG" --latest
```
`--target` sets `target_commitish`, which **must be a branch name or commit SHA — never a tag name**. Passing `--target v0.2.0` → `HTTP 422: Release.target_commitish is invalid`. The tag is always pre-created and pushed (ADR-0025 tag-driven model), so `--verify-tag` alone is correct and `--target` must not be passed.

## Fix
Remove `--target "$TAG"` from both `gh release create` invocations (keep `--verify-tag`). YAML validated.

## Recovery for the in-flight v0.2.0 (does NOT need this PR / a pipeline re-run)
crates.io 0.2.0 is done and immutable. The GitHub Release is created manually out-of-band with the corrected command, then `release-sign.yml` / `release-sbom.yml` are dispatched (`-f tag=v0.2.0`) to attach the signed binaries + SBOM. This PR only prevents the bug for **future** releases.

Agent-authored; do not merge without review. No tag/publish performed by this PR.