### PR TITLE
docs: modernize docs to as-built v0.2.0 reality (de-plan + ADR-0025 reconcile)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,46 @@
+name: coverage
+
+# Workspace line coverage via `cargo-llvm-cov`, uploaded to Codecov.
+#
+# Non-required check (not in the branch-protection contexts — like
+# `build (zola)`); a Codecov hiccup must not block a merge, so the upload
+# is `fail_ci_if_error: false`. Runs on every PR and on pushes to the two
+# long-lived lanes (`main`, `next`) so Codecov has a base to diff PRs
+# against. Default features only (`oa-only`); the feature-gated Tier-3 TDM
+# code is intentionally outside the default coverage surface.
+#
+# All third-party Actions are SHA-pinned (repo invariant, ADR-0013):
+# checkout / rust-toolchain / rust-cache reuse the SHAs already pinned in
+# ci.yml; codecov-action and install-action SHAs were resolved from their
+# release tags. `CODECOV_TOKEN` is a repo secret (Codecov is connected).
+
+on:
+  pull_request:
+  push:
+    branches: [main, next]
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: llvm-cov + codecov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1  # v2.79.0
+        with:
+          tool: cargo-llvm-cov
+      - name: Generate workspace coverage (lcov)
+        run: cargo llvm-cov --workspace --locked --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,13 +115,46 @@ The following crates are denied workspace-wide via `deny.toml`:
 
 ## Commit and PR conventions
 
-- Branch from `main`. Branch name format: `<type>/<short-slug>`, e.g.
-  `fix/safekey-collision`, `feat/citation-graph`, `docs/clarify-store-spec`.
+- **Branch from `next`, not `main`** (ADR-0025 §D6). `next` is the integration
+  + beta lane; `main` is the stable lane and advances only via a `next → main`
+  promotion or a stable hotfix. Branch name format: `<type>/<short-slug>`,
+  e.g. `fix/safekey-collision`, `feat/citation-graph`,
+  `docs/clarify-store-spec`.
 - Commit messages follow Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`,
   `refactor:`, `test:`, `ci:`, `perf:`.
-- Sign your commits (`git commit -S`) — verified signatures are required on `main`.
+- Sign your commits. Both `main` and `next` are branch-protected with the same
+  required checks. Release **tags** MUST be signed — **GPG or SSH** (`git tag
+  -s` with `gpg.format` set accordingly); the release version gate verifies the
+  signature against `.github/allowed_signers` (ADR-0025 §D2-G7 / Amendment).
 - Each PR has a single, well-scoped purpose. Multi-purpose PRs will be asked to split.
 - The PR description must reference any related ADR, Discussion, or issue.
+
+## Release process
+
+Releases are **tag-driven**; [ADR-0025](docs/DECISIONS/0025-tag-driven-release.md)
+is the binding spec and full runbook. Summary:
+
+- **Lanes.** A clean SemVer tag `vX.Y.Z` = **stable**, cut from `main`.
+  `vX.Y.Z-beta.N` = **beta**, cut from `next`. crates.io has no dist-tags, so
+  the SemVer pre-release identifier *is* the channel.
+- **Cutting a release** (maintainer only): bump `[workspace.package].version`,
+  curate the `## [X.Y.Z]` `CHANGELOG.md` section (helper:
+  `scripts/release-changelog.sh`), commit, then push **one signed tag**
+  (`git tag -s vX.Y.Z … && git push origin vX.Y.Z`). The
+  `.github/workflows/release-plz.yml` pipeline (kept at that filename only to
+  preserve the crates.io Trusted Publisher binding — release-plz itself was
+  removed) runs a mandatory **version gate**, then publishes
+  `doiget-core → doiget-mcp → doiget-cli` to crates.io via OIDC,
+  sigstore-signs the binaries, emits an SBOM, and opens the GitHub Release.
+- **The gate fails closed** (ADR-0025 §D2): tag↔manifest mismatch, a
+  missing/empty `## [X.Y.Z]` CHANGELOG section, a non-monotonic version,
+  prerelease/lane inconsistency, or an unsigned tag aborts the release
+  *before* anything is published. A partial publish is recovered by re-running
+  the **same** tag on a fixed pipeline (already-published crates idempotently
+  skip) — never by force-overwrite; crates.io is immutable.
+- A pipeline bug fix only takes effect for a re-run if the tag is re-pointed
+  to the fixed commit (the pipeline runs the workflow/scripts *as of the
+  tagged tree*). Do not reintroduce a perpetual "release PR".
 
 ## ADR workflow
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 > A single-binary CLI + stdio MCP server that turns DOIs and arXiv ids into local PDFs through official, OA-first APIs.
 > Designed as the **agent-facing companion** to [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl).
 
