### PR TITLE
docs(readme): badge-ify docs links (dev docs now live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 [![issues](https://img.shields.io/github/issues/sotashimozono/doiget)](https://github.com/sotashimozono/doiget/issues)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Docs:** stable (`main`) — [site](https://sotashimozono.github.io/doiget/) · [API on docs.rs](https://docs.rs/doiget-core) &nbsp;|&nbsp; dev (`next`/beta) — [`next` branch](https://github.com/sotashimozono/doiget/tree/next) *(source only; no rendered beta docs are published yet)*
+[![docs (stable)](https://img.shields.io/badge/docs-stable-blue)](https://codes.sota-shimozono.com/doiget/)
+[![docs (dev/next)](https://img.shields.io/badge/docs-dev%20%28next%29-orange)](https://codes.sota-shimozono.com/doiget/dev/)
+[![API (docs.rs)](https://img.shields.io/badge/API-docs.rs-blue)](https://docs.rs/doiget-core)
+
+**Docs:** stable = the Zola site (built from `main`); dev = rustdoc built from `next`; API = `docs.rs` (latest published release).
 
 **Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
 `doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub


### PR DESCRIPTION
Follow-up to #174 (dev-docs deploy) — the sequenced README repoint we agreed.

## Why
#174 landed and the dev rustdoc is **live**: gh-pages `/dev/` has 371 files (rustdoc from `next`), the last `push:next` `site` run deployed successfully. **curl-verified (200, HTTPS, no redirect):**
- stable site → `https://codes.sota-shimozono.com/doiget/`
- dev rustdoc → `https://codes.sota-shimozono.com/doiget/dev/`

(`sotashimozono.github.io/doiget/...` 301s to the custom domain over **http** — so the badges use the custom-domain HTTPS URL GitHub Pages reports as canonical.)

## Change
README "**Docs:**" prose line (`dev … source only; no rendered beta docs`) → three shields badges:
`docs (stable)` → site · `docs (dev/next)` → `/dev/` · `API (docs.rs)` → docs.rs, plus a one-line legend. Static badges (always render); link targets are the verified-live URLs. README is not site-projected (no resync).

Agent-authored docs; do not merge without review.