### PR TITLE
chore: back-merge main → next (ADR-0025 §D6)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1  # v2.79.0
+      - uses: taiki-e/install-action@b550161ef8a7bc4f2a671c0b03a18ac9ccedea1e  # v2.79.1
         with:
           tool: cargo-llvm-cov
       - name: Generate workspace coverage (lcov)

--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -170,7 +170,7 @@ jobs:
           echo "stdout-purity: OK"
       - name: Upload logs (always)
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02   # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
         with:
           name: mcp-smoke-logs
           path: /tmp/mcp-smoke/

--- a/.github/workflows/safekey-vectors.yml
+++ b/.github/workflows/safekey-vectors.yml
@@ -121,7 +121,7 @@ jobs:
         # No explicit version pin needed: the workspace `rust-toolchain.toml`
         # declares the channel (stable) and the MSRV (1.86). dtolnay's
         # toolchain action honors that file when no toolchain input is set.
-        uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017   # stable, 2025-10-23
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8   # stable, 2025-10-23
 
       - name: cargo test safekey_matches_reference_vectors
         # The Rust parity test loads tests/fixtures/safekey/vectors.json via

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -116,7 +116,7 @@ jobs:
           cp -r "$RUNNER_TEMP/site/." site/public/
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02   # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
         with:
           name: site-public
           path: site/public/

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -143,7 +143,7 @@ jobs:
           path: site/public/
 
       - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e   # v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453   # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site/public

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -20,4 +20,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      - uses: crate-ci/typos@5374cbf686e897b15713110e233094e2874de7ef     # v1.46.1
+      - uses: crate-ci/typos@aca895bf05aec0cb7dffa6f94495e923224d9f17     # v1.46.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,9 +1470,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -269,10 +269,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1660,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1682,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ petgraph = "0.6"
 # `deny.toml` bans `axum` / `hyper::Server` / `openssl` / `native-tls`.
 # A `cargo tree -p doiget-mcp` after the edit must NOT show any of those
 # crates; `cargo deny check` enforces this in CI.
