### PR TITLE
docs(adr-0025): Amendments 5 & 6 — next-primary + advisory version-check

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,88 @@
+name: version-check
+
+# ADR-0025 D2 / Amendment 6 — ADVISORY (non-blocking) pre-tag visibility of
+# the mandatory release version gate.
+#
+# Runs scripts/release-version-gate.sh against the *prospective* tag derived
+# from [workspace.package].version, so the PR / branch checks list shows at a
+# glance whether tagging this version now would cleanly release (G0–G6 +
+# live crates.io G3/G4; G7 auto-SKIPs in a pre-tag dry-run since no signed
+# tag object exists yet — see the gate script header).
+#
+# This changes NOTHING about how a release is triggered: a release is still
+# cut ONLY by a human-pushed signed tag (ADR-0025 D1). This job is
+# deliberately advisory — it is NOT added to branch-protection required
+# checks; it exists purely so "would this release?" is visually obvious on
+# every PR to `next` and `main`.
+#
+# Reading the result:
+#   * green on `next`  — the beta version (X.Y.Z-beta.N) is release-ready.
+#   * green on `main`  — main carries a promoted, not-yet-published version
+#                        (the promotion window); tagging would release.
+#   * red              — tagging now would NOT cleanly release, e.g. the
+#                        version is already fully published on crates.io
+#                        (the normal steady state on `main` between
+#                        releases), the CHANGELOG section is missing/empty,
+#                        or Cargo.lock drifted. Advisory only — does not
+#                        block the PR.
+
+on:
+  pull_request:
+    branches: [next, main]
+  push:
+    branches: [next, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: version-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-check:
+    name: version-check (advisory — would a release proceed?)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+        with:
+          # Full history so the gate's G7 lane-branch probe can resolve
+          # origin/next | origin/main (G7 still SKIPs pre-tag — no tag
+          # object — but the checkout must not starve later, real-tag runs).
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - name: Derive the prospective tag from [workspace.package].version
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          # First `version = "X.Y.Z(-PRE.N)"` line inside [workspace.package].
+          V="$(awk '
+            /^\[workspace\.package\]/ { inwp = 1; next }
+            /^\[/ { inwp = 0 }
+            inwp && /^[[:space:]]*version[[:space:]]*=/ {
+              gsub(/.*=[[:space:]]*"|".*/, "")
+              print
+              exit
+            }' Cargo.toml)"
+          if [ -z "$V" ]; then
+            echo "::error::version-check: could not read [workspace.package].version from Cargo.toml"
+            exit 1
+          fi
+          echo "tag=v$V" >> "$GITHUB_OUTPUT"
+          echo "Prospective tag: v$V"
+      - name: Run the release version gate (advisory dry-run)
+        shell: bash
+        env:
+          CARGO: cargo
+        run: |
+          set -euo pipefail
+          echo "ADVISORY ONLY — a release is triggered solely by a human-pushed"
+          echo "signed tag (ADR-0025 D1). This job never tags, publishes, or blocks."
+          echo "A red result means: tagging '${{ steps.ver.outputs.tag }}' now would"
+          echo "NOT cleanly release (version already published, CHANGELOG section"
+          echo "missing/empty, Cargo.lock drift, or lane/branch mismatch)."
+          echo
+          bash scripts/release-version-gate.sh "${{ steps.ver.outputs.tag }}"

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -1,7 +1,7 @@
 # 0025 - Tag-driven release with a mandatory version gate and beta/stable lanes
 
 - **Date:** 2026-05-17
-- **Status:** Accepted — implemented by PR #166; amended 2026-05-18 (see Amendment) so the workflow filename stays `.github/workflows/release-plz.yml` (tag-driven pipeline contents + `scripts/release-version-gate.sh` + `cliff.toml`/`scripts/release-changelog.sh`; only `release-plz.toml` removed; `release-sign.yml`/`release-sbom.yml` demoted to `workflow_dispatch`-only and folded in). `0013`'s release portion is `Superseded by 0025` (its CI-baseline / posture-lint / SHA-pin / Dependabot decisions stand). Amendment 5 (2026-05-19) brings the implementation back into compliance with D6 (`next`-primary; the main-primary drift is retired).
+- **Status:** Accepted — implemented by PR #166; amended 2026-05-18 (see Amendment) so the workflow filename stays `.github/workflows/release-plz.yml` (tag-driven pipeline contents + `scripts/release-version-gate.sh` + `cliff.toml`/`scripts/release-changelog.sh`; only `release-plz.toml` removed; `release-sign.yml`/`release-sbom.yml` demoted to `workflow_dispatch`-only and folded in). `0013`'s release portion is `Superseded by 0025` (its CI-baseline / posture-lint / SHA-pin / Dependabot decisions stand). Amendment 5 (2026-05-19) brings the implementation back into compliance with D6 (`next`-primary; the main-primary drift is retired). Amendment 6 (2026-05-19) adds an advisory, non-blocking `version-check` job (release-readiness visible on every PR to `next`/`main`; the signed-tag release trigger of D1 is unchanged).
 - **Supersedes:** 0013 (release portion only — the CI baseline / posture-lint / SHA-pin / Dependabot decisions of 0013 stand)
 - **Source:** Maintainer release-workflow review, 2026-05-17 (release-plz `release-PR` model rejected after the v0.1.4 `#164` changelog defect)
 
@@ -437,3 +437,45 @@ change-sets, human-gated):**
 D6 rules 1/3/4 are authoritative; this Amendment records that the
 implementation is being brought back into compliance with them and that
 Amendments 3/4 are reinterpreted under the corrected (designed) flow.
+
+## Amendment — 2026-05-19 (6): advisory `version-check` job (visibility; tag-trigger unchanged)
+
+**Motivation.** The D2 version gate (`scripts/release-version-gate.sh`,
+G0–G7) already exists, but D1 makes it run **only on a pushed signed
+tag** — so on normal PRs/branches it is invisible, and "would tagging
+this actually release?" is not observable until you cut the tag. The
+maintainer asked for that answer to be **visually obvious on every PR to
+both `next` and `main`**, while explicitly *not* wanting auto-release
+(that motivation was stated only to frame the ask; it is **not** a
+feature here and D1 is unchanged).
+
+**Decision.** Add `.github/workflows/version-check.yml`: an **advisory,
+non-blocking** job that, on `pull_request` and `push` to `next` and
+`main`, derives the prospective tag `v<[workspace.package].version>` and
+runs the *existing* gate script against it. G0–G6 and the live
+crates.io G3/G4 execute; G7 auto-SKIPs pre-tag (no signed tag object —
+per the script's documented guard). It surfaces the gate result as a
+named check so release-readiness is legible at a glance.
+
+Binding properties:
+
+1. **Release trigger unchanged.** A release is still cut *only* by a
+   human-pushed signed tag (D1). This job never tags, publishes, mutates
+   state, or auto-releases. "Auto-release when the check is green" is
+   explicitly **out of scope** — it would change D1, is an irreversible
+   publish, and contradicts Amendment 5 / D6 rule 3's human-gated
+   `next → main` promotion.
+2. **Advisory, not a gate.** The job reports honest PASS/FAIL but is
+   **not** added to `next`/`main` branch-protection required checks. It
+   informs; it does not block merges. (It may be promoted to required
+   later by a separate, explicit decision.)
+3. **Reading it.** Green on `next` = the `X.Y.Z-beta.N` version is
+   release-ready. Green on `main` = `main` carries a promoted,
+   not-yet-published version (the promotion window) — tagging would
+   release. Red is the *correct, informative* steady state on `main`
+   between releases (the published `X.Y.Z` cannot be re-released;
+   crates.io is immutable) and flags real problems elsewhere (missing
+   CHANGELOG section, `Cargo.lock` drift, lane/branch mismatch).
+4. **No new gate logic.** It reuses `scripts/release-version-gate.sh`
+   verbatim; there is one source of truth for the gate (D2). No
+   branch-protection API change is made.

--- a/docs/DECISIONS/0025-tag-driven-release.md
+++ b/docs/DECISIONS/0025-tag-driven-release.md
@@ -1,7 +1,7 @@
 # 0025 - Tag-driven release with a mandatory version gate and beta/stable lanes
 
 - **Date:** 2026-05-17
-- **Status:** Accepted — implemented by PR #166; amended 2026-05-18 (see Amendment) so the workflow filename stays `.github/workflows/release-plz.yml` (tag-driven pipeline contents + `scripts/release-version-gate.sh` + `cliff.toml`/`scripts/release-changelog.sh`; only `release-plz.toml` removed; `release-sign.yml`/`release-sbom.yml` demoted to `workflow_dispatch`-only and folded in). `0013`'s release portion is `Superseded by 0025` (its CI-baseline / posture-lint / SHA-pin / Dependabot decisions stand).
+- **Status:** Accepted — implemented by PR #166; amended 2026-05-18 (see Amendment) so the workflow filename stays `.github/workflows/release-plz.yml` (tag-driven pipeline contents + `scripts/release-version-gate.sh` + `cliff.toml`/`scripts/release-changelog.sh`; only `release-plz.toml` removed; `release-sign.yml`/`release-sbom.yml` demoted to `workflow_dispatch`-only and folded in). `0013`'s release portion is `Superseded by 0025` (its CI-baseline / posture-lint / SHA-pin / Dependabot decisions stand). Amendment 5 (2026-05-19) brings the implementation back into compliance with D6 (`next`-primary; the main-primary drift is retired).
 - **Supersedes:** 0013 (release portion only — the CI baseline / posture-lint / SHA-pin / Dependabot decisions of 0013 stand)
 - **Source:** Maintainer release-workflow review, 2026-05-17 (release-plz `release-PR` model rejected after the v0.1.4 `#164` changelog defect)
 
@@ -349,3 +349,91 @@ status checks** (`test (ubuntu-latest)`, `test (windows-latest)`),
 `strict`). This makes the §D6 rule-4 back-merge PRs mergeable while betas
 remain gated by the same CI as stable. Applied via the branch-protection
 API on 2026-05-18; D6 rule 5 is corrected accordingly above.
+
+## Amendment — 2026-05-19 (5): operate D6 as designed (`next`-primary); retire the main-primary drift
+
+**Diagnosis (drift, not a new model).** D6 already specifies a
+`next`-primary model: rule 1 ("all feature/fix PRs target `next`"), rule 3
+(routine path into `main` is the `next → main` promotion merge), rule 4
+(`main → next` is the *hotfix-only* back-merge). The *implementation*
+diverged from this:
+
+- `.github/dependabot.yml` sets `target-branch: main` for both the
+  `cargo` and `github-actions` ecosystems, so dependency PRs landed on
+  `main`;
+- feature/fix PRs (`#184`, `#187`, `#188`, `#189`) were opened against
+  `main`;
+- Amendment 3's `backmerge.yml` then routinely opened `main → next` PRs
+  (e.g. `#195`) so `next` merely *followed* `main`.
+
+Net effect: `main` became the integration lane and `next` a passive
+mirror — the **inverse** of D6 rules 1/3/4. Amendments 3 and 4 codified
+mechanics for that drifted flow, not for D6 as written.
+
+```mermaid
+flowchart LR
+  subgraph BEFORE["before — main-primary drift"]
+    P1[PRs / dependabot] --> M1[main]
+    M1 -->|backmerge.yml routine| N1[next<br/>passive mirror]
+    M1 -->|tag| R1[release]
+  end
+  subgraph AFTER["after — D6 as designed"]
+    P2[PRs / dependabot] --> N2[next<br/>integration + beta]
+    N2 -->|"git tag -s vX.Y.Z-beta.N"| B2[beta release]
+    N2 -->|"promotion PR (open-only, human merge)"| M2[main]
+    M2 -->|"git tag -s vX.Y.Z"| R2[stable release]
+    M2 -.->|hotfix only → backmerge.yml| N2
+  end
+```
+
+**Decision (effective 2026-05-19).** Operate D6 as written. No
+architectural change — D6 rules 1–6 stand; this Amendment removes the
+drift and reconciles Amendments 3/4:
+
+1. **PR target = `next`** (D6 rule 1, reaffirmed). All feature/fix/dependency
+   PRs target `next`. `.github/dependabot.yml` `target-branch` becomes
+   `next` for both ecosystems.
+2. **`main` is release-only** (D6 rule 3): it receives commits **only**
+   via a `next → main` promotion merge or a stable hotfix. The promotion
+   is a PR — **open-only, human-merged** (consistent with the project's
+   no-auto-merge-of-non-trivial-PRs posture); never auto-merged.
+3. **`backmerge.yml` is hotfix-scoped** (D6 rule 4). It is no longer the
+   routine integration mechanism (routine work no longer reaches `main`);
+   it remains correct for the rare direct-to-`main` stable hotfix, opening
+   the `main → next` PR so the beta lane never regresses. The workflow
+   itself is unchanged (`on: push: main`); in steady state `main` only
+   sees promotion/hotfix pushes, so it fires correctly and rarely.
+   Optionally skipping it on promotion merges is a future enhancement.
+4. **Amendment 4 is retained.** The only `main → next` PRs are now
+   post-hotfix back-merges — exactly the case Amendment 4's non-`strict`
+   resolution exists for. `next` stays non-`strict` with the same required
+   checks; `main` keeps `strict`.
+5. **Branch protection shape is unchanged.** `next` already carries the
+   same required checks + PR-required + enforce-admins (D6 rule 5 /
+   Amendment 4); `main` keeps `strict`. Only the *flow* changes, not the
+   protection configuration — no branch-protection API change is required.
+6. **`site.yml` unchanged.** Stable site from `origin/main`, dev rustdoc
+   from `origin/next`. The publish cadence inverts naturally (`next` now
+   leads) without a workflow edit.
+
+**First-cutover status.** D6 rule 6 is already satisfied: `next` exists
+carrying `0.2.1-beta.1` while `main` carries the clean `0.2.0`. No
+re-cutover is needed; this Amendment only stops the drift.
+
+**Migration checklist (post-merge of this ADR; mechanical, separate
+change-sets, human-gated):**
+
+- [ ] `.github/dependabot.yml`: `target-branch: next` (cargo +
+      github-actions). (PR targets `next`.)
+- [ ] Henceforth open all feature/fix/dependency PRs against `next`.
+- [ ] When blessing a stable release: drop `-beta.N` on `next`, open the
+      `next → main` promotion PR (open-only), human-merge, then tag
+      `vX.Y.Z` on `main` (D6 rule 3 / D1).
+- [ ] Routine `main → next` backmerge PRs cease; `#195`-style PRs only
+      recur after a stable hotfix.
+- [ ] No branch-protection API change (shape already matches §D6 rule 5 /
+      Amendment 4).
+
+D6 rules 1/3/4 are authoritative; this Amendment records that the
+implementation is being brought back into compliance with them and that
+Amendments 3/4 are reinterpreted under the corrected (designed) flow.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -41,7 +41,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0022 | Dry-run mode for fetch operations | Accepted | Slice 2 | #12 |
 | 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |
 | 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
-| 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amendment 5 2026-05-19: operate D6 `next`-primary, retire main-primary drift) | PR #166 / Amendment 5 | maintainer review 2026-05-17 |
+| 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -41,7 +41,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0022 | Dry-run mode for fetch operations | Accepted | Slice 2 | #12 |
 | 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |
 | 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
