### PR TITLE
fix(repo): LICENSE → verbatim SPDX MIT (#157) [PR 1/5, beta.2]

### DIFF
--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -64,6 +64,36 @@ jobs:
             exit 1
           fi
 
+      - name: LICENSE is verbatim SPDX MIT (no trailing prose)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # GitHub's `licensee` classifies the repo as MIT only if LICENSE is
+          # (near-)verbatim SPDX MIT. Trailing prose (e.g. a `---` separator +
+          # a `Note:` paragraph) drops the similarity below threshold, so the
+          # repo reports `licenseInfo: Other` — which propagates to crates.io,
+          # SPDX scanners and shields. Keep posture/legal text in
+          # docs/LEGAL.md + the site posture page, never in LICENSE. See #157.
+          if [ "$(head -n1 LICENSE)" != "MIT License" ]; then
+            echo "::error::posture-lint: LICENSE line 1 must be exactly 'MIT License' (#157)"
+            exit 1
+          fi
+          if grep -nE '^(---|Note:)' LICENSE ; then
+            echo "::error::posture-lint: LICENSE has non-SPDX trailing prose ('---' / 'Note:'). Keep LICENSE verbatim SPDX MIT; posture text belongs in docs/LEGAL.md (#157)"
+            exit 1
+          fi
+          last_content="$(grep -n . LICENSE | tail -n1 | cut -d: -f1)"
+          software_line="$(grep -n '^SOFTWARE\.$' LICENSE | tail -n1 | cut -d: -f1 || true)"
+          if [ -z "$software_line" ] || [ "$last_content" != "$software_line" ]; then
+            echo "::error::posture-lint: content found after the SPDX MIT body (it must end at the line 'SOFTWARE.') — LICENSE is not verbatim MIT (#157)"
+            exit 1
+          fi
+          if grep -qU $'\r' LICENSE ; then
+            echo "::error::posture-lint: LICENSE has CRLF line endings; must be LF for licensee (#157)"
+            exit 1
+          fi
+          echo "LICENSE OK: verbatim SPDX MIT, no trailing prose, ends at SOFTWARE., LF."
+
   network-purity:
     # Phase 0 must make zero outbound network calls from the unit / integration
     # test suite. See `docs/PHASES.md` §3 working principle ("No external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.2] - 2026-05-19
+
+### Fixed
+
+- **[repo]** `LICENSE` is now the verbatim 21-line SPDX MIT body. The
+  trailing `---` separator + paper-licensing `Note:` paragraph (which
+  pushed GitHub's `licensee` classifier below its match threshold, so the
+  repo showed `licenseInfo: Other`) is removed; the identical posture
+  statement already lives in `docs/LEGAL.md` and the site posture page.
+  Restores MIT classification for crates.io / SPDX / shields. (#157)
+
 ## [0.2.0](https://github.com/sotashimozono/doiget/compare/doiget-core-v0.1.3...v0.2.0) - 2026-05-18
 
 First release cut under the tag-driven pipeline (ADR-0025): a single signed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.1"
+version = "0.2.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.1"
+version = "0.2.1-beta.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.1"
+version = "0.2.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.1"
+version       = "0.2.1-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -19,11 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-Note: This MIT license applies to the doiget source code and compiled binaries.
-The license under which papers are retrieved by doiget is determined separately
-by each paper's own license, the originating publisher's API Terms of Service,
-and the user's own access rights. doiget does not relicense fetched content
-and does not redistribute papers.


### PR DESCRIPTION
**PR 1 of a sequential stack (1 issue = 1 PR = 1 beta up). Base: `next`.
Merge in order; I do not merge.**

## #157 — LICENSE not detected as MIT

`LICENSE` lines 1–21 were verbatim SPDX MIT, but lines 22–29 added a
`---` separator + a paper-licensing `Note:` paragraph. That trailing
prose pushed GitHub's `licensee` classifier below threshold → repo
showed `licenseInfo: Other`, propagating to crates.io / SPDX / shields.

### Change
- `LICENSE` trimmed to the verbatim 21-line SPDX MIT body. **No
  information lost** — the identical posture statement already lives in
  `docs/LEGAL.md` and the site posture page.
- **Regression guard (test):** `posture-lint.yml` gains a step that
  fails CI if `LICENSE` regains non-SPDX prose (`---`/`Note:`), doesn't
  start with `MIT License`, has content after `SOFTWARE.`, or is CRLF.
- 1 beta up: `0.2.1-beta.1 → 0.2.1-beta.2` (+ Cargo.lock), CHANGELOG
  `[0.2.1-beta.2]` section.

### Verified locally
- LICENSE guard passes (line1 OK, no prose, ends at SOFTWARE. line 21, LF)
- `release-version-gate.sh v0.2.1-beta.2` → PASS (G1/G2/G5/G6;
  G3/G4 offline-skipped, G7 pre-tag-skipped)
- Post-merge confirmation: `gh repo view --json licenseInfo` → `MIT`.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)