-rmcp = { version = "1.6", default-features = false, features = [
+rmcp = { version = "1.7", default-features = false, features = [
     "server", "macros", "transport-io", "schemars",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ url = "2"
 # response). Default features (no `serde`, no `encoding`) are sufficient
 # — we hand-roll a small event walker in `sources::arxiv`. Not on
 # `deny.toml`'s banned list.
-quick-xml = { version = "0.36", default-features = false }
+quick-xml = { version = "0.40", default-features = false }
 
 # Byte buffer + async stream combinators for streaming-with-cap body reads
 # (see crates/doiget-core/src/http.rs, docs/SECURITY.md §1.2 oversized PDF).

--- a/crates/doiget-cli/tests/graph_e2e.rs
+++ b/crates/doiget-cli/tests/graph_e2e.rs
@@ -32,7 +32,7 @@ async fn graph_subcommand_emits_pretty_json_envelope() -> anyhow::Result<()> {
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/works/10.1234/seed"))
+        .and(path("/works/doi:10.1234/seed"))
         .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
         .mount(&server)
         .await;

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -466,7 +466,7 @@ mod tests {
     async fn expand_walks_depth_2_graph() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/works/10.1234/seed"))
+            .and(path("/works/doi:10.1234/seed"))
             .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
             .mount(&server)
             .await;

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -411,7 +411,13 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
                     // <category term="cs.LG" scheme="..."/> — extract `term`.
                     for attr in e.attributes().flatten() {
                         if attr.key.as_ref() == b"term" {
-                            if let Ok(v) = attr.unescape_value() {
+                            // quick-xml 0.40: `unescape_value()` is
+                            // deprecated in favour of `normalized_value()`
+                            // (attribute-value normalization resolves the
+                            // same character/entity references). arXiv's
+                            // Atom feed is XML 1.0.
+                            if let Ok(v) = attr.normalized_value(quick_xml::XmlVersion::Explicit1_0)
+                            {
                                 categories.push(v.into_owned());
                             }
                         }
@@ -421,8 +427,15 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
             }
             Ok(Event::Text(t)) => {
                 if let Some(tg) = target {
-                    if let Ok(s) = t.unescape() {
-                        let s = s.into_owned();
+                    // quick-xml 0.40 removed `BytesText::unescape`.
+                    // Reproduce the old behaviour: decode the bytes, then
+                    // unescape XML entities via `quick_xml::escape::unescape`.
+                    // Best-effort — skip the text on decode/unescape error.
+                    if let Some(s) = t.decode().ok().and_then(|raw| {
+                        quick_xml::escape::unescape(&raw)
+                            .ok()
+                            .map(|c| c.into_owned())
+                    }) {
                         match tg {
                             Target::Title => title.get_or_insert_with(String::new).push_str(&s),
                             Target::Summary => {

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -82,13 +82,19 @@ impl OpenalexSource {
         }
     }
 
-    /// Build the `/works/{doi}?mailto=<contact>` URL.
+    /// Build the `/works/doi:{doi}?mailto=<contact>` URL.
     ///
-    /// OpenAlex accepts the bare DOI in the path. The `mailto` query
-    /// parameter opts into the polite pool per `docs/SOURCES.md` §6.
-    /// When `contact_email` is empty, the query parameter is omitted.
+    /// OpenAlex's `/works/{id}` endpoint does **not** accept a bare DOI
+    /// in the path — `GET /works/10.1103/PhysRevLett.102.190601` returns
+    /// HTTP 404. It accepts an OpenAlex Work ID (`W…`), the namespaced
+    /// `doi:<doi>` form, or a full `https://doi.org/<doi>` URL. We use
+    /// the `doi:` prefix: it is unambiguous, needs no percent-encoding,
+    /// and (unlike the `https://doi.org/` form) does not confuse
+    /// `Url::join`'s scheme detection. The `mailto` query parameter opts
+    /// into the polite pool per `docs/SOURCES.md` §6; when
+    /// `contact_email` is empty the query parameter is omitted.
     fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
-        let path = format!("/works/{}", doi.as_str());
+        let path = format!("/works/doi:{}", doi.as_str());
         let mut url = self
             .base
             .join(&path)
@@ -293,7 +299,7 @@ mod tests {
     async fn fetch_doi_returns_work_metadata() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/works/10.1234/example"))
+            .and(path("/works/doi:10.1234/example"))
             .and(query_param("mailto", "doiget@localhost"))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_WORK))
             .mount(&server)
@@ -362,7 +368,7 @@ mod tests {
         let server = MockServer::start().await;
         // Response has no `id` field — defensive shape check trips.
         Mock::given(method("GET"))
-            .and(path("/works/10.1234/example"))
+            .and(path("/works/doi:10.1234/example"))
             .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"error":"not found"}"#))
             .mount(&server)
             .await;

--- a/crates/doiget-mcp/tests/expand_citation_graph_e2e.rs
+++ b/crates/doiget-mcp/tests/expand_citation_graph_e2e.rs
@@ -82,7 +82,7 @@ async fn expand_citation_graph_returns_graph_envelope() -> anyhow::Result<()> {
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/works/10.1234/seed"))
+        .and(path("/works/doi:10.1234/seed"))
         .respond_with(ResponseTemplate::new(200).set_body_string(SEED_WORK))
         .mount(&server)
         .await;

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -474,6 +474,10 @@ criteria = "safe-to-run"
 version = "0.36.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.quick-xml]]
+version = "0.40.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.quinn]]
 version = "0.11.9"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -62,6 +62,10 @@ criteria = "safe-to-deploy"
 version = "2.2.1"
 criteria = "safe-to-run"
 
+[[exemptions.assert_cmd]]
+version = "2.2.2"
+criteria = "safe-to-run"
+
 [[exemptions.async-compression]]
 version = "0.4.42"
 criteria = "safe-to-deploy"
@@ -534,8 +538,16 @@ criteria = "safe-to-deploy"
 version = "1.6.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.rmcp]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.rmcp-macros]]
 version = "1.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rmcp-macros]]
+version = "1.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustc-hash]]


### PR DESCRIPTION
Automated **back-merge** so the `next` beta lane does not regress behind the `main` stable lane (ADR-0025 §D6 rule 4). Opened by `.github/workflows/backmerge.yml` because `main` advanced (2 commit(s)) past `next`.

**Not auto-merged.** `next` is branch-protected; human review + CI required.

**Expected merge-time conflict (every back-merge):** `[workspace.package].version` and `Cargo.lock` conflict — `next` carries `X.Y.Z-beta.N`, `main` carries the clean stable `X.Y.Z`. **Keep `next`'s `-beta.N` version**; take `main`'s other changes. Resolve any non-version conflict on its merits.
