### PR TITLE
fix(site): correct Zola base-url to serving domain (fixes missing CSS)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,9 +10,13 @@
 # and both are published together in the single force_orphan deploy. A push
 # to either lane refreshes the whole site (so `next` changes DO update the
 # dev docs). PRs build only (no deploy) — the docs-build invariant from the
-# team's standing feedback. Hosting: `sotashimozono.github.io/doiget/`
-# (the `codes.sota-shimozono.com` CNAME is managed at the user-site level;
-# this workflow does NOT publish a CNAME row).
+# team's standing feedback. The site is SERVED at the custom domain
+# `https://codes.sota-shimozono.com/doiget/` (GitHub Pages canonical URL;
+# the `sotashimozono.github.io/doiget/` URL 301s to it over http). The
+# Zola `--base-url` MUST equal the serving domain or the baked-in absolute
+# CSS/JS URLs downgrade to http and browsers block them (mixed content =
+# unstyled site). The `codes.sota-shimozono.com` CNAME is managed at the
+# user-site level; this workflow does NOT publish a CNAME row.
 name: site
 
 on:
@@ -79,7 +83,7 @@ jobs:
             echo "::error::site/content/ is stale on main; run scripts/sync_docs_to_site.sh and commit." >&2
             exit 1
           fi
-          ( cd site && zola build --base-url "https://sotashimozono.github.io/doiget/" )
+          ( cd site && zola build --base-url "https://codes.sota-shimozono.com/doiget/" )
           # Stash the built site outside the worktree so the next checkout
           # (origin/next) does not clobber it.
           rm -rf "$RUNNER_TEMP/site"

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,15 +1,13 @@
 # Zola configuration for the doiget public site.
 #
-# Hosting target: GitHub Pages on `sotashimozono.github.io/doiget/`.
-# The repo's existing `codes.sota-shimozono.com` CNAME continues to be
-# managed at the user-site level; this project-site is served from its
-# own `/doiget/` prefix (no separate CNAME row needed today).
-#
-# `base_url` may be overridden in CI via `--base-url` when a custom
-# domain is wired up. Keep this value aligned with the GH Pages
-# project-site URL.
+# Served at the custom domain `https://codes.sota-shimozono.com/doiget/`
+# (GitHub Pages canonical; `sotashimozono.github.io/doiget/` 301s to it
+# over http). `base_url` MUST equal the serving domain — Zola bakes it
+# into absolute CSS/JS URLs, and a mismatch downgrades them to http on
+# an https page (mixed content → browsers block → unstyled site). CI
+# also passes the same value via `zola build --base-url`.
 
-base_url = "https://sotashimozono.github.io/doiget"
+base_url = "https://codes.sota-shimozono.com/doiget"
 title = "doiget"
 description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
 default_language = "en"


### PR DESCRIPTION
The deployed docs site renders **unstyled (no CSS)**. Root cause diagnosed from the live HTML.

## Diagnosis (verified)
`https://codes.sota-shimozono.com/doiget/` ships:
`<link rel="stylesheet" href="https://sotashimozono.github.io/doiget/style.css">`
That URL **301-redirects to `http://codes.sota-shimozono.com/doiget/style.css`** (http, not https). On an HTTPS page that is **mixed content → the browser blocks the stylesheet → unstyled site**.

Cause: `site.yml` built Zola with `--base-url https://sotashimozono.github.io/doiget/`, but GitHub Pages serves the site at the custom domain `https://codes.sota-shimozono.com/doiget/` (Pages API canonical URL). Zola bakes `base_url` into absolute asset URLs, so the mismatch breaks CSS/JS.

## Fix
- `.github/workflows/site.yml`: `zola build --base-url` → `https://codes.sota-shimozono.com/doiget/`
- `site/config.toml`: `base_url` → same (local-build/consistency)
- Corrected the misleading "Hosting: github.io" comments in both that caused this.

dev rustdoc (`/dev/`) is **unaffected** — rustdoc uses relative asset paths (verified). After merge, the next `site` deploy rebuilds with the correct base-url and CSS loads. The PR's own `pull_request` build validates the build.

Agent-authored; do not merge without review.