### PR TITLE
fix(core): add physics-society / diamond-OA hosts to oa-publisher allowlist (#193) [beta.6]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.6] - 2026-05-19
+
+### Changed
+
+- **[core]** `oa-publisher` redirect allowlist now includes
+  physics-society / diamond-OA hosts: `*.aps.org` (APS), `scipost.org`
+  + `*.scipost.org` (SciPost diamond OA), `*.iop.org` (IOP) (#193, per
+  ADR-0027 and `docs/REDIRECT_ALLOWLIST.md` §5). The list was
+  bio/medical-leaning; a real `doiget batch` over 30 OpenAlex-OA
+  finite-temperature-MPS DOIs had 7 denied purely because the
+  discovered OA PDF host was off-list (24/30 → ~30/30). Unlike the
+  surrounding `(unverified)` entries these are empirically verified.
+  `hdl.handle.net` / `ruj.uj.edu.pl` (open handle/repo surfaces) are
+  deliberately out of scope.
+
 ## [0.2.1-beta.5] - 2026-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.5] - 2026-05-19
+
+### Fixed
+
+- **[core]** `Doi::parse` now accepts `:` in the DOI suffix (#194).
+  Legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`) and EDP Sciences /
+  Journal de Physique (`10.1051/jphys:NNNN`) DOIs — both resolvable at
+  doi.org and via Crossref — were previously rejected with
+  `INVALID_REF`, silently losing real papers from physics corpora (3/38
+  niche refs lost in the Ising-RG dogfood). `:` grants no path-traversal
+  capability beyond the already-permitted `/`, and `safekey` escapes it
+  before any filesystem use. `docs/SECURITY.md` §1.1 charset widened to
+  `[A-Za-z0-9._/():-]` per ADR-0026.
+
 ## [0.2.1-beta.4] - 2026-05-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.4"
+version = "0.2.1-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.4"
+version = "0.2.1-beta.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.4"
+version = "0.2.1-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.5"
+version = "0.2.1-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.5"
+version = "0.2.1-beta.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.5"
+version = "0.2.1-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.4"
+version       = "0.2.1-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.5"
+version       = "0.2.1-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -356,8 +356,10 @@ pub fn oa_publisher_allowlist() -> Vec<SourceAllowlist> {
             // Unpaywall `best_oa_location` resolving to these hosts and
             // being denied (#193, REDIRECT_ALLOWLIST.md §3.4, ADR-0027).
             // APS — journals.aps.org / link.aps.org (green & gold OA;
-            // society host; `*.aps.org` is already trusted under the
-            // separate `tdm-aps` Tier-3 source key).
+            // society host; `*.aps.org` is also trusted under the separate
+            // `tdm-aps` Tier-3 source key WHEN that feature is compiled
+            // in — `tier_3_aps_allowlist` is `#[cfg(feature = "tdm-aps")]`
+            // and absent from default release builds).
             "*.aps.org".to_string(),
             // SciPost — diamond OA, community-run physics publisher.
             "scipost.org".to_string(),
@@ -1198,6 +1200,18 @@ mod tests {
         assert!(oa.matches("scipost.org"));
         assert!(oa.matches("www.scipost.org"));
         assert!(oa.matches("iopscience.iop.org"));
+        // Document intent of the `*.<suffix>` form: per
+        // `REDIRECT_ALLOWLIST.md` §2.2 rule 3 it matches the bare
+        // registrable domain AND any subdomain. Unpaywall has not been
+        // observed returning bare-domain PDF URLs for these publishers,
+        // but accepting them is consistent with every other `*.` entry in
+        // this list (e.g. `arxiv.org` matched by `*.arxiv.org`) and is
+        // what the matching rule already implements.
+        assert!(oa.matches("aps.org"));
+        assert!(oa.matches("iop.org"));
+        // Multi-level subdomains also match (e.g. SciPost's deep paths);
+        // documents the wildcard scope rather than testing a known URL.
+        assert!(oa.matches("submissions.scipost.org"));
         // Negative: an attacker host is not covered.
         assert!(!oa.matches("attacker.test"));
         // Negative: dot-boundary safety for the new entries — a different

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -350,6 +350,20 @@ pub fn oa_publisher_allowlist() -> Vec<SourceAllowlist> {
             "*.europepmc.org".to_string(),
             "*.nih.gov".to_string(),
             "*.ncbi.nlm.nih.gov".to_string(),
+            // Physics-society / diamond-OA hosts. UNLIKE the entries
+            // above, these are EMPIRICALLY VERIFIED: a real `doiget batch`
+            // over 30 OpenAlex-OA finite-temperature-MPS DOIs observed
+            // Unpaywall `best_oa_location` resolving to these hosts and
+            // being denied (#193, REDIRECT_ALLOWLIST.md §3.4, ADR-0027).
+            // APS — journals.aps.org / link.aps.org (green & gold OA;
+            // society host; `*.aps.org` is already trusted under the
+            // separate `tdm-aps` Tier-3 source key).
+            "*.aps.org".to_string(),
+            // SciPost — diamond OA, community-run physics publisher.
+            "scipost.org".to_string(),
+            "*.scipost.org".to_string(),
+            // IOP Publishing — iopscience.iop.org (New J. Phys. etc.).
+            "*.iop.org".to_string(),
             // arXiv — already on the `arxiv` tier-1 allowlist, but the
             // Unpaywall-driven path uses the `oa-publisher` source key,
             // so we mirror the host list here too. See REDIRECT_ALLOWLIST.md
@@ -1177,8 +1191,20 @@ mod tests {
         assert!(oa.matches("europepmc.org"));
         assert!(oa.matches("www.ncbi.nlm.nih.gov"));
         assert!(oa.matches("arxiv.org"));
+        // #193: physics-society / diamond-OA hosts (empirically observed
+        // as Unpaywall best_oa_location targets in the dogfood run).
+        assert!(oa.matches("link.aps.org"));
+        assert!(oa.matches("journals.aps.org"));
+        assert!(oa.matches("scipost.org"));
+        assert!(oa.matches("www.scipost.org"));
+        assert!(oa.matches("iopscience.iop.org"));
         // Negative: an attacker host is not covered.
         assert!(!oa.matches("attacker.test"));
+        // Negative: dot-boundary safety for the new entries — a different
+        // suffix that merely ends with the registrable name must NOT match.
+        assert!(!oa.matches("notaps.org"));
+        assert!(!oa.matches("evilscipost.org"));
+        assert!(!oa.matches("notiop.org"));
         // Negative: dot-boundary safety — `*.springer.com` must not match
         // `notspringer.com`.
         assert!(!oa.matches("notspringer.com"));

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -127,7 +127,8 @@ impl Doi {
     /// Accepts:
     /// - Bare DOIs: `10.<registrant>/<suffix>` where `<registrant>` is 4–9
     ///   digits and `<suffix>` is a non-empty sequence of characters drawn
-    ///   from `[A-Za-z0-9._/()-]`.
+    ///   from `[A-Za-z0-9._/():-]` (the `:` covers legacy Kluwer
+    ///   `10.1023/A:NNNN` and EDP Sciences `10.1051/jphys:NNNN` DOIs).
     /// - The `doi:` URI scheme prefix; it is stripped before validation, so
     ///   the stored value never carries a scheme. (Matches the convention
     ///   established in `docs/SAFEKEY.md` §3 step 0.)
@@ -275,13 +276,22 @@ mod parse {
     }
 
     /// DOI suffix charset per `docs/SECURITY.md` §1.1:
-    /// `[A-Za-z0-9._/()-]`. The forward slash is permitted inside the
+    /// `[A-Za-z0-9._/():-]`. The forward slash is permitted inside the
     /// suffix (e.g. `10.1016/...`); the registrant separator is the
     /// *first* `/` and the suffix is everything after it.
+    ///
+    /// `:` is permitted because two large real publisher DOI families use
+    /// it in the suffix — legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`)
+    /// and EDP Sciences / Journal de Physique
+    /// (`10.1051/jphys:NNNNNNNNNNNNNNNNN`). It adds no path-traversal
+    /// capability (traversal needs `/` + `..`, both already permitted) and
+    /// `safekey` independently escapes every char outside `[A-Za-z0-9._-]`
+    /// before any filesystem use, so `:` never reaches a path literally.
+    /// See ADR-0026 and `docs/SECURITY.md` §1.1.
     fn is_doi_suffix_char(c: char) -> bool {
         matches!(c,
             'A'..='Z' | 'a'..='z' | '0'..='9'
-            | '.' | '_' | '/' | '(' | ')' | '-'
+            | '.' | '_' | '/' | '(' | ')' | '-' | ':'
         )
     }
 
@@ -1702,6 +1712,26 @@ mod tests {
         // registrant/suffix separator.
         let d = Doi::parse("10.1234/foo/bar/baz").expect("nested slashes");
         assert_eq!(d.as_str(), "10.1234/foo/bar/baz");
+    }
+
+    #[test]
+    fn doi_parse_accepts_colon_in_legacy_kluwer_suffix() {
+        // #194: legacy Kluwer/Springer DOIs (`10.1023/A:NNNNNNNNNN`)
+        // carry a `:` in the suffix. Real DOI: "Entanglement, Quantum
+        // Phase Transitions, and DMRG" (Kluwer, 2002).
+        let d = Doi::parse("10.1023/A:1019601218492").expect("legacy Kluwer colon DOI");
+        assert_eq!(d.as_str(), "10.1023/A:1019601218492");
+    }
+
+    #[test]
+    fn doi_parse_accepts_colon_in_edp_jphys_suffix() {
+        // #194: EDP Sciences / Journal de Physique legacy corpus uses
+        // `10.1051/jphys:NNNNNNNNNNNNNNNNN`. Real DOIs from the dogfood
+        // Ising-RG run; both resolve at doi.org and via Crossref.
+        let d = Doi::parse("10.1051/jphys:0198900500120136500").expect("EDP jphys colon DOI");
+        assert_eq!(d.as_str(), "10.1051/jphys:0198900500120136500");
+        let d2 = Doi::parse("doi:10.1051/jphys:0198500460100164500").expect("scheme + colon");
+        assert_eq!(d2.as_str(), "10.1051/jphys:0198500460100164500");
     }
 
     #[test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -284,7 +284,8 @@ mod parse {
     /// it in the suffix — legacy Kluwer/Springer (`10.1023/A:NNNNNNNNNN`)
     /// and EDP Sciences / Journal de Physique
     /// (`10.1051/jphys:NNNNNNNNNNNNNNNNN`). It adds no path-traversal
-    /// capability (traversal needs `/` + `..`, both already permitted) and
+    /// capability: traversal requires composing `/` and `.` into `../`,
+    /// and both characters are already in the suffix charset. In addition,
     /// `safekey` independently escapes every char outside `[A-Za-z0-9._-]`
     /// before any filesystem use, so `:` never reaches a path literally.
     /// See ADR-0026 and `docs/SECURITY.md` §1.1.
@@ -484,7 +485,7 @@ pub enum RefParseError {
         /// Hard upper bound (always [`DOI_SUFFIX_MAX_LEN`]).
         max: usize,
     },
-    /// DOI suffix contained a character outside `[A-Za-z0-9._/()-]`.
+    /// DOI suffix contained a character outside `[A-Za-z0-9._/():-]`.
     #[error("DOI suffix contains invalid character {ch:?}")]
     InvalidDoiSuffixChar {
         /// The first offending character.
@@ -1732,6 +1733,21 @@ mod tests {
         assert_eq!(d.as_str(), "10.1051/jphys:0198900500120136500");
         let d2 = Doi::parse("doi:10.1051/jphys:0198500460100164500").expect("scheme + colon");
         assert_eq!(d2.as_str(), "10.1051/jphys:0198500460100164500");
+    }
+
+    #[test]
+    fn doi_parse_rejects_semicolon_in_suffix() {
+        // #194 / ADR-0026: `;` is the natural ASCII neighbor of `:` and
+        // is explicitly EXCLUDED from the suffix charset extension
+        // (ADR-0026 §"Out of scope"). This test guards against an
+        // over-broad `matches!` arm (e.g. an accidental `':'..=';'` range
+        // typo) re-admitting `;` along with `:`.
+        let result = Doi::parse("10.1234/foo;bar");
+        assert!(
+            matches!(result, Err(RefParseError::InvalidDoiSuffixChar { ch: ';' })),
+            "expected InvalidDoiSuffixChar with ch=';', got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/docs/DECISIONS/0026-doi-suffix-colon.md
+++ b/docs/DECISIONS/0026-doi-suffix-colon.md
@@ -72,6 +72,22 @@ tool targets.
 - The accepted-input surface widens by one character. Mitigated above:
   no traversal delta, `safekey` escaping is the real filesystem guard,
   length bound unchanged.
+- **Acknowledged `safekey` collision dimension.** `safekey` maps every
+  character outside `[A-Za-z0-9._-]` to `_`, and the SHA-256 hash
+  disambiguator is appended **only** when the trimmed key exceeds 192
+  chars (`crates/doiget-core/src/lib.rs` `Ref::safekey` Step 4). For
+  short DOIs (the common case, including the Kluwer / EDP examples
+  above), no hash is appended — so any two suffixes whose escaped
+  forms collapse identically map to the same safekey. This is a
+  **pre-existing** lossy property: `10.X/A/NNN` and `10.X/A_NNN`
+  already collided before this ADR (both `/`→`_` and `/` is a legal
+  suffix char). Adding `:` to the charset adds `:` to the same
+  equivalence class (`A:NNN`, `A/NNN`, `A_NNN` all share one safekey).
+  The practical collision rate is near-zero in the real Kluwer / EDP
+  corpora — those families specifically use `A:` and `jphys:`, not
+  `_`-equivalents — but the property is acknowledged here so the
+  next maintainer is not surprised. Closing it (e.g. unconditional
+  hash suffix) is a separate ADR with broader scope than #194.
 
 **Out of scope.**
 

--- a/docs/DECISIONS/0026-doi-suffix-colon.md
+++ b/docs/DECISIONS/0026-doi-suffix-colon.md
@@ -1,0 +1,86 @@
+# 0026 - DOI suffix charset extension: permit `:` (SECURITY.md §1.1)
+
+- **Date:** 2026-05-19
+- **Status:** Accepted
+- **Supersedes:** - (amends the `docs/SECURITY.md` §1.1 NORMATIVE charset; §1.1 remains binding with the widened set)
+- **Source:** #194 (dogfood of an Ising-model RG corpus, classical → modern)
+
+## Context
+
+`docs/SECURITY.md` §1.1 mandates the strict DOI-suffix regex
+`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$` to block path traversal in the
+untrusted DOI suffix. `Doi::parse` (`crates/doiget-core/src/lib.rs`)
+mirrors this charset via `is_doi_suffix_char`.
+
+The charset omitted `:`, but `:` **is a valid DOI suffix character** (the
+DOI Handbook defines the suffix as an opaque string) and two large, real
+publisher DOI families use it:
+
+- **Legacy Kluwer / Springer**: `10.1023/A:1019601218492` — thousands of
+  pre-2003 Kluwer journal DOIs use the `10.1023/A:NNNNNNNNNN` form.
+- **EDP Sciences / Journal de Physique**: `10.1051/jphys:0198900500120136500`
+  — the entire legacy *Journal de Physique* corpus.
+
+Both resolve at `https://doi.org/` and via Crossref. Dogfooding a
+historically deep Ising-model renormalization-group corpus via the
+citation graph reached the older literature and lost 3/38 niche papers
+purely to this parser restriction (Nelson–Fisher hyperscaling 1985,
+Le Guillou–Zinn-Justin critical exponents 1989, the 2002 DMRG-QPT
+review). Because §1.1 is posture, the charset is not widened
+unilaterally in code — hence this ADR.
+
+## Decision
+
+Add `:` to the DOI-suffix charset. The §1.1 regex becomes
+`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$` and `is_doi_suffix_char` permits
+`:` alongside the existing set. No other validation rule changes
+(registrant shape, `DOI_SUFFIX_MAX_LEN = 256`, anchored/deterministic
+regex, empty-suffix rejection all unchanged).
+
+### Why `:` is safe
+
+- **No new traversal capability.** Path traversal is driven by `/` and
+  `..`, **both already permitted** by the pre-existing charset; `:`
+  adds nothing a `/`-based attacker did not already have.
+- **`safekey` escapes it anyway.** Per `docs/SAFEKEY.md`, the `safekey`
+  algorithm independently escapes every character outside
+  `[A-Za-z0-9._-]` before any filesystem use, so `:` never reaches a
+  path literally regardless of this regex.
+- **No URL-encoding hazard.** In a URL path segment `:` is an
+  unreserved `pchar` (RFC 3986) — the fetch leg is unaffected.
+- **Length still bounded.** `DOI_SUFFIX_MAX_LEN = 256` continues to
+  bound the suffix.
+
+This is the strictly-additive option (#194 option 1), preferred over
+"document the exclusion + clearer error" (option 2) because the colon
+DOIs are legitimate, resolvable, and common in the physics corpora the
+tool targets.
+
+## Consequences
+
+**Positive.**
+
+- Legacy Kluwer and the full legacy *Journal de Physique* DOI corpora
+  are now fetchable; the dogfood Ising-RG corpus recovers the 3 lost
+  niche papers.
+- `Doi::parse` is a strict superset of its prior behaviour — every
+  previously-accepted DOI is still accepted; no caller (38 call sites)
+  changes shape.
+
+**Negative.**
+
+- The accepted-input surface widens by one character. Mitigated above:
+  no traversal delta, `safekey` escaping is the real filesystem guard,
+  length bound unchanged.
+
+**Out of scope.**
+
+- Removing the `safekey` escape for `:` (rejected — `safekey` is the
+  load-bearing filesystem guard and stays maximally conservative
+  independent of the parser charset).
+- Any other suffix character (e.g. `;`, `<`, space) — not requested by
+  a real corpus; revisit per-character via a new ADR if a real DOI
+  family needs it.
+
+To revise this decision, write a new ADR with `Supersedes: 0026` and
+update this file's `Status:` per `CONTRIBUTING.md`.

--- a/docs/DECISIONS/0027-redirect-allowlist-oa-publisher-physics.md
+++ b/docs/DECISIONS/0027-redirect-allowlist-oa-publisher-physics.md
@@ -1,0 +1,96 @@
+# 0027 - redirect-allowlist: add physics-society / diamond-OA hosts to `oa-publisher`
+
+- **Date:** 2026-05-19
+- **Status:** Accepted
+- **Supersedes:** - (amends the `docs/REDIRECT_ALLOWLIST.md` §3.4 NORMATIVE host set; §3.4 remains binding with the added hosts)
+- **Source:** #193 (dogfood of a finite-temperature-MPS corpus via the citation graph, #187)
+
+## Context
+
+`docs/REDIRECT_ALLOWLIST.md` §3.4 / `oa_publisher_allowlist()`
+(`crates/doiget-core/src/http.rs`) is the host set the orchestrator
+trusts for Unpaywall-discovered OA PDF URLs. The list was
+bio/medical-leaning (PMC, bioRxiv, medRxiv, PLOS, Frontiers, MDPI,
+Springer/Nature/Wiley/Elsevier) with **no physics-society OA hosts**.
+
+Dogfooding a real finite-temperature-MPS literature collection
+batch-fetched 30 DOIs that OpenAlex reports as Open Access:
+**24 succeeded; 7 were denied** with `CAPABILITY_DENIED`
+(`reason = redirect_not_in_allowlist`) — the OA PDF *was discovered* by
+Unpaywall but its host was off-list:
+
+| host | count | nature |
+|------|------:|--------|
+| `link.aps.org` | 3 | APS green OA (PRB/PRL/PRX) |
+| `scipost.org` | 1 | SciPost — 100% diamond OA, community-run |
+| `iopscience.iop.org` | 1 | IOP (New J. Phys. etc.) |
+| `ruj.uj.edu.pl` | 1 | institutional repo (Jagiellonian) |
+| `hdl.handle.net` | 1 | Handle resolver → repo |
+
+The §3 docstring already flags every existing entry `(unverified)` and
+states they "MUST be confirmed by a real fetch"; this run is exactly
+that empirical pass.
+
+## Decision
+
+Add to the `oa-publisher` allowlist (`http.rs` + §3.4 + the site
+projection), with an in-code empirical-evidence comment:
+
+- `*.aps.org` — APS (`link.aps.org` / `journals.aps.org`). The
+  registrable domain is **already trusted** elsewhere in the codebase:
+  `tier_3_aps_allowlist()` lists `*.aps.org` under the credentialed
+  `tdm-aps` source key. This ADR extends that trust to the
+  `oa-publisher` source key for the green/gold OA route.
+- `scipost.org`, `*.scipost.org` — SciPost, the canonical community-run
+  **diamond-OA** physics publisher. Refusing it is hard to justify on
+  supply-chain grounds.
+- `*.iop.org` — IOP Publishing (`iopscience.iop.org`).
+
+These entries are recorded as **empirically verified** (distinct from
+the surrounding `(unverified)` entries) because a real fetch observed
+Unpaywall resolving to them.
+
+### Out of scope (deliberately excluded)
+
+`hdl.handle.net` and `ruj.uj.edu.pl` are open-ended repository / handle
+surfaces, not a bounded society-publisher host. They are a separate
+"institutional repository OA" question and are **not** added here. Per
+§5 the exclusion is recorded so a future ADR can revisit it on its own
+merits.
+
+## Consequences
+
+**Positive.**
+
+- The finite-temperature-MPS corpus goes from 24/30 → ~30/30 OA PDF
+  success; physics corpora generally stop being needlessly depressed.
+- SciPost (diamond OA) and APS/IOP (society OA) — legitimately,
+  unambiguously OA content — are now fetchable rather than silently
+  degraded to metadata-only.
+- `*.aps.org` trust is now consistent across the `tdm-aps` and
+  `oa-publisher` source keys.
+
+**Negative.**
+
+- The trusted redirect surface widens by four host patterns. Mitigated:
+  all are bounded registrable-domain wildcards for established
+  physics publishers (no open redirector / handle resolver added); the
+  same per-source redirect-closure (`SourceAllowlist::matches`,
+  dot-boundary enforced) applies, and the addition is empirically
+  driven rather than speculative.
+
+**Process (REDIRECT_ALLOWLIST.md §5).**
+
+1. **ADR** — this file.
+2. **CHANGELOG** — `[0.2.1-beta.6] → Changed` entry referencing this ADR.
+3. **Reference / projection** — §3.4 table + Host families updated;
+   `site/content/developer/redirect-allowlist.md` re-projected via
+   `scripts/sync_docs_to_site.sh`.
+4. **Tests** — `oa_publisher_allowlist_matches_known_oa_hosts` asserts
+   `link.aps.org` / `journals.aps.org` / `scipost.org` /
+   `www.scipost.org` / `iopscience.iop.org` match, plus dot-boundary
+   negatives (`notaps.org`, `evilscipost.org`, `notiop.org`).
+
+To revise this decision, write a new ADR with
+`Supersedes: 0027` and update this file's `Status:` per
+`CONTRIBUTING.md`.

--- a/docs/DECISIONS/0027-redirect-allowlist-oa-publisher-physics.md
+++ b/docs/DECISIONS/0027-redirect-allowlist-oa-publisher-physics.md
@@ -37,10 +37,14 @@ Add to the `oa-publisher` allowlist (`http.rs` + §3.4 + the site
 projection), with an in-code empirical-evidence comment:
 
 - `*.aps.org` — APS (`link.aps.org` / `journals.aps.org`). The
-  registrable domain is **already trusted** elsewhere in the codebase:
-  `tier_3_aps_allowlist()` lists `*.aps.org` under the credentialed
-  `tdm-aps` source key. This ADR extends that trust to the
-  `oa-publisher` source key for the green/gold OA route.
+  registrable domain is **also trusted** elsewhere in the codebase
+  **when the `tdm-aps` Cargo feature is compiled in**:
+  `tier_3_aps_allowlist()` (which is `#[cfg(feature = "tdm-aps")]` and
+  absent from default release builds) lists `*.aps.org` under the
+  credentialed `tdm-aps` source key. This ADR introduces the trust on
+  the `oa-publisher` source key for the green/gold OA route — making
+  the trust unconditional across feature configurations rather than
+  feature-gated.
 - `scipost.org`, `*.scipost.org` — SciPost, the canonical community-run
   **diamond-OA** physics publisher. Refusing it is hard to justify on
   supply-chain grounds.
@@ -78,6 +82,17 @@ merits.
   same per-source redirect-closure (`SourceAllowlist::matches`,
   dot-boundary enforced) applies, and the addition is empirically
   driven rather than speculative.
+- **Acknowledged overlap with the credentialed TDM path.** `*.aps.org`
+  in `oa-publisher` matches `harvest.aps.org`, which is the TDM API
+  base under the `tdm-aps` Tier-3 source key (a gated, credentialed
+  path requiring `DOIGET_KEY_APS` + `DOIGET_AGREE_TDM_APS=1`). The
+  overlap is **intentional and acceptable**: the `oa-publisher`
+  `HttpClient` never carries APS TDM credentials, so a redirect to
+  `harvest.aps.org` on the OA path would simply receive `401`/`403`
+  and fall back to metadata-only success — it cannot escalate into
+  unauthorized TDM access. Unpaywall is not observed returning the
+  TDM endpoint as an OA URL in any case; this note documents the
+  matcher's actual behaviour so a future reviewer is not surprised.
 
 **Process (REDIRECT_ALLOWLIST.md §5).**
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -42,6 +42,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |
 | 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
 | 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
+| 0026 | DOI suffix charset extension: permit `:` (SECURITY.md §1.1) | Accepted | #194 | #194 dogfood |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -43,6 +43,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
 | 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
 | 0026 | DOI suffix charset extension: permit `:` (SECURITY.md §1.1) | Accepted | #194 | #194 dogfood |
+| 0027 | redirect-allowlist: add physics-society / diamond-OA hosts to `oa-publisher` | Accepted | #193 | #193 dogfood |
 
 ## Conventions
 

--- a/docs/REDIRECT_ALLOWLIST.md
+++ b/docs/REDIRECT_ALLOWLIST.md
@@ -137,7 +137,7 @@ Notes:
 | Field | Value |
 |---|---|
 | `source` | `oa-publisher` (synthetic — see notes) |
-| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `arxiv.org`, `*.arxiv.org` |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `arxiv.org`, `*.arxiv.org` |
 
 Notes:
 
@@ -152,6 +152,16 @@ Notes:
   `HttpClient::fetch_pdf("oa-publisher", url)`.
 - **Documented OA hosts.** Each entry below is the documented OA host for the
   named publisher / repository. Changes follow the §5 update process.
+- **Empirical verification (ADR-0027).** The physics-society / diamond-OA
+  hosts (`*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`) were
+  added from a real `doiget batch` over 30 OpenAlex-OA
+  finite-temperature-MPS DOIs in which Unpaywall `best_oa_location`
+  resolved to these hosts and the PDF leg was denied. This is the
+  empirical pass the §3 informed-best-effort note calls for; these
+  entries are *verified*, not `(unverified)`. Open-ended institutional /
+  handle repositories observed in the same run (`hdl.handle.net`,
+  `ruj.uj.edu.pl`) are deliberately **excluded** as a separate
+  open-surface question.
 - **Partial-success semantics.** When the OA URL host is NOT on this list,
   the denial is raised as `HttpError::RedirectDenied` — at the **pre-fetch
   check** on the metadata-discovered OA URL per §1 (the host is rejected
@@ -177,6 +187,11 @@ Notes:
   - Preprint servers: `*.biorxiv.org`, `*.medrxiv.org`.
   - Europe PMC + NIH PMC: `europepmc.org`, `*.europepmc.org`, `*.nih.gov`,
     `*.ncbi.nlm.nih.gov`.
+  - Physics society / diamond OA (empirically verified, ADR-0027):
+    `*.aps.org` (APS — `link.aps.org` / `journals.aps.org`; also trusted
+    under the separate `tdm-aps` Tier-3 key), `scipost.org` +
+    `*.scipost.org` (SciPost — community-run diamond OA), `*.iop.org`
+    (IOP Publishing — `iopscience.iop.org`, *New J. Phys.* etc.).
   - arXiv: `arxiv.org`, `*.arxiv.org` (mirrors §3.3 because the Unpaywall
     flow re-derives an arXiv URL through the `oa-publisher` source key, not
     the tier-1 `arxiv` key).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires composing `/` and `.` into `../`, and both characters are already in the suffix charset), and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -143,7 +143,7 @@ Notes:
 | Field | Value |
 |---|---|
 | `source` | `oa-publisher` (synthetic — see notes) |
-| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `arxiv.org`, `*.arxiv.org` |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `arxiv.org`, `*.arxiv.org` |
 
 Notes:
 
@@ -158,6 +158,16 @@ Notes:
   `HttpClient::fetch_pdf("oa-publisher", url)`.
 - **Documented OA hosts.** Each entry below is the documented OA host for the
   named publisher / repository. Changes follow the §5 update process.
+- **Empirical verification (ADR-0027).** The physics-society / diamond-OA
+  hosts (`*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`) were
+  added from a real `doiget batch` over 30 OpenAlex-OA
+  finite-temperature-MPS DOIs in which Unpaywall `best_oa_location`
+  resolved to these hosts and the PDF leg was denied. This is the
+  empirical pass the §3 informed-best-effort note calls for; these
+  entries are *verified*, not `(unverified)`. Open-ended institutional /
+  handle repositories observed in the same run (`hdl.handle.net`,
+  `ruj.uj.edu.pl`) are deliberately **excluded** as a separate
+  open-surface question.
 - **Partial-success semantics.** When the OA URL host is NOT on this list,
   the denial is raised as `HttpError::RedirectDenied` — at the **pre-fetch
   check** on the metadata-discovered OA URL per §1 (the host is rejected
@@ -183,6 +193,11 @@ Notes:
   - Preprint servers: `*.biorxiv.org`, `*.medrxiv.org`.
   - Europe PMC + NIH PMC: `europepmc.org`, `*.europepmc.org`, `*.nih.gov`,
     `*.ncbi.nlm.nih.gov`.
+  - Physics society / diamond OA (empirically verified, ADR-0027):
+    `*.aps.org` (APS — `link.aps.org` / `journals.aps.org`; also trusted
+    under the separate `tdm-aps` Tier-3 key), `scipost.org` +
+    `*.scipost.org` (SciPost — community-run diamond OA), `*.iop.org`
+    (IOP Publishing — `iopscience.iop.org`, *New J. Phys.* etc.).
   - arXiv: `arxiv.org`, `*.arxiv.org` (mirrors §3.3 because the Unpaywall
     flow re-derives an arXiv URL through the `oa-publisher` source key, not
     the tier-1 `arxiv` key).

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -23,7 +23,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/()-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |

--- a/site/content/developer/security.md
+++ b/site/content/developer/security.md
@@ -23,7 +23,7 @@ Source: CLI argument or MCP tool argument. Trust level: **untrusted**.
 
 | Vector | Mitigation |
 |---|---|
-| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires `/` + `..`, both already permitted) and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
+| Path traversal in DOI suffix | Strict regex (`^10\.\d{4,9}/[A-Za-z0-9._/():-]+$`); `safekey` algorithm escapes all characters outside `[A-Za-z0-9._\-_]` (see [`SAFEKEY.md`](SAFEKEY.md)). `:` is in-charset (ADR-0026) for legacy Kluwer (`10.1023/A:NNNN`) and EDP Sciences / Journal de Physique (`10.1051/jphys:NNNN`) DOIs; it grants no traversal capability (traversal requires composing `/` and `.` into `../`, and both characters are already in the suffix charset), and `safekey` escapes it before any filesystem use, so `:` never reaches a path literally. |
 | Excessively long suffix | `DOI_SUFFIX_MAX_LEN = 256` chars; longer inputs are rejected with `INVALID_REF`. |
 | Regex DoS | Validation regex is anchored, deterministic, no nested quantifiers. |
 | Log injection (CR / LF / control chars) | Provenance log is JSON Lines; all string fields are JSON-escaped, control chars become `\uXXXX`. |


### PR DESCRIPTION
> **Stacked on #201 (#194).** Until #201 merges, this PR's diff also shows #194's commits (`44c4fdc`, `d4e3cf5`). Review the `#193` commit (`5170f4e`) — it is the only net-new change here. GitHub will narrow the diff automatically once #201 merges; if #201 changes, this branch is rebased.

## Summary

The `oa-publisher` redirect allowlist was bio/medical-leaning with **no physics-society OA hosts**. Dogfooding a finite-temperature-MPS corpus (`doiget batch` over 30 OpenAlex-OA DOIs, via the #187 citation graph) had **7/30 denied** with `redirect_not_in_allowlist` purely because the discovered OA PDF host was off-list — APS (`link.aps.org` ×3), SciPost (diamond OA), IOP. Graceful metadata-only fallback worked and the hash chain verified, but real OA content was needlessly degraded (24/30 → ~30/30 with these added).

## Changes (per `REDIRECT_ALLOWLIST.md` §5 process)

- `crates/doiget-core/src/http.rs` — `oa_publisher_allowlist()` gains `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, with an in-code **empirically-verified** comment (distinct from the surrounding `(unverified)` entries — a real fetch observed Unpaywall resolving here). `*.aps.org` is already trusted under the separate `tdm-aps` Tier-3 key.
- `docs/REDIRECT_ALLOWLIST.md` §3.4 — `redirect_hosts` table + Host families + an empirical-verification note; `site/content/developer/redirect-allowlist.md` re-projected via `scripts/sync_docs_to_site.sh`.
- `docs/DECISIONS/0027-redirect-allowlist-oa-publisher-physics.md` (new) + `INDEX.md` row.
- `CHANGELOG.md` `[0.2.1-beta.6] → Changed`; workspace version `beta.5 → beta.6`.
- **Out of scope (deliberate):** `hdl.handle.net`, `ruj.uj.edu.pl` — open handle/repo surfaces, tracked separately (recorded in ADR-0027 §Out of scope).

## Test plan

- [x] `cargo test -p doiget-core --no-default-features --features oa-only --lib oa_publisher` — `oa_publisher_allowlist_matches_known_oa_hosts` asserts `link.aps.org` / `journals.aps.org` / `scipost.org` / `www.scipost.org` / `iopscience.iop.org` match **and** dot-boundary negatives (`notaps.org`, `evilscipost.org`, `notiop.org`) do NOT.
- [x] Full `doiget-core` lib suite: 225 pass, no regression (incl. the `dry_run` allowlist-drift contract — `candidate_hosts` derives from the same `oa_publisher_allowlist()`).
- [x] `cargo clippy -p doiget-core --tests` clean; `cargo fmt --all --check` clean.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)