### PR TITLE
fix(openalex): use /works/doi:{doi} — bare DOI 404s on OpenAlex

### DIFF
--- a/crates/doiget-cli/tests/graph_e2e.rs
+++ b/crates/doiget-cli/tests/graph_e2e.rs
@@ -32,7 +32,7 @@ async fn graph_subcommand_emits_pretty_json_envelope() -> anyhow::Result<()> {
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/works/10.1234/seed"))
+        .and(path("/works/doi:10.1234/seed"))
         .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
         .mount(&server)
         .await;

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -466,7 +466,7 @@ mod tests {
     async fn expand_walks_depth_2_graph() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/works/10.1234/seed"))
+            .and(path("/works/doi:10.1234/seed"))
             .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
             .mount(&server)
             .await;

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -82,13 +82,19 @@ impl OpenalexSource {
         }
     }
 
-    /// Build the `/works/{doi}?mailto=<contact>` URL.
+    /// Build the `/works/doi:{doi}?mailto=<contact>` URL.
     ///
-    /// OpenAlex accepts the bare DOI in the path. The `mailto` query
-    /// parameter opts into the polite pool per `docs/SOURCES.md` §6.
-    /// When `contact_email` is empty, the query parameter is omitted.
+    /// OpenAlex's `/works/{id}` endpoint does **not** accept a bare DOI
+    /// in the path — `GET /works/10.1103/PhysRevLett.102.190601` returns
+    /// HTTP 404. It accepts an OpenAlex Work ID (`W…`), the namespaced
+    /// `doi:<doi>` form, or a full `https://doi.org/<doi>` URL. We use
+    /// the `doi:` prefix: it is unambiguous, needs no percent-encoding,
+    /// and (unlike the `https://doi.org/` form) does not confuse
+    /// `Url::join`'s scheme detection. The `mailto` query parameter opts
+    /// into the polite pool per `docs/SOURCES.md` §6; when
+    /// `contact_email` is empty the query parameter is omitted.
     fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
-        let path = format!("/works/{}", doi.as_str());
+        let path = format!("/works/doi:{}", doi.as_str());
         let mut url = self
             .base
             .join(&path)
@@ -293,7 +299,7 @@ mod tests {
     async fn fetch_doi_returns_work_metadata() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/works/10.1234/example"))
+            .and(path("/works/doi:10.1234/example"))
             .and(query_param("mailto", "doiget@localhost"))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_WORK))
             .mount(&server)
@@ -362,7 +368,7 @@ mod tests {
         let server = MockServer::start().await;
         // Response has no `id` field — defensive shape check trips.
         Mock::given(method("GET"))
-            .and(path("/works/10.1234/example"))
+            .and(path("/works/doi:10.1234/example"))
             .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"error":"not found"}"#))
             .mount(&server)
             .await;

--- a/crates/doiget-mcp/tests/expand_citation_graph_e2e.rs
+++ b/crates/doiget-mcp/tests/expand_citation_graph_e2e.rs
@@ -82,7 +82,7 @@ async fn expand_citation_graph_returns_graph_envelope() -> anyhow::Result<()> {
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/works/10.1234/seed"))
+        .and(path("/works/doi:10.1234/seed"))
         .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
         .mount(&server)
         .await;


### PR DESCRIPTION
## Summary

Found *by* the now-merged #184 portability fix — installing on a real
research box surfaced that **OpenAlex has never worked**.

`OpenalexSource::request_url` built `/works/{bare-DOI}`. OpenAlex's
`/works/{id}` endpoint returns **HTTP 404** for a bare DOI, so **all**
OpenAlex usage was broken in production:

- OpenAlex **metadata** source (orchestrator), and
- **citation-graph seed** resolution → `doiget graph` CLI + the
  `expand_citation_graph` MCP tool.

The in-code comment wrongly claimed *"OpenAlex accepts the bare DOI in the
path"*, and the unit/e2e mocks mirrored the wrong path — CI stayed green
while live OpenAlex was 100% 404.

Live confirmation: `/works/{bare}` → 404; `/works/doi:{doi}` → 200 (correct
work); `/works/https://doi.org/{doi}` → 200.

## Changes

- `request_url` → `/works/doi:{doi}` (no percent-encoding; unlike the
  `https://doi.org/` form it doesn't confuse `Url::join`'s scheme
  detection).
- Fix the false doc comment.
- Update OpenAlex **seed** mocks (openalex unit, citation_graph, mcp
  `expand_citation_graph_e2e`, cli `graph_e2e`). Child-work mocks
  (`/works/W…`, via `work_url`) unchanged — Work IDs *are* accepted bare.

Crossref (`/works/{doi}`) and Unpaywall (`/v2/{doi}`) genuinely accept
bare DOIs — untouched.

## Test plan

- [x] `cargo test -p doiget-core --features citation` (openalex +
      citation_graph) — passing mocks empirically confirm `Url::join`
      emits `/works/doi:…`
- [x] `doiget-cli graph_e2e`, `doiget-mcp expand_citation_graph_e2e` green
- [x] `doiget-mcp resolve_paper_e2e` (Crossref) green — no regression
- [x] `clippy`/`fmt --check` clean
- [ ] CI green
- [ ] Live re-validation on the research box (FT-MPS citation-graph
      dogfood) — running now from this branch

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)