### PR TITLE
chore: back-merge main → next (ADR-0025 §D6)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -297,15 +297,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux ships a fully static musl binary so the published
+          # artefact runs on old glibc (Ubuntu 20.04 / RHEL 8 research &
+          # HPC boxes), not just the ubuntu-latest glibc the runner has.
+          # macOS/Windows stay native (empty target → no cross-compile).
           - os: ubuntu-latest
             artifact: doiget-linux-x86_64
             ext: ""
+            target: x86_64-unknown-linux-musl
           - os: macos-latest
             artifact: doiget-macos-aarch64
             ext: ""
+            target: ""
           - os: windows-latest
             artifact: doiget-windows-x86_64
             ext: ".exe"
+            target: ""
     steps:
       - name: Checkout the tagged commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -317,18 +324,40 @@ jobs:
           toolchain: stable
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      - name: Install musl toolchain (Linux static build)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `musl-tools` provides `musl-gcc`, the C compiler the `ring`
+          # crypto provider's build script invokes for the musl target
+          # (ADR-0020 Amendment 1 removed aws-lc-rs so no cmake is needed).
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
       - name: Build doiget (release, oa-only)
         shell: bash
         run: |
-          # Native target per runner — no cross-compilation, so the produced
-          # binary's arch matches the runner. `oa-only` matches the feature
-          # surface CI tests/clippy already gate on.
-          cargo build --release -p doiget-cli --no-default-features --features oa-only
+          set -euo pipefail
+          # Linux builds a fully static musl binary (runs on old glibc);
+          # macOS/Windows build native (dynamic libc is fine there — no
+          # cross-compile). `oa-only` matches the feature surface CI
+          # tests/clippy already gate on.
+          if [ -n "${{ matrix.target }}" ]; then
+            cargo build --release -p doiget-cli \
+              --no-default-features --features oa-only \
+              --target "${{ matrix.target }}"
+            echo "BIN_DIR=target/${{ matrix.target }}/release" >> "$GITHUB_ENV"
+          else
+            cargo build --release -p doiget-cli \
+              --no-default-features --features oa-only
+            echo "BIN_DIR=target/release" >> "$GITHUB_ENV"
+          fi
       - name: Stage binary + checksum
         shell: bash
         run: |
           set -euo pipefail
-          src="target/release/doiget${{ matrix.ext }}"
+          src="${BIN_DIR}/doiget${{ matrix.ext }}"
           out="${{ matrix.artifact }}${{ matrix.ext }}"
           cp "$src" "$out"
           # `shasum` is absent on the Windows Git-bash runner and `sha256sum`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[portability]** `doiget` now installs **everywhere** — `cargo install