-| 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted | PR #166 | maintainer review 2026-05-17 |
+| 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amendment 5 2026-05-19: operate D6 `next`-primary, retire main-primary drift) | PR #166 / Amendment 5 | maintainer review 2026-05-17 |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

ADR-0025 release-process evolution, design-first. Two amendments + one
new workflow, on `next` (dogfooding D6 rule 1). **No merge by me.**

### Amendment 5 — operate D6 as designed (`next`-primary)
Not a new model: D6 already specifies `next`-primary (rule 1 PRs→`next`,
rule 3 `next→main` promotion, rule 4 `main→next` hotfix-only). The
implementation drifted to main-primary (dependabot/PRs → `main`;
`backmerge.yml` routinely `main→next`, e.g. #195). Amendment 5 records
operating D6 as written, reconciles Amendments 3/4, before/after mermaid,
post-merge migration checklist. First-cutover already satisfied
(`next`=0.2.1-beta.1, `main`=0.2.0). No branch-protection change.

### Amendment 6 — advisory `version-check` job (visibility)
The D2 version gate exists but D1 makes it run **only on a signed tag**,
so "would this release?" is invisible on PRs. Adds
`.github/workflows/version-check.yml`: advisory, **non-blocking** job on
`pull_request`/`push` to **both `next` and `main`** that runs the
existing `release-version-gate.sh` against the prospective tag
`v<[workspace.package].version>` (G0–G6 + live crates.io G3/G4; G7
auto-SKIPs pre-tag). Release trigger unchanged (D1: human signed tag);
**no auto-release** (explicitly out of scope — it was only the stated
motivation); not added to required checks; reuses the one gate script.

## Reading version-check
- green `next` = beta `X.Y.Z-beta.N` release-ready
- green `main` = promoted, unpublished version (promotion window)
- red = not cleanly releasable (already-published steady state on `main`;
  or missing CHANGELOG section / lockfile drift) — advisory, non-blocking

## Verified
Locally on `next`: awk extracts `0.2.1-beta.1`; gate runs G0/G1/G2 PASS
then correctly flags **G5** (no `## [0.2.1-beta.1]` CHANGELOG section
yet) — i.e. the check honestly shows `next` is not beta-releasable until
that section is curated. Exactly the intended visibility.

## Post-merge migration (separate, human-gated)
- [ ] `.github/dependabot.yml`: `target-branch: next`
- [ ] open future PRs against `next`
- [ ] `#195`-style routine `main→next` PRs cease (hotfix-only thereafter)
- [ ] (optional) promote `version-check` to a required check later

Docs + one advisory CI workflow. No code/branch-protection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)