### PR TITLE
chore: back-merge main → next (ADR-0025 §D6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 [![issues](https://img.shields.io/github/issues/sotashimozono/doiget)](https://github.com/sotashimozono/doiget/issues)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Docs:** stable (`main`) — [site](https://sotashimozono.github.io/doiget/) · [API on docs.rs](https://docs.rs/doiget-core) &nbsp;|&nbsp; dev (`next`/beta) — [`next` branch](https://github.com/sotashimozono/doiget/tree/next) *(source only; no rendered beta docs are published yet)*
+[![docs (stable)](https://img.shields.io/badge/docs-stable-blue)](https://codes.sota-shimozono.com/doiget/)
+[![docs (dev/next)](https://img.shields.io/badge/docs-dev%20%28next%29-orange)](https://codes.sota-shimozono.com/doiget/dev/)
+[![API (docs.rs)](https://img.shields.io/badge/API-docs.rs-blue)](https://docs.rs/doiget-core)
+
+**Docs:** stable = the Zola site (built from `main`); dev = rustdoc built from `next`; API = `docs.rs` (latest published release).
 
 **Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
 `doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -203,10 +203,12 @@ Binding rules of the branch model:
 4. **Hotfix.** An urgent stable fix lands directly on `main` (patch tag
    `vX.Y.Z`), then `main` is **back-merged into `next`** immediately so the
    beta lane never regresses relative to stable.
-5. **Branch protection.** `next` carries the *same* required checks as `main`
-   (`test (ubuntu-latest)`, `test (windows-latest)`) so betas are gated as
-   strictly as stable. "Require branches up to date before merging" applies to
-   both (already in force on `main`).
+5. **Branch protection.** `next` carries the *same required checks* as `main`
+   (`test (ubuntu-latest)`, `test (windows-latest)`) + PR-required +
+   enforce-admins, so betas are gated as strictly as stable. **Exception
+   (Amendment 4): `next` must NOT enable "require branches up to date"
+   (`strict`)** — it is incompatible with the §D6 rule-4 back-merge PR
+   direction. `main` keeps `strict`.
 6. **First cutover.** The implementing PR creates `next` from `main`'s
    post-implementation HEAD and sets `next`'s version to the next
    `X.Y.(Z+1)-beta.1`.
@@ -328,3 +330,22 @@ the existing) `main → next` PR. Scope is deliberately *open-only* — it does
 CI and so could never merge into protected `next`. Auto-resolving the
 version conflict in CI (a merge driver / normalize step) is a possible
 future enhancement, intentionally out of scope here.
+
+## Amendment — 2026-05-18 (4): `next` must not be `strict` (up-to-date)
+
+D6 rule 5 originally said "require branches up to date before merging"
+applies to **both** `main` and `next`. Operationally this is a self-
+contradiction with D6 rule 4: the back-merge bot opens a `main → next` PR
+(PR #175 was the first), but a `strict`/up-to-date requirement on `next`
+makes that PR perpetually `BEHIND` — GitHub's "Update branch" on it would
+merge the base (`next`) into the head (`main`), the *wrong* direction, so
+it can never be brought up to date and never merges through the normal
+flow.
+
+**Resolution:** `next`'s branch protection drops `strict`
+(`required_status_checks.strict = false`); it keeps the same **required
+status checks** (`test (ubuntu-latest)`, `test (windows-latest)`),
+**PR-required**, and **enforce-admins**. `main` is unchanged (keeps
+`strict`). This makes the §D6 rule-4 back-merge PRs mergeable while betas
+remain gated by the same CI as stable. Applied via the branch-protection
+API on 2026-05-18; D6 rule 5 is corrected accordingly above.


### PR DESCRIPTION
Automated **back-merge** so the `next` beta lane does not regress behind the `main` stable lane (ADR-0025 §D6 rule 4). Opened by `.github/workflows/backmerge.yml` because `main` advanced (2 commit(s)) past `next`.

**Not auto-merged.** `next` is branch-protected; human review + CI required.

**Expected merge-time conflict (every back-merge):** `[workspace.package].version` and `Cargo.lock` conflict — `next` carries `X.Y.Z-beta.N`, `main` carries the clean stable `X.Y.Z`. **Keep `next`'s `-beta.N` version**; take `main`'s other changes. Resolve any non-version conflict on its merits.