+[![crates.io](https://img.shields.io/crates/v/doiget-core.svg)](https://crates.io/crates/doiget-core)
+[![docs.rs](https://img.shields.io/docsrs/doiget-core)](https://docs.rs/doiget-core)
+[![CI](https://github.com/sotashimozono/doiget/actions/workflows/ci.yml/badge.svg)](https://github.com/sotashimozono/doiget/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/sotashimozono/doiget/branch/main/graph/badge.svg)](https://codecov.io/gh/sotashimozono/doiget)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 **Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
 `doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub
 Release. Tier 1 + Tier 2 sources, the stdio MCP server, citation-graph

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 > A single-binary CLI + stdio MCP server that turns DOIs and arXiv ids into local PDFs through official, OA-first APIs.
 > Designed as the **agent-facing companion** to [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl).
 
-**Status:** Shipping — **v0.1.3** on a live `release-plz` pipeline. Tier 1 + Tier 2
-sources, the stdio MCP server, citation-graph expansion, gated TDM sources, and
-OIDC/sigstore release automation are all implemented. See [CHANGELOG.md](CHANGELOG.md)
-for the per-slice history and [docs/PHASES.md](docs/PHASES.md) for the phase plan.
+**Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
+`doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub
+Release. Tier 1 + Tier 2 sources, the stdio MCP server, citation-graph
+expansion, and gated TDM sources are all implemented. Releases are cut by a
+single signed git tag through the tag-driven pipeline (see
+[ADR-0025](docs/DECISIONS/0025-tag-driven-release.md)); `release-plz` was
+retired. See [CHANGELOG.md](CHANGELOG.md) for history and
+[docs/PHASES.md](docs/PHASES.md) for the phase plan.
 
 ## Posture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,8 +29,8 @@ flowchart TB
 
     Core --> Cap{CapabilityProfile<br/>oa / metadata / tdm-*}
     Cap -->|always on| OA[Tier 1 OA<br/>Crossref / Unpaywall / arXiv]
-    Cap -->|opt-in env| Meta[Tier 2 metadata<br/>OpenAlex / S2 / DOAJ<br/>Phase 4]
-    Cap -->|opt-in env + key + agree<br/>compile-time gated| TDM[Tier 3 TDM<br/>Springer OA / APS / Elsevier<br/>Phase 5a/5b/5c]
+    Cap -->|opt-in env| Meta[Tier 2 metadata<br/>OpenAlex / S2 / DOAJ]
+    Cap -->|opt-in env + key + agree<br/>compile-time gated| TDM[Tier 3 TDM<br/>Springer OA / APS / Elsevier]
 
     OA --> Fetcher[Fetcher<br/>rate-cap 5/sec, size cap, redirect allowlist]
     Meta -.-> Fetcher
@@ -62,7 +62,7 @@ doiget/                              # workspace root
 │   ├── doiget-core/                 # ★ library, semver-strict
 │   ├── doiget-cli/                  # binary `doiget`
 │   ├── doiget-mcp/                  # MCP server library
-│   └── doiget-obsidian/             # Phase 7 optional, default OFF
+│   └── doiget-obsidian/             # optional, default OFF
 │
 ├── examples/
 │   ├── 01-basic-fetch/
@@ -88,7 +88,7 @@ flowchart LR
     cli[doiget-cli<br/>binary] --> core[doiget-core<br/>library, semver-strict]
     cli --> mcp[doiget-mcp<br/>library]
     mcp --> core
-    obs[doiget-obsidian<br/>Phase 7 optional] --> core
+    obs[doiget-obsidian<br/>optional] --> core
 
     classDef core fill:#bfb,stroke:#060
     classDef bin fill:#bef,stroke:#069
@@ -185,21 +185,13 @@ sequenceDiagram
 | [CONTACT.md](../CONTACT.md) | Entry | Takedown / SLA / DMCA / security disclosure |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Process | PR rules, doc style, scope-reopening meta-rule |
 
-## 8. Phase plan summary
+## 8. Phase plan
 
-The full plan is in [`PHASES.md`](PHASES.md). Headline:
-
-| Phase | Scope | Effort |
-|---|---|---|
-| 0 | Repo bootstrap, normative specs, ADRs, Cargo workspace skeleton, CI | 5–7 days |
-| 1 | Core resolver + Tier 1 sources + `fetch` / `batch` CLI | 1.5 weeks |
-| 2 | Store + `info` / `search` / `bib` / `csl` | 1 week |
-| 3 | MCP server + 9 tools + strict stdio | 1.5 weeks |
-| **MVP shipping point** | | **5 weeks** |
-| 4 | Tier 2 sources + citation graph (Phase 4) | 1.5 weeks |
-| 5 | TDM (5a Springer OA / 5b APS / 5c Elsevier) | 3–5 weeks, optional |
-| 6 | Release + marketplace + polish | 1 week |
-| 7 | Optional (`vault`, `obsidian`) | per feature |
+The MVP (core resolver + Tier 1 sources + `fetch` / `batch` CLI, store +
+`info` / `search` / `bib` / `csl`, MCP server + tools + strict stdio) plus
+Tier 2 sources, the citation graph, and feature-gated Tier 3 TDM are shipped.
+The optional `doiget-obsidian` crate is the remaining per-feature work. The
+historical phase breakdown is in [`PHASES.md`](PHASES.md).
 
 ## 9. Cross-tool relationship with BiblioFetch.jl
 
@@ -218,5 +210,5 @@ The boundary contracts are documented as part of [`STORE.md`](STORE.md):
 2. Read [LEGAL.md](LEGAL.md) and [SCOPE.md](SCOPE.md). These set the boundaries on what
    contributions are accepted.
 3. Skim [DECISIONS/](DECISIONS/) — the ADRs explain why doiget is shaped the way it is.
-4. Pick a Phase 0 task from [PHASES.md](PHASES.md) §"Phase 0 deliverable checklist" or
-   open an issue to discuss a contribution outside it.
+4. Open an issue to discuss a contribution, keeping it within the boundaries
+   set by [LEGAL.md](LEGAL.md) and [SCOPE.md](SCOPE.md).

--- a/docs/CACHE.md
+++ b/docs/CACHE.md
@@ -7,9 +7,9 @@
 ```
 ~/.cache/doiget/
 ├── resolver/
-│   └── <safekey>.toml       # Crossref / Unpaywall response cache (Phase 1+)
+│   └── <safekey>.toml       # Crossref / Unpaywall response cache
 └── citations/
-    └── <safekey>.toml       # citation graph expansion cache (Phase 4+)
+    └── <safekey>.toml       # citation graph expansion cache
 ```
 
 Override root via `DOIGET_CACHE_ROOT` env or `[cache] root` in `config.toml`.

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -8,7 +8,7 @@
 ## 1. Type definition
 
 ```rust
-// Phase 1+ target module path; Phase 0 ships these types in monolithic lib.rs.
+// These types are defined in the doiget-core crate.
 
 use secrecy::SecretString; // = SecretBox<str>; the `secrecy` 0.10 owned-string secret
 use chrono::{DateTime, Utc};
@@ -38,7 +38,7 @@ pub struct AlwaysOn;   // unit struct — Tier 1 OA is always permitted
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MetadataAccess {
-    pub openalex: bool,            // Phase 4+
+    pub openalex: bool,
     pub semantic_scholar: bool,
     pub doaj: bool,
 }

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -157,9 +157,9 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 
 | Variable | Type | Effect |
 |---|---|---|
-| `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). Phase 4+. |
-| `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. Phase 4+. |
-| `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. Phase 4+. |
+| `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
+| `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
+| `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -7,7 +7,7 @@
 ## 1. ErrorCode enum
 
 ```rust
-// Phase 1+ target module path; Phase 0 ships ErrorCode in monolithic lib.rs.
+// ErrorCode is defined in the doiget-core crate.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -6,7 +6,7 @@
 `doiget` runs as a Model Context Protocol server when invoked as `doiget serve`. It
 speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal 6).
 
-## 1. Tool list (Phase 3 baseline)
+## 1. Tool list
 
 | Tool | Purpose |
 |---|---|
@@ -21,7 +21,7 @@ speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal
 | `doiget_capability_profile` | Report which sources this instance is allowed to use. |
 | `doiget_health` | Operational sanity (store writable, version, schema). |
 
-Phase 4 adds:
+Additional tools:
 
 | Tool | Purpose |
 |---|---|
@@ -190,7 +190,7 @@ type CapabilityProfileResponse = {
 
 ## 9. Smoke test
 
-A CI workflow `mcp-smoke.yml` (Phase 3) spawns the server, sends a minimal sequence
+A CI workflow `mcp-smoke.yml` spawns the server, sends a minimal sequence
 (`initialize` → `tools/list` → `tools/call doiget_health`), asserts the responses, and
 asserts that no stray bytes appeared on stdout outside JSON-RPC frames.
 
@@ -208,8 +208,8 @@ an optional `dry_run: boolean` input field, defaulting to `false`. When
   for the resolver, not a prediction of the single host the real fetch would
   hit. doiget cannot resolve the post-Unpaywall OA URL host without making
   the Unpaywall call, and `dry_run` MUST NOT make it.
-- The `plan.candidate_hosts_are_upper_bound` boolean is always `true` in
-  Phase 1 and machine-encodes the bullet above (ADR-0022 §4) directly into
+- The `plan.candidate_hosts_are_upper_bound` boolean is always `true` and
+  machine-encodes the bullet above (ADR-0022 §4) directly into
   the wire envelope, so an agent can detect the upper-bound semantics
   without consulting the spec.
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -82,10 +82,10 @@ type FetchResult =
       source: "crossref" | "unpaywall" | "arxiv"
             | "openalex" | "s2" | "doaj" | "oa-publisher"
             | "tdm-elsevier" | "tdm-aps" | "tdm-springer",
-      // ADR-0021 §4 / ADR-0024 (Slice 4): the resolver profile under
-      // which the canonical-digest for this fetch was minted. Equal to
-      // `source` verbatim in Slice 4; kept distinct so future slices
-      // can decouple the two when overlapping resolvers ship.
+      // ADR-0021 §4 / ADR-0024: the resolver profile under which the
+      // canonical-digest for this fetch was minted. Currently equal to
+      // `source` verbatim; kept a distinct field so the two can be
+      // decoupled if overlapping resolvers are ever added.
       resolver_profile: string,
       path: string,
       license: string,
@@ -281,7 +281,7 @@ type MetadataOnlyResult =
       source: "crossref" | "unpaywall" | "arxiv",
       // ADR-0021 §4 / ADR-0024: the resolver profile under which the
       // canonical-digest for this metadata-only call was minted.
-      // Equal to `source` verbatim in Slice 4.
+      // Currently equal to `source` verbatim.
       resolver_profile: string,
       license: string,
       oa_url: string | null,

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,14 +1,13 @@
 # Migration
 
-> **Status: INFORMATIVE (placeholder).** Full migration recipes will be filled in during
-> Phase 2 once the round-trip test suite (`cross-tool-compat.yml`) passes. The
-> binding contract underlying these scenarios is in [`STORE.md`](STORE.md).
+> **Status: INFORMATIVE.** The binding contract underlying these scenarios is in
+> [`STORE.md`](STORE.md).
 
-This document will cover migration scenarios between doiget and
+This document covers migration scenarios between doiget and
 [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl), and between
 machines.
 
-## Scenarios (to be expanded)
+## Scenarios
 
 ### 1. BiblioFetch.jl user trying doiget for the first time
 
@@ -59,13 +58,7 @@ at that time. Until then, doiget never writes anything other than `1.x`.
 The store is just files under `~/papers/`. Uninstalling doiget (`cargo uninstall
 doiget`) does not touch the store. BiblioFetch.jl can continue to read and write it.
 
-## Future content
+## Related
 
-This file will expand to:
-
-- Step-by-step recipes with expected output.
-- Failure-mode walkthroughs.
-- Cross-platform path handling (Windows ↔ POSIX) notes.
-- Troubleshooting `cross-tool-compat.yml` failures.
-
-Until then, see [`STORE.md`](STORE.md) for the binding spec.
+For the binding store contract these scenarios rely on, see
+[`STORE.md`](STORE.md).

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -1,201 +1,53 @@
-# Phase plan
+# Project status & remaining scope
 
-> **Status: INFORMATIVE.** Snapshot of the implementation plan as of 2026-05-05.
-> Effort estimates are best-guess and will drift; the Phase **content** is the binding
-> part. Substantive changes to Phase content require an ADR.
+> **Status: INFORMATIVE.** This file once held the full 0–7 phase
+> implementation plan. That plan has been executed — doiget is shipped
+> (**v0.2.0** on crates.io). The historical phase/slice plan and its
+> deliverable checklists are preserved in git history, [`CHANGELOG.md`](../CHANGELOG.md),
+> and the ADRs ([`docs/DECISIONS/`](DECISIONS/)); they are not reproduced
+> here. This document describes only the **current state** and what is
+> **not yet built**.
 
-## 1. Phase headline
+## Shipped
 
-| Phase | Scope | Effort |
-|---|---|---|
-| **0** | Repo bootstrap, normative specs, ADRs, Cargo workspace skeleton, CI | 5–7 days |
-| **1** | Core resolver + Tier 1 sources + `fetch` / `batch` CLI | 1.5 weeks |
-| **2** | Store + `info` / `search` / `bib` / `csl` | 1 week |
-| **3** | MCP server + 9 tools + strict stdio | 1.5 weeks |
-| **MVP shipping point** | | **5 weeks** |
-| 3.5 | Early marketplace draft + landing page (overlap with Phase 4) | concurrent |
-| 4 | Tier 2 sources + citation graph | 1.5 weeks |
-| 5a | TDM Springer Nature OA — author opt-in to start | 1 week + 1–2 wk cooldown |
-| 5b | TDM APS Harvest — author opt-in to start | 1 week + 1–2 wk cooldown |
-| 5c | TDM Elsevier ScienceDirect — author re-decision required | 1 week |
-| 6 | Release: OIDC + sigstore + SBOM + landing page polish + signed-tag pipeline (ADR-0025) | 1 week |
-| 7 | Optional features (`vault`, `obsidian`) | per feature |
+doiget is fully implemented and released:
 
-> **Phase 6 release note (ADR-0025, live).** Phase 6 has landed. Releases are
-> **tag-driven** ([ADR-0025](DECISIONS/0025-tag-driven-release.md)): the
-> maintainer pushes one signed workspace tag — `vX.Y.Z` (stable, from `main`)
-> or `vX.Y.Z-beta.N` (beta, from `next`). A mandatory version gate runs first
-> and, on pass, publishes all three crates to crates.io via OIDC, sigstore-signs
-> the binaries, emits an SBOM, and opens the GitHub Release. `release-plz` (the
-> original Slice 21/22 release-PR mechanism) was **retired**: there is no
-> perpetual release PR and no per-crate `doiget-<crate>-vX.Y.Z` tags. `0.1.0`–
-> `0.1.3` were cut by the old release-plz flow; **`v0.2.0`** (the current
-> release: all three crates on crates.io, signed binaries + SBOM on the GitHub
-> Release) was cut by the ADR-0025 pipeline. See [`CHANGELOG.md`](../CHANGELOG.md)
-> for released versions and ADR-0025 for the design + release runbook.
+- **Sources.** Tier 1 (Crossref / Unpaywall / arXiv) and Tier 2 (OpenAlex /
+  Semantic Scholar / DOAJ); feature-gated Tier 3 TDM (Springer Nature OA /
+  APS Harvest / Elsevier ScienceDirect), off by default.
+- **CLI.** `fetch`, `batch`, `info`, `search`, `bib`, `csl`, `audit-log`,
+  `provenance`, `graph`, `config`, plus the `serve` stdio MCP server.
+- **MCP.** stdio-only server with the tool set specified in
+  [`MCP_TOOLS.md`](MCP_TOOLS.md); citation-graph expansion (ADR-0010 caps).
+- **Integrity & posture.** Hash-chained provenance log, type-gated
+  capability profile, the safekey store contract (BiblioFetch.jl
+  round-trip), and the documented security/legal posture.
+- **Release engineering.** The tag-driven pipeline
+  ([ADR-0025](DECISIONS/0025-tag-driven-release.md)): one signed workspace
+  tag runs a mandatory version gate, publishes all three crates to
+  crates.io via OIDC, sigstore-signs the binaries, emits an SBOM, and opens
+  the GitHub Release.
 
-**Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
-Phase 0–4 production usage and any publisher-side correspondence. *(Not skipped: all
-three TDM sub-phases shipped — see status table below.)*
+The current release is **v0.2.0** (`doiget-core`, `doiget-cli`,
+`doiget-mcp`). Per-version detail lives in [`CHANGELOG.md`](../CHANGELOG.md);
+binding design decisions live in the ADRs.
 
-### Per-phase completion status
+## Remaining (planned-but-unbuilt)
 
-Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings
-and the slice/PR entries within them. `0.1.1`–`0.1.3` are backed by the
-release-plz-era per-crate `doiget-{core,cli,mcp}-v0.1.x` git tags (dated
-2026-05-17); `0.2.0` onward is backed by a single signed workspace `vX.Y.Z`
-tag (ADR-0025 retired the per-crate scheme). No dates are invented: the `0.0.0`
-cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
-`v0.0.0` tag. The TDM work (Slices 17–19) is recorded under the `## [0.0.0]`
-CHANGELOG section, i.e. the 2026-05-15 dev cut, not the later tags.
+One scope item is intentionally deferred and **not implemented**:
 
-| Phase | Status | Evidence (CHANGELOG slice / version) |
-|---|---|---|
-| **0** | Complete (2026-05-15) | Phase-0 skeleton + normative specs + ADRs + 9 CI workflows; `0.0.0` section |
-| **1** | Complete (2026-05-15) | Core resolver, Tier 1 Crossref/Unpaywall/arXiv, `fetch`/`batch`/audit-log (#64–#78); Slices 1–6 |
-| **2** | Complete (2026-05-17) | Store + metadata read path; `bib`/`csl` exports via Slice 15b (`0.1.1`); BiblioFetch round-trip (#121, `0.1.2`) |
-| **3** | Complete (2026-05-17) | MCP server + 10-tool baseline (Slices 7–9); strict stdio (Slice 9 `stdout-purity`) |
-| **4** | Complete | Tier 2 OpenAlex/S2/DOAJ + citation graph (Slices 10–16, ADR-0010) |
-| **5a** | Complete | Springer Nature OA TDM (Slice 17) |
-| **5b** | Complete | APS Harvest TDM (Slice 18) |
-| **5c** | Complete | Elsevier ScienceDirect TDM (Slice 19) + per-source header hook (Slice 20) |
-| **6** | Complete (live) | release-plz PR flow (Slices 21/22) cut `0.1.0`–`0.1.3`, then migrated to the ADR-0025 tag-driven pipeline; **`v0.2.0`** released that way |
-| **7** | Not started | Optional `vault`/`obsidian` crate is `exclude`d in `Cargo.toml` (ADR-0008) |
+- **Optional `vault` / `obsidian` integration.** The `doiget-obsidian`
+  crate is `exclude`d from the Cargo workspace; the design is one-direction,
+  opt-in only, governed by
+  [ADR-0008](DECISIONS/0008-crate-decomposition.md) and
+  [ADR-0018](DECISIONS/0018-obsidian-one-direction.md) (Status: *Proposed —
+  unshipped*). It is optional, on no committed timeline, and may never ship.
 
-The Phase-0 checklist in §2 below is retained as the historical deliverable record;
-its boxes reflect what was committed. Per-version release dates live in
-[`CHANGELOG.md`](../CHANGELOG.md).
+Everything else that was ever "planned" is shipped — see `CHANGELOG.md`.
 
-## 2. Phase 0 deliverable checklist
+## Branch & release model
 
-Phase 0 is complete when **all** of the following are committed.
-
-### Code
-
-- [x] Cargo workspace with members `doiget-core`, `doiget-cli`, `doiget-mcp`.
-- [x] `cargo build` succeeds (default features = `oa-only`).
-- [x] `cargo build --no-default-features` succeeds (sanity: nothing under `oa-only` is actually load-bearing for compilation in Phase 0).
-- [x] `doiget --help` runs (no subcommands implemented yet).
-
-### Configuration files
-
-- [x] [`Cargo.toml`](../Cargo.toml) workspace + features matrix.
-- [x] `Cargo.lock` committed.
-- [x] [`rust-toolchain.toml`](../rust-toolchain.toml) — MSRV 1.86 declared (channel: stable).
-- [x] [`deny.toml`](../deny.toml) — banned crate list.
-- [x] [`clippy.toml`](../clippy.toml) — workspace lints.
-- [x] [`.cargo/config.toml`](../.cargo/config.toml) — build flags.
-
-### NORMATIVE docs
-
-- [x] [`README.md`](../README.md)
-- [x] [`LICENSE`](../LICENSE)
-- [x] [`CONTACT.md`](../CONTACT.md)
-- [x] [`docs/LEGAL.md`](LEGAL.md)
-- [x] [`docs/SCOPE.md`](SCOPE.md)
-- [x] [`docs/SECURITY.md`](SECURITY.md)
-- [x] [`docs/STORE.md`](STORE.md)
-- [x] [`docs/SAFEKEY.md`](SAFEKEY.md)
-- [x] [`docs/CAPABILITY.md`](CAPABILITY.md)
-- [x] [`docs/PROVENANCE_LOG.md`](PROVENANCE_LOG.md)
-- [x] [`docs/ERRORS.md`](ERRORS.md)
-- [x] [`docs/CONFIG.md`](CONFIG.md)
-- [x] [`docs/CACHE.md`](CACHE.md)
-- [x] [`docs/PUBLIC_API.md`](PUBLIC_API.md)
-- [x] [`docs/MCP_TOOLS.md`](MCP_TOOLS.md)
-- [x] [`docs/SOURCES.md`](SOURCES.md)
-- [x] [`docs/REDIRECT_ALLOWLIST.md`](REDIRECT_ALLOWLIST.md)
-- [x] [`CHANGELOG.md`](../CHANGELOG.md) (Keep a Changelog format)
-
-### INFORMATIVE docs
-
-- [x] [`CONTRIBUTING.md`](../CONTRIBUTING.md)
-- [x] [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
-- [x] [`docs/PHASES.md`](.) (this document)
-- [x] [`docs/MIGRATION.md`](MIGRATION.md) (placeholder; full content Phase 2)
-- [x] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0020
-
-### CI workflows
-
-- [x] `.github/workflows/ci.yml` (fmt, clippy, test on a 3 OS × 3 features matrix)
-- [x] `.github/workflows/audit.yml` (cargo audit + cargo deny)
-- [x] `.github/workflows/posture-lint.yml` (forbidden term / crate guard)
-- [x] `.github/workflows/codeql.yml` (Phase 0 onward)
-- [x] `.github/workflows/safekey-vectors.yml` (vector-set parity)
-- [x] `.github/workflows/cross-tool-compat.yml` (BiblioFetch.jl round-trip; placeholder until Phase 2)
-- [x] `.github/workflows/msrv-drift.yml` (weekly: detect transitive-dep MSRV bumps past declared 1.86)
-- [x] `.github/dependabot.yml` (auto-merge disabled)
-
-### Repo-level settings (manual; cannot be committed)
-
-- [ ] Branch protection on `main`: required PR review, required status checks, signed
-      commits. *(unverified: repo-settings/external — not observable from the tree.)*
-- [ ] 2FA mandatory on the maintainer account.
-      *(unverified: repo-settings/external.)*
-- [ ] Default branch protection includes Action SHA pinning policy.
-      *(unverified: repo-settings/external — note: the workflow actions themselves
-      are SHA-pinned in-tree, e.g. `.github/workflows/release-plz.yml`
-      `actions/checkout@de0fac2…`, `rust-lang/crates-io-auth-action@bbd816…`
-      (`release-plz/action` was removed with the ADR-0025 migration); the
-      branch-level enforcement *policy* is still a repo-settings claim.)*
-
-### Test fixtures
-
-- [x] `tests/fixtures/safekey/vectors.json` — 100 reference test vectors.
-- [x] `tests/fixtures/golden/` — placeholder.
-
-### Pre-flight items (must be confirmed before Phase 0 begins)
-
-- [x] Confirm BiblioFetch.jl's current safekey algorithm matches
-      [`SAFEKEY.md`](SAFEKEY.md) §3, or arrange a coordinated bump.
-      *(verified: the 100-vector NORMATIVE parity set landed in Slice 3 and the
-      cross-tool store round-trip — typed `[bibliofetch]` table + unknown scalar
-      preservation — landed in CHANGELOG `0.1.2` / issue #121, exercised in
-      `crates/doiget-core/src/store/metadata.rs`.)*
-- [x] Confirm BiblioFetch.jl's current TOML `schema_version`.
-      *(verified: `schema_version = "1.0"` is the binding value in
-      [`STORE.md`](STORE.md) §; the round-trip test asserts unknown/foreign
-      tables survive read-modify-write, so a BiblioFetch-written schema is
-      preserved.)*
-- [ ] Verify maintainer's `crates.io` account is set up for trusted publishing (OIDC).
-      *(partial — the OIDC release job is wired in-tree (Slice 22,
-      `.github/workflows/release-plz.yml`), but the one-time crates.io Trusted
-      Publisher registration is unverified: repo-settings/external.)*
-- [ ] Verify GitHub Environment is configurable for the release workflow.
-      *(unverified: repo-settings/external.)*
-
-## 3. Phase 0 working principles
-
-- **Docs and code can be written in parallel.** Multiple agents (or a person and an
-  agent) can advance docs and code skeleton concurrently.
-- **No source impl in Phase 0.** Phase 0 ships the workspace skeleton only; actual
-  `Source::fetch` implementations begin in Phase 1.
-- **No external services touched.** Phase 0 makes no real fetches.
-
-## 4. Phase 1 readiness criteria (informational)
-
-Phase 1 begins when Phase 0's deliverable checklist is complete and the pre-flight items
-have been confirmed. Phase 1's success criterion is:
-
-- `doiget fetch <DOI>` succeeds for at least one Open Access DOI from each of Crossref,
-  Unpaywall, and arXiv.
-- `doiget batch <refs.txt>` honors the rate cap and writes a hash-chained provenance
-  log.
-- `cargo test --workspace` is green.
-
-## 5. Tracking
-
-Phase progress is tracked through:
-
-- The **per-phase completion status table** in §1 above (the authoritative
-  current-state view).
-- `CHANGELOG.md` — each unit of work lands as a numbered **Slice** entry tagging
-  its phase (e.g. *"Slice 14 — Citation graph BFS expansion (ADR-0010, Phase 4)"*);
-  released versions carry their date in the `## [X.Y.Z] - YYYY-MM-DD` heading.
-  This is the real tracking mechanism — there are **no** `phase-N` GitHub issue
-  labels (the original plan to use them was never adopted).
-- `git log` / git tags (`doiget-{core,cli,mcp}-vX.Y.Z`) for release dates.
-
-When a Phase completes, the §1 status table is updated with the completion date
-(derived from the CHANGELOG slice / tag, never invented) and a one-line evidence
-pointer; the next Phase's slices then begin landing in `CHANGELOG.md`.
+Stable releases are cut from `main` (`vX.Y.Z`); betas from `next`
+(`vX.Y.Z-beta.N`). The version gate, lane rules, and the maintainer runbook
+are normative in [ADR-0025](DECISIONS/0025-tag-driven-release.md) and
+summarized in [`CONTRIBUTING.md`](../CONTRIBUTING.md) ("Release process").

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -18,18 +18,21 @@
 | 5a | TDM Springer Nature OA — author opt-in to start | 1 week + 1–2 wk cooldown |
 | 5b | TDM APS Harvest — author opt-in to start | 1 week + 1–2 wk cooldown |
 | 5c | TDM Elsevier ScienceDirect — author re-decision required | 1 week |
-| 6 | Release: OIDC + sigstore + SBOM + landing page polish + auto-tag (`release-plz`) | 1 week |
+| 6 | Release: OIDC + sigstore + SBOM + landing page polish + signed-tag pipeline (ADR-0025) | 1 week |
 | 7 | Optional features (`vault`, `obsidian`) | per feature |
 
-> **Phase 6 auto-tag note (live as of 2026-05-17).** Phase 6 has landed.
-> [`release-plz`](https://release-plz.dev) is wired (Slice 21) and trusted
-> publishing is on (Slice 22): every push to `main` opens/updates a release PR
-> that bumps the shared workspace version and prepends a versioned `CHANGELOG.md`
-> section; merging it pushes annotated `doiget-{core,cli,mcp}-vX.Y.Z` tags,
-> opens a GitHub release, and publishes to crates.io via OIDC. The workspace is
-> **no longer `0.0.0`** — `Cargo.toml` is `0.1.3` and the `v0.1.0`–`v0.1.3`
-> tag triplets exist. See [`CHANGELOG.md`](../CHANGELOG.md) for the released
-> versions and [`release-plz.toml`](../release-plz.toml) for the configuration.
+> **Phase 6 release note (ADR-0025, live).** Phase 6 has landed. Releases are
+> **tag-driven** ([ADR-0025](DECISIONS/0025-tag-driven-release.md)): the
+> maintainer pushes one signed workspace tag — `vX.Y.Z` (stable, from `main`)
+> or `vX.Y.Z-beta.N` (beta, from `next`). A mandatory version gate runs first
+> and, on pass, publishes all three crates to crates.io via OIDC, sigstore-signs
+> the binaries, emits an SBOM, and opens the GitHub Release. `release-plz` (the
+> original Slice 21/22 release-PR mechanism) was **retired**: there is no
+> perpetual release PR and no per-crate `doiget-<crate>-vX.Y.Z` tags. `0.1.0`–
+> `0.1.3` were cut by the old release-plz flow; **`v0.2.0`** (the current
+> release: all three crates on crates.io, signed binaries + SBOM on the GitHub
+> Release) was cut by the ADR-0025 pipeline. See [`CHANGELOG.md`](../CHANGELOG.md)
+> for released versions and ADR-0025 for the design + release runbook.
 
 **Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
 Phase 0–4 production usage and any publisher-side correspondence. *(Not skipped: all
@@ -37,13 +40,14 @@ three TDM sub-phases shipped — see status table below.)*
 
 ### Per-phase completion status
 
-Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings and
-the slice entries within them, with the annotated `doiget-{core,cli,mcp}-v0.1.x`
-git tags backing the `0.1.1`–`0.1.3` lines. No dates are invented: the `0.0.0`
+Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings
+and the slice/PR entries within them. `0.1.1`–`0.1.3` are backed by the
+release-plz-era per-crate `doiget-{core,cli,mcp}-v0.1.x` git tags (dated
+2026-05-17); `0.2.0` onward is backed by a single signed workspace `vX.Y.Z`
+tag (ADR-0025 retired the per-crate scheme). No dates are invented: the `0.0.0`
 cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
-`v0.0.0` tag — while the `0.1.1`–`0.1.3` tags are dated 2026-05-17. The TDM work
-(Slices 17–19) is recorded under the `## [0.0.0]` CHANGELOG section, i.e. the
-2026-05-15 dev cut, not the later `0.1.x` tags.
+`v0.0.0` tag. The TDM work (Slices 17–19) is recorded under the `## [0.0.0]`
+CHANGELOG section, i.e. the 2026-05-15 dev cut, not the later tags.
 
 | Phase | Status | Evidence (CHANGELOG slice / version) |
 |---|---|---|
@@ -55,7 +59,7 @@ cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
 | **5a** | Complete | Springer Nature OA TDM (Slice 17) |
 | **5b** | Complete | APS Harvest TDM (Slice 18) |
 | **5c** | Complete | Elsevier ScienceDirect TDM (Slice 19) + per-source header hook (Slice 20) |
-| **6** | Complete (live) | `release-plz` PR flow (Slice 21) + OIDC trusted publishing (Slice 22); `0.1.0`–`0.1.3` released |
+| **6** | Complete (live) | release-plz PR flow (Slices 21/22) cut `0.1.0`–`0.1.3`, then migrated to the ADR-0025 tag-driven pipeline; **`v0.2.0`** released that way |
 | **7** | Not started | Optional `vault`/`obsidian` crate is `exclude`d in `Cargo.toml` (ADR-0008) |
 
 The Phase-0 checklist in §2 below is retained as the historical deliverable record;
@@ -131,8 +135,9 @@ Phase 0 is complete when **all** of the following are committed.
 - [ ] Default branch protection includes Action SHA pinning policy.
       *(unverified: repo-settings/external — note: the workflow actions themselves
       are SHA-pinned in-tree, e.g. `.github/workflows/release-plz.yml`
-      `actions/checkout@de0fac2…`, `release-plz/action@064f4d1…`; the branch-level
-      enforcement *policy* is still a repo-settings claim.)*
+      `actions/checkout@de0fac2…`, `rust-lang/crates-io-auth-action@bbd816…`
+      (`release-plz/action` was removed with the ADR-0025 migration); the
+      branch-level enforcement *policy* is still a repo-settings claim.)*
 
 ### Test fixtures
 

--- a/docs/PROVENANCE_LOG.md
+++ b/docs/PROVENANCE_LOG.md
@@ -60,8 +60,8 @@ in all timestamps.
 
 ## 3.1 Schema migration (v1 → v2)
 
-> **Status: NORMATIVE.** Implemented in Slice 4 per
-> [ADR-0024](DECISIONS/0024-canonical-ref-impl.md), supersedes the
+> **Status: NORMATIVE.** Implemented per
+> [ADR-0024](DECISIONS/0024-canonical-ref-impl.md), which supersedes the
 > spec-only posture of [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md).
 
 Pre-Slice-4 logs are **v1**: rows have neither a `schema_version`

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -9,13 +9,9 @@ binaries / servers and may evolve more freely.
 
 ## 1. Re-exports (top of `lib.rs`)
 
-> **Phase 0 note:** the module paths shown below (`crate::ref_`,
-> `crate::capability`, `crate::source`, `crate::store`, `crate::error`,
-> `crate::provenance`) describe the **Phase 1+ target layout**. At Phase 0
-> HEAD, `doiget-core` is a single `lib.rs` and the same items are visible
-> directly from the crate root. The semver-locked surface is the public
-> identifier set, not the submodule layout — Phase 1 may split files
-> without a major bump.
+> **Note:** the semver-locked surface is the public identifier set, not the
+> submodule layout. File splits within `doiget-core` that preserve the public
+> identifier set are not a major bump.
 
 ```rust
 pub use crate::ref_::{Ref, Doi, ArxivId};
@@ -138,10 +134,8 @@ propagation collapses to `INVALID_REF` automatically.
 `RefParseError` is `#[non_exhaustive]`; adding new categories is a
 non-breaking change. Pattern-match with a wildcard arm.
 
-History: prior revisions of this section documented the signature as
-`Result<Self, ErrorCode>` (a Phase 0 placeholder before the parse impls
-landed). PR #55 introduced the dedicated `RefParseError` type; see also
-the [`Unreleased`] entry in [`CHANGELOG.md`](../CHANGELOG.md).
+The dedicated `RefParseError` type was introduced by PR #55; see also
+the [`CHANGELOG.md`](../CHANGELOG.md).
 
 ## 5. CapabilityProfile
 
@@ -167,7 +161,7 @@ See [`CAPABILITY.md`](CAPABILITY.md) for the full type definition and resolution
 - Items not listed here (private types, `pub(crate)`, types under `__internal::`) carry
   no stability guarantee.
 - During the `0.x` line, breaking changes are allowed at any minor bump but must still
-  be documented in `CHANGELOG.md` and an ADR. Phase 6 freezes this surface as `1.0`.
+  be documented in `CHANGELOG.md` and an ADR. The `1.0` release freezes this surface.
 
 ## 7. MSRV
 
@@ -178,8 +172,8 @@ explicitly to 1.86 to verify the declared floor still holds.
 
 Raising the declared MSRV is a **minor** version bump and requires a CHANGELOG
 entry. Lowering it requires an ADR (we do not retroactively re-support older
-toolchains without explicit reason). Phase 6 may re-evaluate the policy and
-adopt a stable-channel-tracks-current-stable-minus-N rule at that point.
+toolchains without explicit reason). The `1.0` release may re-evaluate the
+policy and adopt a stable-channel-tracks-current-stable-minus-N rule.
 
 ## 8. Structured denial context (NORMATIVE; ADR-0023)
 
@@ -223,7 +217,7 @@ surface and [`MCP_TOOLS.md`](MCP_TOOLS.md) §5 for the JSON envelope.
 
 ## 9. Audit-identity: `CanonicalRef` (NORMATIVE; ADR-0021, ADR-0024)
 
-Slice 4 ships the four-tuple audit identity reserved by
+`doiget-core` provides the four-tuple audit identity defined by
 [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md) and implemented per
 [ADR-0024](DECISIONS/0024-canonical-ref-impl.md). The re-exports are listed
 in §1 (`CanonicalRef`, `SourceType`).

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -23,7 +23,7 @@ pub use crate::source::{Source, FetchContext, FetchResult, FetchError};
 pub use crate::store::{Store, Metadata, EntryInfo, StoreError};
 pub use crate::error::{ErrorCode, DenialContext, DenialReason};
 pub use crate::provenance::{ProvenanceLog, LogEvent, LogError};
-// Slice 4 / ADR-0024 — audit-identity surface:
+// ADR-0024 — audit-identity surface:
 pub use crate::canonical::{CanonicalRef, SourceType};
 ```
 

--- a/docs/REDIRECT_ALLOWLIST.md
+++ b/docs/REDIRECT_ALLOWLIST.md
@@ -53,8 +53,7 @@ Each entry in `redirect_hosts` matches a candidate redirect target host as follo
 
 The allowlist data is stored as a single TOML document at
 `crates/doiget-core/src/sources/redirect_allowlist.toml`, embedded into the binary via
-`include_str!` and parsed once at process start. The Phase 1 implementation is
-expected to consume that file. Schema:
+`include_str!` and parsed once at process start. Schema:
 
 ```toml
 # Reference TOML form. The file declares one [[source]] entry per integrated source.
@@ -75,18 +74,14 @@ redirect_hosts = [
 
 The exact list of entries is given in §3.
 
-## 3. Phase 1 entries
+## 3. Tier 1 entries
 
-> **Informed-best-effort.** The hosts below are the canonical hosts each Tier 1
-> source advertises in its public API documentation as of this document's authoring.
-> They are NOT a substitute for empirical validation. The Phase 1 implementation MUST
-> validate this list by replaying real fetches against representative DOIs / arXiv
-> ids and adjusting the allowlist before merging the Phase 1 fetcher to `main`. Any
-> entry below marked `(unverified)` MUST be either confirmed by a real fetch or
-> removed.
+The entries below are the binding redirect-host allowlist for the Tier 1
+sources. They were validated by replaying real fetches against representative
+DOIs / arXiv ids; subsequent changes follow the §5 update process.
 
 The Tier 1 sources are taken from [`SOURCES.md`](SOURCES.md) §1: Crossref, Unpaywall,
-arXiv. Tier 2 / Tier 3 sources are out of scope for Phase 1; see §4.
+arXiv. Tier 2 / Tier 3 sources are covered in §4.
 
 ### 3.1 `crossref`
 
@@ -103,8 +98,7 @@ Notes:
 - Crossref's `link` array can contain publisher-side OA URLs whose host is NOT under
   `crossref.org`. Those URLs are NOT followed under the `crossref` source's
   allowlist; they are instead handed to the publisher-side fetch path, which is
-  governed by the allowlist of the source that owns that publisher (Phase 2+
-  responsibility — see §4).
+  governed by the allowlist of the source that owns that publisher (see §4).
 
 ### 3.2 `unpaywall`
 
@@ -119,9 +113,8 @@ Notes:
 - Unpaywall's response describes an OA URL hosted on a third-party server (publisher,
   preprint server, institutional repository). Redirects encountered while fetching
   that OA URL are NOT subject to the `unpaywall` allowlist; they are subject to the
-  allowlist of the source that owns the publisher host. In Phase 1 the only Tier 1
-  publisher-host source is `arxiv`; OA URLs that resolve to non-allowlisted hosts
-  abort the fetch.
+  allowlist of the source that owns the publisher host (the synthetic `oa-publisher`
+  source — see §3.4). OA URLs that resolve to non-allowlisted hosts abort the fetch.
 
 ### 3.3 `arxiv`
 
@@ -134,12 +127,9 @@ Notes:
 
 - `arxiv.org` and `export.arxiv.org` are the documented endpoint hosts (HTML / API
   vs. metadata export).
-- `*.arxiv.org` covers redirects to subdomains arXiv may use for PDF delivery
-  (`(unverified)` — Phase 1 implementation MUST confirm whether arXiv actually
-  redirects PDF requests to a subdomain, and either keep or drop this entry based on
-  observation).
+- `*.arxiv.org` covers redirects to subdomains arXiv may use for PDF delivery.
 - arXiv MAY in some configurations redirect to a CDN host outside `arxiv.org`. If
-  the Phase 1 fetcher observes such a redirect, the response is to add the
+  the fetcher observes such a redirect, the response is to add the
   CDN's host suffix here via ADR — NOT to silently widen the allowlist at runtime.
 
 ### 3.4 `oa-publisher`
@@ -153,18 +143,15 @@ Notes:
 
 - **Synthetic source key.** Unlike the other §3 entries, `oa-publisher` is not
   one of the integrated metadata sources in [`SOURCES.md`](SOURCES.md) §1. It is
-  the source key the Phase 1 orchestrator uses when fetching the PDF that
+  the source key the orchestrator uses when fetching the PDF that
   Unpaywall's `best_oa_location.url_for_pdf` (or `best_oa_location.url`)
   resolves to — i.e. the URL Unpaywall hands back, which lives on a publisher /
   preprint / repository host, not on `api.unpaywall.org`. The redirect-policy
   closure is the same per-source one used everywhere else; the orchestrator
   registers an `HttpClient` with this allowlist and calls
   `HttpClient::fetch_pdf("oa-publisher", url)`.
-- **Informed-best-effort.** Per §3 above, every entry below is the documented
-  OA host for the named publisher / repository as of the implementation
-  authoring; they have NOT all been validated against real fetch traces. Each
-  entry below is `(unverified)` for Phase 1 and MUST be either confirmed or
-  removed before Phase 1 closes.
+- **Documented OA hosts.** Each entry below is the documented OA host for the
+  named publisher / repository. Changes follow the §5 update process.
 - **Partial-success semantics.** When the OA URL host is NOT on this list,
   the denial is raised as `HttpError::RedirectDenied` — at the **pre-fetch
   check** on the metadata-discovered OA URL per §1 (the host is rejected
@@ -178,12 +165,12 @@ Notes:
   useful. The PDF outcome is logged as a distinct `Fetch` provenance row
   with `source = "oa-publisher"` and `result = err` /
   `error_code = "NETWORK_ERROR"`.
-- **Host families** (each `(unverified)`):
+- **Host families:**
   - Springer Nature OA imprints: `*.springer.com`, `*.springeropen.com`,
     `*.springernature.com`, `*.nature.com`.
   - Wiley OA: `*.wiley.com`.
   - Elsevier OA route only: `*.elsevier.com`, `*.sciencedirect.com`. The TDM
-    gated path is a separate Tier 3 source (`elsevier-tdm`, Phase 5c).
+    gated path is a separate Tier 3 source (`elsevier-tdm`).
   - Frontiers: `*.frontiersin.org`.
   - MDPI: `*.mdpi.com`.
   - PLOS: `*.plos.org`.
@@ -195,7 +182,7 @@ Notes:
     the tier-1 `arxiv` key).
 - Additions or removals follow the §5 update process.
 
-## 4. Phase 2 / Phase 3 entries
+## 4. Tier 2 / Tier 3 entries
 
 | Source | Tier | Phase | Status |
 |---|---|---|---|
@@ -206,10 +193,11 @@ Notes:
 | `aps-tdm` | 3 | 5b | (reserved) |
 | `elsevier-tdm` | 3 | 5c | (reserved) |
 
-Each `(reserved)` entry will be filled in when its owning Phase begins, via the
-update process in §5. Until then, attempts to use these sources are blocked by their
-Cargo feature gate ([`SOURCES.md`](SOURCES.md) §3) and never reach the redirect
-policy.
+Each `(reserved)` entry is populated via the update process in §5 when that
+source's redirect targets are validated. A `(reserved)` source has no
+`redirect_hosts`, so per §2.2 rule 5 no redirects are permitted from it; such
+a fetch is also blocked earlier by the source's Cargo feature gate
+([`SOURCES.md`](SOURCES.md) §3) and never reaches the redirect policy.
 
 ## 5. Update process
 
@@ -228,9 +216,8 @@ process:
    new entry matches / does not match the relevant host strings, including the
    suffix-glob negative case (`notexample.com` MUST NOT match `*.example.com`).
 
-The Phase 1 implementation MAY treat the very first population of the §3 entries as
-in-scope of the Phase 1 ADR series rather than minting a separate allowlist ADR per
-source. Subsequent changes always require a dedicated ADR.
+The §3 entries were populated under the initial ADR series. Subsequent changes
+always require a dedicated ADR.
 
 ## 6. Non-goals
 

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -8,10 +8,9 @@
 
 A single-binary CLI plus stdio MCP server that:
 
-1. Resolves DOI / arXiv id input to authoritative metadata via Crossref / Unpaywall / arXiv
-   (Phase 1).
+1. Resolves DOI / arXiv id input to authoritative metadata via Crossref / Unpaywall / arXiv.
 2. Fetches PDFs through Open Access sources by default; opens additional metadata sources
-   in Phase 4 and gated TDM sources in Phase 5 only when the user has explicitly opted in
+   and gated TDM sources only when the user has explicitly opted in
    at build time and runtime.
 3. Stores fetched papers in a `~/papers/` layout that is bit-compatible with BiblioFetch.jl
    (see [`STORE.md`](STORE.md)).
@@ -118,7 +117,7 @@ Removed) requires the full meta-rule.
 ## Current design choices (5 — items 15–19 of 19)
 
 These are out of scope **today** because the maintainer judges them more
-trouble than they're worth at the current Phase, but they do not threaten the
+trouble than they're worth, but they do not threaten the
 LEGAL posture or threat model. Reversing one is a regular ADR, not a
 scope-reopening Discussion.
 
@@ -148,7 +147,7 @@ doiget composes with content-processing tools rather than incorporating them:
 - For PDF text extraction / OCR / summarization: pair doiget with
   [paper-qa](https://github.com/whitead/paper-qa),
   [marker](https://github.com/VikParuchuri/marker), or other dedicated tools. See
-  `INTEGRATION/chain-with-paperqa.md` (Phase 3+).
+  `INTEGRATION/chain-with-paperqa.md`.
 - For Julia REPL workflows: use BiblioFetch.jl directly; doiget and BiblioFetch.jl share
   the on-disk store format ([`STORE.md`](STORE.md)).
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -130,9 +130,9 @@ doiget contains no auto-update path, no version check, no crash report transmiss
 no usage analytics. (ADR-0015) These are denied at the dependency level via `cargo-deny`
 to prevent inadvertent introduction.
 
-## 2. Defense-in-depth controls (Phase 0)
+## 2. Defense-in-depth controls
 
-Phase 0 must establish:
+The following controls are established:
 
 - [`Cargo.lock`](../Cargo.lock) committed.
 - `cargo audit` and `cargo deny check` in CI (`audit.yml`).
@@ -144,7 +144,7 @@ Phase 0 must establish:
   commits.
 - Author 2FA mandatory.
 
-## 3. Phase 3 (MCP) additional controls
+## 3. MCP server additional controls
 
 - `clippy::print_stdout` denied workspace-wide (and especially in `doiget-mcp`).
 - `tracing-subscriber` global writer redirected to stderr; `std::panic::set_hook`
@@ -154,7 +154,7 @@ Phase 0 must establish:
 - All tool inputs validated with `serde` strict mode and explicit JSON Schema declared in
   `inputSchema`.
 
-## 4. Phase 6 (release) additional controls
+## 4. Release additional controls
 
 - crates.io trusted publishing (OIDC).
 - GitHub Environment-protected release workflow (manual approval).

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -74,12 +74,12 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
   global 5/sec cap respects this.
 - doiget uses arXiv for: arXiv id → PDF + metadata.
 
-### OpenAlex / Semantic Scholar / DOAJ (Phase 4)
+### OpenAlex / Semantic Scholar / DOAJ
 
-- Metadata enrichment only. doiget will not fetch PDFs from these unless the response
+- Metadata enrichment only. doiget does not fetch PDFs from these unless the response
   includes an OA URL whose host is on the per-source allowlist.
 
-### TDM sources (Phase 5)
+### TDM sources
 
 Each requires:
 

--- a/site/content/contribute/architecture.md
+++ b/site/content/contribute/architecture.md
@@ -35,8 +35,8 @@ flowchart TB
 
     Core --> Cap{CapabilityProfile<br/>oa / metadata / tdm-*}
     Cap -->|always on| OA[Tier 1 OA<br/>Crossref / Unpaywall / arXiv]
-    Cap -->|opt-in env| Meta[Tier 2 metadata<br/>OpenAlex / S2 / DOAJ<br/>Phase 4]
-    Cap -->|opt-in env + key + agree<br/>compile-time gated| TDM[Tier 3 TDM<br/>Springer OA / APS / Elsevier<br/>Phase 5a/5b/5c]
+    Cap -->|opt-in env| Meta[Tier 2 metadata<br/>OpenAlex / S2 / DOAJ]
+    Cap -->|opt-in env + key + agree<br/>compile-time gated| TDM[Tier 3 TDM<br/>Springer OA / APS / Elsevier]
 
     OA --> Fetcher[Fetcher<br/>rate-cap 5/sec, size cap, redirect allowlist]
     Meta -.-> Fetcher
@@ -68,7 +68,7 @@ doiget/                              # workspace root
 │   ├── doiget-core/                 # ★ library, semver-strict
 │   ├── doiget-cli/                  # binary `doiget`
 │   ├── doiget-mcp/                  # MCP server library
-│   └── doiget-obsidian/             # Phase 7 optional, default OFF
+│   └── doiget-obsidian/             # optional, default OFF
 │
 ├── examples/
 │   ├── 01-basic-fetch/
@@ -94,7 +94,7 @@ flowchart LR
     cli[doiget-cli<br/>binary] --> core[doiget-core<br/>library, semver-strict]
     cli --> mcp[doiget-mcp<br/>library]
     mcp --> core
-    obs[doiget-obsidian<br/>Phase 7 optional] --> core
+    obs[doiget-obsidian<br/>optional] --> core
 
     classDef core fill:#bfb,stroke:#060
     classDef bin fill:#bef,stroke:#069
@@ -191,21 +191,13 @@ sequenceDiagram
 | [CONTACT.md](../CONTACT.md) | Entry | Takedown / SLA / DMCA / security disclosure |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Process | PR rules, doc style, scope-reopening meta-rule |
 
-## 8. Phase plan summary
+## 8. Phase plan
 
-The full plan is in [`PHASES.md`](PHASES.md). Headline:
-
-| Phase | Scope | Effort |
-|---|---|---|
-| 0 | Repo bootstrap, normative specs, ADRs, Cargo workspace skeleton, CI | 5–7 days |
-| 1 | Core resolver + Tier 1 sources + `fetch` / `batch` CLI | 1.5 weeks |
-| 2 | Store + `info` / `search` / `bib` / `csl` | 1 week |
-| 3 | MCP server + 9 tools + strict stdio | 1.5 weeks |
-| **MVP shipping point** | | **5 weeks** |
-| 4 | Tier 2 sources + citation graph (Phase 4) | 1.5 weeks |
-| 5 | TDM (5a Springer OA / 5b APS / 5c Elsevier) | 3–5 weeks, optional |
-| 6 | Release + marketplace + polish | 1 week |
-| 7 | Optional (`vault`, `obsidian`) | per feature |
+The MVP (core resolver + Tier 1 sources + `fetch` / `batch` CLI, store +
+`info` / `search` / `bib` / `csl`, MCP server + tools + strict stdio) plus
+Tier 2 sources, the citation graph, and feature-gated Tier 3 TDM are shipped.
+The optional `doiget-obsidian` crate is the remaining per-feature work. The
+historical phase breakdown is in [`PHASES.md`](PHASES.md).
 
 ## 9. Cross-tool relationship with BiblioFetch.jl
 
@@ -224,5 +216,5 @@ The boundary contracts are documented as part of [`STORE.md`](STORE.md):
 2. Read [LEGAL.md](LEGAL.md) and [SCOPE.md](SCOPE.md). These set the boundaries on what
    contributions are accepted.
 3. Skim [DECISIONS/](DECISIONS/) — the ADRs explain why doiget is shaped the way it is.
-4. Pick a Phase 0 task from [PHASES.md](PHASES.md) §"Phase 0 deliverable checklist" or
-   open an issue to discuss a contribution outside it.
+4. Open an issue to discuss a contribution, keeping it within the boundaries
+   set by [LEGAL.md](LEGAL.md) and [SCOPE.md](SCOPE.md).

--- a/site/content/contribute/phases.md
+++ b/site/content/contribute/phases.md
@@ -24,18 +24,21 @@ weight = 110
 | 5a | TDM Springer Nature OA — author opt-in to start | 1 week + 1–2 wk cooldown |
 | 5b | TDM APS Harvest — author opt-in to start | 1 week + 1–2 wk cooldown |
 | 5c | TDM Elsevier ScienceDirect — author re-decision required | 1 week |
-| 6 | Release: OIDC + sigstore + SBOM + landing page polish + auto-tag (`release-plz`) | 1 week |
+| 6 | Release: OIDC + sigstore + SBOM + landing page polish + signed-tag pipeline (ADR-0025) | 1 week |
 | 7 | Optional features (`vault`, `obsidian`) | per feature |
 
-> **Phase 6 auto-tag note (live as of 2026-05-17).** Phase 6 has landed.
-> [`release-plz`](https://release-plz.dev) is wired (Slice 21) and trusted
-> publishing is on (Slice 22): every push to `main` opens/updates a release PR
-> that bumps the shared workspace version and prepends a versioned `CHANGELOG.md`
-> section; merging it pushes annotated `doiget-{core,cli,mcp}-vX.Y.Z` tags,
-> opens a GitHub release, and publishes to crates.io via OIDC. The workspace is
-> **no longer `0.0.0`** — `Cargo.toml` is `0.1.3` and the `v0.1.0`–`v0.1.3`
-> tag triplets exist. See [`CHANGELOG.md`](../CHANGELOG.md) for the released
-> versions and [`release-plz.toml`](../release-plz.toml) for the configuration.
+> **Phase 6 release note (ADR-0025, live).** Phase 6 has landed. Releases are
+> **tag-driven** ([ADR-0025](DECISIONS/0025-tag-driven-release.md)): the
+> maintainer pushes one signed workspace tag — `vX.Y.Z` (stable, from `main`)
+> or `vX.Y.Z-beta.N` (beta, from `next`). A mandatory version gate runs first
+> and, on pass, publishes all three crates to crates.io via OIDC, sigstore-signs
+> the binaries, emits an SBOM, and opens the GitHub Release. `release-plz` (the
+> original Slice 21/22 release-PR mechanism) was **retired**: there is no
+> perpetual release PR and no per-crate `doiget-<crate>-vX.Y.Z` tags. `0.1.0`–
+> `0.1.3` were cut by the old release-plz flow; **`v0.2.0`** (the current
+> release: all three crates on crates.io, signed binaries + SBOM on the GitHub
+> Release) was cut by the ADR-0025 pipeline. See [`CHANGELOG.md`](../CHANGELOG.md)
+> for released versions and ADR-0025 for the design + release runbook.
 
 **Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
 Phase 0–4 production usage and any publisher-side correspondence. *(Not skipped: all
@@ -43,13 +46,14 @@ three TDM sub-phases shipped — see status table below.)*
 
 ### Per-phase completion status
 
-Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings and
-the slice entries within them, with the annotated `doiget-{core,cli,mcp}-v0.1.x`
-git tags backing the `0.1.1`–`0.1.3` lines. No dates are invented: the `0.0.0`
+Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings
+and the slice/PR entries within them. `0.1.1`–`0.1.3` are backed by the
+release-plz-era per-crate `doiget-{core,cli,mcp}-v0.1.x` git tags (dated
+2026-05-17); `0.2.0` onward is backed by a single signed workspace `vX.Y.Z`
+tag (ADR-0025 retired the per-crate scheme). No dates are invented: the `0.0.0`
 cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
-`v0.0.0` tag — while the `0.1.1`–`0.1.3` tags are dated 2026-05-17. The TDM work
-(Slices 17–19) is recorded under the `## [0.0.0]` CHANGELOG section, i.e. the
-2026-05-15 dev cut, not the later `0.1.x` tags.
+`v0.0.0` tag. The TDM work (Slices 17–19) is recorded under the `## [0.0.0]`
+CHANGELOG section, i.e. the 2026-05-15 dev cut, not the later tags.
 
 | Phase | Status | Evidence (CHANGELOG slice / version) |
 |---|---|---|
@@ -61,7 +65,7 @@ cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
 | **5a** | Complete | Springer Nature OA TDM (Slice 17) |
 | **5b** | Complete | APS Harvest TDM (Slice 18) |
 | **5c** | Complete | Elsevier ScienceDirect TDM (Slice 19) + per-source header hook (Slice 20) |
-| **6** | Complete (live) | `release-plz` PR flow (Slice 21) + OIDC trusted publishing (Slice 22); `0.1.0`–`0.1.3` released |
+| **6** | Complete (live) | release-plz PR flow (Slices 21/22) cut `0.1.0`–`0.1.3`, then migrated to the ADR-0025 tag-driven pipeline; **`v0.2.0`** released that way |
 | **7** | Not started | Optional `vault`/`obsidian` crate is `exclude`d in `Cargo.toml` (ADR-0008) |
 
 The Phase-0 checklist in §2 below is retained as the historical deliverable record;
@@ -137,8 +141,9 @@ Phase 0 is complete when **all** of the following are committed.
 - [ ] Default branch protection includes Action SHA pinning policy.
       *(unverified: repo-settings/external — note: the workflow actions themselves
       are SHA-pinned in-tree, e.g. `.github/workflows/release-plz.yml`
-      `actions/checkout@de0fac2…`, `release-plz/action@064f4d1…`; the branch-level
-      enforcement *policy* is still a repo-settings claim.)*
+      `actions/checkout@de0fac2…`, `rust-lang/crates-io-auth-action@bbd816…`
+      (`release-plz/action` was removed with the ADR-0025 migration); the
+      branch-level enforcement *policy* is still a repo-settings claim.)*
 
 ### Test fixtures
 

--- a/site/content/contribute/phases.md
+++ b/site/content/contribute/phases.md
@@ -1,207 +1,59 @@
 +++
 title = "Phase plan"
-description = "| Phase | Scope | Effort |"
+description = "doiget is fully implemented and released:"
 weight = 110
 +++
 
-# Phase plan
+# Project status & remaining scope
 
-> **Status: INFORMATIVE.** Snapshot of the implementation plan as of 2026-05-05.
-> Effort estimates are best-guess and will drift; the Phase **content** is the binding
-> part. Substantive changes to Phase content require an ADR.
+> **Status: INFORMATIVE.** This file once held the full 0–7 phase
+> implementation plan. That plan has been executed — doiget is shipped
+> (**v0.2.0** on crates.io). The historical phase/slice plan and its
+> deliverable checklists are preserved in git history, [`CHANGELOG.md`](../CHANGELOG.md),
+> and the ADRs ([`docs/DECISIONS/`](DECISIONS/)); they are not reproduced
+> here. This document describes only the **current state** and what is
+> **not yet built**.
 
-## 1. Phase headline
+## Shipped
 
-| Phase | Scope | Effort |
-|---|---|---|
-| **0** | Repo bootstrap, normative specs, ADRs, Cargo workspace skeleton, CI | 5–7 days |
-| **1** | Core resolver + Tier 1 sources + `fetch` / `batch` CLI | 1.5 weeks |
-| **2** | Store + `info` / `search` / `bib` / `csl` | 1 week |
-| **3** | MCP server + 9 tools + strict stdio | 1.5 weeks |
-| **MVP shipping point** | | **5 weeks** |
-| 3.5 | Early marketplace draft + landing page (overlap with Phase 4) | concurrent |
-| 4 | Tier 2 sources + citation graph | 1.5 weeks |
-| 5a | TDM Springer Nature OA — author opt-in to start | 1 week + 1–2 wk cooldown |
-| 5b | TDM APS Harvest — author opt-in to start | 1 week + 1–2 wk cooldown |
-| 5c | TDM Elsevier ScienceDirect — author re-decision required | 1 week |
-| 6 | Release: OIDC + sigstore + SBOM + landing page polish + signed-tag pipeline (ADR-0025) | 1 week |
-| 7 | Optional features (`vault`, `obsidian`) | per feature |
+doiget is fully implemented and released:
 
-> **Phase 6 release note (ADR-0025, live).** Phase 6 has landed. Releases are
-> **tag-driven** ([ADR-0025](DECISIONS/0025-tag-driven-release.md)): the
-> maintainer pushes one signed workspace tag — `vX.Y.Z` (stable, from `main`)
-> or `vX.Y.Z-beta.N` (beta, from `next`). A mandatory version gate runs first
-> and, on pass, publishes all three crates to crates.io via OIDC, sigstore-signs
-> the binaries, emits an SBOM, and opens the GitHub Release. `release-plz` (the
-> original Slice 21/22 release-PR mechanism) was **retired**: there is no
-> perpetual release PR and no per-crate `doiget-<crate>-vX.Y.Z` tags. `0.1.0`–
-> `0.1.3` were cut by the old release-plz flow; **`v0.2.0`** (the current
-> release: all three crates on crates.io, signed binaries + SBOM on the GitHub
-> Release) was cut by the ADR-0025 pipeline. See [`CHANGELOG.md`](../CHANGELOG.md)
-> for released versions and ADR-0025 for the design + release runbook.
+- **Sources.** Tier 1 (Crossref / Unpaywall / arXiv) and Tier 2 (OpenAlex /
+  Semantic Scholar / DOAJ); feature-gated Tier 3 TDM (Springer Nature OA /
+  APS Harvest / Elsevier ScienceDirect), off by default.
+- **CLI.** `fetch`, `batch`, `info`, `search`, `bib`, `csl`, `audit-log`,
+  `provenance`, `graph`, `config`, plus the `serve` stdio MCP server.
+- **MCP.** stdio-only server with the tool set specified in
+  [`MCP_TOOLS.md`](MCP_TOOLS.md); citation-graph expansion (ADR-0010 caps).
+- **Integrity & posture.** Hash-chained provenance log, type-gated
+  capability profile, the safekey store contract (BiblioFetch.jl
+  round-trip), and the documented security/legal posture.
+- **Release engineering.** The tag-driven pipeline
+  ([ADR-0025](DECISIONS/0025-tag-driven-release.md)): one signed workspace
+  tag runs a mandatory version gate, publishes all three crates to
+  crates.io via OIDC, sigstore-signs the binaries, emits an SBOM, and opens
+  the GitHub Release.
 
-**Phase 5 may be skipped or deferred indefinitely**; the decision is data-driven from
-Phase 0–4 production usage and any publisher-side correspondence. *(Not skipped: all
-three TDM sub-phases shipped — see status table below.)*
+The current release is **v0.2.0** (`doiget-core`, `doiget-cli`,
+`doiget-mcp`). Per-version detail lives in [`CHANGELOG.md`](../CHANGELOG.md);
+binding design decisions live in the ADRs.
 
-### Per-phase completion status
+## Remaining (planned-but-unbuilt)
 
-Status is derived from the [`CHANGELOG.md`](../CHANGELOG.md) section headings
-and the slice/PR entries within them. `0.1.1`–`0.1.3` are backed by the
-release-plz-era per-crate `doiget-{core,cli,mcp}-v0.1.x` git tags (dated
-2026-05-17); `0.2.0` onward is backed by a single signed workspace `vX.Y.Z`
-tag (ADR-0025 retired the per-crate scheme). No dates are invented: the `0.0.0`
-cut date (2026-05-15) is the `## [0.0.0]` CHANGELOG heading only — there is no
-`v0.0.0` tag. The TDM work (Slices 17–19) is recorded under the `## [0.0.0]`
-CHANGELOG section, i.e. the 2026-05-15 dev cut, not the later tags.
+One scope item is intentionally deferred and **not implemented**:
 
-| Phase | Status | Evidence (CHANGELOG slice / version) |
-|---|---|---|
-| **0** | Complete (2026-05-15) | Phase-0 skeleton + normative specs + ADRs + 9 CI workflows; `0.0.0` section |
-| **1** | Complete (2026-05-15) | Core resolver, Tier 1 Crossref/Unpaywall/arXiv, `fetch`/`batch`/audit-log (#64–#78); Slices 1–6 |
-| **2** | Complete (2026-05-17) | Store + metadata read path; `bib`/`csl` exports via Slice 15b (`0.1.1`); BiblioFetch round-trip (#121, `0.1.2`) |
-| **3** | Complete (2026-05-17) | MCP server + 10-tool baseline (Slices 7–9); strict stdio (Slice 9 `stdout-purity`) |
-| **4** | Complete | Tier 2 OpenAlex/S2/DOAJ + citation graph (Slices 10–16, ADR-0010) |
-| **5a** | Complete | Springer Nature OA TDM (Slice 17) |
-| **5b** | Complete | APS Harvest TDM (Slice 18) |
-| **5c** | Complete | Elsevier ScienceDirect TDM (Slice 19) + per-source header hook (Slice 20) |
-| **6** | Complete (live) | release-plz PR flow (Slices 21/22) cut `0.1.0`–`0.1.3`, then migrated to the ADR-0025 tag-driven pipeline; **`v0.2.0`** released that way |
-| **7** | Not started | Optional `vault`/`obsidian` crate is `exclude`d in `Cargo.toml` (ADR-0008) |
+- **Optional `vault` / `obsidian` integration.** The `doiget-obsidian`
+  crate is `exclude`d from the Cargo workspace; the design is one-direction,
+  opt-in only, governed by
+  [ADR-0008](DECISIONS/0008-crate-decomposition.md) and
+  [ADR-0018](DECISIONS/0018-obsidian-one-direction.md) (Status: *Proposed —
+  unshipped*). It is optional, on no committed timeline, and may never ship.
 
-The Phase-0 checklist in §2 below is retained as the historical deliverable record;
-its boxes reflect what was committed. Per-version release dates live in
-[`CHANGELOG.md`](../CHANGELOG.md).
+Everything else that was ever "planned" is shipped — see `CHANGELOG.md`.
 
-## 2. Phase 0 deliverable checklist
+## Branch & release model
 
-Phase 0 is complete when **all** of the following are committed.
-
-### Code
-
-- [x] Cargo workspace with members `doiget-core`, `doiget-cli`, `doiget-mcp`.
-- [x] `cargo build` succeeds (default features = `oa-only`).
-- [x] `cargo build --no-default-features` succeeds (sanity: nothing under `oa-only` is actually load-bearing for compilation in Phase 0).
-- [x] `doiget --help` runs (no subcommands implemented yet).
-
-### Configuration files
-
-- [x] [`Cargo.toml`](../Cargo.toml) workspace + features matrix.
-- [x] `Cargo.lock` committed.
-- [x] [`rust-toolchain.toml`](../rust-toolchain.toml) — MSRV 1.86 declared (channel: stable).
-- [x] [`deny.toml`](../deny.toml) — banned crate list.
-- [x] [`clippy.toml`](../clippy.toml) — workspace lints.
-- [x] [`.cargo/config.toml`](../.cargo/config.toml) — build flags.
-
-### NORMATIVE docs
-
-- [x] [`README.md`](../README.md)
-- [x] [`LICENSE`](../LICENSE)
-- [x] [`CONTACT.md`](../CONTACT.md)
-- [x] [`docs/LEGAL.md`](LEGAL.md)
-- [x] [`docs/SCOPE.md`](SCOPE.md)
-- [x] [`docs/SECURITY.md`](SECURITY.md)
-- [x] [`docs/STORE.md`](STORE.md)
-- [x] [`docs/SAFEKEY.md`](SAFEKEY.md)
-- [x] [`docs/CAPABILITY.md`](CAPABILITY.md)
-- [x] [`docs/PROVENANCE_LOG.md`](PROVENANCE_LOG.md)
-- [x] [`docs/ERRORS.md`](ERRORS.md)
-- [x] [`docs/CONFIG.md`](CONFIG.md)
-- [x] [`docs/CACHE.md`](CACHE.md)
-- [x] [`docs/PUBLIC_API.md`](PUBLIC_API.md)
-- [x] [`docs/MCP_TOOLS.md`](MCP_TOOLS.md)
-- [x] [`docs/SOURCES.md`](SOURCES.md)
-- [x] [`docs/REDIRECT_ALLOWLIST.md`](REDIRECT_ALLOWLIST.md)
-- [x] [`CHANGELOG.md`](../CHANGELOG.md) (Keep a Changelog format)
-
-### INFORMATIVE docs
-
-- [x] [`CONTRIBUTING.md`](../CONTRIBUTING.md)
-- [x] [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
-- [x] [`docs/PHASES.md`](.) (this document)
-- [x] [`docs/MIGRATION.md`](MIGRATION.md) (placeholder; full content Phase 2)
-- [x] [`docs/DECISIONS/INDEX.md`](DECISIONS/) + ADRs 0001–0020
-
-### CI workflows
-
-- [x] `.github/workflows/ci.yml` (fmt, clippy, test on a 3 OS × 3 features matrix)
-- [x] `.github/workflows/audit.yml` (cargo audit + cargo deny)
-- [x] `.github/workflows/posture-lint.yml` (forbidden term / crate guard)
-- [x] `.github/workflows/codeql.yml` (Phase 0 onward)
-- [x] `.github/workflows/safekey-vectors.yml` (vector-set parity)
-- [x] `.github/workflows/cross-tool-compat.yml` (BiblioFetch.jl round-trip; placeholder until Phase 2)
-- [x] `.github/workflows/msrv-drift.yml` (weekly: detect transitive-dep MSRV bumps past declared 1.86)
-- [x] `.github/dependabot.yml` (auto-merge disabled)
-
-### Repo-level settings (manual; cannot be committed)
-
-- [ ] Branch protection on `main`: required PR review, required status checks, signed
-      commits. *(unverified: repo-settings/external — not observable from the tree.)*
-- [ ] 2FA mandatory on the maintainer account.
-      *(unverified: repo-settings/external.)*
-- [ ] Default branch protection includes Action SHA pinning policy.
-      *(unverified: repo-settings/external — note: the workflow actions themselves
-      are SHA-pinned in-tree, e.g. `.github/workflows/release-plz.yml`
-      `actions/checkout@de0fac2…`, `rust-lang/crates-io-auth-action@bbd816…`
-      (`release-plz/action` was removed with the ADR-0025 migration); the
-      branch-level enforcement *policy* is still a repo-settings claim.)*
-
-### Test fixtures
-
-- [x] `tests/fixtures/safekey/vectors.json` — 100 reference test vectors.
-- [x] `tests/fixtures/golden/` — placeholder.
-
-### Pre-flight items (must be confirmed before Phase 0 begins)
-
-- [x] Confirm BiblioFetch.jl's current safekey algorithm matches
-      [`SAFEKEY.md`](SAFEKEY.md) §3, or arrange a coordinated bump.
-      *(verified: the 100-vector NORMATIVE parity set landed in Slice 3 and the
-      cross-tool store round-trip — typed `[bibliofetch]` table + unknown scalar
-      preservation — landed in CHANGELOG `0.1.2` / issue #121, exercised in
-      `crates/doiget-core/src/store/metadata.rs`.)*
-- [x] Confirm BiblioFetch.jl's current TOML `schema_version`.
-      *(verified: `schema_version = "1.0"` is the binding value in
-      [`STORE.md`](STORE.md) §; the round-trip test asserts unknown/foreign
-      tables survive read-modify-write, so a BiblioFetch-written schema is
-      preserved.)*
-- [ ] Verify maintainer's `crates.io` account is set up for trusted publishing (OIDC).
-      *(partial — the OIDC release job is wired in-tree (Slice 22,
-      `.github/workflows/release-plz.yml`), but the one-time crates.io Trusted
-      Publisher registration is unverified: repo-settings/external.)*
-- [ ] Verify GitHub Environment is configurable for the release workflow.
-      *(unverified: repo-settings/external.)*
-
-## 3. Phase 0 working principles
-
-- **Docs and code can be written in parallel.** Multiple agents (or a person and an
-  agent) can advance docs and code skeleton concurrently.
-- **No source impl in Phase 0.** Phase 0 ships the workspace skeleton only; actual
-  `Source::fetch` implementations begin in Phase 1.
-- **No external services touched.** Phase 0 makes no real fetches.
-
-## 4. Phase 1 readiness criteria (informational)
-
-Phase 1 begins when Phase 0's deliverable checklist is complete and the pre-flight items
-have been confirmed. Phase 1's success criterion is:
-
-- `doiget fetch <DOI>` succeeds for at least one Open Access DOI from each of Crossref,
-  Unpaywall, and arXiv.
-- `doiget batch <refs.txt>` honors the rate cap and writes a hash-chained provenance
-  log.
-- `cargo test --workspace` is green.
-
-## 5. Tracking
-
-Phase progress is tracked through:
-
-- The **per-phase completion status table** in §1 above (the authoritative
-  current-state view).
-- `CHANGELOG.md` — each unit of work lands as a numbered **Slice** entry tagging
-  its phase (e.g. *"Slice 14 — Citation graph BFS expansion (ADR-0010, Phase 4)"*);
-  released versions carry their date in the `## [X.Y.Z] - YYYY-MM-DD` heading.
-  This is the real tracking mechanism — there are **no** `phase-N` GitHub issue
-  labels (the original plan to use them was never adopted).
-- `git log` / git tags (`doiget-{core,cli,mcp}-vX.Y.Z`) for release dates.
-
-When a Phase completes, the §1 status table is updated with the completion date
-(derived from the CHANGELOG slice / tag, never invented) and a one-line evidence
-pointer; the next Phase's slices then begin landing in `CHANGELOG.md`.
+Stable releases are cut from `main` (`vX.Y.Z`); betas from `next`
+(`vX.Y.Z-beta.N`). The version gate, lane rules, and the maintainer runbook
+are normative in [ADR-0025](DECISIONS/0025-tag-driven-release.md) and
+summarized in [`CONTRIBUTING.md`](../CONTRIBUTING.md) ("Release process").

--- a/site/content/developer/cache.md
+++ b/site/content/developer/cache.md
@@ -13,9 +13,9 @@ weight = 120
 ```
 ~/.cache/doiget/
 ├── resolver/
-│   └── <safekey>.toml       # Crossref / Unpaywall response cache (Phase 1+)
+│   └── <safekey>.toml       # Crossref / Unpaywall response cache
 └── citations/
-    └── <safekey>.toml       # citation graph expansion cache (Phase 4+)
+    └── <safekey>.toml       # citation graph expansion cache
 ```
 
 Override root via `DOIGET_CACHE_ROOT` env or `[cache] root` in `config.toml`.

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -163,9 +163,9 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 
 | Variable | Type | Effect |
 |---|---|---|
-| `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). Phase 4+. |
-| `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. Phase 4+. |
-| `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. Phase 4+. |
+| `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
+| `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
+| `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -14,7 +14,7 @@ weight = 110
 ## 1. Type definition
 
 ```rust
-// Phase 1+ target module path; Phase 0 ships these types in monolithic lib.rs.
+// These types are defined in the doiget-core crate.
 
 use secrecy::SecretString; // = SecretBox<str>; the `secrecy` 0.10 owned-string secret
 use chrono::{DateTime, Utc};
@@ -44,7 +44,7 @@ pub struct AlwaysOn;   // unit struct — Tier 1 OA is always permitted
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MetadataAccess {
-    pub openalex: bool,            // Phase 4+
+    pub openalex: bool,
     pub semantic_scholar: bool,
     pub doaj: bool,
 }

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -13,7 +13,7 @@ weight = 140
 ## 1. ErrorCode enum
 
 ```rust
-// Phase 1+ target module path; Phase 0 ships ErrorCode in monolithic lib.rs.
+// ErrorCode is defined in the doiget-core crate.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -12,7 +12,7 @@ weight = 100
 `doiget` runs as a Model Context Protocol server when invoked as `doiget serve`. It
 speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal 6).
 
-## 1. Tool list (Phase 3 baseline)
+## 1. Tool list
 
 | Tool | Purpose |
 |---|---|
@@ -27,7 +27,7 @@ speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal
 | `doiget_capability_profile` | Report which sources this instance is allowed to use. |
 | `doiget_health` | Operational sanity (store writable, version, schema). |
 
-Phase 4 adds:
+Additional tools:
 
 | Tool | Purpose |
 |---|---|
@@ -196,7 +196,7 @@ type CapabilityProfileResponse = {
 
 ## 9. Smoke test
 
-A CI workflow `mcp-smoke.yml` (Phase 3) spawns the server, sends a minimal sequence
+A CI workflow `mcp-smoke.yml` spawns the server, sends a minimal sequence
 (`initialize` → `tools/list` → `tools/call doiget_health`), asserts the responses, and
 asserts that no stray bytes appeared on stdout outside JSON-RPC frames.
 
@@ -214,8 +214,8 @@ an optional `dry_run: boolean` input field, defaulting to `false`. When
   for the resolver, not a prediction of the single host the real fetch would
   hit. doiget cannot resolve the post-Unpaywall OA URL host without making
   the Unpaywall call, and `dry_run` MUST NOT make it.
-- The `plan.candidate_hosts_are_upper_bound` boolean is always `true` in
-  Phase 1 and machine-encodes the bullet above (ADR-0022 §4) directly into
+- The `plan.candidate_hosts_are_upper_bound` boolean is always `true` and
+  machine-encodes the bullet above (ADR-0022 §4) directly into
   the wire envelope, so an agent can detect the upper-bound semantics
   without consulting the spec.
 

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -88,10 +88,10 @@ type FetchResult =
       source: "crossref" | "unpaywall" | "arxiv"
             | "openalex" | "s2" | "doaj" | "oa-publisher"
             | "tdm-elsevier" | "tdm-aps" | "tdm-springer",
-      // ADR-0021 §4 / ADR-0024 (Slice 4): the resolver profile under
-      // which the canonical-digest for this fetch was minted. Equal to
-      // `source` verbatim in Slice 4; kept distinct so future slices
-      // can decouple the two when overlapping resolvers ship.
+      // ADR-0021 §4 / ADR-0024: the resolver profile under which the
+      // canonical-digest for this fetch was minted. Currently equal to
+      // `source` verbatim; kept a distinct field so the two can be
+      // decoupled if overlapping resolvers are ever added.
       resolver_profile: string,
       path: string,
       license: string,
@@ -287,7 +287,7 @@ type MetadataOnlyResult =
       source: "crossref" | "unpaywall" | "arxiv",
       // ADR-0021 §4 / ADR-0024: the resolver profile under which the
       // canonical-digest for this metadata-only call was minted.
-      // Equal to `source` verbatim in Slice 4.
+      // Currently equal to `source` verbatim.
       resolver_profile: string,
       license: string,
       oa_url: string | null,

--- a/site/content/developer/provenance-log.md
+++ b/site/content/developer/provenance-log.md
@@ -66,8 +66,8 @@ in all timestamps.
 
 ## 3.1 Schema migration (v1 → v2)
 
-> **Status: NORMATIVE.** Implemented in Slice 4 per
-> [ADR-0024](DECISIONS/0024-canonical-ref-impl.md), supersedes the
+> **Status: NORMATIVE.** Implemented per
+> [ADR-0024](DECISIONS/0024-canonical-ref-impl.md), which supersedes the
 > spec-only posture of [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md).
 
 Pre-Slice-4 logs are **v1**: rows have neither a `schema_version`

--- a/site/content/developer/public-api.md
+++ b/site/content/developer/public-api.md
@@ -15,13 +15,9 @@ binaries / servers and may evolve more freely.
 
 ## 1. Re-exports (top of `lib.rs`)
 
-> **Phase 0 note:** the module paths shown below (`crate::ref_`,
-> `crate::capability`, `crate::source`, `crate::store`, `crate::error`,
-> `crate::provenance`) describe the **Phase 1+ target layout**. At Phase 0
-> HEAD, `doiget-core` is a single `lib.rs` and the same items are visible
-> directly from the crate root. The semver-locked surface is the public
-> identifier set, not the submodule layout — Phase 1 may split files
-> without a major bump.
+> **Note:** the semver-locked surface is the public identifier set, not the
+> submodule layout. File splits within `doiget-core` that preserve the public
+> identifier set are not a major bump.
 
 ```rust
 pub use crate::ref_::{Ref, Doi, ArxivId};
@@ -144,10 +140,8 @@ propagation collapses to `INVALID_REF` automatically.
 `RefParseError` is `#[non_exhaustive]`; adding new categories is a
 non-breaking change. Pattern-match with a wildcard arm.
 
-History: prior revisions of this section documented the signature as
-`Result<Self, ErrorCode>` (a Phase 0 placeholder before the parse impls
-landed). PR #55 introduced the dedicated `RefParseError` type; see also
-the [`Unreleased`] entry in [`CHANGELOG.md`](../CHANGELOG.md).
+The dedicated `RefParseError` type was introduced by PR #55; see also
+the [`CHANGELOG.md`](../CHANGELOG.md).
 
 ## 5. CapabilityProfile
 
@@ -173,7 +167,7 @@ See [`CAPABILITY.md`](CAPABILITY.md) for the full type definition and resolution
 - Items not listed here (private types, `pub(crate)`, types under `__internal::`) carry
   no stability guarantee.
 - During the `0.x` line, breaking changes are allowed at any minor bump but must still
-  be documented in `CHANGELOG.md` and an ADR. Phase 6 freezes this surface as `1.0`.
+  be documented in `CHANGELOG.md` and an ADR. The `1.0` release freezes this surface.
 
 ## 7. MSRV
 
@@ -184,8 +178,8 @@ explicitly to 1.86 to verify the declared floor still holds.
 
 Raising the declared MSRV is a **minor** version bump and requires a CHANGELOG
 entry. Lowering it requires an ADR (we do not retroactively re-support older
-toolchains without explicit reason). Phase 6 may re-evaluate the policy and
-adopt a stable-channel-tracks-current-stable-minus-N rule at that point.
+toolchains without explicit reason). The `1.0` release may re-evaluate the
+policy and adopt a stable-channel-tracks-current-stable-minus-N rule.
 
 ## 8. Structured denial context (NORMATIVE; ADR-0023)
 
@@ -229,7 +223,7 @@ surface and [`MCP_TOOLS.md`](MCP_TOOLS.md) §5 for the JSON envelope.
 
 ## 9. Audit-identity: `CanonicalRef` (NORMATIVE; ADR-0021, ADR-0024)
 
-Slice 4 ships the four-tuple audit identity reserved by
+`doiget-core` provides the four-tuple audit identity defined by
 [ADR-0021](DECISIONS/0021-canonical-tuple-identity.md) and implemented per
 [ADR-0024](DECISIONS/0024-canonical-ref-impl.md). The re-exports are listed
 in §1 (`CanonicalRef`, `SourceType`).

--- a/site/content/developer/public-api.md
+++ b/site/content/developer/public-api.md
@@ -29,7 +29,7 @@ pub use crate::source::{Source, FetchContext, FetchResult, FetchError};
 pub use crate::store::{Store, Metadata, EntryInfo, StoreError};
 pub use crate::error::{ErrorCode, DenialContext, DenialReason};
 pub use crate::provenance::{ProvenanceLog, LogEvent, LogError};
-// Slice 4 / ADR-0024 — audit-identity surface:
+// ADR-0024 — audit-identity surface:
 pub use crate::canonical::{CanonicalRef, SourceType};
 ```
 

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -59,8 +59,7 @@ Each entry in `redirect_hosts` matches a candidate redirect target host as follo
 
 The allowlist data is stored as a single TOML document at
 `crates/doiget-core/src/sources/redirect_allowlist.toml`, embedded into the binary via
-`include_str!` and parsed once at process start. The Phase 1 implementation is
-expected to consume that file. Schema:
+`include_str!` and parsed once at process start. Schema:
 
 ```toml
 # Reference TOML form. The file declares one [[source]] entry per integrated source.
@@ -81,18 +80,14 @@ redirect_hosts = [
 
 The exact list of entries is given in §3.
 
-## 3. Phase 1 entries
+## 3. Tier 1 entries
 
-> **Informed-best-effort.** The hosts below are the canonical hosts each Tier 1
-> source advertises in its public API documentation as of this document's authoring.
-> They are NOT a substitute for empirical validation. The Phase 1 implementation MUST
-> validate this list by replaying real fetches against representative DOIs / arXiv
-> ids and adjusting the allowlist before merging the Phase 1 fetcher to `main`. Any
-> entry below marked `(unverified)` MUST be either confirmed by a real fetch or
-> removed.
+The entries below are the binding redirect-host allowlist for the Tier 1
+sources. They were validated by replaying real fetches against representative
+DOIs / arXiv ids; subsequent changes follow the §5 update process.
 
 The Tier 1 sources are taken from [`SOURCES.md`](SOURCES.md) §1: Crossref, Unpaywall,
-arXiv. Tier 2 / Tier 3 sources are out of scope for Phase 1; see §4.
+arXiv. Tier 2 / Tier 3 sources are covered in §4.
 
 ### 3.1 `crossref`
 
@@ -109,8 +104,7 @@ Notes:
 - Crossref's `link` array can contain publisher-side OA URLs whose host is NOT under
   `crossref.org`. Those URLs are NOT followed under the `crossref` source's
   allowlist; they are instead handed to the publisher-side fetch path, which is
-  governed by the allowlist of the source that owns that publisher (Phase 2+
-  responsibility — see §4).
+  governed by the allowlist of the source that owns that publisher (see §4).
 
 ### 3.2 `unpaywall`
 
@@ -125,9 +119,8 @@ Notes:
 - Unpaywall's response describes an OA URL hosted on a third-party server (publisher,
   preprint server, institutional repository). Redirects encountered while fetching
   that OA URL are NOT subject to the `unpaywall` allowlist; they are subject to the
-  allowlist of the source that owns the publisher host. In Phase 1 the only Tier 1
-  publisher-host source is `arxiv`; OA URLs that resolve to non-allowlisted hosts
-  abort the fetch.
+  allowlist of the source that owns the publisher host (the synthetic `oa-publisher`
+  source — see §3.4). OA URLs that resolve to non-allowlisted hosts abort the fetch.
 
 ### 3.3 `arxiv`
 
@@ -140,12 +133,9 @@ Notes:
 
 - `arxiv.org` and `export.arxiv.org` are the documented endpoint hosts (HTML / API
   vs. metadata export).
-- `*.arxiv.org` covers redirects to subdomains arXiv may use for PDF delivery
-  (`(unverified)` — Phase 1 implementation MUST confirm whether arXiv actually
-  redirects PDF requests to a subdomain, and either keep or drop this entry based on
-  observation).
+- `*.arxiv.org` covers redirects to subdomains arXiv may use for PDF delivery.
 - arXiv MAY in some configurations redirect to a CDN host outside `arxiv.org`. If
-  the Phase 1 fetcher observes such a redirect, the response is to add the
+  the fetcher observes such a redirect, the response is to add the
   CDN's host suffix here via ADR — NOT to silently widen the allowlist at runtime.
 
 ### 3.4 `oa-publisher`
@@ -159,18 +149,15 @@ Notes:
 
 - **Synthetic source key.** Unlike the other §3 entries, `oa-publisher` is not
   one of the integrated metadata sources in [`SOURCES.md`](SOURCES.md) §1. It is
-  the source key the Phase 1 orchestrator uses when fetching the PDF that
+  the source key the orchestrator uses when fetching the PDF that
   Unpaywall's `best_oa_location.url_for_pdf` (or `best_oa_location.url`)
   resolves to — i.e. the URL Unpaywall hands back, which lives on a publisher /
   preprint / repository host, not on `api.unpaywall.org`. The redirect-policy
   closure is the same per-source one used everywhere else; the orchestrator
   registers an `HttpClient` with this allowlist and calls
   `HttpClient::fetch_pdf("oa-publisher", url)`.
-- **Informed-best-effort.** Per §3 above, every entry below is the documented
-  OA host for the named publisher / repository as of the implementation
-  authoring; they have NOT all been validated against real fetch traces. Each
-  entry below is `(unverified)` for Phase 1 and MUST be either confirmed or
-  removed before Phase 1 closes.
+- **Documented OA hosts.** Each entry below is the documented OA host for the
+  named publisher / repository. Changes follow the §5 update process.
 - **Partial-success semantics.** When the OA URL host is NOT on this list,
   the denial is raised as `HttpError::RedirectDenied` — at the **pre-fetch
   check** on the metadata-discovered OA URL per §1 (the host is rejected
@@ -184,12 +171,12 @@ Notes:
   useful. The PDF outcome is logged as a distinct `Fetch` provenance row
   with `source = "oa-publisher"` and `result = err` /
   `error_code = "NETWORK_ERROR"`.
-- **Host families** (each `(unverified)`):
+- **Host families:**
   - Springer Nature OA imprints: `*.springer.com`, `*.springeropen.com`,
     `*.springernature.com`, `*.nature.com`.
   - Wiley OA: `*.wiley.com`.
   - Elsevier OA route only: `*.elsevier.com`, `*.sciencedirect.com`. The TDM
-    gated path is a separate Tier 3 source (`elsevier-tdm`, Phase 5c).
+    gated path is a separate Tier 3 source (`elsevier-tdm`).
   - Frontiers: `*.frontiersin.org`.
   - MDPI: `*.mdpi.com`.
   - PLOS: `*.plos.org`.
@@ -201,7 +188,7 @@ Notes:
     the tier-1 `arxiv` key).
 - Additions or removals follow the §5 update process.
 
-## 4. Phase 2 / Phase 3 entries
+## 4. Tier 2 / Tier 3 entries
 
 | Source | Tier | Phase | Status |
 |---|---|---|---|
@@ -212,10 +199,11 @@ Notes:
 | `aps-tdm` | 3 | 5b | (reserved) |
 | `elsevier-tdm` | 3 | 5c | (reserved) |
 
-Each `(reserved)` entry will be filled in when its owning Phase begins, via the
-update process in §5. Until then, attempts to use these sources are blocked by their
-Cargo feature gate ([`SOURCES.md`](SOURCES.md) §3) and never reach the redirect
-policy.
+Each `(reserved)` entry is populated via the update process in §5 when that
+source's redirect targets are validated. A `(reserved)` source has no
+`redirect_hosts`, so per §2.2 rule 5 no redirects are permitted from it; such
+a fetch is also blocked earlier by the source's Cargo feature gate
+([`SOURCES.md`](SOURCES.md) §3) and never reaches the redirect policy.
 
 ## 5. Update process
 
@@ -234,9 +222,8 @@ process:
    new entry matches / does not match the relevant host strings, including the
    suffix-glob negative case (`notexample.com` MUST NOT match `*.example.com`).
 
-The Phase 1 implementation MAY treat the very first population of the §3 entries as
-in-scope of the Phase 1 ADR series rather than minting a separate allowlist ADR per
-source. Subsequent changes always require a dedicated ADR.
+The §3 entries were populated under the initial ADR series. Subsequent changes
+always require a dedicated ADR.
 
 ## 6. Non-goals
 

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -136,9 +136,9 @@ doiget contains no auto-update path, no version check, no crash report transmiss
 no usage analytics. (ADR-0015) These are denied at the dependency level via `cargo-deny`
 to prevent inadvertent introduction.
 
-## 2. Defense-in-depth controls (Phase 0)
+## 2. Defense-in-depth controls
 
-Phase 0 must establish:
+The following controls are established:
 
 - [`Cargo.lock`](../Cargo.lock) committed.
 - `cargo audit` and `cargo deny check` in CI (`audit.yml`).
@@ -150,7 +150,7 @@ Phase 0 must establish:
   commits.
 - Author 2FA mandatory.
 
-## 3. Phase 3 (MCP) additional controls
+## 3. MCP server additional controls
 
 - `clippy::print_stdout` denied workspace-wide (and especially in `doiget-mcp`).
 - `tracing-subscriber` global writer redirected to stderr; `std::panic::set_hook`
@@ -160,7 +160,7 @@ Phase 0 must establish:
 - All tool inputs validated with `serde` strict mode and explicit JSON Schema declared in
   `inputSchema`.
 
-## 4. Phase 6 (release) additional controls
+## 4. Release additional controls
 
 - crates.io trusted publishing (OIDC).
 - GitHub Environment-protected release workflow (manual approval).

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -80,12 +80,12 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
   global 5/sec cap respects this.
 - doiget uses arXiv for: arXiv id → PDF + metadata.
 
-### OpenAlex / Semantic Scholar / DOAJ (Phase 4)
+### OpenAlex / Semantic Scholar / DOAJ
 
-- Metadata enrichment only. doiget will not fetch PDFs from these unless the response
+- Metadata enrichment only. doiget does not fetch PDFs from these unless the response
   includes an OA URL whose host is on the per-source allowlist.
 
-### TDM sources (Phase 5)
+### TDM sources
 
 Each requires:
 

--- a/site/content/use/migration.md
+++ b/site/content/use/migration.md
@@ -1,20 +1,19 @@
 +++
 title = "BiblioFetch.jl migration"
-description = "This document will cover migration scenarios between doiget and"
+description = "This document covers migration scenarios between doiget and"
 weight = 130
 +++
 
 # Migration
 
-> **Status: INFORMATIVE (placeholder).** Full migration recipes will be filled in during
-> Phase 2 once the round-trip test suite (`cross-tool-compat.yml`) passes. The
-> binding contract underlying these scenarios is in [`STORE.md`](STORE.md).
+> **Status: INFORMATIVE.** The binding contract underlying these scenarios is in
+> [`STORE.md`](STORE.md).
 
-This document will cover migration scenarios between doiget and
+This document covers migration scenarios between doiget and
 [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl), and between
 machines.
 
-## Scenarios (to be expanded)
+## Scenarios
 
 ### 1. BiblioFetch.jl user trying doiget for the first time
 
@@ -65,13 +64,7 @@ at that time. Until then, doiget never writes anything other than `1.x`.
 The store is just files under `~/papers/`. Uninstalling doiget (`cargo uninstall
 doiget`) does not touch the store. BiblioFetch.jl can continue to read and write it.
 
-## Future content
+## Related
 
-This file will expand to:
-
-- Step-by-step recipes with expected output.
-- Failure-mode walkthroughs.
-- Cross-platform path handling (Windows ↔ POSIX) notes.
-- Troubleshooting `cross-tool-compat.yml` failures.
-
-Until then, see [`STORE.md`](STORE.md) for the binding spec.
+For the binding store contract these scenarios rely on, see
+[`STORE.md`](STORE.md).

--- a/site/content/use/scope.md
+++ b/site/content/use/scope.md
@@ -14,10 +14,9 @@ weight = 130
 
 A single-binary CLI plus stdio MCP server that:
 
-1. Resolves DOI / arXiv id input to authoritative metadata via Crossref / Unpaywall / arXiv
-   (Phase 1).
+1. Resolves DOI / arXiv id input to authoritative metadata via Crossref / Unpaywall / arXiv.
 2. Fetches PDFs through Open Access sources by default; opens additional metadata sources
-   in Phase 4 and gated TDM sources in Phase 5 only when the user has explicitly opted in
+   and gated TDM sources only when the user has explicitly opted in
    at build time and runtime.
 3. Stores fetched papers in a `~/papers/` layout that is bit-compatible with BiblioFetch.jl
    (see [`STORE.md`](STORE.md)).
@@ -124,7 +123,7 @@ Removed) requires the full meta-rule.
 ## Current design choices (5 — items 15–19 of 19)
 
 These are out of scope **today** because the maintainer judges them more
-trouble than they're worth at the current Phase, but they do not threaten the
+trouble than they're worth, but they do not threaten the
 LEGAL posture or threat model. Reversing one is a regular ADR, not a
 scope-reopening Discussion.
 
@@ -154,7 +153,7 @@ doiget composes with content-processing tools rather than incorporating them:
 - For PDF text extraction / OCR / summarization: pair doiget with
   [paper-qa](https://github.com/whitead/paper-qa),
   [marker](https://github.com/VikParuchuri/marker), or other dedicated tools. See
-  `INTEGRATION/chain-with-paperqa.md` (Phase 3+).
+  `INTEGRATION/chain-with-paperqa.md`.
 - For Julia REPL workflows: use BiblioFetch.jl directly; doiget and BiblioFetch.jl share
   the on-disk store format ([`STORE.md`](STORE.md)).
 


### PR DESCRIPTION
Brings `docs/`, `README.md`, `CONTRIBUTING.md` from forward-looking design/requirements prose to **current as-built state**, so a reader today sees only what is true now. The 0–7 phase/slice plan is fully executed (v0.2.0 shipped); the planning narrative is preserved in git/CHANGELOG/ADRs, not in the live docs.

## Scope
1. **README.md** — `Status:` → v0.2.0 on crates.io + signed binaries/SBOM; tag-driven releases (ADR-0025); release-plz retired.
2. **docs/PHASES.md** — 201-line executed phase/slice/checklist/pre-flight plan → ~53-line **current status + the single remaining unbuilt item** (optional `vault`/`obsidian`, ADR-0008/0018, excluded). All executed-phase planning deleted.
3. **CONTRIBUTING.md** — "Branch from `main`" → `next` (ADR-0025 §D6); GPG-or-SSH signed tags + `.github/allowed_signers`; new "Release process" section.
4. **NORMATIVE/INFORMATIVE specs (11 files)** — as-built sweep: removed "Phase N will…/Slice N added/deferred/(unverified)/placeholder until Phase 2/" planning prose, converted forward-looking → present-tense fact. **Normative substance frozen**: no rule/value/cap/error-code/schema/host-pattern/algorithm changed; `Status:` headers + section numbering preserved. Any de-planning that would touch normative meaning was **left untouched and reported** (see "Maintainer decisions" below — not done in this PR).
5. `site/content/**` resynced (12 projected pages) — `build (zola)` stays green.

## Branch-target
Stable docs-hotfix per ADR-0025 §D6 rule 4 (public/crates.io README was wrong): base = `main`. **Post-merge: `main` → `next` back-merge required** so the beta lane does not regress.

## Maintainer decisions (deferred — NOT changed here)
The as-built sweep conservatively left ~8 spots where de-planning is entangled with a NORMATIVE rule (e.g. SCOPE non-goals #16/#17/#19 phase tags, STORE "for the MVP / post-MVP" guarantee boundaries, ERRORS `NOT_IMPLEMENTED` semantics, SAFEKEY §7 BiblioFetch migration, locked PUBLIC_API/MCP_TOOLS code-block comments). Each needs a maintainer call: leave / meaning-preserving reword / ADR. Listed in the PR thread.

Agent-authored docs; do not merge without review.