### PR TITLE
feat(cli): --mode json bodies for 6 human-table commands (#204) [beta.9]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.8] - 2026-05-20
+
+### Changed
+
+- **[cli]** `--mode quiet` (and `-q`/`--quiet`/`DOIGET_MODE=quiet`/the
+  non-TTY default) now suppresses *informational* stdout in the six
+  commands that previously emitted it unconditionally: `audit-log
+  --verify` (header / per-segment summary / per-issue lines), `info`
+  (TOML dump), `list-recent` (TSV table), `search` (TSV table),
+  `config show` (TOML dump), `config path` (path), and
+  `provenance migrate` (summary). Errors (stderr), exit codes, and
+  on-disk side effects are unaffected — `audit-log` with chain issues
+  still exits non-zero even with `stdout == ""`. `fetch` /
+  `batch` were already quiet by design (success/summary on stderr per
+  ADR-0001), and product-output commands (`bib` / `csl` / `graph` /
+  `*-dry-run` plan) are deliberately not suppressed. Existing e2e
+  tests that assert specific human stdout opt in via
+  `DOIGET_MODE=human`. (#203)
+
 ## [0.2.1-beta.7] - 2026-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.7] - 2026-05-20
+
+### Added
+
+- **[cli]** Global output-mode flags `--mode <human|json|quiet|mcp>`,
+  `--json`, `-q`/`--quiet`, and the `DOIGET_MODE` environment variable
+  are now parsed and resolved per the ADR-0017 precedence ladder
+  (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit
+  > TTY > quiet default). The three flag forms are mutually exclusive
+  (clap-enforced). `doiget serve` is pinned to `mcp` regardless of
+  flags / env, preserving the load-bearing stdout-purity invariant
+  (CONFIG.md §5 / Slice 9). The resolved `OutputMode` is threaded into
+  every command's `run(..)`; per-mode honouring (Quiet stdout
+  suppression, Json bodies for human-table commands, ERRORS.md §3
+  batch JSONL) is tracked in follow-up issues #203 / #204 / #205. This
+  PR ships the **machinery** that those follow-ups build on. (#144)
+
 ## [0.2.1-beta.6] - 2026-05-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.9] - 2026-05-20
+
+### Added
+
+- **[cli]** `--mode json` (and `--json`/`DOIGET_MODE=json`) now emits
+  structured JSON for six commands that previously emitted human-only
+  output: `info` (the `Metadata` struct), `list-recent` / `search`
+  (a JSON array of `EntryInfo` objects with
+  `{safekey, title, year, fetched_at}`), `config show` (the
+  `ResolvedConfig` struct), `config path`
+  (`{"config_path": "..."}`), `audit-log --verify` (a report object
+  with `total_rows` / `total_ok` / `total_issues` / per-segment
+  summaries / per-issue records), and `provenance migrate` (the
+  `MigrationReport` wrapped with `log_path`). Single-value bodies
+  (NOT JSON-Lines — the batch JSONL contract is the separate ERRORS.md
+  §3 surface tracked in #205). Stderr (human errors) is unaffected.
+  `Serialize` was added to two additive public types in `doiget-core`:
+  `store::EntryInfo` and `provenance::MigrationReport`. (#204)
+
 ## [0.2.1-beta.8] - 2026-05-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.6"
+version = "0.2.1-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.6"
+version = "0.2.1-beta.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.6"
+version = "0.2.1-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.8"
+version = "0.2.1-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.8"
+version = "0.2.1-beta.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.8"
+version = "0.2.1-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.7"
+version = "0.2.1-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.7"
+version = "0.2.1-beta.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.7"
+version = "0.2.1-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.7"
+version       = "0.2.1-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.8"
+version       = "0.2.1-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.6"
+version       = "0.2.1-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -62,7 +62,9 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 /// per-issue breakdown is always written to stdout BEFORE returning, so a
 /// caller scripting this subcommand can inspect both the structured stdout
 /// and the non-zero exit code.
-pub fn run(verify_flag: bool) -> Result<()> {
+pub fn run(verify_flag: bool, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // Json-body honoring are tracked in #203 / #204.
     if !verify_flag {
         // Issue #149: a missing required flag is argument misuse →
         // `docs/ERRORS.md` §4 exit 2, NOT the generic exit 1 a bare
@@ -241,7 +243,8 @@ mod tests {
         // returned error carries a `CliExit(2)` so `main` exits 2
         // instead of the old generic 1.
         let _g = EnvGuard::unset("DOIGET_LOG_PATH");
-        let err = run(false).expect_err("--verify must be required in Phase 1");
+        let err = run(false, crate::commands::output::OutputMode::Human)
+            .expect_err("--verify must be required in Phase 1");
         let cli_exit = err
             .downcast_ref::<CliExit>()
             .expect("missing --verify must carry a CliExit (issue #149)");
@@ -279,7 +282,8 @@ mod tests {
         drop(log);
 
         let _g = EnvGuard::set("DOIGET_LOG_PATH", path.as_str());
-        run(true).expect("verify must pass on a clean log");
+        run(true, crate::commands::output::OutputMode::Human)
+            .expect("verify must pass on a clean log");
     }
 
     #[test]
@@ -292,6 +296,7 @@ mod tests {
         assert!(!path.exists(), "precondition: log must not exist");
 
         let _g = EnvGuard::set("DOIGET_LOG_PATH", path.as_str());
-        run(true).expect("verify must succeed on missing log");
+        run(true, crate::commands::output::OutputMode::Human)
+            .expect("verify must succeed on missing log");
     }
 }

--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -97,7 +97,76 @@ pub fn run(verify_flag: bool, mode: super::output::OutputMode) -> Result<()> {
     // `stdout()` and using `writeln!` is the sanctioned way to emit lines.
     // `Quiet` mode short-circuits the emit block but keeps the bail!() at
     // the bottom so failure-on-issues exit codes still fire (#203).
-    if mode != super::output::OutputMode::Quiet {
+    if mode == super::output::OutputMode::Json {
+        // #204: structured report. Schema:
+        //   {"total_rows", "total_ok", "total_issues",
+        //    "segments": [{"name", "rows", "ok", "issues"}],
+        //    "issues":   [{"segment", "line", "kind", "message"}]}
+        // Single value (NOT JSON-Lines) so the whole report parses with
+        // one `JSON.parse` call. Sibling commands' shapes are sibling
+        // schemas — see commands/{list_recent,search,config,info,provenance}.
+        #[derive(serde::Serialize)]
+        struct SegmentSummary<'a> {
+            name: &'a str,
+            rows: usize,
+            ok: usize,
+            issues: usize,
+        }
+        #[derive(serde::Serialize)]
+        struct IssueRecord<'a> {
+            segment: &'a str,
+            line: usize,
+            kind: &'static str,
+            message: &'a str,
+        }
+        #[derive(serde::Serialize)]
+        struct Report<'a> {
+            total_rows: usize,
+            total_ok: usize,
+            total_issues: usize,
+            segments: Vec<SegmentSummary<'a>>,
+            issues: Vec<IssueRecord<'a>>,
+        }
+
+        let mut segs: Vec<SegmentSummary> = Vec::with_capacity(segments.len());
+        let mut issues: Vec<IssueRecord> = Vec::new();
+        for (path, report) in &segments {
+            let seg = path.file_name().unwrap_or(path.as_str());
+            segs.push(SegmentSummary {
+                name: seg,
+                rows: report.total_rows,
+                ok: report.ok_rows,
+                issues: report.errors.len(),
+            });
+            for issue in &report.errors {
+                let kind = match issue.kind {
+                    VerifyIssueKind::ParseError => "parse",
+                    VerifyIssueKind::PrevHashMismatch => "prev-hash",
+                    VerifyIssueKind::ThisHashMismatch => "this-hash",
+                    VerifyIssueKind::SequenceJump => "sequence",
+                    _ => "other",
+                };
+                issues.push(IssueRecord {
+                    segment: seg,
+                    line: issue.line,
+                    kind,
+                    message: &issue.message,
+                });
+            }
+        }
+        let report = Report {
+            total_rows,
+            total_ok,
+            total_issues,
+            segments: segs,
+            issues,
+        };
+        let s =
+            serde_json::to_string_pretty(&report).context("serialize audit-log report to JSON")?;
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        writeln!(out, "{s}").context("failed to write audit-log JSON to stdout")?;
+    } else if mode != super::output::OutputMode::Quiet {
         let stdout = std::io::stdout();
         let mut out = stdout.lock();
         // Aggregate header — byte-identical to the pre-rotation output when

--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -62,9 +62,12 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 /// per-issue breakdown is always written to stdout BEFORE returning, so a
 /// caller scripting this subcommand can inspect both the structured stdout
 /// and the non-zero exit code.
-pub fn run(verify_flag: bool, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
-    // Json-body honoring are tracked in #203 / #204.
+pub fn run(verify_flag: bool, mode: super::output::OutputMode) -> Result<()> {
+    // `mode` honors ADR-0017: `Quiet` suppresses the informational stdout
+    // (header + per-segment summary + per-issue lines). The verification
+    // itself still runs and the non-zero exit on issues is still raised,
+    // so quiet pipelines see the failure via exit code (#203). Rich Json
+    // body is tracked in #204.
     if !verify_flag {
         // Issue #149: a missing required flag is argument misuse →
         // `docs/ERRORS.md` §4 exit 2, NOT the generic exit 1 a bare
@@ -92,50 +95,55 @@ pub fn run(verify_flag: bool, _mode: super::output::OutputMode) -> Result<()> {
     // `print_stdout` is workspace-deny for MCP stdio safety — see module docs.
     // The `audit-log` CLI is the explicit human-facing channel; locking
     // `stdout()` and using `writeln!` is the sanctioned way to emit lines.
-    let stdout = std::io::stdout();
-    let mut out = stdout.lock();
-    // Aggregate header — byte-identical to the pre-rotation output when
-    // there is a single segment (back-compat with audit_log_e2e.rs).
-    writeln!(out, "audit-log verify: {total_rows} rows")
-        .context("failed to write header to stdout")?;
-    writeln!(out, "  ok:     {total_ok}").context("failed to write ok-row count to stdout")?;
-    writeln!(out, "  issues: {total_issues}").context("failed to write issue count to stdout")?;
+    // `Quiet` mode short-circuits the emit block but keeps the bail!() at
+    // the bottom so failure-on-issues exit codes still fire (#203).
+    if mode != super::output::OutputMode::Quiet {
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        // Aggregate header — byte-identical to the pre-rotation output when
+        // there is a single segment (back-compat with audit_log_e2e.rs).
+        writeln!(out, "audit-log verify: {total_rows} rows")
+            .context("failed to write header to stdout")?;
+        writeln!(out, "  ok:     {total_ok}").context("failed to write ok-row count to stdout")?;
+        writeln!(out, "  issues: {total_issues}")
+            .context("failed to write issue count to stdout")?;
 
-    for (path, report) in &segments {
-        let seg = path.file_name().unwrap_or(path.as_str());
-        if multi {
-            writeln!(
-                out,
-                "  segment {}: {} rows, {} ok, {} issues",
-                seg,
-                report.total_rows,
-                report.ok_rows,
-                report.errors.len()
-            )
-            .context("failed to write segment summary to stdout")?;
-        }
-        for issue in &report.errors {
-            // `VerifyIssueKind` is `#[non_exhaustive]` (forward-compat for
-            // future variants like `SessionIdChange`); the wildcard arm uses
-            // a generic label so older CLI builds keep producing well-formed
-            // output even when run against a newer core that adds variants.
-            let kind = match issue.kind {
-                VerifyIssueKind::ParseError => "parse",
-                VerifyIssueKind::PrevHashMismatch => "prev-hash",
-                VerifyIssueKind::ThisHashMismatch => "this-hash",
-                VerifyIssueKind::SequenceJump => "sequence",
-                _ => "other",
-            };
+        for (path, report) in &segments {
+            let seg = path.file_name().unwrap_or(path.as_str());
             if multi {
                 writeln!(
                     out,
-                    "  [{}] line {}: {} — {}",
-                    seg, issue.line, kind, issue.message
+                    "  segment {}: {} rows, {} ok, {} issues",
+                    seg,
+                    report.total_rows,
+                    report.ok_rows,
+                    report.errors.len()
                 )
-            } else {
-                writeln!(out, "  line {}: {} — {}", issue.line, kind, issue.message)
+                .context("failed to write segment summary to stdout")?;
             }
-            .context("failed to write issue line to stdout")?;
+            for issue in &report.errors {
+                // `VerifyIssueKind` is `#[non_exhaustive]` (forward-compat for
+                // future variants like `SessionIdChange`); the wildcard arm uses
+                // a generic label so older CLI builds keep producing well-formed
+                // output even when run against a newer core that adds variants.
+                let kind = match issue.kind {
+                    VerifyIssueKind::ParseError => "parse",
+                    VerifyIssueKind::PrevHashMismatch => "prev-hash",
+                    VerifyIssueKind::ThisHashMismatch => "this-hash",
+                    VerifyIssueKind::SequenceJump => "sequence",
+                    _ => "other",
+                };
+                if multi {
+                    writeln!(
+                        out,
+                        "  [{}] line {}: {} — {}",
+                        seg, issue.line, kind, issue.message
+                    )
+                } else {
+                    writeln!(out, "  line {}: {} — {}", issue.line, kind, issue.message)
+                }
+                .context("failed to write issue line to stdout")?;
+            }
         }
     }
 

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -58,7 +58,13 @@ use super::resolve_store_root;
 /// single `dry_run: bool` parameter — the option bundle's single-bool
 /// shape was YAGNI, and the wrapper only existed to spare integration
 /// tests a `BatchOptions::default()` literal.
-pub async fn run_with_options(path: String, dry_run: bool) -> Result<()> {
+pub async fn run_with_options(
+    path: String,
+    dry_run: bool,
+    _mode: super::output::OutputMode,
+) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // the CI-persona JSON-Lines per-ref shape are tracked in #203 / #205.
     // Step 1: read the input file. Failures surface before any fetch starts.
     let raw =
         std::fs::read_to_string(&path).with_context(|| format!("reading batch file: {path}"))?;

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -24,7 +24,10 @@ use super::resolve_store_root;
 /// On success, a BibTeX entry derived from the entry's `Metadata` is
 /// written to stdout. On a missing entry, the function returns an error
 /// so the CLI exits non-zero.
-pub fn run(input: String) -> Result<()> {
+pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Bib's BibTeX output is
+    // product output (the requested artifact), not informational, so
+    // Quiet does NOT suppress it. No follow-up issue is needed here.
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
 

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -119,17 +119,24 @@ impl ResolvedConfig {
 // belong on stderr by design (stdout stays clean for `| jq` style pipes
 // when we add `--json` later).
 #[allow(clippy::print_stdout, clippy::print_stderr)]
-pub fn run(action: String, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
-    // a Json body for `config show` are tracked in #203 / #204.
+pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
+    // `mode` honors ADR-0017: `Quiet` suppresses the TOML dump (`show`)
+    // and the path println! (`path`); `doctor` is unaffected because its
+    // per-check output is on stderr and only the failure/success exit
+    // code is the user-visible signal (#203). Json body for `show` is
+    // tracked in #204.
     let cfg = ResolvedConfig::from_env()?;
     match action.as_str() {
         "show" => {
-            let s = toml::to_string_pretty(&cfg)?;
-            print!("{s}");
+            if mode != super::output::OutputMode::Quiet {
+                let s = toml::to_string_pretty(&cfg)?;
+                print!("{s}");
+            }
         }
         "path" => {
-            println!("{}", cfg.config_path);
+            if mode != super::output::OutputMode::Quiet {
+                println!("{}", cfg.config_path);
+            }
         }
         "doctor" => {
             let mut all_ok = true;

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -127,17 +127,35 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
     // tracked in #204.
     let cfg = ResolvedConfig::from_env()?;
     match action.as_str() {
-        "show" => {
-            if mode != super::output::OutputMode::Quiet {
+        "show" => match mode {
+            super::output::OutputMode::Quiet => {}
+            super::output::OutputMode::Json => {
+                // #204: `ResolvedConfig` is `Serialize` (already used for
+                // the TOML branch).
+                let s = serde_json::to_string_pretty(&cfg)
+                    .map_err(|e| anyhow::anyhow!("serialise config to JSON: {e}"))?;
+                println!("{s}");
+            }
+            _ => {
                 let s = toml::to_string_pretty(&cfg)?;
                 print!("{s}");
             }
-        }
-        "path" => {
-            if mode != super::output::OutputMode::Quiet {
+        },
+        "path" => match mode {
+            super::output::OutputMode::Quiet => {}
+            super::output::OutputMode::Json => {
+                // Minimal JSON object so callers can parse the path
+                // uniformly; no trailing-newline ambiguity vs the raw
+                // `path` form.
+                println!(
+                    "{}",
+                    serde_json::json!({ "config_path": cfg.config_path.as_str() })
+                );
+            }
+            _ => {
                 println!("{}", cfg.config_path);
             }
-        }
+        },
         "doctor" => {
             let mut all_ok = true;
             check(

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -119,7 +119,9 @@ impl ResolvedConfig {
 // belong on stderr by design (stdout stays clean for `| jq` style pipes
 // when we add `--json` later).
 #[allow(clippy::print_stdout, clippy::print_stderr)]
-pub fn run(action: String) -> Result<()> {
+pub fn run(action: String, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // a Json body for `config show` are tracked in #203 / #204.
     let cfg = ResolvedConfig::from_env()?;
     match action.as_str() {
         "show" => {
@@ -304,7 +306,7 @@ mod tests {
         // The human-readable line moved to stderr; the error now carries
         // a `CliExit(2)` rather than a Display-formatted anyhow string.
         let _g = unset_all_doiget_config_env();
-        let err = run("doctor".into())
+        let err = run("doctor".into(), crate::commands::output::OutputMode::Human)
             .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
         let cli_exit = err
             .downcast_ref::<CliExit>()
@@ -322,7 +324,8 @@ mod tests {
         let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
         // home_dir() / config_dir() resolve to real, existing parents on
         // every supported test host (CI runners always have $HOME).
-        run("doctor".into()).expect("doctor should pass with contact email + real home dir");
+        run("doctor".into(), crate::commands::output::OutputMode::Human)
+            .expect("doctor should pass with contact email + real home dir");
     }
 
     #[test]
@@ -332,7 +335,8 @@ mod tests {
         // `docs/ERRORS.md` §4 exit 2. The descriptive line moved to
         // stderr; the error carries `CliExit(2)`.
         let _g = unset_all_doiget_config_env();
-        let err = run("bogus".into()).expect_err("bogus action should error");
+        let err = run("bogus".into(), crate::commands::output::OutputMode::Human)
+            .expect_err("bogus action should error");
         let cli_exit = err
             .downcast_ref::<CliExit>()
             .expect("unknown config action must carry a CliExit (issue #149)");

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -24,7 +24,9 @@ use super::resolve_store_root;
 /// [`Ref::parse`]). On success a single-element CSL JSON 1.0 array is
 /// written to stdout; a missing entry returns an error so the CLI exits
 /// non-zero (pipelines can distinguish "not in store" from "empty").
-pub fn run(input: String) -> Result<()> {
+pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Csl's JSON output is
+    // product output, not informational; Quiet does NOT suppress it.
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
 

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -528,7 +528,15 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
 /// single `dry_run: bool` parameter — the option bundle's single-bool
 /// shape was YAGNI, and the wrapper only existed to spare integration
 /// tests a `FetchOptions::default()` literal.
-pub async fn run_with_options(input: String, dry_run: bool) -> Result<()> {
+pub async fn run_with_options(
+    input: String,
+    dry_run: bool,
+    _mode: super::output::OutputMode,
+) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression of the
+    // success line is tracked in #203. The dry-run plan envelope is
+    // product output (the requested artifact) and is unaffected by
+    // mode.
     // Step 1: parse + safekey. Issue #119: render the cargo-style
     // `error[INVALID_REF]:` line + carry the exit code, rather than
     // letting the granular `RefParseError` fall out as an opaque

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -58,7 +58,11 @@ pub async fn run(
     depth: Option<u32>,
     total: Option<u32>,
     per_paper: Option<u32>,
+    _mode: super::output::OutputMode,
 ) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Graph's JSON output is
+    // product output (the requested artifact), not informational; Quiet
+    // does NOT suppress it.
     let ref_ = match Ref::parse(&input) {
         Ok(r) => r,
         Err(e) => {

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -25,7 +25,9 @@ use super::resolve_store_root;
 /// written to stdout as TOML. On a missing entry, the function returns an
 /// error so the CLI exits non-zero — the caller (a shell pipeline) can
 /// distinguish "entry not in store" from "entry was empty".
-pub fn run(input: String) -> Result<()> {
+pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // a Json body for `info` are tracked in #203 / #204.
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
 

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -26,9 +26,11 @@ use super::resolve_store_root;
 /// error so the CLI exits non-zero — the caller (a shell pipeline) can
 /// distinguish "entry not in store" from "entry was empty".
 pub fn run(input: String, mode: super::output::OutputMode) -> Result<()> {
-    // `mode` honors ADR-0017: `Quiet` skips the TOML dump but still
+    // `mode` honors ADR-0017: `Quiet` skips emission but still
     // resolves the entry so the "not-found → exit non-zero" contract
-    // continues to hold (#203). Json body is tracked in #204.
+    // continues to hold (#203). `Json` serialises `Metadata` directly
+    // (it carries `Serialize`); the wire form is the field-name JSON of
+    // the on-disk TOML (#204).
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
 
@@ -45,12 +47,6 @@ pub fn run(input: String, mode: super::output::OutputMode) -> Result<()> {
                 // Quiet: existence-check only; exit 0 with no stdout.
                 return Ok(());
             }
-            // Re-serialize to TOML for stdout. We use `toml::to_string_pretty`
-            // for human readability; this is NOT the §7-normalized form
-            // written to disk, but `info` is a presentation surface, not a
-            // round-tripper.
-            let s = toml::to_string_pretty(&m)
-                .context("failed to serialize metadata to TOML for stdout")?;
             // Workspace lints deny `print_stdout` (the `print!`/`println!`
             // macros) so JSON-RPC frames never collide with diagnostics.
             // `writeln!` / `write!` against an explicit `stdout().lock()`
@@ -58,6 +54,18 @@ pub fn run(input: String, mode: super::output::OutputMode) -> Result<()> {
             // explicitly. See `docs/SECURITY.md` §3 / ADR-0001.
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
+            if mode == super::output::OutputMode::Json {
+                let s = serde_json::to_string_pretty(&m)
+                    .context("failed to serialize metadata to JSON for stdout")?;
+                writeln!(out, "{s}").context("failed to write metadata JSON to stdout")?;
+                return Ok(());
+            }
+            // Human (default): re-serialize to TOML for stdout. We use
+            // `toml::to_string_pretty` for human readability; this is NOT
+            // the §7-normalized form written to disk, but `info` is a
+            // presentation surface, not a round-tripper.
+            let s = toml::to_string_pretty(&m)
+                .context("failed to serialize metadata to TOML for stdout")?;
             write!(out, "{s}").context("failed to write metadata to stdout")?;
             // toml::to_string_pretty already emits a trailing newline, but
             // be defensive in case a future toml-rs revision changes that.

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -25,9 +25,10 @@ use super::resolve_store_root;
 /// written to stdout as TOML. On a missing entry, the function returns an
 /// error so the CLI exits non-zero — the caller (a shell pipeline) can
 /// distinguish "entry not in store" from "entry was empty".
-pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
-    // a Json body for `info` are tracked in #203 / #204.
+pub fn run(input: String, mode: super::output::OutputMode) -> Result<()> {
+    // `mode` honors ADR-0017: `Quiet` skips the TOML dump but still
+    // resolves the entry so the "not-found → exit non-zero" contract
+    // continues to hold (#203). Json body is tracked in #204.
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
 
@@ -40,6 +41,10 @@ pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
 
     match metadata {
         Some(m) => {
+            if mode == super::output::OutputMode::Quiet {
+                // Quiet: existence-check only; exit 0 with no stdout.
+                return Ok(());
+            }
             // Re-serialize to TOML for stdout. We use `toml::to_string_pretty`
             // for human readability; this is NOT the §7-normalized form
             // written to disk, but `info` is a presentation surface, not a

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -28,14 +28,19 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// Emits a tab-separated table on stdout. The column order is intentionally
 /// stable for `cut(1)` consumption; future fields will be APPENDED, not
 /// inserted.
-pub fn run(limit: usize, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
-    // a Json body for `list-recent` are tracked in #203 / #204.
+pub fn run(limit: usize, mode: super::output::OutputMode) -> Result<()> {
+    // `mode` honors ADR-0017: `Quiet` suppresses the TSV table but the
+    // store read still runs (so I/O failures surface as exit 1) (#203).
+    // Json body is tracked in #204.
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
     let entries = store
         .list_recent(limit)
         .context("failed to list recent store entries")?;
+
+    if mode == super::output::OutputMode::Quiet {
+        return Ok(());
+    }
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -44,6 +44,16 @@ pub fn run(limit: usize, mode: super::output::OutputMode) -> Result<()> {
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
+    if mode == super::output::OutputMode::Json {
+        // #204: `EntryInfo` carries `Serialize`; emit a JSON array, one
+        // object per entry. Single value (NOT JSON-Lines) so the whole
+        // result round-trips through `JSON.parse` in one call — JSONL
+        // batch shape is a separate contract (ERRORS.md §3 / #205).
+        let s = serde_json::to_string_pretty(&entries)
+            .context("failed to serialize list-recent entries to JSON")?;
+        writeln!(out, "{s}").context("failed to write list-recent JSON to stdout")?;
+        return Ok(());
+    }
     writeln!(out, "safekey\tyear\ttitle\tfetched_at")
         .context("failed to write list-recent header to stdout")?;
     for e in entries {

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -28,7 +28,9 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// Emits a tab-separated table on stdout. The column order is intentionally
 /// stable for `cut(1)` consumption; future fields will be APPENDED, not
 /// inserted.
-pub fn run(limit: usize) -> Result<()> {
+pub fn run(limit: usize, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // a Json body for `list-recent` are tracked in #203 / #204.
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
     let entries = store

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod csl;
 pub mod fetch;
 pub mod info;
 pub mod list_recent;
+pub mod output;
 pub mod provenance;
 pub mod search;
 

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -1,0 +1,234 @@
+//! Output-mode resolution for the `doiget` CLI (ADR-0017, #144).
+//!
+//! ADR-0017 specifies the precedence ladder
+//! `--mode > --json/--quiet > DOIGET_MODE env > subcommand-implicit > TTY > quiet`.
+//! CONFIG.md §5 additionally pins `doiget serve` to `mcp` mode regardless
+//! of flags — a load-bearing security invariant (the stdout-purity Slice 9
+//! CI job already enforces "MCP mode forbids non-JSON stdout"). The
+//! `forced_implicit` parameter to [`resolve`] expresses that override: when
+//! `Some(_)`, it overrides everything else.
+//!
+//! Resolution is split into a pure function ([`resolve`]) plus a thin
+//! TTY-detection wrapper ([`stdout_is_tty`]) so the ladder is fully
+//! unit-testable without environment manipulation.
+//!
+//! # Phase-1 scope (#144 / PR5)
+//!
+//! This PR delivers the **machinery** — global flags, ladder, threading,
+//! `serve`→`mcp` invariant. Per-command rich JSON bodies for the
+//! human-table commands (`info`, `list-recent`, `search`, `config show`,
+//! `audit-log`) and the ERRORS.md §3 JSON-Lines batch error shape are
+//! tracked as follow-ups; in this PR `Json` mode is honored where a
+//! command already emits JSON (`csl`, `graph`, `fetch`/`batch` dry-run
+//! plan) and `Quiet` mode is a stdout-suppression hint everywhere.
+
+use clap::ValueEnum;
+
+/// The four output modes from `docs/CONFIG.md` §3 / ADR-0017.
+///
+/// - `Human`: line-oriented text, intended for a terminal.
+/// - `Json`: structured machine output (where the command supports it).
+/// - `Quiet`: no informational stdout; errors still go to stderr.
+/// - `Mcp`: JSON-RPC framing on stdout (forbidden for non-`serve`
+///   commands; entered only via the `Serve` subcommand).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum OutputMode {
+    /// Line-oriented text output, intended for a terminal.
+    Human,
+    /// Structured JSON output (where the command supports it).
+    Json,
+    /// No informational stdout; errors still go to stderr.
+    Quiet,
+    /// JSON-RPC framing on stdout (only via `doiget serve`).
+    Mcp,
+}
+
+/// Which short-form implication, if any, was given on the command line.
+///
+/// `--mode <m>` carries an explicit [`OutputMode`]; `--json` / `--quiet`
+/// are short-form implications per CONFIG.md §5. Mutual exclusion among
+/// the three flags is enforced at the clap layer via `conflicts_with`,
+/// so [`resolve`]'s caller is guaranteed to pass at most one of the
+/// three.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlagInput {
+    /// `--mode <human|json|quiet|mcp>` was given.
+    Explicit(OutputMode),
+    /// `--json` was given (implies `Json`).
+    JsonShort,
+    /// `--quiet`/`-q` was given (implies `Quiet`).
+    QuietShort,
+    /// No mode-related flag was given.
+    None,
+}
+
+/// Resolve the effective [`OutputMode`] per ADR-0017.
+///
+/// Precedence (highest first):
+///
+/// 1. `forced_implicit` — a subcommand-pinned mode that overrides
+///    everything (e.g. `doiget serve` → `Mcp` per CONFIG.md §5; required
+///    for the Slice 9 stdout-purity invariant).
+/// 2. `flag` — `--mode` / `--json` / `--quiet` on the command line.
+/// 3. `env` — `DOIGET_MODE` (parsed by [`parse_env_mode`]; unrecognised
+///    values are ignored, matching CONFIG.md §4's "doiget reads only the
+///    keys it knows about" posture).
+/// 4. `is_tty` — `Human` when stdout is a terminal, otherwise `Quiet`
+///    (CONFIG.md §3.b's "implicit + TTY > quiet (default)").
+///
+/// This function is pure: no env reads, no I/O. The caller plumbs
+/// `env::var("DOIGET_MODE").ok()` and an `is_tty` probe in.
+pub fn resolve(
+    forced_implicit: Option<OutputMode>,
+    flag: FlagInput,
+    env: Option<&str>,
+    is_tty: bool,
+) -> OutputMode {
+    if let Some(m) = forced_implicit {
+        return m;
+    }
+    match flag {
+        FlagInput::Explicit(m) => m,
+        FlagInput::JsonShort => OutputMode::Json,
+        FlagInput::QuietShort => OutputMode::Quiet,
+        FlagInput::None => env.and_then(parse_env_mode).unwrap_or(if is_tty {
+            OutputMode::Human
+        } else {
+            OutputMode::Quiet
+        }),
+    }
+}
+
+/// Parse a `DOIGET_MODE` env-var value. Recognises the four
+/// CONFIG.md §3 modes case-insensitively; returns `None` for empty,
+/// whitespace-only, or unrecognised input (the resolution ladder then
+/// falls through to TTY detection).
+pub fn parse_env_mode(s: &str) -> Option<OutputMode> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "human" => Some(OutputMode::Human),
+        "json" => Some(OutputMode::Json),
+        "quiet" => Some(OutputMode::Quiet),
+        "mcp" => Some(OutputMode::Mcp),
+        _ => None,
+    }
+}
+
+/// `true` if stdout is attached to a terminal. Wraps the standard
+/// library's [`std::io::IsTerminal`] probe; the trait is in scope only
+/// here so test code can call [`resolve`] with a synthetic `is_tty`
+/// boolean without linking to `IsTerminal`.
+pub fn stdout_is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- forced_implicit overrides everything ---------------------------
+
+    #[test]
+    fn forced_mcp_wins_over_flag_env_and_tty() {
+        // `doiget serve` MUST be `Mcp` even if the user passes
+        // `--mode quiet` or sets `DOIGET_MODE=human` (CONFIG.md §5).
+        let m = resolve(
+            Some(OutputMode::Mcp),
+            FlagInput::Explicit(OutputMode::Quiet),
+            Some("human"),
+            true,
+        );
+        assert_eq!(m, OutputMode::Mcp);
+    }
+
+    // ---- flag > env > tty ---------------------------------------------
+
+    #[test]
+    fn explicit_flag_wins_over_env_and_tty() {
+        let m = resolve(
+            None,
+            FlagInput::Explicit(OutputMode::Json),
+            Some("human"),
+            true,
+        );
+        assert_eq!(m, OutputMode::Json);
+    }
+
+    #[test]
+    fn json_short_flag_implies_json() {
+        let m = resolve(None, FlagInput::JsonShort, Some("human"), true);
+        assert_eq!(m, OutputMode::Json);
+    }
+
+    #[test]
+    fn quiet_short_flag_implies_quiet() {
+        let m = resolve(None, FlagInput::QuietShort, Some("human"), true);
+        assert_eq!(m, OutputMode::Quiet);
+    }
+
+    #[test]
+    fn env_wins_when_no_flag() {
+        let m = resolve(None, FlagInput::None, Some("json"), true);
+        assert_eq!(m, OutputMode::Json);
+    }
+
+    #[test]
+    fn env_is_case_insensitive_and_trims_whitespace() {
+        assert_eq!(parse_env_mode("HUMAN"), Some(OutputMode::Human));
+        assert_eq!(parse_env_mode("  Json  "), Some(OutputMode::Json));
+        assert_eq!(parse_env_mode("MCP"), Some(OutputMode::Mcp));
+    }
+
+    #[test]
+    fn unrecognised_env_falls_through_to_tty() {
+        // `DOIGET_MODE=garbage` is ignored, ladder continues to TTY.
+        let tty = resolve(None, FlagInput::None, Some("garbage"), true);
+        let pipe = resolve(None, FlagInput::None, Some("garbage"), false);
+        assert_eq!(tty, OutputMode::Human);
+        assert_eq!(pipe, OutputMode::Quiet);
+    }
+
+    #[test]
+    fn empty_env_falls_through_to_tty() {
+        // `DOIGET_MODE=""` (empty) is treated as unset (parse_env_mode
+        // returns None on an empty/whitespace string).
+        assert_eq!(parse_env_mode(""), None);
+        assert_eq!(parse_env_mode("   "), None);
+        let tty = resolve(None, FlagInput::None, Some(""), true);
+        assert_eq!(tty, OutputMode::Human);
+    }
+
+    // ---- TTY tail ------------------------------------------------------
+
+    #[test]
+    fn tty_with_no_flag_no_env_yields_human() {
+        let m = resolve(None, FlagInput::None, None, true);
+        assert_eq!(m, OutputMode::Human);
+    }
+
+    #[test]
+    fn no_tty_with_no_flag_no_env_yields_quiet() {
+        let m = resolve(None, FlagInput::None, None, false);
+        assert_eq!(m, OutputMode::Quiet);
+    }
+
+    // ---- env never overrides flag, never beats forced_implicit --------
+
+    #[test]
+    fn env_does_not_override_explicit_flag() {
+        let m = resolve(
+            None,
+            FlagInput::Explicit(OutputMode::Quiet),
+            Some("human"),
+            true,
+        );
+        assert_eq!(m, OutputMode::Quiet);
+    }
+
+    #[test]
+    fn forced_implicit_overrides_env() {
+        let m = resolve(Some(OutputMode::Mcp), FlagInput::None, Some("human"), true);
+        assert_eq!(m, OutputMode::Mcp);
+    }
+}

--- a/crates/doiget-cli/src/commands/provenance.rs
+++ b/crates/doiget-cli/src/commands/provenance.rs
@@ -30,7 +30,9 @@ use doiget_core::provenance::{migrate_v1_to_v2, MigrationReport};
 /// rewrite path runs: the original log is preserved as
 /// `<log_path>.v1-backup` and the migrated v2 log is atomically
 /// swapped in.
-pub fn migrate(dry_run: bool) -> Result<()> {
+pub fn migrate(dry_run: bool, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // a Json body for the migration report are tracked in #203 / #204.
     let log_path = resolve_log_path()?;
     let report = migrate_v1_to_v2(&log_path, dry_run)
         .with_context(|| format!("migrating provenance log at {log_path}"))?;
@@ -140,6 +142,7 @@ mod tests {
         assert!(!path.exists(), "precondition");
 
         let _g = EnvGuard::set("DOIGET_LOG_PATH", path.as_str());
-        migrate(true).expect("dry-run on missing log must succeed");
+        migrate(true, crate::commands::output::OutputMode::Human)
+            .expect("dry-run on missing log must succeed");
     }
 }

--- a/crates/doiget-cli/src/commands/provenance.rs
+++ b/crates/doiget-cli/src/commands/provenance.rs
@@ -30,13 +30,18 @@ use doiget_core::provenance::{migrate_v1_to_v2, MigrationReport};
 /// rewrite path runs: the original log is preserved as
 /// `<log_path>.v1-backup` and the migrated v2 log is atomically
 /// swapped in.
-pub fn migrate(dry_run: bool, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
-    // a Json body for the migration report are tracked in #203 / #204.
+pub fn migrate(dry_run: bool, output_mode: super::output::OutputMode) -> Result<()> {
+    // `output_mode` honors ADR-0017: `Quiet` suppresses the human
+    // summary, but the migration itself (mutation + backup rename) still
+    // runs and any error still propagates (#203). Json body is tracked
+    // in #204.
     let log_path = resolve_log_path()?;
     let report = migrate_v1_to_v2(&log_path, dry_run)
         .with_context(|| format!("migrating provenance log at {log_path}"))?;
 
+    if output_mode == super::output::OutputMode::Quiet {
+        return Ok(());
+    }
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     emit_summary(&mut out, &log_path, &report)?;

--- a/crates/doiget-cli/src/commands/provenance.rs
+++ b/crates/doiget-cli/src/commands/provenance.rs
@@ -44,6 +44,24 @@ pub fn migrate(dry_run: bool, output_mode: super::output::OutputMode) -> Result<
     }
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
+    if output_mode == super::output::OutputMode::Json {
+        // #204: `MigrationReport` is `Serialize`. We wrap it with the
+        // `log_path` so the JSON consumer doesn't have to re-derive it
+        // from `DOIGET_LOG_PATH` / the platform's config dir.
+        #[derive(serde::Serialize)]
+        struct JsonReport<'a> {
+            log_path: &'a str,
+            report: &'a doiget_core::provenance::MigrationReport,
+        }
+        let payload = JsonReport {
+            log_path: log_path.as_str(),
+            report: &report,
+        };
+        let s =
+            serde_json::to_string_pretty(&payload).context("serialize migration report to JSON")?;
+        writeln!(out, "{s}").context("failed to write migration JSON to stdout")?;
+        return Ok(());
+    }
     emit_summary(&mut out, &log_path, &report)?;
     Ok(())
 }

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -37,9 +37,10 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// error on stderr — the on-disk `Store::search` would otherwise return
 /// every entry up to `DEFAULT_LIMIT`, which is almost never what the caller
 /// intended.
-pub fn run(query: String, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
-    // a Json body for `search` are tracked in #203 / #204.
+pub fn run(query: String, mode: super::output::OutputMode) -> Result<()> {
+    // `mode` honors ADR-0017: `Quiet` suppresses the TSV table; the
+    // empty-query bail!() and store error paths still raise (#203). Json
+    // body is tracked in #204.
     if query.trim().is_empty() {
         anyhow::bail!("search query is empty");
     }
@@ -49,6 +50,10 @@ pub fn run(query: String, _mode: super::output::OutputMode) -> Result<()> {
     let entries = store
         .search(&query, DEFAULT_LIMIT)
         .with_context(|| format!("search failed for query {query:?}"))?;
+
+    if mode == super::output::OutputMode::Quiet {
+        return Ok(());
+    }
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -57,6 +57,13 @@ pub fn run(query: String, mode: super::output::OutputMode) -> Result<()> {
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
+    if mode == super::output::OutputMode::Json {
+        // #204: `EntryInfo` carries `Serialize`; emit a JSON array.
+        let s = serde_json::to_string_pretty(&entries)
+            .context("failed to serialize search entries to JSON")?;
+        writeln!(out, "{s}").context("failed to write search JSON to stdout")?;
+        return Ok(());
+    }
     writeln!(out, "safekey\tyear\ttitle\tfetched_at")
         .context("failed to write search header to stdout")?;
     for e in entries {

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -37,7 +37,9 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// error on stderr — the on-disk `Store::search` would otherwise return
 /// every entry up to `DEFAULT_LIMIT`, which is almost never what the caller
 /// intended.
-pub fn run(query: String) -> Result<()> {
+pub fn run(query: String, _mode: super::output::OutputMode) -> Result<()> {
+    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression and
+    // a Json body for `search` are tracked in #203 / #204.
     if query.trim().is_empty() {
         anyhow::bail!("search query is empty");
     }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -8,6 +8,7 @@
 //! stdio (ADR-0001).
 
 use clap::{Parser, Subcommand};
+use doiget_cli::commands::output::{self, FlagInput, OutputMode};
 
 /// `doiget provenance ...` action selector. Ships only the v1→v2
 /// migration in Slice 4 (ADR-0024); further actions (e.g. `compact`,
@@ -50,6 +51,28 @@ enum ProvenanceAction {
                   See README.md and docs/ for the full specification."
 )]
 struct Cli {
+    /// Output mode (`human` | `json` | `quiet` | `mcp`). Highest-precedence
+    /// signal in the ADR-0017 resolution ladder. Conflicts with `--json`
+    /// and `--quiet`. `doiget serve` ignores this and always runs in `mcp`
+    /// (CONFIG.md §5 — load-bearing security invariant for stdout purity).
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        conflicts_with_all = ["json", "quiet"],
+    )]
+    mode: Option<OutputMode>,
+
+    /// Short form of `--mode json` (CONFIG.md §5). Conflicts with `--mode`
+    /// and `--quiet`.
+    #[arg(long, global = true, conflicts_with_all = ["mode", "quiet"])]
+    json: bool,
+
+    /// Short form of `--mode quiet` (CONFIG.md §5). Conflicts with
+    /// `--mode` and `--json`.
+    #[arg(short = 'q', long, global = true, conflicts_with_all = ["mode", "json"])]
+    quiet: bool,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -173,7 +196,44 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+/// Build the `FlagInput` from the three mutually-exclusive global
+/// flags. Clap's `conflicts_with_all` guarantees at most one is set, so
+/// the ordering of the if-arms below is irrelevant to correctness.
+fn flag_input_from(cli: &Cli) -> FlagInput {
+    if let Some(m) = cli.mode {
+        FlagInput::Explicit(m)
+    } else if cli.json {
+        FlagInput::JsonShort
+    } else if cli.quiet {
+        FlagInput::QuietShort
+    } else {
+        FlagInput::None
+    }
+}
+
+/// Compute the `forced_implicit` mode from the subcommand. Only `serve`
+/// pins a mode (`Mcp`) — CONFIG.md §5 / ADR-0017 / SECURITY.md §3: the
+/// MCP server emits JSON-RPC frames on stdout and a `--mode quiet` /
+/// `--mode human` override there would break the protocol, so the
+/// override is unconditional.
+fn forced_implicit_for(command: &Option<Command>) -> Option<OutputMode> {
+    match command {
+        Some(Command::Serve) => Some(OutputMode::Mcp),
+        _ => None,
+    }
+}
+
 async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
+    // Resolve the effective output mode ONCE per invocation per ADR-0017.
+    // The pure resolver lives in `commands::output`; this site is the
+    // single I/O-touching layer that reads env + probes the TTY.
+    let mode = output::resolve(
+        forced_implicit_for(&cli.command),
+        flag_input_from(&cli),
+        std::env::var("DOIGET_MODE").ok().as_deref(),
+        output::stdout_is_tty(),
+    );
+
     match cli.command {
         None => {
             anyhow::bail!("no subcommand. Run `doiget --help` for available commands.");
@@ -181,30 +241,40 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         // Phase 1 subcommands. All command modules live in the library half
         // of this crate (see `src/lib.rs`) so integration tests can drive them
         // in-process.
-        Some(Command::AuditLog { verify }) => doiget_cli::commands::audit_log::run(verify),
+        //
+        // Each command receives the resolved `mode`. Per-mode behaviour
+        // (Quiet stdout suppression, Json bodies for human-table
+        // commands) is tracked in follow-up issues #203 / #204 / #205;
+        // this PR only wires the threading and the `serve→Mcp` invariant.
+        Some(Command::AuditLog { verify }) => doiget_cli::commands::audit_log::run(verify, mode),
         Some(Command::Provenance { action }) => match action {
             ProvenanceAction::Migrate { dry_run } => {
-                doiget_cli::commands::provenance::migrate(dry_run)
+                doiget_cli::commands::provenance::migrate(dry_run, mode)
             }
         },
-        Some(Command::Config { action }) => doiget_cli::commands::config::run(action),
-        Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_),
-        Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit),
-        Some(Command::Search { query }) => doiget_cli::commands::search::run(query),
+        Some(Command::Config { action }) => doiget_cli::commands::config::run(action, mode),
+        Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_, mode),
+        Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit, mode),
+        Some(Command::Search { query }) => doiget_cli::commands::search::run(query, mode),
         Some(Command::Fetch { ref_, dry_run }) => {
-            doiget_cli::commands::fetch::run_with_options(ref_, dry_run).await
+            doiget_cli::commands::fetch::run_with_options(ref_, dry_run, mode).await
         }
         Some(Command::Batch { path, dry_run }) => {
-            doiget_cli::commands::batch::run_with_options(path, dry_run).await
+            doiget_cli::commands::batch::run_with_options(path, dry_run, mode).await
         }
-        Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_),
-        Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_),
+        Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_, mode),
+        Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_, mode),
         // Phase 3 (MCP foundation). The MCP server runs on stdio per
         // ADR-0001. The `tracing_subscriber` installed at the top of
         // `main` is already redirected to stderr, so any rmcp / tool
         // tracing output will not collide with JSON-RPC frames on stdout.
         // See docs/SECURITY.md §3 / docs/MCP_TOOLS.md §8.
+        //
+        // The resolver above forces `mode == Mcp` here (CONFIG.md §5);
+        // the mcp server itself hard-codes JSON-RPC framing on stdout
+        // regardless, so the `mode` value is informational at this site.
         Some(Command::Serve) => {
+            debug_assert_eq!(mode, OutputMode::Mcp, "serve must resolve to Mcp");
             let profile = doiget_core::CapabilityProfile::from_env()?;
             doiget_mcp::Server::new(profile).run().await
         }
@@ -216,6 +286,6 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             depth,
             total,
             per_paper,
-        }) => doiget_cli::commands::graph::run(ref_, depth, total, per_paper).await,
+        }) => doiget_cli::commands::graph::run(ref_, depth, total, per_paper, mode).await,
     }
 }

--- a/crates/doiget-cli/tests/audit_log_e2e.rs
+++ b/crates/doiget-cli/tests/audit_log_e2e.rs
@@ -72,7 +72,11 @@ fn doiget(log_path: &Utf8PathBuf, dir_root: &Utf8PathBuf) -> Command {
         // resolver bug can't accidentally point at the developer's real
         // `~/.config/doiget/access.jsonl`.
         .env("HOME", dir_root.as_str())
-        .env("USERPROFILE", dir_root.as_str());
+        .env("USERPROFILE", dir_root.as_str())
+        // #203: these tests assert specific human-mode stdout; the
+        // subprocess runs non-TTY (assert_cmd captures stdout) which
+        // defaults to Quiet after #203's honoring. Opt in explicitly.
+        .env("DOIGET_MODE", "human");
     cmd
 }
 

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -19,6 +19,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use doiget_cli::commands::batch;
+use doiget_cli::commands::output::OutputMode;
 use doiget_core::provenance::{LogEvent, LogResult, LogRow};
 use serial_test::serial;
 use tempfile::TempDir;
@@ -125,7 +126,7 @@ async fn batch_three_arxiv_refs_succeeds_end_to_end() {
     )
     .expect("write refs file");
 
-    batch::run_with_options(refs_path.as_str().to_string(), false)
+    batch::run_with_options(refs_path.as_str().to_string(), false, OutputMode::Human)
         .await
         .expect("batch::run_with_options succeeds");
 
@@ -237,7 +238,8 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
     )
     .expect("write refs file");
 
-    let result = batch::run_with_options(refs_path.as_str().to_string(), false).await;
+    let result =
+        batch::run_with_options(refs_path.as_str().to_string(), false, OutputMode::Human).await;
     let err = result.expect_err("batch with a malformed ref must surface an error to the binary");
     // Issue #143 / `docs/ERRORS.md` §4: the batch exit code is the number
     // of failures (capped at 255), NOT a blanket 1. Exactly one entry

--- a/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
@@ -25,6 +25,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use doiget_cli::commands::fetch;
+use doiget_cli::commands::output::OutputMode;
 use doiget_core::provenance::{LogEvent, LogResult, LogRow};
 use doiget_core::store::Metadata;
 use serial_test::serial;
@@ -80,7 +81,7 @@ async fn arxiv_2401_12345_end_to_end() {
 
     // Step 3: run the orchestrator end-to-end. No child binary; no real
     // network traffic.
-    fetch::run_with_options("arxiv:2401.12345".to_string(), false)
+    fetch::run_with_options("arxiv:2401.12345".to_string(), false, OutputMode::Human)
         .await
         .expect("fetch::run_with_options succeeds");
 

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -26,6 +26,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use doiget_cli::commands::fetch;
+use doiget_cli::commands::output::OutputMode;
 use doiget_core::provenance::{LogEvent, LogResult, LogRow};
 use doiget_core::store::Metadata;
 use serial_test::serial;
@@ -151,7 +152,7 @@ async fn fetch_doi_oa_pdf_happy_path() {
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
     // Step 3: run the orchestrator end-to-end. No real network traffic.
-    fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
         .await
         .expect("fetch::run_with_options succeeds");
 
@@ -336,7 +337,7 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     // assertions below remain (the pre-fetch denial emits the same
     // closed-set `NETWORK_ERROR` provenance row as a redirect-time
     // denial; the process EXIT code is the reclassified value).
-    let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
+    let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
         .await
         .expect_err("a blocked OA PDF leg must NOT be a silent success (issue #145)");
     let cli_exit = err
@@ -449,7 +450,7 @@ async fn fetch_doi_crossref_down_unpaywall_oa_still_yields_pdf() {
     env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", base_uri));
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
-    fetch::run_with_options(format!("doi:{}", TEST_DOI), false)
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
         .await
         .expect("fetch must succeed via Unpaywall even though Crossref failed");
 

--- a/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
@@ -21,6 +21,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use doiget_cli::commands::fetch::{build_dry_run_envelope, build_fetch_plan, run_with_options};
+use doiget_cli::commands::output::OutputMode;
 use doiget_core::Ref;
 use serial_test::serial;
 use tempfile::TempDir;
@@ -60,7 +61,7 @@ async fn dry_run_fetch_doi_returns_ok_without_side_effects() {
     // crossref/unpaywall/oa-publisher hosts is not stubbed). The fact
     // that this call returns Ok proves the dry-run path short-circuits
     // before any network call.
-    let result = run_with_options("10.1234/foo".to_string(), true).await;
+    let result = run_with_options("10.1234/foo".to_string(), true, OutputMode::Human).await;
     result.expect("dry-run fetch::run_with_options succeeds");
 
     // Step 3: assert the on-disk side-effects are empty. The store
@@ -112,7 +113,7 @@ async fn dry_run_fetch_arxiv_returns_ok_without_side_effects() {
     env.set("DOIGET_STORE_ROOT", store_root.as_str());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
 
-    let result = run_with_options("arxiv:2401.12345".to_string(), true).await;
+    let result = run_with_options("arxiv:2401.12345".to_string(), true, OutputMode::Human).await;
     result.expect("dry-run arxiv fetch::run_with_options succeeds");
 
     assert!(

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -100,7 +100,10 @@ fn doiget(root: &Utf8PathBuf) -> Command {
     let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
     cmd.env("DOIGET_STORE_ROOT", root.as_str())
         .env("HOME", root.as_str())
-        .env("USERPROFILE", root.as_str());
+        .env("USERPROFILE", root.as_str())
+        // #203: opt into human stdout — assert_cmd's captured stdout is
+        // non-TTY, which defaults to Quiet after #203 honoring.
+        .env("DOIGET_MODE", "human");
     cmd
 }
 

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -222,3 +222,50 @@ fn list_recent_on_empty_store_prints_only_header() {
         "empty store should produce header-only stdout, got:\n{stdout}"
     );
 }
+
+// ---- #204 JSON-mode coverage --------------------------------------------
+
+#[test]
+fn info_json_emits_metadata_object() {
+    let (_dir_guard, root) = seeded_store();
+
+    let out = doiget(&root)
+        // The #203 helper sets DOIGET_MODE=human; override per-test for
+        // the JSON case (env_clear is too invasive — we still need
+        // DOIGET_STORE_ROOT / HOME for the resolver).
+        .env("DOIGET_MODE", "json")
+        .args(["info", "10.1234/alpha"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("info JSON stdout utf-8");
+    let v: serde_json::Value = serde_json::from_str(&s).expect("info JSON parses");
+    // The Metadata struct's `title` field is the only stable assertion
+    // surface at this level (the rest is the on-disk TOML schema).
+    assert_eq!(v["title"], "First Quantum Result");
+}
+
+#[test]
+fn list_recent_json_emits_array_of_entries() {
+    let (_dir_guard, root) = seeded_store();
+
+    let out = doiget(&root)
+        .env("DOIGET_MODE", "json")
+        .args(["list-recent"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("list-recent JSON stdout utf-8");
+    let v: serde_json::Value = serde_json::from_str(&s).expect("list-recent JSON parses");
+    let arr = v.as_array().expect("list-recent JSON is an array");
+    assert_eq!(arr.len(), 2, "seeded store has 2 entries");
+    // EntryInfo schema (#204): {safekey, title, year, fetched_at}.
+    for entry in arr {
+        assert!(entry["safekey"].is_string(), "safekey is a string");
+        assert!(entry["title"].is_string(), "title is a string");
+    }
+}

--- a/crates/doiget-cli/tests/json_bodies_e2e.rs
+++ b/crates/doiget-cli/tests/json_bodies_e2e.rs
@@ -99,6 +99,35 @@ fn list_recent_json_empty_store_emits_empty_array() {
     assert_eq!(v.as_array().unwrap().len(), 0, "empty store → []");
 }
 
+// ---- provenance migrate --json -----------------------------------------
+
+#[test]
+fn provenance_migrate_dry_run_json_emits_report_object() {
+    // A missing log is the cleanest no-setup path: `migrate_v1_to_v2`
+    // returns an empty `MigrationReport` in dry-run mode, which the
+    // JSON branch wraps with `log_path` and emits.
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["--json", "provenance", "migrate", "--dry-run"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    let v: Value = serde_json::from_str(&s).expect("provenance migrate JSON parses");
+    assert!(v["log_path"].is_string(), "log_path field present");
+    assert_eq!(
+        v["report"]["dry_run"],
+        Value::Bool(true),
+        "dry_run flag round-trips"
+    );
+    assert!(
+        v["report"]["rows_rewritten"].is_number(),
+        "rows_rewritten present"
+    );
+}
+
 // ---- regression: human / quiet modes still behave as before ------------
 
 #[test]

--- a/crates/doiget-cli/tests/json_bodies_e2e.rs
+++ b/crates/doiget-cli/tests/json_bodies_e2e.rs
@@ -15,7 +15,11 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
+use std::fs;
+
 use assert_cmd::Command;
+use camino::Utf8PathBuf;
+use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -97,6 +101,135 @@ fn list_recent_json_empty_store_emits_empty_array() {
     let v: Value = serde_json::from_str(&s).expect("list-recent JSON parses");
     assert!(v.is_array(), "list-recent emits an array");
     assert_eq!(v.as_array().unwrap().len(), 0, "empty store → []");
+}
+
+// ---- audit-log issue-rendering JSON path -------------------------------
+
+/// Seed a 2-row chain at `path`, then tamper row 2's `this_hash` to an
+/// all-zero (valid 64-hex, impossible-SHA-256) value. Mirrors the
+/// helper in `audit_log_e2e.rs` for the multi-segment test.
+fn seed_then_tamper(path: &Utf8PathBuf) {
+    let log = ProvenanceLog::open(path.clone(), "01JCKZ7Q0000000000000000AB".to_string())
+        .expect("open provenance log");
+    for _ in 0..2 {
+        log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: None,
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+            canonical_digest: None,
+        })
+        .expect("append seed row");
+    }
+    drop(log);
+    let raw = fs::read_to_string(path).expect("read log");
+    let mut lines: Vec<String> = raw.lines().map(str::to_string).collect();
+    let needle = "\"this_hash\":\"";
+    let target = &lines[1];
+    let start = target.find(needle).expect("this_hash field") + needle.len();
+    let end = start + target[start..].find('"').expect("closing quote");
+    let mut new_line = String::with_capacity(target.len());
+    new_line.push_str(&target[..start]);
+    new_line.push_str("0000000000000000000000000000000000000000000000000000000000000000");
+    new_line.push_str(&target[end..]);
+    lines[1] = new_line;
+    let mut out = lines.join("\n");
+    out.push('\n');
+    fs::write(path, out).expect("write tampered log");
+}
+
+#[test]
+fn audit_log_json_with_tampered_log_emits_issue_records() {
+    let dir = TempDir::new().expect("tempdir");
+    let log_path =
+        Utf8PathBuf::from_path_buf(dir.path().join("access.jsonl")).expect("utf-8 log path");
+    seed_then_tamper(&log_path);
+
+    let p = dir.path().to_str().expect("tempdir path is UTF-8");
+    let out = Command::cargo_bin("doiget")
+        .expect("locate doiget binary")
+        .env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        .env("DOIGET_LOG_PATH", log_path.as_str())
+        .args(["--json", "audit-log", "--verify"])
+        .assert()
+        .failure() // tampered → non-zero exit, but stdout is still JSON
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    let v: Value = serde_json::from_str(&s).expect("audit-log JSON parses");
+    assert_eq!(v["total_rows"], 2);
+    assert_eq!(v["total_issues"], 1, "exactly one tampered row");
+    let issues = v["issues"].as_array().expect("issues array");
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0]["line"], 2);
+    assert_eq!(issues[0]["kind"], "this-hash");
+    assert!(issues[0]["message"].is_string());
+    let segs = v["segments"].as_array().expect("segments array");
+    assert_eq!(segs.len(), 1, "single segment (no rotation)");
+    assert_eq!(segs[0]["rows"], 2);
+    assert_eq!(segs[0]["ok"], 1);
+    assert_eq!(segs[0]["issues"], 1);
+}
+
+// ---- config show / config path --json ----------------------------------
+//
+// These rely on `dirs::config_dir()` resolving from `XDG_CONFIG_HOME`,
+// which works on the Linux CI runners that drive codecov. The earlier
+// local Windows fail (Known-Folder API ignores env overrides) is a
+// platform quirk, not a contract gap; the tests are gated to non-Windows
+// at the runtime layer so a contributor on Windows isn't surprised.
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn config_show_json_emits_resolved_config_object() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+        .args(["--json", "config", "show"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("config show JSON stdout utf-8");
+    let v: Value = serde_json::from_str(&s).expect("config show JSON parses");
+    // ResolvedConfig schema (#204): store_root / log_path / config_path
+    // are always populated.
+    assert!(v["store_root"].is_string(), "store_root present");
+    assert!(v["log_path"].is_string(), "log_path present");
+    assert!(v["config_path"].is_string(), "config_path present");
+    assert_eq!(v["contact_email"], "test@example.com");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn config_path_json_emits_config_path_object() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+        .args(["--json", "config", "path"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("config path JSON stdout utf-8");
+    let v: Value = serde_json::from_str(&s).expect("config path JSON parses");
+    assert!(v["config_path"].is_string(), "config_path field present");
+    assert!(
+        v["config_path"].as_str().unwrap().ends_with("config.toml"),
+        "config_path points at config.toml: {}",
+        v["config_path"]
+    );
 }
 
 // ---- provenance migrate --json -----------------------------------------

--- a/crates/doiget-cli/tests/json_bodies_e2e.rs
+++ b/crates/doiget-cli/tests/json_bodies_e2e.rs
@@ -1,0 +1,120 @@
+//! End-to-end tests for `--mode json` bodies (#204).
+//!
+//! Each command that emits a JSON body MUST produce a single parseable
+//! JSON value on stdout (NOT JSON-Lines; the batch JSONL contract is
+//! a separate ERRORS.md §3 surface tracked in #205). Stderr remains
+//! the human-error sink.
+//!
+//! The store-population-free commands are exercised here:
+//! `audit-log --verify` on a missing log (empty 0-row report) and
+//! `list-recent` on an empty store (empty array). The store-populated
+//! `info` / `search` bodies and the mutation-requiring
+//! `provenance migrate` JSON output round-trip the same `Serialize`
+//! impls, so the in-code structure is covered by `cargo build` + the
+//! integration shape here.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path is UTF-8");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        .env("DOIGET_LOG_PATH", dir.path().join("access.jsonl"))
+        .env("DOIGET_STORE_ROOT", dir.path().join("store"));
+    cmd
+}
+
+// ---- audit-log --verify -------------------------------------------------
+
+#[test]
+fn audit_log_json_emits_report_object() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["--json", "audit-log", "--verify"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    let v: Value = serde_json::from_str(&s).expect("audit-log JSON parses");
+    assert_eq!(v["total_rows"], 0, "missing log → 0 rows");
+    assert_eq!(v["total_ok"], 0);
+    assert_eq!(v["total_issues"], 0);
+    assert!(v["segments"].is_array(), "segments is an array");
+    assert!(v["issues"].is_array(), "issues is an array");
+}
+
+#[test]
+fn audit_log_json_via_mode_flag_parses() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["--mode", "json", "audit-log", "--verify"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    let _: Value = serde_json::from_str(&s).expect("audit-log JSON parses");
+}
+
+#[test]
+fn audit_log_json_via_env_parses() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .env("DOIGET_MODE", "json")
+        .args(["audit-log", "--verify"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    let _: Value = serde_json::from_str(&s).expect("audit-log JSON parses");
+}
+
+// ---- list-recent -------------------------------------------------------
+
+#[test]
+fn list_recent_json_empty_store_emits_empty_array() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["--json", "list-recent"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    let v: Value = serde_json::from_str(&s).expect("list-recent JSON parses");
+    assert!(v.is_array(), "list-recent emits an array");
+    assert_eq!(v.as_array().unwrap().len(), 0, "empty store → []");
+}
+
+// ---- regression: human / quiet modes still behave as before ------------
+
+#[test]
+fn audit_log_human_is_not_json() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .env("DOIGET_MODE", "human")
+        .args(["audit-log", "--verify"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("stdout utf-8");
+    assert!(
+        serde_json::from_str::<Value>(&s).is_err(),
+        "human stdout MUST NOT parse as JSON: {s}"
+    );
+}

--- a/crates/doiget-cli/tests/output_mode_e2e.rs
+++ b/crates/doiget-cli/tests/output_mode_e2e.rs
@@ -1,0 +1,135 @@
+//! End-to-end tests for the ADR-0017 / #144 global output-mode flags.
+//!
+//! These exercise the **resolver as a black box** through the freshly-built
+//! `doiget` binary: clap's parse acceptance of `--mode` / `--json` /
+//! `--quiet`, the mutual-exclusion enforcement, and `DOIGET_MODE` env
+//! plumbing. Per-command output bodies are tracked in follow-up issues
+//! #203 / #204 / #205.
+//!
+//! The unit-tested ladder lives in `commands::output::tests` (12 cases);
+//! this file proves the wiring through clap reaches the resolver
+//! correctly.
+
+// Tests panic on failure by design; the workspace deny-lints for
+// `expect`/`unwrap`/`panic` are scoped to production code.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// Build an `assert_cmd::Command` for the freshly-built `doiget` binary,
+/// with `HOME` / `USERPROFILE` overridden so the home-dir resolver in
+/// `commands::*` never touches the developer's real `~/.config/doiget/`.
+fn doiget() -> Command {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("HOME", dir.path()).env("USERPROFILE", dir.path());
+    // Leak the TempDir so it survives until the child exits.
+    Box::leak(Box::new(dir));
+    cmd
+}
+
+// ---- `--mode` / `--json` / `--quiet` parse acceptance ---------------------
+
+#[test]
+fn mode_flag_accepts_all_four_values_on_help() {
+    // `--help` short-circuits without needing the subcommand, so it is a
+    // safe vehicle for confirming clap accepts each `--mode <m>` value.
+    for value in ["human", "json", "quiet", "mcp"] {
+        doiget()
+            .args(["--mode", value, "--help"])
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn json_short_flag_is_accepted() {
+    doiget().args(["--json", "--help"]).assert().success();
+}
+
+#[test]
+fn quiet_short_flag_is_accepted_long_form() {
+    doiget().args(["--quiet", "--help"]).assert().success();
+}
+
+#[test]
+fn q_short_flag_is_accepted_short_form() {
+    doiget().args(["-q", "--help"]).assert().success();
+}
+
+// ---- mutual exclusion (clap conflicts_with_all) ---------------------------
+
+// NOTE: these conflict-check probes intentionally omit `--help`. Clap
+// processes `--help` (a `DisplayHelp` short-circuit) BEFORE running the
+// `conflicts_with_all` validator, so `doiget --mode x --json --help`
+// shows help and exits 0. Targeting a real subcommand (`audit-log
+// --verify`, which would otherwise exit 0 on a clean log here) forces
+// clap to validate the global-flag conflicts before dispatch.
+
+#[test]
+fn mode_and_json_conflict() {
+    doiget()
+        .args(["--mode", "human", "--json", "audit-log", "--verify"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used"));
+}
+
+#[test]
+fn mode_and_quiet_conflict() {
+    doiget()
+        .args(["--mode", "human", "--quiet", "audit-log", "--verify"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used"));
+}
+
+#[test]
+fn json_and_quiet_conflict() {
+    doiget()
+        .args(["--json", "--quiet", "audit-log", "--verify"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used"));
+}
+
+// ---- unknown `--mode` value rejected ---------------------------------------
+
+#[test]
+fn unknown_mode_value_is_rejected() {
+    doiget()
+        .args(["--mode", "garbage", "--help"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+// ---- DOIGET_MODE env passes through clap untouched -------------------------
+
+#[test]
+fn doiget_mode_env_does_not_break_clap_parsing() {
+    // `DOIGET_MODE` is consumed by the resolver, not clap; setting it MUST
+    // not change argument parsing. Confirm by combining it with `--help`.
+    for value in ["human", "json", "quiet", "mcp", "garbage", ""] {
+        doiget()
+            .env("DOIGET_MODE", value)
+            .args(["--help"])
+            .assert()
+            .success();
+    }
+}
+
+// ---- flags are global (appear after the subcommand) ------------------------
+
+#[test]
+fn mode_flag_is_global_after_subcommand() {
+    // `global = true` on the Cli fields means `--mode` may appear on the
+    // subcommand line: `doiget config show --mode human` is equivalent to
+    // `doiget --mode human config show`. We probe with `--help` on a
+    // subcommand to avoid touching the store / network.
+    doiget()
+        .args(["audit-log", "--mode", "human", "--help"])
+        .assert()
+        .success();
+}

--- a/crates/doiget-cli/tests/quiet_honoring_e2e.rs
+++ b/crates/doiget-cli/tests/quiet_honoring_e2e.rs
@@ -1,0 +1,120 @@
+//! End-to-end tests for `--mode quiet` honoring across commands (#203).
+//!
+//! Each command that emits informational stdout in human mode MUST emit
+//! exactly zero bytes on stdout under any of the three Quiet triggers:
+//! `--mode quiet`, `-q` / `--quiet`, or `DOIGET_MODE=quiet`. Exit codes
+//! and on-disk side effects are unaffected. Stderr (errors, warnings)
+//! is also unaffected.
+//!
+//! The commands covered here are the no-setup-needed ones:
+//! `audit-log --verify` (missing log = clean 0 rows), `config show` /
+//! `config path` (always work), `list-recent` (empty store works). The
+//! store-populated commands (`info` / `search`) and the
+//! mutation-requiring `provenance migrate` get their Quiet coverage
+//! through the seeded e2e tests in their respective files (those e2e
+//! helpers explicitly set `DOIGET_MODE=human`, so any Quiet-leak there
+//! would surface as a diff against the asserted human output).
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Build a `doiget` command rooted in `dir`, with `HOME` / `USERPROFILE`
+/// / `DOIGET_LOG_PATH` / `DOIGET_STORE_ROOT` all under the tempdir so
+/// the test never touches the developer's real `~/.config/doiget/` and
+/// produces deterministic output.
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path is UTF-8");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        // Cover all platforms' config-dir resolution so `config show` /
+        // `config path` resolve successfully even in CI.
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        .env("DOIGET_LOG_PATH", dir.path().join("access.jsonl"))
+        .env("DOIGET_STORE_ROOT", dir.path().join("store"));
+    cmd
+}
+
+// ---- audit-log --verify -------------------------------------------------
+
+#[test]
+fn audit_log_quiet_via_mode_flag_produces_no_stdout() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--mode", "quiet", "audit-log", "--verify"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn audit_log_quiet_via_short_q_flag_produces_no_stdout() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["-q", "audit-log", "--verify"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn audit_log_quiet_via_env_produces_no_stdout() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_MODE", "quiet")
+        .args(["audit-log", "--verify"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn audit_log_human_still_emits_header() {
+    // Regression: human-mode output unchanged.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_MODE", "human")
+        .args(["audit-log", "--verify"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("audit-log verify: 0 rows"));
+}
+
+// NOTE: `config show` / `config path` Quiet honoring is covered by the
+// in-code structure (`if mode != Quiet { print!(..) }` in
+// `crates/doiget-cli/src/commands/config.rs`); a subprocess e2e for
+// them requires reliably overriding the platform's config-dir resolver
+// (`dirs::config_dir()` on Windows reads `FOLDERID_RoamingAppData`
+// directly from the Known Folder API, which is intentionally not env-
+// driven). Adding a platform-shim for the test is out of scope here;
+// the lib-level unit tests in `output::tests` plus the config doctor
+// e2e already exercise the resolver path.
+
+// ---- list-recent --------------------------------------------------------
+
+#[test]
+fn list_recent_quiet_empty_store_produces_no_stdout() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--mode", "quiet", "list-recent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn list_recent_human_empty_store_still_emits_header() {
+    // Regression: even on an empty store the header line is emitted in
+    // human mode so `cut -f1 | tail -n +2` shell pipelines do not break.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_MODE", "human")
+        .args(["list-recent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("safekey\tyear\ttitle\tfetched_at"));
+}

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -110,7 +110,10 @@ fn doiget(root: &Utf8PathBuf) -> Command {
     let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
     cmd.env("DOIGET_STORE_ROOT", root.as_str())
         .env("HOME", root.as_str())
-        .env("USERPROFILE", root.as_str());
+        .env("USERPROFILE", root.as_str())
+        // #203: opt into human stdout — assert_cmd's captured stdout is
+        // non-TTY, which defaults to Quiet after #203 honoring.
+        .env("DOIGET_MODE", "human");
     cmd
 }
 

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -169,3 +169,29 @@ fn search_rejects_empty_query() {
         .failure()
         .stderr(predicate::str::contains("search query is empty"));
 }
+
+// ---- #204 JSON-mode coverage --------------------------------------------
+
+#[test]
+fn search_json_emits_array_of_entries() {
+    let (_dir_guard, root) = seeded_store();
+
+    let out = doiget(&root)
+        // The #203 helper pins DOIGET_MODE=human; override per-test.
+        .env("DOIGET_MODE", "json")
+        .args(["search", "quantum"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).expect("search JSON stdout utf-8");
+    let v: serde_json::Value = serde_json::from_str(&s).expect("search JSON parses");
+    let arr = v.as_array().expect("search JSON is an array");
+    assert!(!arr.is_empty(), "seeded query should match >=1 entry");
+    for entry in arr {
+        // EntryInfo schema (#204): {safekey, title, year, fetched_at}.
+        assert!(entry["safekey"].is_string(), "safekey is a string");
+        assert!(entry["title"].is_string(), "title is a string");
+    }
+}

--- a/crates/doiget-core/src/provenance.rs
+++ b/crates/doiget-core/src/provenance.rs
@@ -1098,7 +1098,11 @@ pub fn verify(path: &Utf8Path) -> Result<VerifyReport, LogError> {
 /// Marked `#[non_exhaustive]` so future fields (e.g. a per-row error
 /// list, an aborted-row count) can be added without breaking callers
 /// that pattern-match.
-#[derive(Debug, Clone)]
+///
+/// `Serialize` enables `provenance migrate --mode json` (#204) — the
+/// wire form is `{"rows_rewritten": N, "dry_run": bool,
+/// "first_row_v1_chain_hash": "...", "first_row_v2_chain_hash": "..."}`.
+#[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct MigrationReport {
     /// Number of rows rewritten (or that WOULD be rewritten under

--- a/crates/doiget-core/src/store/mod.rs
+++ b/crates/doiget-core/src/store/mod.rs
@@ -28,6 +28,7 @@ pub use metadata::{DoigetExtension, Metadata};
 pub use render::{to_bibtex, to_csl_array};
 
 use camino::Utf8Path;
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::Safekey;
@@ -37,7 +38,12 @@ use crate::Safekey;
 ///
 /// `non_exhaustive` so adding new summary fields (e.g. `doi`, `authors`) in a
 /// later revision is non-breaking. Pattern-match with a wildcard arm.
-#[derive(Debug, Clone)]
+///
+/// `Serialize` enables `list-recent --mode json` / `search --mode json`
+/// (#204) — the wire form is the obvious field-name JSON: `{"safekey":
+/// "...", "title": "...", "year": 2024, "fetched_at": "2026-05-20T…Z"}`,
+/// with `null` for absent optionals.
+#[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct EntryInfo {
     /// The safekey of the entry. See `docs/SAFEKEY.md`.

--- a/docs/DECISIONS/0017-output-mode-resolution.md
+++ b/docs/DECISIONS/0017-output-mode-resolution.md
@@ -1,7 +1,7 @@
 # 0017 - Output mode resolution (flag > env > implicit > TTY > quiet)
 
 - **Date:** 2026-05-05
-- **Status:** Accepted — implemented (load-bearing invariant); MCP mode forbids non-JSON stdout and tracing is redirected to stderr — enforced by the Slice 9 `stdout-purity` CI job + Slice 1 `metadata_only` wiring. *(Judgment call: the full `--mode`/`DOIGET_MODE`/TTY resolution ladder has no dedicated CHANGELOG slice; the security-critical half of the decision is verifiably shipped, so this is Accepted rather than Proposed.)*
+- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205.
 - **Supersedes:** -
 - **Source:** Discussion #14
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -33,7 +33,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0014 | Docs split into NORMATIVE / INFORMATIVE with ADR change-control | Accepted | Phase 0 (in force) | #11 |
 | 0015 | No telemetry / phone-home / self-update | Accepted | standing policy (SCOPE.md #10/#11 + posture-lint) | #12 |
 | 0016 | Common foundation crates + deny list | Accepted | Phase 0 (deny.toml) | #13 |
-| 0017 | Output mode resolution (flag > env > implicit > TTY > quiet) | Accepted | Slice 9 stdout-purity + Slice 1 (see ADR note) | #14 |
+| 0017 | Output mode resolution (flag > env > implicit > TTY > quiet) | Accepted | Slice 9 stdout-purity + Slice 1 + #144 (full ladder, 0.2.1-beta.7) | #14 |
 | 0018 | Obsidian export is one-direction, optional Phase 7 | Proposed (Phase 7, unshipped) | — | #15 |
 | 0019 | Eight-safeguard legal posture (5 social + 3 technical) | Accepted | standing posture (Phase 1 onward) | #16 |
 | 0020 | reqwest TLS feature stack (rustls-only; ring provider) | Accepted (Amendment 1 2026-05-18: aws-lc-rs → ring, portability) | PR #30 / PR #49 / Amendment 1 | PR #30 / PR #49 |


### PR DESCRIPTION
> **Stacked on #207 (#203).** Net-new commit: \`cd48063\`. \`Closes #204\`.

## Summary

#144 wired the OutputMode plumbing; #203 honored Quiet; this PR makes \`--mode json\` actually emit structured bodies for the six human-table commands. Each command produces a SINGLE JSON value on stdout (the batch JSONL contract is the separate ERRORS.md §3 surface, tracked in #205).

## Per-command shapes

| Command | JSON body |
|---|---|
| \`info <ref>\` | The on-disk \`Metadata\` struct (already \`Serialize\`). |
| \`list-recent [N]\` | JSON array of \`EntryInfo\` objects: \`{safekey, title, year, fetched_at}\` (\`null\` for absent optionals). |
| \`search <query>\` | Same shape as \`list-recent\` (array of \`EntryInfo\`). |
| \`config show\` | The \`ResolvedConfig\` struct (already \`Serialize\`). |
| \`config path\` | \`{"config_path": "..."}\` — small wrapper so the value parses uniformly. |
| \`audit-log --verify\` | Report object: \`{"total_rows","total_ok","total_issues","segments":[{"name","rows","ok","issues"}],"issues":[{"segment","line","kind","message"}]}\`. |
| \`provenance migrate\` | \`{"log_path":"...", "report": {MigrationReport}}\`. |

## doiget-core changes (strictly additive)

- \`store::EntryInfo\`: add \`Serialize\` derive.
- \`provenance::MigrationReport\`: add \`Serialize\` derive.

Both types are public and \`#[non_exhaustive]\`; adding \`Serialize\` is non-breaking. No behavior change in non-CLI consumers.

## Test plan

- [x] New \`tests/json_bodies_e2e.rs\` (5 cases): \`audit-log --verify\` JSON parses under all three triggers (\`--json\` / \`--mode json\` / \`DOIGET_MODE=json\`); \`list-recent --json\` on an empty store emits \`[]\`; regression: human mode stdout is NOT parseable JSON.
- [x] Full \`cargo test --workspace\` pass — no existing test broken (\`DOIGET_MODE=human\` opt-in introduced by #203 protects the human-stdout assertions).
- [x] \`cargo clippy --workspace --tests\` clean; \`cargo fmt -- --check\` clean.

\`Closes #204\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)