### PR TITLE
fix(core/mcp): doiget_metadata_only writes the metadata TOML (#139) [PR 2/5, beta.3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.3] - 2026-05-19
+
+### Fixed
+
+- **[mcp/core]** `doiget_metadata_only` now writes the metadata TOML to
+  the store (`<root>/.metadata/<safekey>.toml`) — the documented
+  `docs/MCP_TOOLS.md` §11 SIDE EFFECT that was previously a `TODO`
+  (orchestrator returned provenance rows but zero disk artifacts, so
+  `doiget_info` after `doiget_metadata_only` returned `metadata: null`).
+  Implemented as a new `metadata_only_to_store` wrapper around the
+  unchanged **pure** `metadata_only`; `doiget_resolve_paper`
+  (`resolve_only`) keeps delegating to the pure resolver, so its
+  `docs/MCP_TOOLS.md` §1 "NEVER writes a metadata TOML" contract now
+  holds *structurally* (the store-write lives in a separate entry point
+  `resolve_only` does not call) and cannot regress. e2e tests assert
+  metadata-only persists a readable TOML and resolve-only writes
+  nothing. (#139)
+
 ## [0.2.1-beta.2] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.2"
+version = "0.2.1-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.2"
+version = "0.2.1-beta.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.2"
+version = "0.2.1-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.2"
+version       = "0.2.1-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -102,11 +102,15 @@ pub struct MetadataOnlyOutcome {
 /// rows — that is the MCP server's responsibility (it owns the
 /// per-tool-call session boundary).
 ///
-/// TODO Phase 2.x: write the metadata TOML to the store after the
-/// orchestrator path is proven; the spec entry in `docs/MCP_TOOLS.md`
-/// §11 lists this as a SIDE EFFECT but Phase 2 store invariants
-/// (which directory, schema_version handling) are out of scope for
-/// Slice 1.
+/// This function is the **pure resolver**: it consults the source(s)
+/// and emits provenance rows, but it does NOT write to the store.
+/// The `docs/MCP_TOOLS.md` §11 store-write SIDE EFFECT is provided by
+/// [`metadata_only_to_store`], which wraps this and persists the
+/// metadata TOML to `<root>/.metadata/<safekey>.toml`. Keeping the
+/// store-write in a *separate* entry point is exactly what lets
+/// [`resolve_only`] safely delegate here — its contract forbids any
+/// store write, and a pure `metadata_only` can never regress that
+/// invariant (#139).
 ///
 /// # Errors
 ///
@@ -123,8 +127,8 @@ pub async fn metadata_only(
         Ref::Arxiv(id) => {
             let arxiv = arxiv_source_from_env();
             let metadata = arxiv.fetch_metadata_only(id, ctx).await?;
-            // TODO Phase 2.x: write metadata TOML to store after
-            // orchestrator path is proven.
+            // Pure resolver — no store write here (see fn doc); the
+            // store-write side effect lives in `metadata_only_to_store`.
             Ok(MetadataOnlyOutcome {
                 source: arxiv.name().to_string(),
                 resolver_profile: arxiv.name().to_string(),
@@ -150,18 +154,15 @@ pub async fn metadata_only(
 ///
 /// # Why this exists as a distinct orchestrator
 ///
-/// Today [`metadata_only`] does not write to the store (the Phase 2.x
-/// TODO inside `metadata_only_doi` and the arXiv branch), so the two
-/// functions are functionally identical. When Phase 2.x lands the store
-/// write for `metadata_only`, [`resolve_only`] MUST NOT pick it up —
-/// the future divergence is the entire reason this function exists.
-///
-/// Concretely: when the Phase 2.x change happens, this function must be
-/// refactored to call the **inner** dispatchers (`metadata_only_doi` for
-/// DOI, the arXiv-Atom path for arXiv) directly with the store-write
-/// step **excluded**, rather than continuing to delegate to
-/// [`metadata_only`]. The audit-trail / provenance-row emission is
-/// retained either way.
+/// [`metadata_only`] is the **pure resolver** and never writes to the
+/// store; the store-write SIDE EFFECT lives only in the separate
+/// [`metadata_only_to_store`] wrapper. Because the write is in a
+/// *different* entry point that this function does not call,
+/// delegating to [`metadata_only`] is permanently safe — there is no
+/// code path by which `resolve_only` can acquire a store write, now or
+/// in future (#139). This structural separation is the entire reason
+/// `metadata_only` was split into a pure core + a persisting wrapper
+/// rather than gaining a `write: bool` parameter.
 ///
 /// # Dispatch
 ///
@@ -184,13 +185,158 @@ pub async fn resolve_only(
     profile: &CapabilityProfile,
     ctx: &FetchContext,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
-    // Slice 7: delegate to `metadata_only` because the latter does not
-    // yet write to the store. When Phase 2.x adds the store-write to
-    // `metadata_only`, this delegation MUST be replaced with a direct
-    // call to the inner dispatchers (`metadata_only_doi` + the arXiv
-    // Atom path) with the store-write step excluded. See the function
-    // doc-comment for the binding contract.
+    // Delegating to the PURE `metadata_only` is the contract-correct
+    // implementation, not a placeholder: `metadata_only` never writes
+    // to the store (the persisting path is the separate
+    // `metadata_only_to_store`, which this function does not call), so
+    // `resolve_only`'s "no store mutation" guarantee holds structurally
+    // and cannot regress (#139).
     metadata_only(ref_, profile, ctx).await
+}
+
+/// Resolve a [`Ref`] to metadata **and persist the metadata TOML to the
+/// store** — the `docs/MCP_TOOLS.md` §11 `doiget_metadata_only` SIDE
+/// EFFECT (#139).
+///
+/// Wraps the pure [`metadata_only`]: it runs the same resolver dispatch
+/// (so the provenance hash chain is identical), then writes
+/// `<root>/.metadata/<safekey>.toml` via the same
+/// [`write_metadata_and_pdf`] path `fetch_paper` uses for its
+/// metadata-only fallback, emitting one `StoreWrite` provenance row.
+///
+/// [`resolve_only`] MUST NOT call this — its contract forbids any store
+/// write. The split (pure core vs. persisting wrapper) makes that
+/// invariant structural rather than a convention.
+///
+/// # Errors
+///
+/// [`FetchError`] from the underlying resolver dispatch, or
+/// [`FetchError::SourceSchema`] if the store write fails (the
+/// `StoreWrite` failure row is recorded before the error propagates,
+/// fail-closed per `docs/PROVENANCE_LOG.md`).
+pub async fn metadata_only_to_store(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &dyn Store,
+) -> Result<MetadataOnlyOutcome, FetchError> {
+    let outcome = metadata_only(ref_, profile, ctx).await?;
+    let safekey = ref_.safekey();
+    let metadata = build_metadata_only_metadata(ref_, &outcome);
+    // `pdf_src = None` => writes `<root>/.metadata/<safekey>.toml` and
+    // appends the `StoreWrite` row (the exact path `fetch_paper` uses
+    // for its DOI metadata-only fallback).
+    write_metadata_and_pdf(store, &safekey, &metadata, None, ctx)?;
+    Ok(outcome)
+}
+
+/// Build the [`Metadata`] persisted by [`metadata_only_to_store`].
+///
+/// Minimal but valid: enough that a subsequent `doiget_info` returns a
+/// non-null `metadata` object (the #139 acceptance criterion). Title is
+/// best-effort from the resolver payload (`title` as a string, or the
+/// first element if it is an array — Crossref's `message.title` is an
+/// array, arXiv/Unpaywall a string); it falls back to the ref id so the
+/// required `title` field is never empty. Bibliographic enrichment
+/// (year, venue, …) is intentionally out of scope here — the
+/// metadata-only contract is "persist what the resolver returned", and
+/// the raw payload is preserved verbatim in `MetadataOnlyOutcome`.
+fn build_metadata_only_metadata(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Metadata {
+    let (doi, arxiv_id) = match ref_ {
+        Ref::Doi(d) => (Some(d.clone()), None),
+        Ref::Arxiv(a) => (None, Some(a.clone())),
+    };
+    let ref_id = match ref_ {
+        Ref::Doi(d) => d.as_str().to_string(),
+        Ref::Arxiv(a) => a.as_str().to_string(),
+    };
+    let title = extract_metadata_title(&outcome.metadata).unwrap_or(ref_id);
+    Metadata {
+        schema_version: SCHEMA_VERSION.to_string(),
+        title,
+        authors: extract_metadata_authors(&outcome.metadata),
+        year: None,
+        doi,
+        arxiv_id,
+        abstract_: None,
+        venue: None,
+        publisher: None,
+        issn: None,
+        isbn: None,
+        type_: None,
+        keywords: Vec::new(),
+        url: outcome.oa_url.clone(),
+        pdf_path: None,
+        doiget: Some(DoigetExtension {
+            fetched_at: Utc::now(),
+            source: outcome.source.clone(),
+            license: outcome
+                .license
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+            size_bytes: 0,
+            mcp_call_id: None,
+        }),
+        other: BTreeMap::new(),
+    }
+}
+
+/// `title` from a resolver payload: a bare string, or the first element
+/// of an array (Crossref `message.title` is `[String]`). `None` if
+/// absent/blank.
+fn extract_metadata_title(meta: &Value) -> Option<String> {
+    let t = meta.get("title")?;
+    let s = t.as_str().map(str::to_string).or_else(|| {
+        t.as_array()?
+            .iter()
+            .find_map(|v| v.as_str())
+            .map(str::to_string)
+    })?;
+    let s = s.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Best-effort author list, tolerant of the three resolver shapes:
+/// Crossref `author: [{given,family}]`, Unpaywall `z_authors:
+/// [{given,family}]`, arXiv `authors: [String]`. Returns `Vec::new()`
+/// when none are parseable (a valid metadata TOML — #139 only requires
+/// the entry to exist and be readable).
+fn extract_metadata_authors(meta: &Value) -> Vec<String> {
+    if let Some(arr) = meta.get("authors").and_then(Value::as_array) {
+        let v: Vec<String> = arr
+            .iter()
+            .filter_map(|a| a.as_str().map(str::to_string))
+            .collect();
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    for key in ["author", "z_authors"] {
+        if let Some(arr) = meta.get(key).and_then(Value::as_array) {
+            let v: Vec<String> = arr
+                .iter()
+                .filter_map(|a| {
+                    let given = a.get("given").and_then(Value::as_str).unwrap_or("");
+                    let family = a.get("family").and_then(Value::as_str).unwrap_or("");
+                    let name = format!("{given} {family}");
+                    let name = name.trim();
+                    if name.is_empty() {
+                        a.get("name").and_then(Value::as_str).map(str::to_string)
+                    } else {
+                        Some(name.to_string())
+                    }
+                })
+                .collect();
+            if !v.is_empty() {
+                return v;
+            }
+        }
+    }
+    Vec::new()
 }
 
 // ---------------------------------------------------------------------------
@@ -253,8 +399,8 @@ async fn metadata_only_doi(
         Ok(res) => {
             let metadata = res.metadata_json.unwrap_or(Value::Null);
             let oa_url = extract_crossref_oa_url(&metadata);
-            // TODO Phase 2.x: write metadata TOML to store after
-            // orchestrator path is proven.
+            // Pure resolver — no store write here (see `metadata_only`
+            // doc); persistence is `metadata_only_to_store`'s job.
             Ok(MetadataOnlyOutcome {
                 source: crossref.name().to_string(),
                 resolver_profile: crossref.name().to_string(),
@@ -1714,5 +1860,145 @@ mod tests {
         assert_eq!(dc_pre.hop_index, None);
         assert_eq!(dc_pre.cap, None);
         assert_eq!(dc_pre.actual, None);
+    }
+
+    // -----------------------------------------------------------------
+    // #139 — metadata_only_to_store writes the metadata TOML;
+    //        resolve_only / pure metadata_only write NOTHING.
+    // -----------------------------------------------------------------
+
+    /// Build a ctx + FsStore under a fresh tempdir and point Crossref at
+    /// a wiremock origin that returns one minimal `message`. Returns
+    /// `(server, ctx, store, store_root, _td)` — `_td` keeps the tempdir
+    /// alive for the test body.
+    async fn md139_harness() -> (
+        wiremock::MockServer,
+        FetchContext,
+        crate::store::FsStore,
+        Utf8PathBuf,
+        tempfile::TempDir,
+    ) {
+        use crate::http::HttpClient;
+        use crate::provenance::ProvenanceLog;
+        use crate::rate_limiter::RateLimiter;
+        use crate::store::FsStore;
+        use crate::RateLimits;
+        use std::sync::Arc;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"status":"ok","message":{"title":["Example Paper"],"author":[{"given":"Ada","family":"Lovelace"}]}}"#,
+            ))
+            .mount(&server)
+            .await;
+        std::env::set_var("DOIGET_CROSSREF_BASE", server.uri());
+
+        // wiremock serves http://127.0.0.1:PORT; the production client is
+        // https_only, so the test ctx uses the allow-http test client
+        // scoped to the crossref/unpaywall source keys + the wiremock host.
+        let host = server
+            .uri()
+            .parse::<url::Url>()
+            .expect("uri")
+            .host_str()
+            .expect("host")
+            .to_string();
+
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let base = Utf8Path::from_path(td.path()).expect("utf-8");
+        let log_path = base.join("log.jsonl");
+        let store_root = base.join("papers");
+        let ctx = FetchContext {
+            http: Arc::new(HttpClient::new_for_tests_allow_http_multi(&[
+                ("crossref", &host),
+                ("unpaywall", &host),
+            ])),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log: Arc::new(
+                ProvenanceLog::open(log_path, "01J0000000000000000000TEST".into())
+                    .expect("provenance log"),
+            ),
+            session_id: "01J0000000000000000000TEST".into(),
+        };
+        let store = FsStore::new(store_root.clone()).expect("fs store");
+        (server, ctx, store, store_root, td)
+    }
+
+    fn metadata_dir_tomls(store_root: &Utf8Path) -> Vec<Utf8PathBuf> {
+        let md = store_root.join(".metadata");
+        match std::fs::read_dir(md.as_std_path()) {
+            Ok(rd) => rd
+                .filter_map(|e| e.ok())
+                .filter_map(|e| Utf8PathBuf::from_path_buf(e.path()).ok())
+                .filter(|p| p.extension() == Some("toml"))
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn metadata_only_to_store_writes_metadata_toml_139() {
+        let (_server, ctx, store, store_root, _td) = md139_harness().await;
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let ref_ = Ref::Doi(Doi("10.1234/example".to_string()));
+
+        let outcome = metadata_only_to_store(&ref_, &profile, &ctx, &store)
+            .await
+            .expect("metadata_only_to_store ok");
+        assert_eq!(outcome.source, "crossref");
+
+        let tomls = metadata_dir_tomls(&store_root);
+        assert_eq!(
+            tomls.len(),
+            1,
+            "exactly one .metadata/*.toml must be written (MCP_TOOLS.md §11 SIDE EFFECT, #139); got {tomls:?}"
+        );
+        let body = std::fs::read_to_string(&tomls[0]).expect("read metadata toml");
+        let meta: crate::store::Metadata = toml::from_str(&body).expect("parse metadata toml");
+        assert_eq!(meta.title, "Example Paper");
+        assert_eq!(
+            meta.doi.as_ref().map(|d| d.as_str()),
+            Some("10.1234/example")
+        );
+        let ext = meta.doiget.expect("[doiget] table present");
+        assert_eq!(ext.source, "crossref");
+        assert_eq!(ext.size_bytes, 0, "metadata-only entry has no PDF");
+
+        std::env::remove_var("DOIGET_CROSSREF_BASE");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn resolve_only_and_pure_metadata_only_write_nothing_139() {
+        let (_server, ctx, _store, store_root, _td) = md139_harness().await;
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let ref_ = Ref::Doi(Doi("10.1234/example".to_string()));
+
+        // resolve_only: contractually MUST NOT touch the store.
+        let r = resolve_only(&ref_, &profile, &ctx)
+            .await
+            .expect("resolve_only ok");
+        assert_eq!(r.source, "crossref");
+        assert!(
+            metadata_dir_tomls(&store_root).is_empty(),
+            "resolve_only MUST NOT write a metadata TOML (docs/MCP_TOOLS.md §1; #139)"
+        );
+
+        // The pure metadata_only is also write-free (the store-write
+        // lives only in metadata_only_to_store).
+        let m = metadata_only(&ref_, &profile, &ctx)
+            .await
+            .expect("metadata_only ok");
+        assert_eq!(m.source, "crossref");
+        assert!(
+            metadata_dir_tomls(&store_root).is_empty(),
+            "pure metadata_only MUST NOT write to the store (#139)"
+        );
+
+        std::env::remove_var("DOIGET_CROSSREF_BASE");
     }
 }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -210,7 +210,7 @@ pub async fn resolve_only(
 /// Wraps the pure [`metadata_only`]: it runs the same resolver dispatch
 /// (so the provenance hash chain is identical), then writes
 /// `<root>/.metadata/<safekey>.toml` via the same
-/// [`write_metadata_and_pdf`] path `fetch_paper` uses for its
+/// `write_metadata_and_pdf` path `fetch_paper` uses for its
 /// metadata-only fallback, emitting one `StoreWrite` provenance row.
 ///
 /// [`resolve_only`] MUST NOT call this — its contract forbids any store

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -117,11 +117,11 @@ pub struct MetadataOnlyOutcome {
 /// Returns [`FetchError`] from the underlying [`Source`] dispatch. The
 /// MCP boundary converts these to the closed [`crate::ErrorCode`] set
 /// via the existing `From<FetchError> for ErrorCode` impl.
-// Stays `pub` (a `pub(crate)` compile-time guard was evaluated for
-// PR #199 review I4 and rejected): `crates/doiget-core/tests/`
-// integration tests (`real_world_fixtures_e2e`) legitimately drive
-// the PURE resolver directly and assert its outcome, and `tests/`
-// compiles as a separate crate. The #139 pre-fix bug (an MCP caller
+// Stays `pub` (a `pub(crate)` compile-time guard was considered and
+// rejected): `crates/doiget-core/tests/` integration tests
+// (`real_world_fixtures_e2e`) legitimately drive the PURE resolver
+// directly and assert its outcome, and `tests/` compiles as a separate
+// crate. The #139 pre-fix bug (an MCP caller
 // picking the pure variant when it needed persistence) is instead
 // prevented *structurally*: the MCP layer imports only
 // `metadata_only_to_store`, and `resolve_only` delegates to this pure
@@ -219,9 +219,12 @@ pub async fn resolve_only(
 ///
 /// # Errors
 ///
-/// [`FetchError`] from the underlying resolver dispatch, or
-/// [`FetchError::SourceSchema`] if the store write fails. On store-write
-/// failure `write_metadata_and_pdf` makes a **best-effort** attempt to
+/// [`FetchError`] from the underlying resolver dispatch, or — if the
+/// store write fails — [`FetchError::SourceSchema`] (the closest
+/// closed-set arm; there is no dedicated `FetchError::StoreError`, so
+/// the MCP boundary maps it to `INTERNAL_ERROR` — see the inline note
+/// in `write_metadata_and_pdf`). On store-write failure
+/// `write_metadata_and_pdf` makes a **best-effort** attempt to
 /// append a `StoreWrite`/`Err` provenance row before the error
 /// propagates (that append's own failure is not separately surfaced —
 /// this matches the pre-existing `fetch_paper` metadata-only fallback
@@ -261,7 +264,22 @@ fn build_metadata_only_metadata(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Me
         Ref::Arxiv(a) => (None, Some(a.clone())),
     };
     let ref_id = ref_.as_input_str().to_string();
-    let title = extract_metadata_title(&outcome.metadata).unwrap_or(ref_id);
+    let title = match extract_metadata_title(&outcome.metadata) {
+        Some(t) => t,
+        None => {
+            // The resolver returned a payload with no usable title.
+            // Persisting the ref id keeps the entry valid (#139), but
+            // emit a diagnostic so a broken/partial resolver response is
+            // not silently indistinguishable from a genuine title.
+            tracing::warn!(
+                ref_id = %ref_id,
+                source = %outcome.source,
+                "metadata-only: no usable title in resolver payload; \
+                 persisting the ref id as the title placeholder"
+            );
+            ref_id
+        }
+    };
     Metadata {
         schema_version: SCHEMA_VERSION.to_string(),
         title,
@@ -292,22 +310,26 @@ fn build_metadata_only_metadata(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Me
     }
 }
 
-/// `title` from a resolver payload: a bare string, or the first element
-/// of an array (Crossref `message.title` is `[String]`). `None` if
-/// absent/blank.
+/// `title` from a resolver payload: a bare string, or the first
+/// **non-blank** element of an array (Crossref `message.title` is
+/// `[String]`; a leading empty/whitespace element is skipped rather
+/// than masking the real title). Trimmed. `None` if absent/blank.
 fn extract_metadata_title(meta: &Value) -> Option<String> {
     let t = meta.get("title")?;
-    let s = t.as_str().map(str::to_string).or_else(|| {
-        t.as_array()?
+    let s = match t.as_str() {
+        Some(s) => s.trim().to_string(),
+        None => t
+            .as_array()?
             .iter()
-            .find_map(|v| v.as_str())
-            .map(str::to_string)
-    })?;
-    let s = s.trim();
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .find(|s| !s.is_empty())?
+            .to_string(),
+    };
     if s.is_empty() {
         None
     } else {
-        Some(s.to_string())
+        Some(s)
     }
 }
 
@@ -2121,13 +2143,15 @@ mod tests {
         assert_eq!(extract_metadata_title(&json!({"title": "   "})), None);
         // empty array -> None
         assert_eq!(extract_metadata_title(&json!({"title": []})), None);
-        // Documented minimal behavior: the FIRST string element is taken
-        // then trimmed, so a leading blank element yields None (best-
-        // effort; caller falls back to the ref id — acceptable per #139).
+        // A leading blank/whitespace array element is SKIPPED — the first
+        // non-blank element is taken (a stray leading empty element must
+        // not mask the real Crossref title).
         assert_eq!(
             extract_metadata_title(&json!({"title": ["  ", "Real Title"]})),
-            None
+            Some("Real Title".to_string())
         );
+        // all-blank array -> None (caller falls back to ref id)
+        assert_eq!(extract_metadata_title(&json!({"title": ["  ", ""]})), None);
     }
 
     #[test]

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -117,6 +117,15 @@ pub struct MetadataOnlyOutcome {
 /// Returns [`FetchError`] from the underlying [`Source`] dispatch. The
 /// MCP boundary converts these to the closed [`crate::ErrorCode`] set
 /// via the existing `From<FetchError> for ErrorCode` impl.
+// Stays `pub` (a `pub(crate)` compile-time guard was evaluated for
+// PR #199 review I4 and rejected): `crates/doiget-core/tests/`
+// integration tests (`real_world_fixtures_e2e`) legitimately drive
+// the PURE resolver directly and assert its outcome, and `tests/`
+// compiles as a separate crate. The #139 pre-fix bug (an MCP caller
+// picking the pure variant when it needed persistence) is instead
+// prevented *structurally*: the MCP layer imports only
+// `metadata_only_to_store`, and `resolve_only` delegates to this pure
+// fn — neither can acquire or skip the store-write by mistake.
 pub async fn metadata_only(
     ref_: &Ref,
     profile: &CapabilityProfile,
@@ -211,9 +220,12 @@ pub async fn resolve_only(
 /// # Errors
 ///
 /// [`FetchError`] from the underlying resolver dispatch, or
-/// [`FetchError::SourceSchema`] if the store write fails (the
-/// `StoreWrite` failure row is recorded before the error propagates,
-/// fail-closed per `docs/PROVENANCE_LOG.md`).
+/// [`FetchError::SourceSchema`] if the store write fails. On store-write
+/// failure `write_metadata_and_pdf` makes a **best-effort** attempt to
+/// append a `StoreWrite`/`Err` provenance row before the error
+/// propagates (that append's own failure is not separately surfaced —
+/// this matches the pre-existing `fetch_paper` metadata-only fallback
+/// path and is out of scope for #139).
 pub async fn metadata_only_to_store(
     ref_: &Ref,
     profile: &CapabilityProfile,
@@ -235,9 +247,11 @@ pub async fn metadata_only_to_store(
 /// Minimal but valid: enough that a subsequent `doiget_info` returns a
 /// non-null `metadata` object (the #139 acceptance criterion). Title is
 /// best-effort from the resolver payload (`title` as a string, or the
-/// first element if it is an array — Crossref's `message.title` is an
-/// array, arXiv/Unpaywall a string); it falls back to the ref id so the
-/// required `title` field is never empty. Bibliographic enrichment
+/// first element if it is an array — Crossref's `message.title` is
+/// typically an array, arXiv/Unpaywall typically a string; the
+/// extractor tolerates either regardless of source); it falls back to
+/// the ref id so the required `title` field is never empty.
+/// Bibliographic enrichment
 /// (year, venue, …) is intentionally out of scope here — the
 /// metadata-only contract is "persist what the resolver returned", and
 /// the raw payload is preserved verbatim in `MetadataOnlyOutcome`.
@@ -246,10 +260,7 @@ fn build_metadata_only_metadata(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Me
         Ref::Doi(d) => (Some(d.clone()), None),
         Ref::Arxiv(a) => (None, Some(a.clone())),
     };
-    let ref_id = match ref_ {
-        Ref::Doi(d) => d.as_str().to_string(),
-        Ref::Arxiv(a) => a.as_str().to_string(),
-    };
+    let ref_id = ref_.as_input_str().to_string();
     let title = extract_metadata_title(&outcome.metadata).unwrap_or(ref_id);
     Metadata {
         schema_version: SCHEMA_VERSION.to_string(),
@@ -300,11 +311,16 @@ fn extract_metadata_title(meta: &Value) -> Option<String> {
     }
 }
 
-/// Best-effort author list, tolerant of the three resolver shapes:
-/// Crossref `author: [{given,family}]`, Unpaywall `z_authors:
-/// [{given,family}]`, arXiv `authors: [String]`. Returns `Vec::new()`
-/// when none are parseable (a valid metadata TOML — #139 only requires
-/// the entry to exist and be readable).
+/// Best-effort author list, tolerant of the resolver shapes we may see:
+/// Crossref `author: [{given,family}]`, arXiv `authors: [String]`, and
+/// a `z_authors: [{given,family}]` fallback. NOTE: doiget's Unpaywall
+/// source deserializes a *partial* `UnpaywallWork` that does not capture
+/// `z_authors`, so the `z_authors` branch is currently inert for the
+/// Unpaywall path (kept as forward-compat for if/when that struct
+/// captures it) — Unpaywall-sourced metadata-only entries get an empty
+/// author list. Returns `Vec::new()` when nothing is parseable (a valid
+/// metadata TOML — #139 only requires the entry to exist and be
+/// readable).
 fn extract_metadata_authors(meta: &Value) -> Vec<String> {
     if let Some(arr) = meta.get("authors").and_then(Value::as_array) {
         let v: Vec<String> = arr
@@ -2000,5 +2016,150 @@ mod tests {
         );
 
         std::env::remove_var("DOIGET_CROSSREF_BASE");
+    }
+
+    /// #139 — the arXiv branch of `metadata_only_to_store` must also
+    /// write the metadata TOML (different code path: Atom feed,
+    /// source="arxiv", license="arxiv-default", doi=None). Review I3/C1.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn metadata_only_to_store_arxiv_writes_metadata_toml_139() {
+        use crate::http::HttpClient;
+        use crate::provenance::ProvenanceLog;
+        use crate::rate_limiter::RateLimiter;
+        use crate::store::FsStore;
+        use crate::RateLimits;
+        use std::sync::Arc;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let atom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <published>2024-01-15T00:00:00Z</published>
+    <title>Example arXiv Paper Title</title>
+    <summary>Example abstract.</summary>
+    <author><name>Jane Doe</name></author>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"#;
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(atom))
+            .mount(&server)
+            .await;
+        std::env::set_var("DOIGET_ARXIV_BASE", server.uri());
+        let host = server
+            .uri()
+            .parse::<url::Url>()
+            .expect("uri")
+            .host_str()
+            .expect("host")
+            .to_string();
+
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let base = Utf8Path::from_path(td.path()).expect("utf-8");
+        let store_root = base.join("papers");
+        let ctx = FetchContext {
+            http: Arc::new(HttpClient::new_for_tests_allow_http("arxiv", &host)),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log: Arc::new(
+                ProvenanceLog::open(base.join("log.jsonl"), "01J0000000000000000000TEST".into())
+                    .expect("provenance log"),
+            ),
+            session_id: "01J0000000000000000000TEST".into(),
+        };
+        let store = FsStore::new(store_root.clone()).expect("fs store");
+        let profile = CapabilityProfile::from_env().expect("clean env");
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+
+        let outcome = metadata_only_to_store(&ref_, &profile, &ctx, &store)
+            .await
+            .expect("metadata_only_to_store (arxiv) ok");
+        assert_eq!(outcome.source, "arxiv");
+
+        let tomls = metadata_dir_tomls(&store_root);
+        assert_eq!(
+            tomls.len(),
+            1,
+            "arXiv metadata-only must write one TOML; got {tomls:?}"
+        );
+        let meta: crate::store::Metadata =
+            toml::from_str(&std::fs::read_to_string(&tomls[0]).expect("read")).expect("parse");
+        assert_eq!(meta.title, "Example arXiv Paper Title");
+        assert_eq!(
+            meta.arxiv_id.as_ref().map(|a| a.as_str()),
+            Some("2401.12345")
+        );
+        assert!(meta.doi.is_none(), "arXiv entry has no DOI");
+        let ext = meta.doiget.expect("[doiget] table");
+        assert_eq!(ext.source, "arxiv");
+        assert_eq!(ext.license, "arxiv-default");
+
+        std::env::remove_var("DOIGET_ARXIV_BASE");
+    }
+
+    // ----- pure-function unit tests for the #139 extraction helpers ----
+
+    #[test]
+    fn extract_metadata_title_handles_string_array_missing_blank() {
+        use serde_json::json;
+        // bare string (arXiv/Unpaywall shape)
+        assert_eq!(
+            extract_metadata_title(&json!({"title": "Hello"})),
+            Some("Hello".to_string())
+        );
+        // single-element array (Crossref `message.title` in practice)
+        assert_eq!(
+            extract_metadata_title(&json!({"title": ["Real Title"]})),
+            Some("Real Title".to_string())
+        );
+        // missing key -> None (caller falls back to ref id)
+        assert_eq!(extract_metadata_title(&json!({"x": 1})), None);
+        // blank string -> None (must not persist an empty title)
+        assert_eq!(extract_metadata_title(&json!({"title": "   "})), None);
+        // empty array -> None
+        assert_eq!(extract_metadata_title(&json!({"title": []})), None);
+        // Documented minimal behavior: the FIRST string element is taken
+        // then trimmed, so a leading blank element yields None (best-
+        // effort; caller falls back to the ref id — acceptable per #139).
+        assert_eq!(
+            extract_metadata_title(&json!({"title": ["  ", "Real Title"]})),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_metadata_authors_handles_each_resolver_shape() {
+        use serde_json::json;
+        // arXiv: authors: [String]
+        assert_eq!(
+            extract_metadata_authors(&json!({"authors": ["Jane Doe", "John Roe"]})),
+            vec!["Jane Doe".to_string(), "John Roe".to_string()]
+        );
+        // Crossref: author: [{given,family}]
+        assert_eq!(
+            extract_metadata_authors(&json!({"author": [{"given": "Ada", "family": "Lovelace"}]})),
+            vec!["Ada Lovelace".to_string()]
+        );
+        // family-only (given absent) -> trimmed, no leading space
+        assert_eq!(
+            extract_metadata_authors(&json!({"author": [{"family": "Onsager"}]})),
+            vec!["Onsager".to_string()]
+        );
+        // `name` fallback when given+family both absent
+        assert_eq!(
+            extract_metadata_authors(&json!({"author": [{"name": "K. Wilson"}]})),
+            vec!["K. Wilson".to_string()]
+        );
+        // z_authors fallback shape (forward-compat branch)
+        assert_eq!(
+            extract_metadata_authors(&json!({"z_authors": [{"given": "L", "family": "Kadanoff"}]})),
+            vec!["L Kadanoff".to_string()]
+        );
+        // nothing parseable -> empty (still a valid TOML)
+        assert!(extract_metadata_authors(&json!({"x": 1})).is_empty());
+        assert!(extract_metadata_authors(&json!({"authors": []})).is_empty());
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -47,8 +47,8 @@ use doiget_core::dry_run::{
 use doiget_core::http::{oa_publisher_allowlist, tier_1_allowlist, tier_2_allowlist, HttpClient};
 use doiget_core::orchestrator::{
     batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
-    metadata_only, resolve_only as core_resolve_only, FetchPaperOutcome, MetadataOnlyOutcome,
-    PdfLegStatus,
+    metadata_only_to_store, resolve_only as core_resolve_only, FetchPaperOutcome,
+    MetadataOnlyOutcome, PdfLegStatus,
 };
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
@@ -291,7 +291,32 @@ impl Server {
             )));
         }
 
-        let outcome = metadata_only(&ref_, &self.profile, &ctx).await;
+        // §11 SIDE EFFECT: persist the metadata TOML to the store
+        // (#139). Resolve the store root + open the FsStore the same way
+        // `doiget_fetch_paper` does; a store-init failure is surfaced as
+        // an error envelope (the resolver work has not run yet).
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    "store root could not be resolved (set DOIGET_STORE_ROOT or $HOME)",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
+        let outcome = metadata_only_to_store(&ref_, &self.profile, &ctx, &store).await;
 
         // SessionEnd bookend. Best-effort: if this append fails we still
         // surface the orchestrator's outcome (a fresh log error here

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -189,7 +189,7 @@ impl Server {
     ///
     /// Per `docs/MCP_TOOLS.md` §11 (NORMATIVE).
     ///
-    /// Slice 1 wired both branches:
+    /// Both branches are wired:
     ///
     /// - `dry_run: true` → builds a [`FetchPlan`] preview and returns
     ///   it without touching the network, store, or provenance log
@@ -254,8 +254,9 @@ impl Server {
         }
 
         // Step 3: non-dry-run path. Dispatch through the
-        // `metadata_only` orchestrator (Slice 1). The orchestrator owns
-        // source selection and per-leg politeness; we own the per-call
+        // `metadata_only_to_store` orchestrator (resolves metadata AND
+        // writes the §11 metadata TOML). The orchestrator owns source
+        // selection and per-leg politeness; we own the per-call
         // session boundary (SessionStart / SessionEnd bookend rows) and
         // the wire envelope shape (`docs/MCP_TOOLS.md` §11).
         let ctx = match build_fetch_context() {
@@ -274,9 +275,9 @@ impl Server {
         // `doiget_fetch_paper` does — and crucially do this BEFORE the
         // `SessionStart` bookend, so a store-init failure cannot leave an
         // orphaned `SessionStart` with no `SessionEnd` in the fail-closed
-        // provenance log (PR #199 review C1). Mirrors
-        // `doiget_fetch_paper`'s ordering. `StoreError` matches every
-        // other `FsStore::new` failure site in this file (review C2).
+        // provenance log. Mirrors `doiget_fetch_paper`'s ordering.
+        // `StoreError` matches every other `FsStore::new` failure site
+        // in this file.
         let store_root = match resolve_store_root() {
             Some(p) => p,
             None => {
@@ -383,7 +384,7 @@ impl Server {
     /// row is emitted (no store mutation).
     ///
     /// `dry_run` is **not** a supported input field per
-    /// `docs/MCP_TOOLS.md` §10/§11 (the spec lists `doiget_resolve_paper`
+    /// `docs/MCP_TOOLS.md` §10 (the spec lists `doiget_resolve_paper`
     /// in the "dry_run does not apply" set). The schema's
     /// `deny_unknown_fields` posture rejects an attempted `dry_run`
     /// field at deserialize time, which surfaces as the rmcp transport's

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -12,13 +12,15 @@
 //! - `doiget_capability_profile` — reports the runtime [`CapabilityProfile`].
 //! - `doiget_metadata_only` — DOI / arXiv id metadata resolution. Both
 //!   the `dry_run: true` preview path (ADR-0022) and the live
-//!   non-dry-run path (Slice 1: dispatches through
-//!   [`doiget_core::orchestrator::metadata_only`]) are wired. The
-//!   tool MUST NOT call `HttpClient::fetch_pdf` — that contract is
-//!   enforced by the orchestrator and the posture-lint workflow.
+//!   non-dry-run path (dispatches through
+//!   [`doiget_core::orchestrator::metadata_only_to_store`], which also
+//!   performs the `docs/MCP_TOOLS.md` §11 store-write SIDE EFFECT) are
+//!   wired. The tool MUST NOT call `HttpClient::fetch_pdf` — that
+//!   contract is enforced by the orchestrator and the posture-lint
+//!   workflow.
 //!
-//! The remaining tools named in `docs/MCP_TOOLS.md` (`doiget_resolve_paper`,
-//! `doiget_fetch_paper`, `doiget_batch_fetch`, `doiget_info`,
+//! The remaining tools named in `docs/MCP_TOOLS.md` (`doiget_fetch_paper`,
+//! `doiget_batch_fetch`, `doiget_info`,
 //! `doiget_search_local`, `doiget_list_recent`, `doiget_paper_pdf_path`)
 //! land in follow-up PRs. The exact count is intentionally left unstated
 //! in this docstring so it does not rot as tools land.
@@ -193,7 +195,9 @@ impl Server {
     ///   it without touching the network, store, or provenance log
     ///   (ADR-0022 §2).
     /// - `dry_run: false` (default) → dispatches through
-    ///   [`doiget_core::orchestrator::metadata_only`]:
+    ///   [`doiget_core::orchestrator::metadata_only_to_store`] (which
+    ///   resolves the metadata **and** writes the `docs/MCP_TOOLS.md`
+    ///   §11 metadata TOML to the store):
     ///   - DOI → Crossref (`message` metadata + OA URL via
     ///     `message.link[]`), with Unpaywall as a fallback when
     ///     Crossref fails.
@@ -265,10 +269,41 @@ impl Server {
             }
         };
 
+        // §11 SIDE EFFECT: persist the metadata TOML to the store
+        // (#139). Resolve the store root + open the FsStore the same way
+        // `doiget_fetch_paper` does — and crucially do this BEFORE the
+        // `SessionStart` bookend, so a store-init failure cannot leave an
+        // orphaned `SessionStart` with no `SessionEnd` in the fail-closed
+        // provenance log (PR #199 review C1). Mirrors
+        // `doiget_fetch_paper`'s ordering. `StoreError` matches every
+        // other `FsStore::new` failure site in this file (review C2).
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    "store root could not be resolved (set DOIGET_STORE_ROOT or $HOME)",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(metadata_only_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
         // SessionStart bookend (mirrors the CLI orchestrator pattern in
         // `crates/doiget-cli/src/commands/fetch.rs::FetchHarness::log_session_start`).
         // A log-append failure here is fail-closed per
-        // `docs/PROVENANCE_LOG.md` §5 — abort the call.
+        // `docs/PROVENANCE_LOG.md` §5 — abort the call. Store init above
+        // is the only fallible step before this point and it cannot have
+        // emitted a row, so there is no orphaned-session window.
         if let Err(e) = ctx.log.append(RowInput {
             event: LogEvent::SessionStart,
             result: LogResult::Ok,
@@ -290,31 +325,6 @@ impl Server {
                 &format!("SessionStart append failed: {e}"),
             )));
         }
-
-        // §11 SIDE EFFECT: persist the metadata TOML to the store
-        // (#139). Resolve the store root + open the FsStore the same way
-        // `doiget_fetch_paper` does; a store-init failure is surfaced as
-        // an error envelope (the resolver work has not run yet).
-        let store_root = match resolve_store_root() {
-            Some(p) => p,
-            None => {
-                return Ok(CallToolResult::structured(metadata_only_error_envelope(
-                    Some(&input.ref_),
-                    ErrorCode::InternalError,
-                    "store root could not be resolved (set DOIGET_STORE_ROOT or $HOME)",
-                )));
-            }
-        };
-        let store = match FsStore::new(store_root.clone()) {
-            Ok(s) => s,
-            Err(e) => {
-                return Ok(CallToolResult::structured(metadata_only_error_envelope(
-                    Some(&input.ref_),
-                    ErrorCode::InternalError,
-                    &format!("opening store at {store_root}: {e}"),
-                )));
-            }
-        };
 
         let outcome = metadata_only_to_store(&ref_, &self.profile, &ctx, &store).await;
 
@@ -359,9 +369,12 @@ impl Server {
     /// Per `docs/MCP_TOOLS.md` §1 (Phase 3 baseline tool list — Slice 7).
     ///
     /// Delegates to [`core_resolve_only`], whose binding contract is that
-    /// no metadata TOML is ever written to the store — present or future
-    /// (when Phase 2.x adds the store-write to `metadata_only`, the
-    /// orchestrator-level divergence kicks in there, not here).
+    /// no metadata TOML is ever written to the store. This holds
+    /// **structurally**: `core_resolve_only` delegates to the *pure*
+    /// `orchestrator::metadata_only`, while the §11 store-write lives in
+    /// the separate `orchestrator::metadata_only_to_store` (which this
+    /// path never calls). The divergence is enforced by construction,
+    /// not by a future-slice convention (#139).
     ///
     /// Per-call boundary semantics mirror [`Self::doiget_metadata_only`]:
     /// the MCP server emits `SessionStart` / `SessionEnd` bookend rows,
@@ -370,7 +383,7 @@ impl Server {
     /// row is emitted (no store mutation).
     ///
     /// `dry_run` is **not** a supported input field per
-    /// `docs/MCP_TOOLS.md` §10/§211 (the spec lists `doiget_resolve_paper`
+    /// `docs/MCP_TOOLS.md` §10/§11 (the spec lists `doiget_resolve_paper`
     /// in the "dry_run does not apply" set). The schema's
     /// `deny_unknown_fields` posture rejects an attempted `dry_run`
     /// field at deserialize time, which surfaces as the rmcp transport's
@@ -1971,9 +1984,10 @@ fn batch_fetch_error_envelope(code: ErrorCode, message: &str) -> Value {
 /// path.
 ///
 /// Mirrors `crates/doiget-cli/src/commands/fetch.rs::FetchHarness::from_env`
-/// minus the on-disk store (which the orchestrator does not touch in
-/// Slice 1 — see the `TODO Phase 2.x` in
-/// `crates/doiget-core/src/orchestrator.rs::metadata_only`):
+/// minus the on-disk store: the `FetchContext` carries no store handle
+/// because the store is opened per-call in `doiget_metadata_only` and
+/// passed explicitly to `orchestrator::metadata_only_to_store` (the §11
+/// store-write entry point), keeping the context store-agnostic:
 ///
 /// - `HttpClient` — production allowlist (Tier 1 ∪ OA publisher), or
 ///   the test-mode multi-source allowlist when any `DOIGET_*_BASE` env

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -600,6 +600,96 @@ async fn doiget_metadata_only_doi_crossref_happy_path_returns_metadata_envelope(
     Ok(())
 }
 
+/// #139 literal acceptance + the headline regression guard: after
+/// `doiget_metadata_only`, `doiget_info` on the same ref MUST return a
+/// non-null `metadata` (i.e. the §11 store-write actually happened).
+/// This is the ONE test that fails if the mcp handler is ever rewired
+/// back to the pure `metadata_only` (no store-write) instead of
+/// `metadata_only_to_store` (PR #199 2nd-pass review).
+#[tokio::test]
+#[serial_test::serial]
+async fn doiget_metadata_only_then_doiget_info_returns_non_null_metadata() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/example"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{"status":"ok","message":{"title":["Example Paper"]}}"#),
+        )
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let base = camino::Utf8Path::from_path(td.path()).expect("tempdir is utf-8");
+    let log_path = base.join("mcp-meta.jsonl");
+    let store_root = base.join("papers");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_LOG_PATH",
+        "DOIGET_STORE_ROOT",
+    ]);
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    // Pin the store to the tempdir so the §11 write does NOT land in the
+    // developer's real ~/papers/, and so doiget_info reads it back here.
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut meta_args = serde_json::Map::new();
+    meta_args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    let meta = client
+        .peer()
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new("doiget_metadata_only")
+                .with_arguments(meta_args),
+        )
+        .await?;
+    let meta_s = meta
+        .structured_content
+        .as_ref()
+        .expect("doiget_metadata_only structured");
+    assert_eq!(
+        meta_s["ok"],
+        serde_json::json!(true),
+        "metadata_only envelope: {meta_s:?}"
+    );
+
+    let mut info_args = serde_json::Map::new();
+    info_args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    let info = client
+        .peer()
+        .call_tool(rmcp::model::CallToolRequestParams::new("doiget_info").with_arguments(info_args))
+        .await?;
+    let info_s = info
+        .structured_content
+        .as_ref()
+        .expect("doiget_info structured");
+    assert_eq!(info_s["ok"], serde_json::json!(true), "info: {info_s:?}");
+    assert!(
+        !info_s["metadata"].is_null(),
+        "doiget_info MUST return non-null metadata after doiget_metadata_only \
+         (the §11 store-write SIDE EFFECT, #139); got: {info_s:?}"
+    );
+    assert_eq!(
+        info_s["metadata"]["title"],
+        serde_json::json!("Example Paper"),
+        "persisted title round-trips through doiget_info; got: {info_s:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn doiget_metadata_only_network_failure_returns_network_error_envelope() -> anyhow::Result<()>


### PR DESCRIPTION
**PR 2 of the sequential stack. Base: `fix/157-license-mit` (PR #198 —
merge that first). 1 issue = 1 PR = 1 beta up. I do not merge.**

## #139 — metadata_only / resolve_only never wrote the metadata TOML

`docs/MCP_TOOLS.md` §11 (NORMATIVE) requires `doiget_metadata_only` to
write `<root>/.metadata/<safekey>.toml` as a SIDE EFFECT. The
orchestrator carried `TODO Phase 2.x` and skipped it → `doiget_info`
after `doiget_metadata_only` returned `metadata: null`. Coupled hazard
(per the issue): `resolve_only` delegated to `metadata_only`, so naïvely
adding the write there would silently break `resolve_only`'s
"NEVER writes" contract (§1).

## Design (minimal blast radius, contract-safe)

- `metadata_only` stays the **pure resolver** — unchanged signature, no
  store write.
- New `metadata_only_to_store(ref, profile, ctx, store)` wrapper does the
  §11 write via the **same** `write_metadata_and_pdf` path `fetch_paper`
  uses for its metadata-only fallback (one `StoreWrite` provenance row).
- mcp `doiget_metadata_only` opens an `FsStore` (same pattern as
  `doiget_fetch_paper`) and calls the wrapper.
- `doiget_resolve_paper` keeps delegating to the **pure** `metadata_only`;
  the store-write lives in a separate entry point it never calls, so the
  §1 "no store write" guarantee is now **structural** and cannot regress
  — the issue's coupled hazard is removed by construction.

No existing public signature changed (smaller ripple than the issue's
literal "refactor resolve_only off the delegation" step; the divergence
is achieved by the pure/persisting split — documented in-code).

## Tests
- `metadata_only_to_store_writes_metadata_toml_139` — asserts a readable
  `Metadata` TOML (`title`, `doi`, `[doiget].source=crossref`,
  `size_bytes=0`).
- `resolve_only_and_pure_metadata_only_write_nothing_139` — asserts the
  store stays empty for both.
- Full orchestrator suite green (21/21); clippy + fmt clean.
- `release-version-gate.sh v0.2.1-beta.3` → PASS.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)