### PR TITLE
chore: back-merge main → next (ADR-0025 §D6)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,9 +10,13 @@
 # and both are published together in the single force_orphan deploy. A push
 # to either lane refreshes the whole site (so `next` changes DO update the
 # dev docs). PRs build only (no deploy) — the docs-build invariant from the
-# team's standing feedback. Hosting: `sotashimozono.github.io/doiget/`
-# (the `codes.sota-shimozono.com` CNAME is managed at the user-site level;
-# this workflow does NOT publish a CNAME row).
+# team's standing feedback. The site is SERVED at the custom domain
+# `https://codes.sota-shimozono.com/doiget/` (GitHub Pages canonical URL;
+# the `sotashimozono.github.io/doiget/` URL 301s to it over http). The
+# Zola `--base-url` MUST equal the serving domain or the baked-in absolute
+# CSS/JS URLs downgrade to http and browsers block them (mixed content =
+# unstyled site). The `codes.sota-shimozono.com` CNAME is managed at the
+# user-site level; this workflow does NOT publish a CNAME row.
 name: site
 
 on:
@@ -79,7 +83,7 @@ jobs:
             echo "::error::site/content/ is stale on main; run scripts/sync_docs_to_site.sh and commit." >&2
             exit 1
           fi
-          ( cd site && zola build --base-url "https://sotashimozono.github.io/doiget/" )
+          ( cd site && zola build --base-url "https://codes.sota-shimozono.com/doiget/" )
           # Stash the built site outside the worktree so the next checkout
           # (origin/next) does not clobber it.
           rm -rf "$RUNNER_TEMP/site"

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,15 +1,13 @@
 # Zola configuration for the doiget public site.
 #
-# Hosting target: GitHub Pages on `sotashimozono.github.io/doiget/`.
-# The repo's existing `codes.sota-shimozono.com` CNAME continues to be
-# managed at the user-site level; this project-site is served from its
-# own `/doiget/` prefix (no separate CNAME row needed today).
-#
-# `base_url` may be overridden in CI via `--base-url` when a custom
-# domain is wired up. Keep this value aligned with the GH Pages
-# project-site URL.
+# Served at the custom domain `https://codes.sota-shimozono.com/doiget/`
+# (GitHub Pages canonical; `sotashimozono.github.io/doiget/` 301s to it
+# over http). `base_url` MUST equal the serving domain — Zola bakes it
+# into absolute CSS/JS URLs, and a mismatch downgrades them to http on
+# an https page (mixed content → browsers block → unstyled site). CI
+# also passes the same value via `zola build --base-url`.
 
-base_url = "https://sotashimozono.github.io/doiget"
+base_url = "https://codes.sota-shimozono.com/doiget"
 title = "doiget"
 description = "DOIs and arXiv ids -> local PDFs, through official APIs. The agent-facing companion to BiblioFetch.jl."
 default_language = "en"


### PR DESCRIPTION
Automated **back-merge** so the `next` beta lane does not regress behind the `main` stable lane (ADR-0025 §D6 rule 4). Opened by `.github/workflows/backmerge.yml` because `main` advanced (2 commit(s)) past `next`.

**Not auto-merged.** `next` is branch-protected; human review + CI required.

**Expected merge-time conflict (every back-merge):** `[workspace.package].version` and `Cargo.lock` conflict — `next` carries `X.Y.Z-beta.N`, `main` carries the clean stable `X.Y.Z`. **Keep `next`'s `-beta.N` version**; take `main`'s other changes. Resolve any non-version conflict on its merits.
