### PR TITLE
ci: automate main → next back-merge PR (ADR-0025 §D6)

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,73 @@
+name: backmerge
+
+# ADR-0025 §D6 rule 4 automation: keep `next` (beta lane) from regressing
+# behind `main` (stable lane). On every push to `main`, if `next` is missing
+# commits from `main`, open the `main → next` back-merge PR (or leave the
+# existing one — its diff auto-tracks new main commits).
+#
+# Scope = OPEN the PR only. It is NOT auto-merged: `next` is branch-protected
+# (PR + required checks + enforce_admins) and the predictable Cargo.toml /
+# Cargo.lock version conflict (next carries `X.Y.Z-beta.N`, main is the clean
+# stable `X.Y.Z`) is resolved by the human at merge time, keeping next's
+# `-beta.N`.
+#
+# Auth: `RELEASE_PLZ_TOKEN` (fine-grained PAT, contents + pull-requests
+# write). The default `GITHUB_TOKEN` cannot be used — PRs it opens do not
+# trigger the required CI checks (GitHub recursion guard), so they could
+# never be merged into the protected `next`. (Same constraint the release-plz
+# era already hit; the secret is reused.)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backmerge-pr:
+    name: open main → next back-merge PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Open or refresh the back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch origin main next --quiet || true
+
+          if ! git rev-parse --verify -q origin/next >/dev/null; then
+            echo "::notice::no 'next' branch — beta lane not open; nothing to back-merge."
+            exit 0
+          fi
+
+          behind="$(git rev-list --count origin/next..origin/main)"
+          if [ "$behind" -eq 0 ]; then
+            echo "::notice::'next' already contains all of 'main' — no back-merge needed."
+            exit 0
+          fi
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --base next --head main \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "::notice::back-merge PR #$existing already open — it tracks new main commits automatically ($behind ahead)."
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          {
+            echo "Automated **back-merge** so the \`next\` beta lane does not regress behind the \`main\` stable lane (ADR-0025 §D6 rule 4). Opened by \`.github/workflows/backmerge.yml\` because \`main\` advanced ($behind commit(s)) past \`next\`."
+            echo
+            echo "**Not auto-merged.** \`next\` is branch-protected; human review + CI required."
+            echo
+            echo "**Expected merge-time conflict (every back-merge):** \`[workspace.package].version\` and \`Cargo.lock\` conflict — \`next\` carries \`X.Y.Z-beta.N\`, \`main\` carries the clean stable \`X.Y.Z\`. **Keep \`next\`'s \`-beta.N\` version**; take \`main\`'s other changes. Resolve any non-version conflict on its merits."
+          } > "$body_file"
+
+          gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
+            --title "chore: back-merge main → next (ADR-0025 §D6)" \
+            --body-file "$body_file"
+          echo "::notice::opened main → next back-merge PR."

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -313,3 +313,18 @@ for the existing tag (`gh workflow run release-plz.yml -f tag=v0.2.0`) — the
 gate now passes as partial-recovery, `doiget-core@0.2.0` idempotently skips,
 and `doiget-mcp@0.2.0` then `doiget-cli@0.2.0` publish. No new tag is minted;
 `doiget-core@0.2.0` (already immutable on crates.io) is reused as-is.
+
+## Amendment — 2026-05-18 (3): back-merge PR automation
+
+§D6 rule 4 (anything landing on `main` → back-merge to `next` so the beta
+lane never regresses) is automated by `.github/workflows/backmerge.yml`:
+on every push to `main`, if `next` is behind `main`, it **opens** (or leaves
+the existing) `main → next` PR. Scope is deliberately *open-only* — it does
+**not** auto-merge: `next` is branch-protected, and the predictable
+`Cargo.toml`/`Cargo.lock` version conflict (`next` carries `X.Y.Z-beta.N`,
+`main` the clean `X.Y.Z`) is resolved by the human at merge time, **keeping
+`next`'s `-beta.N`**. It authenticates with the `RELEASE_PLZ_TOKEN` PAT
+(reused) because a `GITHUB_TOKEN`-opened PR would not trigger the required
+CI and so could never merge into protected `next`. Auto-resolving the
+version conflict in CI (a merge driver / normalize step) is a possible
+future enhancement, intentionally out of scope here.


### PR DESCRIPTION
Automates ADR-0025 §D6 rule 4 so the `next` beta lane never silently regresses behind `main`.

## What
`.github/workflows/backmerge.yml`: on push to `main` (+ manual dispatch), if `next` is behind `main`, **open** (or leave the existing) `main → next` PR.

- **Open-only — NOT auto-merged.** `next` is branch-protected; the predictable `Cargo.toml`/`Cargo.lock` version conflict (`next` = `X.Y.Z-beta.N`, `main` = clean `X.Y.Z`) is resolved by the human at merge, **keeping next's `-beta.N`**. The PR body states this every time.
- **Auth = `RELEASE_PLZ_TOKEN`** (reused PAT). `GITHUB_TOKEN`-opened PRs don't trigger required CI (recursion guard) → could never merge into protected `next`.
- Idempotent: skips if `next` is up to date or a `main → next` PR is already open. All third-party actions SHA-pinned.
- ADR-0025 **Amendment 2026-05-18 (3)** records it; auto-resolving the version conflict in CI is a noted out-of-scope future enhancement.

YAML validated. Agent-authored; do not merge without review.