### PR TITLE
fix(core): accept ':' in DOI suffix (#194) [beta.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.5] - 2026-05-19
+
+### Fixed
+
+- **[core]** `Doi::parse` now accepts `:` in the DOI suffix (#194).
+  Legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`) and EDP Sciences /
+  Journal de Physique (`10.1051/jphys:NNNN`) DOIs — both resolvable at
+  doi.org and via Crossref — were previously rejected with
+  `INVALID_REF`, silently losing real papers from physics corpora (3/38
+  niche refs lost in the Ising-RG dogfood). `:` grants no path-traversal
+  capability beyond the already-permitted `/`, and `safekey` escapes it
+  before any filesystem use. `docs/SECURITY.md` §1.1 charset widened to
+  `[A-Za-z0-9._/():-]` per ADR-0026.
+
 ## [0.2.1-beta.4] - 2026-05-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.4"
+version = "0.2.1-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.4"
+version = "0.2.1-beta.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.4"
+version = "0.2.1-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.4"
+version       = "0.2.1-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -127,7 +127,8 @@ impl Doi {
     /// Accepts:
     /// - Bare DOIs: `10.<registrant>/<suffix>` where `<registrant>` is 4–9
     ///   digits and `<suffix>` is a non-empty sequence of characters drawn
-    ///   from `[A-Za-z0-9._/()-]`.
+    ///   from `[A-Za-z0-9._/():-]` (the `:` covers legacy Kluwer
+    ///   `10.1023/A:NNNN` and EDP Sciences `10.1051/jphys:NNNN` DOIs).
     /// - The `doi:` URI scheme prefix; it is stripped before validation, so
     ///   the stored value never carries a scheme. (Matches the convention
     ///   established in `docs/SAFEKEY.md` §3 step 0.)
@@ -275,13 +276,22 @@ mod parse {
     }
 
     /// DOI suffix charset per `docs/SECURITY.md` §1.1:
-    /// `[A-Za-z0-9._/()-]`. The forward slash is permitted inside the
+    /// `[A-Za-z0-9._/():-]`. The forward slash is permitted inside the
     /// suffix (e.g. `10.1016/...`); the registrant separator is the
     /// *first* `/` and the suffix is everything after it.
+    ///
+    /// `:` is permitted because two large real publisher DOI families use
+    /// it in the suffix — legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`)
+    /// and EDP Sciences / Journal de Physique
+    /// (`10.1051/jphys:NNNNNNNNNNNNNNNNN`). It adds no path-traversal
+    /// capability (traversal needs `/` + `..`, both already permitted) and
+    /// `safekey` independently escapes every char outside `[A-Za-z0-9._-]`
+    /// before any filesystem use, so `:` never reaches a path literally.
+    /// See ADR-0026 and `docs/SECURITY.md` §1.1.
     fn is_doi_suffix_char(c: char) -> bool {
         matches!(c,
             'A'..='Z' | 'a'..='z' | '0'..='9'
-            | '.' | '_' | '/' | '(' | ')' | '-'
+            | '.' | '_' | '/' | '(' | ')' | '-' | ':'
         )
     }
 
@@ -1702,6 +1712,26 @@ mod tests {
         // registrant/suffix separator.
         let d = Doi::parse("10.1234/foo/bar/baz").expect("nested slashes");
         assert_eq!(d.as_str(), "10.1234/foo/bar/baz");
+    }
+
+    #[test]
+    fn doi_parse_accepts_colon_in_legacy_kluwer_suffix() {
+        // #194: legacy Kluwer/Springer DOIs (`10.1023/A:NNNNNNNNNN`)
+        // carry a `:` in the suffix. Real DOI: "Entanglement, Quantum
+        // Phase Transitions, and DMRG" (Kluwer, 2002).
+        let d = Doi::parse("10.1023/A:1019601218492").expect("legacy Kluwer colon DOI");
+        assert_eq!(d.as_str(), "10.1023/A:1019601218492");
+    }
+
+    #[test]
+    fn doi_parse_accepts_colon_in_edp_jphys_suffix() {
+        // #194: EDP Sciences / Journal de Physique legacy corpus uses
+        // `10.1051/jphys:NNNNNNNNNNNNNNNNN`. Real DOIs from the dogfood
+        // Ising-RG run; both resolve at doi.org and via Crossref.
+        let d = Doi::parse("10.1051/jphys:0198900500120136500").expect("EDP jphys colon DOI");
+        assert_eq!(d.as_str(), "10.1051/jphys:0198900500120136500");
+        let d2 = Doi::parse("doi:10.1051/jphys:0198500460100164500").expect("scheme + colon");
+        assert_eq!(d2.as_str(), "10.1051/jphys:0198500460100164500");
     }
 
     #[test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -284,7 +284,8 @@ mod parse {
     /// it in the suffix — legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`)
     /// and EDP Sciences / Journal de Physique
     /// (`10.1051/jphys:NNNNNNNNNNNNNNNNN`). It adds no path-traversal
-    /// capability (traversal needs `/` + `..`, both already permitted) and
+    /// capability: traversal requires composing `/` and `.` into `../`,
+    /// and both characters are already in the suffix charset. In addition,
     /// `safekey` independently escapes every char outside `[A-Za-z0-9._-]`
     /// before any filesystem use, so `:` never reaches a path literally.
     /// See ADR-0026 and `docs/SECURITY.md` §1.1.
@@ -484,7 +485,7 @@ pub enum RefParseError {
         /// Hard upper bound (always [`DOI_SUFFIX_MAX_LEN`]).
         max: usize,
     },
-    /// DOI suffix contained a character outside `[A-Za-z0-9._/()-]`.
+    /// DOI suffix contained a character outside `[A-Za-z0-9._/():-]`.
     #[error("DOI suffix contains invalid character {ch:?}")]
     InvalidDoiSuffixChar {
         /// The first offending character.
@@ -1732,6 +1733,21 @@ mod tests {
         assert_eq!(d.as_str(), "10.1051/jphys:0198900500120136500");
         let d2 = Doi::parse("doi:10.1051/jphys:0198500460100164500").expect("scheme + colon");
         assert_eq!(d2.as_str(), "10.1051/jphys:0198500460100164500");
+    }
+
+    #[test]
+    fn doi_parse_rejects_semicolon_in_suffix() {
+        // #194 / ADR-0026: `;` is the natural ASCII neighbor of `:` and
+        // is explicitly EXCLUDED from the suffix charset extension
+        // (ADR-0026 §"Out of scope"). This test guards against an
+        // over-broad `matches!` arm (e.g. an accidental `':'..=';'` range
+        // typo) re-admitting `;` along with `:`.
+        let result = Doi::parse("10.1234/foo;bar");
+        assert!(
+            matches!(result, Err(RefParseError::InvalidDoiSuffixChar { ch: ';' })),
+            "expected InvalidDoiSuffixChar with ch=';', got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/docs/DECISIONS/0026-doi-suffix-colon.md
+++ b/docs/DECISIONS/0026-doi-suffix-colon.md
@@ -72,6 +72,22 @@ tool targets.
 - The accepted-input surface widens by one character. Mitigated above:
   no traversal delta, `safekey` escaping is the real filesystem guard,
   length bound unchanged.
+- **Acknowledged `safekey` collision dimension.** `safekey` maps every
+  character outside `[A-Za-z0-9._-]` to `_`, and the SHA-256 hash
+  disambiguator is appended **only** when the trimmed key exceeds 192
+  chars (`crates/doiget-core/src/lib.rs` `Ref::safekey` Step 4). For
+  short DOIs (the common case, including the Kluwer / EDP examples
+  above), no hash is appended — so any two suffixes whose escaped
+  forms collapse identically map to the same safekey. This is a
+  **pre-existing** lossy property: `10.X/A/NNN` and `10.X/A_NNN`
+  already collided before this ADR (both `/`→`_` and `/` is a legal
+  suffix char). Adding `:` to the charset adds `:` to the same
+  equivalence class (`A:NNN`, `A/NNN`, `A_NNN` all share one safekey).
+  The practical collision rate is near-zero in the real Kluwer / EDP
+  corpora — those families specifically use `A:` and `jphys:`, not
+  `_`-equivalents — but the property is acknowledged here so the
+  next maintainer is not surprised. Closing it (e.g. unconditional
+  hash suffix) is a separate ADR with broader scope than #194.
 
 **Out of scope.**
 

--- a/docs/DECISIONS/0026-doi-suffix-colon.md
+++ b/docs/DECISIONS/0026-doi-suffix-colon.md
@@ -1,0 +1,86 @@
+# 0026 - DOI suffix charset extension: permit `:` (SECURITY.md §1.1)
+
+- **Date:** 2026-05-19
+- **Status:** Accepted
+- **Supersedes:** - (amends the `docs/SECURITY.md` §1.1 NORMATIVE charset; §1.1 remains binding with the widened set)
+- **Source:** #194 (dogfood of an Ising-model RG corpus, classical → modern)
+
+## Context
+
+`docs/SECURITY.md` §1.1 mandates the strict DOI-suffix regex
+`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$` to block path traversal in the
+untrusted DOI suffix. `Doi::parse` (`crates/doiget-core/src/lib.rs`)
+mirrors this charset via `is_doi_suffix_char`.
+
+The charset omitted `:`, but `:` **is a valid DOI suffix character** (the
+DOI Handbook defines the suffix as an opaque string) and two large, real
+publisher DOI families use it:
+
+- **Legacy Kluwer / Springer**: `10.1023/A:1019601218492` — thousands of
+  pre-2003 Kluwer journal DOIs use the `10.1023/A:NNNNNNNNNN` form.
+- **EDP Sciences / Journal de Physique**: `10.1051/jphys:0198900500120136500`
+  — the entire legacy *Journal de Physique* corpus.
+
+Both resolve at `https://doi.org/` and via Crossref. Dogfooding a
+historically deep Ising-model renormalization-group corpus via the
+citation graph reached the older literature and lost 3/38 niche papers
+purely to this parser restriction (Nelson–Fisher hyperscaling 1985,
+Le Guillou–Zinn-Justin critical exponents 1989, the 2002 DMRG-QPT
+review). Because §1.1 is posture, the charset is not widened
+unilaterally in code — hence this ADR.
+
+## Decision
+
+Add `:` to the DOI-suffix charset. The §1.1 regex becomes
+`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$` and `is_doi_suffix_char` permits
+`:` alongside the existing set. No other validation rule changes
+(registrant shape, `DOI_SUFFIX_MAX_LEN = 256`, anchored/deterministic
+regex, empty-suffix rejection all unchanged).
+
+### Why `:` is safe
+
+- **No new traversal capability.** Path traversal is driven by `/` and
+  `..`, **both already permitted** by the pre-existing charset; `:`
+  adds nothing a `/`-based attacker did not already have.
+- **`safekey` escapes it anyway.** Per `docs/SAFEKEY.md`, the `safekey`
+  algorithm independently escapes every character outside
+  `[A-Za-z0-9._-]` before any filesystem use, so `:` never reaches a
+  path literally regardless of this regex.
+- **No URL-encoding hazard.** In a URL path segment `:` is an
+  unreserved `pchar` (RFC 3986) — the fetch leg is unaffected.
+- **Length still bounded.** `DOI_SUFFIX_MAX_LEN = 256` continues to
+  bound the suffix.
+
+This is the strictly-additive option (#194 option 1), preferred over
+"document the exclusion + clearer error" (option 2) because the colon
+DOIs are legitimate, resolvable, and common in the physics corpora the
+tool targets.
+
+## Consequences
+
+**Positive.**
+
+- Legacy Kluwer and the full legacy *Journal de Physique* DOI corpora
+  are now fetchable; the dogfood Ising-RG corpus recovers the 3 lost
+  niche papers.
+- `Doi::parse` is a strict superset of its prior behaviour — every
+  previously-accepted DOI is still accepted; no caller (38 call sites)
+  changes shape.
+
+**Negative.**
+
+- The accepted-input surface widens by one character. Mitigated above:
+  no traversal delta, `safekey` escaping is the real filesystem guard,
+  length bound unchanged.
+
+**Out of scope.**
+
+- Removing the `safekey` escape for `:` (rejected — `safekey` is the
+  load-bearing filesystem guard and stays maximally conservative
+  independent of the parser charset).
+- Any other suffix character (e.g. `;`, `<`, space) — not requested by
+  a real corpus; revisit per-character via a new ADR if a real DOI
+  family needs it.
+
+To revise this decision, write a new ADR with `Supersedes: 0026` and
+update this file's `Status:` per `CONTRIBUTING.md`.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -42,6 +42,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |
 | 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
 | 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
+| 0026 | DOI suffix charset extension: permit `:` (SECURITY.md §1.1) | Accepted | #194 | #194 dogfood |
 
 ## Conventions
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires composing `/` and `.` into `../`, and both characters are already in the suffix charset), and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -23,7 +23,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -23,7 +23,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires composing `/` and `.` into `../`, and both characters are already in the suffix charset), and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |


### PR DESCRIPTION
## Summary

- `Doi::parse` now accepts `:` in the DOI suffix. Legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs resolve fine at doi.org / Crossref but were rejected with `INVALID_REF`, silently losing real papers from physics corpora (3/38 niche refs lost in the Ising-RG dogfood — Nelson–Fisher 1985, Le Guillou–Zinn-Justin 1989, the 2002 DMRG-QPT review).
- **Posture change** to `docs/SECURITY.md` §1.1 (DOI-suffix charset → `[A-Za-z0-9._/():-]`), documented and rationalised in **ADR-0026**. `:` grants no path-traversal capability beyond the already-permitted `/`; `safekey` independently escapes it before any filesystem use, so `:` never reaches a path literally. Length bound (`DOI_SUFFIX_MAX_LEN = 256`) and all reject paths unchanged.

## Changes

- `crates/doiget-core/src/lib.rs`: `is_doi_suffix_char` permits `:`; `is_doi_suffix_char` + `Doi::parse` docstrings updated.
- `docs/SECURITY.md` §1.1: regex widened + safety rationale.
- `docs/DECISIONS/0026-doi-suffix-colon.md` (new) + `INDEX.md` row.
- `CHANGELOG.md` `[0.2.1-beta.5]`; workspace version `beta.4 → beta.5`.

## Test plan

- [x] `cargo test -p doiget-core --no-default-features --features oa-only --lib doi_parse` — 18 pass incl. new `doi_parse_accepts_colon_in_legacy_kluwer_suffix`, `doi_parse_accepts_colon_in_edp_jphys_suffix` (+ `doi:` scheme + colon case).
- [x] Full `doiget-core` lib suite: 225 pass, no regression (reject paths for control/non-ascii/over-len still hold — widening is scoped to `:` only).
- [x] `cargo clippy -p doiget-core --tests` clean; `cargo fmt --all --check` clean.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)