### PR TITLE
docs(readme): downloads/MSRV/issues badges + stable|dev docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@
 > Designed as the **agent-facing companion** to [BiblioFetch.jl](https://github.com/sotashimozono/BiblioFetch.jl).
 
 [![crates.io](https://img.shields.io/crates/v/doiget-core.svg)](https://crates.io/crates/doiget-core)
+[![downloads](https://img.shields.io/crates/d/doiget-core.svg)](https://crates.io/crates/doiget-core)
+[![MSRV](https://img.shields.io/crates/msrv/doiget-core.svg)](https://crates.io/crates/doiget-core)
 [![docs.rs](https://img.shields.io/docsrs/doiget-core)](https://docs.rs/doiget-core)
 [![CI](https://github.com/sotashimozono/doiget/actions/workflows/ci.yml/badge.svg)](https://github.com/sotashimozono/doiget/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sotashimozono/doiget/branch/main/graph/badge.svg)](https://codecov.io/gh/sotashimozono/doiget)
+[![issues](https://img.shields.io/github/issues/sotashimozono/doiget)](https://github.com/sotashimozono/doiget/issues)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+**Docs:** stable (`main`) — [site](https://sotashimozono.github.io/doiget/) · [API on docs.rs](https://docs.rs/doiget-core) &nbsp;|&nbsp; dev (`next`/beta) — [`next` branch](https://github.com/sotashimozono/doiget/tree/next) *(source only; no rendered beta docs are published yet)*
 
 **Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
 `doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub


### PR DESCRIPTION
Extends the README badge row and adds an explicit stable/dev docs split.

## Badges added (all real shields endpoints — no broken/placeholder URLs)
- **downloads** — `crates/d/doiget-core`
- **MSRV** — `crates/msrv/doiget-core` (auto-tracks `rust-version = 1.86`)
- **issues** — `github/issues/sotashimozono/doiget`

(kept: crates.io version, docs.rs, CI, codecov, MIT.)

## Docs links — stable vs dev
- **stable (`main`)**: the Zola **site** (deployed from `main`) + **docs.rs** (latest published stable API).
- **dev (`next`/beta)**: links the **`next` branch** and is labelled *source only*.

### Why dev docs is "source only" (decision flagged)
There is **no rendered dev/beta docs target today**: no `-beta` is published to crates.io (so docs.rs has no beta build), and `site.yml` deploys only from `main`. Rather than ship a 404 link, dev points at the `next` source. To get real rendered dev docs, the proper fix (separate, your call) is one of: (a) publish a `vX.Y.Z-beta.N` so docs.rs builds it (then point dev → that docs.rs version), or (b) add a `next`-branch docs/site deploy. Not done here.

Agent-authored docs; do not merge without review.