### PR TITLE
chore: back-merge main → next (ADR-0025 §D6)

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -37,7 +37,7 @@ include_content = true
 # Surfaced in templates so we can show the current development phase in
 # the footer without editing the template. Update when the phase plan
 # advances.
-phase_status = "Phase 3 in progress"
+phase_status = "v0.2.0 — shipping"
 github_url = "https://github.com/sotashimozono/doiget"
 crates_io_url = "https://crates.io/crates/doiget-core"
 docs_rs_url = "https://docs.rs/doiget-core"

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -1,11 +1,32 @@
 <!DOCTYPE html>
 <html lang="{{ config.default_language }}">
+{%- if page is defined and page.title %}
+  {%- set seo_title = page.title ~ " · " ~ config.title %}
+  {%- set seo_desc = page.description | default(value=config.description) %}
+{%- elif section is defined and section.title %}
+  {%- set seo_title = section.title ~ " · " ~ config.title %}
+  {%- set seo_desc = section.description | default(value=config.description) %}
+{%- else %}
+  {%- set seo_title = config.title %}
+  {%- set seo_desc = config.description %}
+{%- endif %}
+{%- set canonical = current_url | default(value=config.base_url) %}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% block title %}{{ config.title }}{% endblock %}</title>
-  <meta name="description" content="{% block description %}{{ config.description }}{% endblock %}">
+  <title>{% block title %}{{ seo_title }}{% endblock %}</title>
+  <meta name="description" content="{% block description %}{{ seo_desc }}{% endblock %}">
+  <link rel="canonical" href="{{ canonical | safe }}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.title }}">
+  <meta property="og:title" content="{{ seo_title }}">
+  <meta property="og:description" content="{{ seo_desc }}">
+  <meta property="og:url" content="{{ canonical | safe }}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ seo_title }}">
+  <meta name="twitter:description" content="{{ seo_desc }}">
   <link rel="stylesheet" href="{{ get_url(path='style.css') | safe }}">
+  {% block structured_data %}{% endblock %}
 </head>
 <body>
   <header class="site-header">

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -22,9 +22,11 @@
   <meta property="og:title" content="{{ seo_title }}">
   <meta property="og:description" content="{{ seo_desc }}">
   <meta property="og:url" content="{{ canonical | safe }}">
+  <meta property="og:image" content="https://avatars.githubusercontent.com/u/187091095?v=4">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="{{ seo_title }}">
   <meta name="twitter:description" content="{{ seo_desc }}">
+  <meta name="twitter:image" content="https://avatars.githubusercontent.com/u/187091095?v=4">
   <link rel="stylesheet" href="{{ get_url(path='style.css') | safe }}">
   {% block structured_data %}{% endblock %}
 </head>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1,5 +1,22 @@
 {% extends "base.html" %}
 
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "name": "doiget",
+  "description": "{{ config.description }}",
+  "url": "{{ canonical | safe }}",
+  "codeRepository": "{{ config.extra.github_url }}",
+  "programmingLanguage": "Rust",
+  "runtimePlatform": "Rust 1.86+",
+  "license": "https://opensource.org/licenses/MIT",
+  "applicationCategory": "DeveloperApplication"
+}
+</script>
+{% endblock %}
+
 {% block content %}
 <section class="hero">
   <h1>doiget</h1>
@@ -52,18 +69,18 @@ wrote ~/papers/2L/2LpQ.../paper.pdf  (412 KB, license: cc-by)
 </section>
 
 <section class="roadmap">
-  <h2>Roadmap</h2>
+  <h2>Status</h2>
   <p>
-    <span class="done">Phase 0 done</span> &middot;
-    <span class="done">Phase 1 done</span> &middot;
-    <span class="done">Phase 2 done</span> &middot;
-    <span class="active">Phase 3 in progress</span> &middot;
-    <span>Phase 4-6 upcoming</span>
+    <span class="done">Shipping &mdash; <strong>v0.2.0</strong></span> on
+    crates.io (<code>doiget-core</code>, <code>doiget-cli</code>,
+    <code>doiget-mcp</code>), with sigstore-signed binaries and an SBOM on
+    every GitHub Release.
   </p>
   <p>
-    MVP ships at the end of Phase 6 (release plumbing: OIDC trusted
-    publishing + sigstore + SBOM). Until then the workspace stays at
-    <code>0.0.0</code>; see <a href="{{ get_url(path='@/contribute/phases.md') | safe }}">the phase plan</a>.
+    Tier&nbsp;1 + Tier&nbsp;2 sources, the stdio MCP server, citation-graph
+    expansion, and feature-gated TDM are all implemented. See the
+    <a href="{{ config.extra.github_url }}/blob/main/CHANGELOG.md">changelog</a>
+    and <a href="{{ get_url(path='@/contribute/phases.md') | safe }}">project status</a>.
   </p>
 </section>
 {% endblock %}


### PR DESCRIPTION
Automated **back-merge** so the `next` beta lane does not regress behind the `main` stable lane (ADR-0025 §D6 rule 4). Opened by `.github/workflows/backmerge.yml` because `main` advanced (3 commit(s)) past `next`.

**Not auto-merged.** `next` is branch-protected; human review + CI required.

**Expected merge-time conflict (every back-merge):** `[workspace.package].version` and `Cargo.lock` conflict — `next` carries `X.Y.Z-beta.N`, `main` carries the clean stable `X.Y.Z`. **Keep `next`'s `-beta.N` version**; take `main`'s other changes. Resolve any non-version conflict on its merits.