+  doiget-cli` no longer requires cmake/nasm/go, and the published Linux
+  binary runs on old glibc (Ubuntu 20.04 / RHEL 8 / HPC boxes). Root
+  cause: reqwest's `rustls` feature pulled the aws-lc-rs crypto provider
+  (heavy C toolchain) and the release binary was dynamically linked
+  against the runner's glibc. Now: `reqwest` uses `rustls-no-provider`
+  with the `ring` crypto provider (cc + perl only), installed as the
+  process default in `doiget-core`'s `http` module; the release Linux
+  artefact is a static `x86_64-unknown-linux-musl` build. TLS posture is
+  unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
+  still satisfied). See ADR-0020 Amendment 1.
+
 ## [0.2.0](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.3...v0.2.0) - 2026-05-18
 
 First release cut under the tag-driven pipeline (ADR-0025): a single signed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,28 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,8 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -285,12 +261,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -345,15 +315,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -581,6 +542,7 @@ dependencies = [
  "proptest",
  "quick-xml",
  "reqwest",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -620,12 +582,6 @@ dependencies = [
  "url",
  "wiremock",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -710,12 +666,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -812,10 +762,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -825,11 +773,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1230,16 +1176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,12 +1240,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1548,62 +1478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,7 +1625,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -1821,12 +1694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,8 +1721,9 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1880,7 +1748,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -1917,7 +1784,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2320,21 +2186,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2941,16 +2792,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2968,31 +2810,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3002,22 +2827,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3026,22 +2839,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3050,22 +2851,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3074,22 +2863,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,13 +75,35 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"]
 # ADR-0002). `doiget-core/Cargo.toml` does this correctly.
 secrecy = { version = "0.10", features = ["serde"] }
 
-# HTTP client (rustls only — no openssl by deny.toml).
-# reqwest 0.13 split the old `rustls-tls` umbrella into composable pieces:
-#   `rustls`       = rustls backend + aws-lc-rs crypto provider + platform-verifier roots
-#   `webpki-roots` = bundled Mozilla WebPKI roots (cross-platform, no system store needed)
-# Together these reproduce the 0.12 `rustls-tls` behaviour.
+# HTTP client (rustls only — no openssl by deny.toml; see ADR-0020).
+#
+# reqwest 0.13's `rustls` feature bundles the **aws-lc-rs** crypto
+# provider, whose `aws-lc-sys` build script needs a heavy C toolchain
+# (cmake + nasm/go/clang). That makes `cargo install doiget-cli` fail on
+# stock research/HPC boxes (e.g. Ubuntu 20.04 with only gcc+make) and
+# fights musl-static cross-builds. We do NOT need FIPS or post-quantum,
+# so we drop aws-lc-rs entirely:
+#
+#   reqwest `rustls-no-provider` = rustls backend + platform-verifier
+#                                  roots, but NO bundled crypto provider
+#                                  (caller installs the process default).
+#   rustls `ring`                = the ring crypto provider (cc + perl
+#                                  only — no cmake), installed as the
+#                                  process default in `doiget-core`'s
+#                                  `http` module before any client builds.
+#
+# Result: identical TLS posture (rustls-only, platform-verifier roots),
+# but a pure cc/perl build that compiles anywhere. See ADR-0020
+# Amendment 1 for the portability rationale.
 reqwest = { version = "0.13", default-features = false, features = [
-    "rustls", "json", "gzip", "brotli", "stream",
+    "rustls-no-provider", "json", "gzip", "brotli", "stream",
+] }
+# Explicit rustls pin so the `ring` provider is compiled in and can be
+# installed as the process default. `default-features = false` drops
+# rustls's own aws_lc_rs default and `prefer-post-quantum` (aws-lc-rs
+# only). Must stay version-compatible with the rustls reqwest resolves.
+rustls = { version = "0.23", default-features = false, features = [
+    "ring", "std", "tls12", "logging",
 ] }
 
 # Filesystem

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -33,6 +33,11 @@ async-trait = { workspace = true }
 tracing     = { workspace = true }
 secrecy     = { workspace = true, optional = true }
 reqwest     = { workspace = true }
+# Pulled in solely to install the `ring` crypto provider as the process
+# default before any reqwest client is built (reqwest uses
+# `rustls-no-provider` — no bundled provider). See ADR-0020 Amendment 1
+# and `src/http.rs::ensure_crypto_provider`.
+rustls      = { workspace = true }
 camino      = { workspace = true, features = ["serde1"] }
 fs2         = { workspace = true }
 tempfile    = { workspace = true }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -25,6 +25,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Once;
 use std::time::Duration;
 
 use bytes::{Bytes, BytesMut};
@@ -958,6 +959,7 @@ impl HttpClient {
 }
 
 fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
+    ensure_crypto_provider();
     let allowlist_for_closure = allowlist.clone();
     let redirect_policy = Policy::custom(move |attempt| {
         let scheme = attempt.url().scheme().to_string();
@@ -1008,7 +1010,30 @@ fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest
 // ClientBuilder helpers
 // ---------------------------------------------------------------------------
 
+/// Install the `ring` `rustls` crypto provider as the process default,
+/// exactly once.
+///
+/// reqwest is built with the `rustls-no-provider` feature (ADR-0020
+/// Amendment 1: drop aws-lc-rs so `cargo install` needs no cmake/C
+/// toolchain and musl-static builds cleanly). With no bundled provider,
+/// `reqwest::ClientBuilder::build` calls
+/// `rustls::crypto::CryptoProvider::get_default()` and **panics**
+/// (`"No provider set"`) unless a process-default provider was installed
+/// first. Every client constructor below calls this; the `Once` makes it
+/// safe to invoke from many sites and from concurrent tests.
+fn ensure_crypto_provider() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        // `install_default` errors only if a provider is already set;
+        // under `Once` that is unreachable, but ignore it rather than
+        // panic (another linked crate could have installed one first).
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
+    ensure_crypto_provider();
+
     let user_agent = format!(
         "doiget/{} (+https://github.com/sotashimozono/doiget)",
         VERSION
@@ -1073,9 +1098,11 @@ fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
         .read_timeout(READ_TIMEOUT)
         .user_agent(user_agent)
         // `tls_backend_rustls()` is the non-deprecated equivalent of the
-        // older `use_rustls_tls()`. The workspace `reqwest` features
-        // already pin `rustls`, so this is a re-assertion at builder
-        // level rather than a feature switch.
+        // older `use_rustls_tls()`. The workspace pins reqwest with
+        // `rustls-no-provider` (ADR-0020 Amendment 1), so this is a
+        // re-assertion at builder level rather than a feature switch; the
+        // `ring` provider installed by `ensure_crypto_provider()` above
+        // is what reqwest picks up via `CryptoProvider::get_default()`.
         .tls_backend_rustls()
         .build()
 }
@@ -1513,6 +1540,7 @@ mod tests {
             }
             attempt.follow()
         });
+        ensure_crypto_provider();
         let raw_client = ClientBuilder::new()
             .https_only(false)
             .redirect(policy)

--- a/docs/DECISIONS/0020-reqwest-tls-feature-stack.md
+++ b/docs/DECISIONS/0020-reqwest-tls-feature-stack.md
@@ -1,9 +1,9 @@
 # 0020 - reqwest TLS feature stack (rustls-only, webpki bundled)
 
-- **Date:** 2026-05-06
-- **Status:** Accepted — implemented; `reqwest` on the rustls + bundled-webpki-roots stack (PR #30, refined PR #49); `openssl`/`native-tls` banned by `deny.toml`
+- **Date:** 2026-05-06 (Amendment 1: 2026-05-18)
+- **Status:** Accepted — implemented; `reqwest` on the rustls + platform-verifier stack (PR #30, refined PR #49); **Amendment 1** swaps the aws-lc-rs crypto provider for `ring` (portability); `openssl`/`native-tls` banned by `deny.toml`
 - **Supersedes:** -
-- **Source:** PR #30, PR #49
+- **Source:** PR #30, PR #49; Amendment 1 — portability fix (musl-static + cmake-free `cargo install`)
 
 ## Context
 
@@ -69,6 +69,56 @@ See the source PRs (#30, #49) for the analyzed positives and negatives. The
 binding result is captured in the Decision above and is referenced from the
 relevant NORMATIVE doc(s) under docs/ (notably `docs/SECURITY.md` §1.9 and
 ADR-0016).
+
+## Amendment 1 (2026-05-18) — drop aws-lc-rs for `ring` (portability)
+
+**Context.** reqwest 0.13's `rustls` feature transitively pulls the
+**aws-lc-rs** crypto provider, whose `aws-lc-sys` build script requires a
+heavy C toolchain (cmake + nasm/go/clang). Dogfooding `doiget` on a
+university research box (Ubuntu 20.04, only `gcc 9.4` + `make` + `python3`,
+no `sudo`) surfaced two failures that both trace to this provider:
+
+- **F1 — glibc.** The published `ubuntu-latest` release binary is
+  dynamically linked against the runner's glibc 2.38; it fails with
+  `GLIBC_2.38 not found` on older but entirely reasonable targets
+  (Ubuntu 20.04 / RHEL 8). The fix is a static `x86_64-unknown-linux-musl`
+  build — but musl-static cross-builds fight aws-lc-sys's cmake/assembly.
+- **F2 — `cargo install`.** `cargo install doiget-cli` (and `--locked`)
+  fails at `aws-lc-sys` `cc_builder.rs` because cmake is absent. A user
+  who cannot `sudo apt-get install cmake` cannot install doiget at all.
+
+doiget does **not** need FIPS certification or the post-quantum key
+exchange (the only capabilities that justify aws-lc-rs over `ring`).
+
+**Decision.** Switch the crypto provider from aws-lc-rs to `ring`, which
+builds with only `cc` + `perl` (no cmake), cross-compiles cleanly to
+musl, and is the long-standing portable default in the rustls ecosystem:
+
+- `reqwest` feature `rustls` → `rustls-no-provider` (rustls backend +
+  `rustls-platform-verifier` roots, **no** bundled crypto provider).
+- Add an explicit `rustls = { default-features = false, features =
+  ["ring", "std", "tls12", "logging"] }` workspace pin (drops rustls's
+  own `aws_lc_rs` default and `prefer-post-quantum`, which is aws-lc-rs
+  only).
+- `doiget-core`'s `http` module installs `ring` as the **process-default**
+  `CryptoProvider` exactly once (`ensure_crypto_provider()`, `std::sync::Once`)
+  before any `reqwest::Client` is built. This is mandatory: under
+  `rustls-no-provider`, `reqwest::ClientBuilder::build` panics
+  (`"No provider set"`) if no default provider is installed first.
+- The release `sign` job builds the Linux artefact for
+  `x86_64-unknown-linux-musl` (static); the artefact name
+  `doiget-linux-x86_64` is unchanged so signing/SBOM/docs are stable.
+
+**TLS posture is unchanged:** still rustls-only (no openssl/native-tls,
+`deny.toml` allowlist still satisfied — verified by `cargo tree -i
+aws-lc-sys` returning *no packages*), still using
+`rustls-platform-verifier` for roots. Only the symmetric/asymmetric
+primitive implementation changes (aws-lc-rs → ring), both audited and
+Rustls-supported. The Decision section's version-bump audit rule still
+applies; additionally, **any future reqwest/rustls bump MUST re-run
+`cargo tree -i aws-lc-sys` and confirm it stays empty**, and MUST keep
+the explicit `rustls` pin version-compatible with the `rustls` reqwest
+resolves.
 
 To revise this decision, write a new ADR with Status: Accepted and Supersedes: 0020,
 and update this file's Status to Superseded by NNNN per CONTRIBUTING.md.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -36,7 +36,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0017 | Output mode resolution (flag > env > implicit > TTY > quiet) | Accepted | Slice 9 stdout-purity + Slice 1 (see ADR note) | #14 |
 | 0018 | Obsidian export is one-direction, optional Phase 7 | Proposed (Phase 7, unshipped) | — | #15 |
 | 0019 | Eight-safeguard legal posture (5 social + 3 technical) | Accepted | standing posture (Phase 1 onward) | #16 |
-| 0020 | reqwest TLS feature stack (rustls-only, webpki bundled) | Accepted | PR #30 / PR #49 | PR #30 / PR #49 |
+| 0020 | reqwest TLS feature stack (rustls-only; ring provider) | Accepted (Amendment 1 2026-05-18: aws-lc-rs → ring, portability) | PR #30 / PR #49 / Amendment 1 | PR #30 / PR #49 |
 | 0021 | Canonical-tuple identity for fetched papers (spec-only) | Superseded by 0024 (impl); §1–§4 NORMATIVE remains binding | Slice 4 (via 0024) | #12 |
 | 0022 | Dry-run mode for fetch operations | Accepted | Slice 2 | #12 |
 | 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |


### PR DESCRIPTION
Automated **back-merge** so the `next` beta lane does not regress behind the `main` stable lane (ADR-0025 §D6 rule 4). Opened by `.github/workflows/backmerge.yml` because `main` advanced (2 commit(s)) past `next`.

**Not auto-merged.** `next` is branch-protected; human review + CI required.

**Expected merge-time conflict (every back-merge):** `[workspace.package].version` and `Cargo.lock` conflict — `next` carries `X.Y.Z-beta.N`, `main` carries the clean stable `X.Y.Z`. **Keep `next`'s `-beta.N` version**; take `main`'s other changes. Resolve any non-version conflict on its merits.
