### PR TITLE
feat(cli): doiget capabilities — single-shot inventory JSON for LLM cold-boot (#214) [beta.12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,33 +66,33 @@ they are documented here for audit:
 - **Wire-format stability via `#[non_exhaustive]`** on every public
   schema struct + the `JsonMode` / `FlagKind` / `ArgKind` enums.
   Adding a field is non-breaking; renaming / removing one is now a
-  compile-time break for Rust consumers (C1).
+  compile-time break for Rust consumers.
 - **`--help` no longer leaks into per-subcommand `flags[]`** —
   clap built-ins (`Help`/`HelpShort`/`HelpLong`/`Version` actions)
-  are now filtered in `split_args_and_flags` (I1).
+  are now filtered in `split_args_and_flags` (filter on the ArgAction).
 - **`json_mode` JSON shape unified** via `#[serde(tag = "status")]`
   so every variant emits `{"status":"…", …}` instead of mixed
   string / object. `Product` renamed to `Artifact` with a clarified
   doc: the artifact may or may not be JSON; consult `examples`
-  for the per-flag stdout form (I4 + I6).
+  for the per-flag stdout form — addressing the prior misleading "Product" label.
 - **`FlagSpec.kind` and `ArgSpec.kind` are typed enums** rather than
-  `&'static str` (I10).
+  `&'static str`.
 - **`arg_to_flag_spec` `values` harvest is generic** via clap's
   `PossibleValuesParser` instead of a hardcoded `--mode` special
   case. `FlagSpec.values` type widens to `Option<Vec<String>>`;
-  serialised output unchanged (I7).
+  serialised output unchanged.
 - **`DOIGET_CACHE_ROOT` added to `ENV_VARS`** (was missing from the
   inventory vs `CONFIG.md` §4). Two new exact-set parity unit tests
   (`env_vars_exact_set_matches_expected` /
   `mcp_tools_exact_set_matches_expected`) lock the canonical sets so
-  drift between code and docs becomes a CI failure (I2 + I3).
+  drift between code and docs becomes a CI failure.
 - **`graph` in the shadow `test_cli`** under `#[cfg(feature =
-  "citation")]`, mirroring the production gate (I5).
+  "citation")]`, mirroring the production gate.
 - **Doc cross-ref fixes**: two `CONFIG.md §3` references corrected
   to `§5`; the `features` doc no longer claims "empty when only
   oa-only is enabled" (the inverse of actual behaviour);
   `SubcommandMeta` block carries a `feature_gated` maintainer note
-  (I8 + I9).
+ .
 
 ## [0.2.1-beta.11] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ### Added
 
 - **[cli] `doiget capabilities` — single-shot inventory JSON for LLM
-  cold-boot (#214).** A new subcommand that emits one parseable JSON
+  cold-boot (#214).** *(Includes the self-review pass against this
+  same slice: see "Wire-format & correctness refinements" below.)* A new subcommand that emits one parseable JSON
   value listing the binary's full surface in one round-trip:
   - `version` + compile-time `features` (so an agent can tell whether
     `graph` / TDM is available in *this* build);
@@ -54,6 +55,44 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   regression test asserts every subcommand declared in the `Cli`
   enum has a metadata entry, so adding a new subcommand without
   registering it in the static table fails at lib-test time.
+
+### Wire-format & correctness refinements to `capabilities` (#215 self-review)
+
+Pre-release tightening of the inventory JSON shape and the clap walk,
+applied before any consumer binds to the format. None of these are
+backwards-incompatible for the zero-consumer state we're in pre-merge;
+they are documented here for audit:
+
+- **Wire-format stability via `#[non_exhaustive]`** on every public
+  schema struct + the `JsonMode` / `FlagKind` / `ArgKind` enums.
+  Adding a field is non-breaking; renaming / removing one is now a
+  compile-time break for Rust consumers (C1).
+- **`--help` no longer leaks into per-subcommand `flags[]`** —
+  clap built-ins (`Help`/`HelpShort`/`HelpLong`/`Version` actions)
+  are now filtered in `split_args_and_flags` (I1).
+- **`json_mode` JSON shape unified** via `#[serde(tag = "status")]`
+  so every variant emits `{"status":"…", …}` instead of mixed
+  string / object. `Product` renamed to `Artifact` with a clarified
+  doc: the artifact may or may not be JSON; consult `examples`
+  for the per-flag stdout form (I4 + I6).
+- **`FlagSpec.kind` and `ArgSpec.kind` are typed enums** rather than
+  `&'static str` (I10).
+- **`arg_to_flag_spec` `values` harvest is generic** via clap's
+  `PossibleValuesParser` instead of a hardcoded `--mode` special
+  case. `FlagSpec.values` type widens to `Option<Vec<String>>`;
+  serialised output unchanged (I7).
+- **`DOIGET_CACHE_ROOT` added to `ENV_VARS`** (was missing from the
+  inventory vs `CONFIG.md` §4). Two new exact-set parity unit tests
+  (`env_vars_exact_set_matches_expected` /
+  `mcp_tools_exact_set_matches_expected`) lock the canonical sets so
+  drift between code and docs becomes a CI failure (I2 + I3).
+- **`graph` in the shadow `test_cli`** under `#[cfg(feature =
+  "citation")]`, mirroring the production gate (I5).
+- **Doc cross-ref fixes**: two `CONFIG.md §3` references corrected
+  to `§5`; the `features` doc no longer claims "empty when only
+  oa-only is enabled" (the inverse of actual behaviour);
+  `SubcommandMeta` block carries a `feature_gated` maintainer note
+  (I8 + I9).
 
 ## [0.2.1-beta.11] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,37 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unchanged (rustls-only, platform-verifier roots; `deny.toml` allowlist
   still satisfied). See ADR-0020 Amendment 1.
 
+## [0.2.1-beta.12] - 2026-05-20
+
+### Added
+
+- **[cli] `doiget capabilities` — single-shot inventory JSON for LLM
+  cold-boot (#214).** A new subcommand that emits one parseable JSON
+  value listing the binary's full surface in one round-trip:
+  - `version` + compile-time `features` (so an agent can tell whether
+    `graph` / TDM is available in *this* build);
+  - the four `OutputMode` values;
+  - `global_flags` (`--mode` / `--json` / `--quiet`) with help text +
+    accepted values;
+  - `subcommands[]` walked from the live `clap::Command` tree (cannot
+    drift from the parser) — each with name, summary, positional
+    `args`, named `flags`, hand-maintained `examples`, a `json_mode`
+    label (`product` / `supported` / `deferred`), and any
+    `feature_gated` Cargo feature;
+  - `env_vars[]` (DOIGET_* table mirroring `docs/CONFIG.md` §4);
+  - `mcp_tools[]` (the `doiget_*` tool inventory from
+    `docs/MCP_TOOLS.md` §1);
+  - `docs{}` map pointing at the canonical spec files.
+
+  Output is **always JSON** (product-output convention from #204);
+  `--mode quiet` is the one mode that suppresses, per ADR-0017 /
+  #203. Field names are part of the public wire format (same
+  stability discipline as `EntryInfo` / `MigrationReport` —
+  renaming → semver minor with `[BREAKING]` callout). A unit-level
+  regression test asserts every subcommand declared in the `Cli`
+  enum has a metadata entry, so adding a new subcommand without
+  registering it in the static table fails at lib-test time.
+
 ## [0.2.1-beta.11] - 2026-05-20
 
 ### Changed (potentially breaking)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.2.1-beta.11"
+version = "0.2.1-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.2.1-beta.11"
+version = "0.2.1-beta.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.2.1-beta.11"
+version = "0.2.1-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.2.1-beta.11"
+version       = "0.2.1-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -22,6 +22,15 @@
 //! ADR-0017 convention (`--mode` is informational; the JSON inventory
 //! is the artefact). `--mode quiet` is the one mode that suppresses
 //! stdout (#203 / CONFIG.md §5); every other mode emits the same JSON.
+//!
+//! # Wire-format stability (whole module)
+//!
+//! Every `pub` struct / enum below carries `#[non_exhaustive]`. Adding
+//! a field is non-breaking; renaming or removing one is a
+//! compile-time break for downstream Rust consumers and a
+//! `[BREAKING]`-class change for JSON consumers (CHANGELOG must call
+//! it out). The per-item `#[non_exhaustive]` attributes intentionally
+//! carry no inline comment; this module-doc says it once.
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -31,15 +40,17 @@ use serde::Serialize;
 /// any field is a semver minor with a CHANGELOG `\[BREAKING\]` callout
 /// (same discipline as `EntryInfo` / `MigrationReport` in #213).
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct Capabilities {
     /// `CARGO_PKG_VERSION` for this build.
     pub version: &'static str,
     /// Cargo features compiled into this binary. Contains `"oa-only"`
-    /// when the default feature set is active (which it is in stock
-    /// release builds); empty only when the crate was built with
-    /// `default-features = false`.
+    /// in stock release builds (the default feature). Empty only when
+    /// the crate was built with `--no-default-features` and **no
+    /// other features enabled**; a build like
+    /// `cargo build --no-default-features --features citation`
+    /// yields `["citation"]`, not `[]`.
     pub features: Vec<&'static str>,
     /// All four [`super::output::OutputMode`] values; the parser accepts these for
     /// `--mode`. Mirrors `CONFIG.md` §5 (CLI flags).
@@ -61,7 +72,7 @@ pub struct Capabilities {
 ///
 /// Typed (not `&'static str`) so a typo can't slip into the wire
 /// format and the `Enum`-implies-`values`-present invariant is
-/// expressible at the type layer (#215 self-review §I10). Serialises
+/// expressible at the type layer (see #215 for the design pass). Serialises
 /// as the lowercased variant name: `"bool"`, `"enum"`, `"string"`.
 #[non_exhaustive]
 #[derive(Debug, Serialize)]
@@ -71,12 +82,15 @@ pub enum FlagKind {
     Bool,
     /// Value-bounded flag — `values` carries the accepted set.
     Enum,
-    /// Free-form string / path / int value.
+    /// Any non-`Bool`, non-`Enum` flag. Today every such flag emits
+    /// `"string"`; richer typing (`Path` / `Int` etc.) is intentionally
+    /// out of scope until a real consumer needs it — `#[non_exhaustive]`
+    /// reserves space without commitment.
     String,
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct FlagSpec {
     /// e.g. `--mode`, `--json`, `-q`.
@@ -88,13 +102,13 @@ pub struct FlagSpec {
     /// For `kind == FlagKind::Enum`: the accepted values, harvested
     /// from clap's `PossibleValuesParser`. Owned (not `&'static`) so
     /// the helper works for any future enum flag, not just `--mode`
-    /// (#215 self-review §I7).
+    /// (see #215).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct SubcommandSpec {
     pub name: String,
@@ -124,13 +138,13 @@ pub enum ArgKind {
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct ArgSpec {
     pub name: String,
     /// Always [`ArgKind::Positional`] today. Kept as a discriminator
     /// so the JSON shape can grow new arg kinds later without
-    /// renaming fields (#215 self-review §I10).
+    /// renaming fields (see #215 for the design pass).
     pub kind: ArgKind,
     pub help: Option<String>,
     /// `true` when the arg has no default and no `Option<T>` wrapper.
@@ -141,36 +155,42 @@ pub struct ArgSpec {
 ///
 /// Wire shape: every variant serialises to an object with a `status`
 /// discriminant, so a consumer sees uniform `{"status":"…", …}`
-/// records (`#[serde(tag = "status")]`). Pre-#215 self-review §I6:
-/// the previous mixed string/object representation forced consumers
-/// to handle two JSON shapes for sibling variants.
+/// records (`#[serde(tag = "status")]`). Before #215 the previous
+/// mixed string/object representation forced consumers to handle two
+/// JSON shapes for sibling variants.
+///
+/// **Tuple variants not permitted.** `#[serde(tag = "status")]`
+/// requires the tag to live in the same flat object as variant
+/// fields; tuple variants are incompatible with internally-tagged
+/// representation. Future variants MUST use named fields.
 #[non_exhaustive] // Adding a future variant is non-breaking for JSON consumers.
 #[derive(Debug, Serialize)]
 #[serde(tag = "status", rename_all = "lowercase")]
 pub enum JsonMode {
     /// The command's primary output IS the requested artifact, not
     /// informational chatter. `--mode` is informational here; the
-    /// exact stdout shape (JSON for `csl` / `graph` / `capabilities`
-    /// and the JSON-RPC stream from `serve`; BibTeX for `bib`;
-    /// PDF-on-disk + stderr summary for `fetch`; a `--dry-run` JSON
-    /// plan in the dry-run variants) is fixed by the subcommand and
-    /// may vary across flags. **Consult `examples` for the per-flag
-    /// stdout form** rather than assuming JSON.
+    /// exact stdout shape (e.g. JSON for `csl` / `graph` /
+    /// `capabilities` and the JSON-RPC stream from `serve`; BibTeX
+    /// for `bib`; PDF-on-disk + stderr summary for `fetch`; a
+    /// `--dry-run` JSON plan in the dry-run variants) is fixed by
+    /// the subcommand and may vary across flags. **Consult
+    /// `examples` for the per-flag stdout form** rather than
+    /// assuming JSON.
     Artifact,
     /// Under `--mode json` the command emits a structured JSON body
     /// on stdout; otherwise the human form (e.g. `info`,
     /// `list-recent`, `audit-log`, `provenance migrate`, `batch`).
     Supported,
-    /// JSON body honoring not yet implemented; tracked at the issue
-    /// named inside.
-    Deferred {
-        /// The follow-up issue (e.g. `"#210"`).
-        tracking: &'static str,
-    },
+    // NOTE: a `Deferred { tracking: &'static str }` variant was
+    // sketched during #214's design phase but never instantiated by
+    // any subcommand. Removed in the #215 self-review pass to avoid
+    // shipping an unused wire shape; `#[non_exhaustive]` keeps the
+    // door open to add it back non-breakingly when a real consumer
+    // emerges.
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct EnvVar {
     pub name: &'static str,
@@ -180,7 +200,7 @@ pub struct EnvVar {
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct McpTool {
     pub name: &'static str,
@@ -189,7 +209,7 @@ pub struct McpTool {
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
-#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
+#[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct Docs {
     pub config: &'static str,
@@ -347,8 +367,9 @@ const DOCS: Docs = Docs {
 /// regression test does not cover feature-gating directly — it only
 /// asserts metadata exists. Add a CI matrix entry (`--features
 /// citation`) when introducing new gated subcommands so the e2e
-/// assertion list catches drift (#215 self-review §I5 / comment-analyzer
-/// note 4).
+/// assertion list catches drift (see #215). Alternatively, add a
+/// unit test that asserts `metadata_for("graph").unwrap().feature_gated
+/// == Some("citation")` to lock the gate at the lib-test layer.
 struct SubcommandMeta {
     examples: &'static [&'static str],
     json_mode: JsonMode,
@@ -560,11 +581,18 @@ fn split_args_and_flags(
         if global_names.contains(a.get_id().as_str()) {
             continue;
         }
-        // #215 self-review §I1: clap auto-adds `--help` (and `--version`
-        // on the root) to every subcommand. They're not positional and
-        // not `is_global_set()`, so they would otherwise leak into
-        // every subcommand's `flags[]` as `kind: "string"`. Filter on
-        // the action to be robust across future clap built-ins.
+        // Clap auto-adds `--help` (and `--version` on the root) to
+        // every subcommand. They're not positional and not
+        // `is_global_set()`, so they would otherwise leak into every
+        // subcommand's `flags[]` as `kind: "string"`. Filter on the
+        // action against the known built-in variants.
+        //
+        // **Maintenance:** `clap::ArgAction` is itself
+        // `#[non_exhaustive]` upstream. A future clap release that
+        // adds a new built-in action (e.g. a hypothetical
+        // `HelpMarkdown`) would fall through this `matches!` and
+        // reappear in `flags[]`. Re-audit this filter on every clap
+        // minor-version bump.
         if matches!(
             a.get_action(),
             clap::ArgAction::Help
@@ -597,7 +625,7 @@ fn arg_to_flag_spec(a: &clap::Arg) -> FlagSpec {
     // Boolean switches → `Bool`; value-enum flags → `Enum` with the
     // accepted values harvested from clap directly; everything else
     // → `String`. The `possible_values()` harvest covers any future
-    // enum flag without code change (#215 self-review §I7).
+    // enum flag without code change (see #215).
     let possible: Option<Vec<String>> = a
         .get_value_parser()
         .possible_values()
@@ -745,7 +773,7 @@ mod tests {
             .subcommand(Command::new("serve").about("MCP server"));
         // `graph` is `#[cfg(feature = "citation")]` in main.rs; mirror
         // the gate so the shadow CLI matches the production surface
-        // (#215 self-review §I5).
+        // (see #215).
         #[cfg(feature = "citation")]
         let cmd = cmd.subcommand(
             Command::new("graph")
@@ -828,9 +856,8 @@ mod tests {
         }
     }
 
-    // #215 self-review §I2: exact-set parity guard against drift
-    // between CONFIG.md §4's env-var table and the static `ENV_VARS`
-    // inventory. The expected set is the SOURCE OF TRUTH at test time;
+    // Exact-set parity guard against drift between the static
+    // `ENV_VARS` table and the documented surface (#215). The expected set is the SOURCE OF TRUTH at test time;
     // adding a new DOIGET_* env var requires updating both ENV_VARS
     // and this list in lockstep. CHANGELOG records cross-PR changes.
     #[test]
@@ -864,8 +891,8 @@ mod tests {
         );
     }
 
-    // #215 self-review §I3: exact-set parity guard against drift
-    // between docs/MCP_TOOLS.md §1 and the static `MCP_TOOLS` array.
+    // Exact-set parity guard against drift between the static
+    // `MCP_TOOLS` table and `docs/MCP_TOOLS.md` §1 (#215).
     #[test]
     fn mcp_tools_exact_set_matches_expected() {
         let actual: std::collections::BTreeSet<&str> = MCP_TOOLS.iter().map(|t| t.name).collect();
@@ -891,6 +918,69 @@ mod tests {
             "MCP_TOOLS table drifted from the expected set; update both \
              `MCP_TOOLS` and this test together (and docs/MCP_TOOLS.md §1)."
         );
+    }
+
+    // Pin the `#[serde(tag = "status")]` wire shape: every variant
+    // serialises to a `{"status":"…", …}` object. Accidentally
+    // removing the `tag` attribute (or renaming the discriminant)
+    // would silently degrade the wire format; this test catches it
+    // (#215 N1).
+    #[test]
+    fn json_mode_serialises_with_status_discriminant() {
+        let s = serde_json::to_string(&JsonMode::Artifact).expect("serialise");
+        assert_eq!(
+            s, r#"{"status":"artifact"}"#,
+            "Artifact must emit a status-tagged object"
+        );
+        let s = serde_json::to_string(&JsonMode::Supported).expect("serialise");
+        assert_eq!(s, r#"{"status":"supported"}"#);
+    }
+
+    // `arg_to_flag_spec` was generalised in #215 to harvest the
+    // accepted values from clap's `PossibleValuesParser` instead of
+    // hard-coding `--mode`. Pin the contract: the `--mode` entry in
+    // `global_flags` MUST report `kind: Enum` with all four mode
+    // strings. A future regression that silently degrades `--mode`
+    // to `kind: String, values: None` would otherwise pass every
+    // existing test (#215 N3).
+    #[test]
+    fn mode_flag_carries_enum_kind_and_all_four_values() {
+        let global = &caps().global_flags;
+        let mode = global
+            .iter()
+            .find(|f| f.name == "--mode")
+            .expect("--mode flag is in global_flags");
+        assert!(
+            matches!(mode.kind, FlagKind::Enum),
+            "--mode kind MUST be Enum, got {:?}",
+            mode.kind
+        );
+        let vs = mode.values.as_ref().expect("--mode carries values");
+        let mut sorted = vs.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["human", "json", "mcp", "quiet"]);
+    }
+
+    // `compile_time_features()` pushes string literals that must
+    // exactly match the Cargo feature names in `Cargo.toml`. A
+    // typo in the literal (`"oa_only"` vs `"oa-only"`) would
+    // silently invert the inventory's `features` field for every
+    // consumer. The default build has `oa-only` active; assert
+    // the literal round-trips (#215 A9).
+    #[test]
+    fn compile_time_features_contains_oa_only_under_default() {
+        // `cfg!(feature = "oa-only")` is true in the default test
+        // build; if a future maintainer disables the default feature
+        // for the test target, this test becomes meaningless but
+        // does not cause a false failure.
+        if cfg!(feature = "oa-only") {
+            let f = compile_time_features();
+            assert!(
+                f.contains(&"oa-only"),
+                "oa-only feature was enabled at compile time but \
+                 `compile_time_features()` did not list it: {f:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -1,0 +1,719 @@
+//! `doiget capabilities` — single-shot inventory JSON for LLM cold-boot
+//! (#214).
+//!
+//! Emits a single JSON value describing the **full surface** of this
+//! `doiget` binary: subcommands (walked from the live `clap::Command`
+//! tree so the inventory cannot drift from the parser), positional args
+//! and named flags per subcommand, global flags, the four
+//! [`super::output::OutputMode`] values, hand-maintained env-var + example tables, the
+//! `doiget_*` MCP tool list, compile-time features, and a `docs` map
+//! pointing at the canonical spec files.
+//!
+//! Design rationale: the existing `--help` output lists subcommand
+//! names but the rest of doiget's surface (env vars, MCP tools, JSON
+//! schemas, ADR refs) is scattered across `docs/`. An LLM cold-booted
+//! into doiget — no repo access, no follow-up doc reads — cannot
+//! discover those via `--help` alone. This subcommand closes that gap
+//! with one round-trip.
+//!
+//! # Output mode
+//!
+//! `doiget capabilities` is a **product-output** command per the
+//! ADR-0017 convention (`--mode` is informational; the JSON inventory
+//! is the artefact). `--mode quiet` is the one mode that suppresses
+//! stdout (#203 / CONFIG.md §3); every other mode emits the same JSON.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+/// Top-level capability inventory. Serialised to stdout as one JSON
+/// value. Field names are part of the public wire format: renaming
+/// any field is a semver minor with a CHANGELOG `\[BREAKING\]` callout
+/// (same discipline as `EntryInfo` / `MigrationReport` in #213).
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct Capabilities {
+    /// `CARGO_PKG_VERSION` for this build.
+    pub version: &'static str,
+    /// Cargo features compiled into this binary. Empty when only the
+    /// `oa-only` default is enabled.
+    pub features: Vec<&'static str>,
+    /// All four [`super::output::OutputMode`] values; the parser accepts these for
+    /// `--mode`. Mirrors `CONFIG.md` §3.
+    pub modes: &'static [&'static str],
+    /// Global flags that apply to every subcommand.
+    pub global_flags: Vec<FlagSpec>,
+    /// One entry per CLI subcommand (clap-walked).
+    pub subcommands: Vec<SubcommandSpec>,
+    /// `DOIGET_*` env vars from CONFIG.md §4.
+    pub env_vars: &'static [EnvVar],
+    /// MCP tools exposed by `doiget serve` (hand-coded; the source of
+    /// truth is `docs/MCP_TOOLS.md` §1).
+    pub mcp_tools: &'static [McpTool],
+    /// Canonical doc paths an LLM can pull for deeper context.
+    pub docs: Docs,
+}
+
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct FlagSpec {
+    /// e.g. `--mode`, `--json`, `-q`.
+    pub name: String,
+    /// `bool` for boolean switches, `enum` for value-bounded flags,
+    /// `string` / `path` otherwise.
+    pub kind: &'static str,
+    /// `clap` `help` text.
+    pub help: Option<String>,
+    /// For `enum` kind only: accepted values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<&'static [&'static str]>,
+}
+
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct SubcommandSpec {
+    pub name: String,
+    pub summary: Option<String>,
+    pub args: Vec<ArgSpec>,
+    pub flags: Vec<FlagSpec>,
+    /// Hand-maintained canonical invocations.
+    pub examples: &'static [&'static str],
+    /// How this command interacts with `--mode json`. See [`JsonMode`].
+    pub json_mode: JsonMode,
+    /// Cargo feature this subcommand is gated behind, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feature_gated: Option<&'static str>,
+}
+
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct ArgSpec {
+    pub name: String,
+    /// `positional` | `flag-value`.
+    pub kind: &'static str,
+    pub help: Option<String>,
+    /// `true` when the arg has no default and no `Option<T>` wrapper.
+    pub required: bool,
+}
+
+#[allow(missing_docs)] // Variants are documented inline; the enum-level allow silences clippy.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JsonMode {
+    /// The command's primary output IS JSON regardless of `--mode`
+    /// (e.g. `csl`, `graph`, `*-dry-run`).
+    Product,
+    /// The command emits a structured JSON body when `--mode json` is
+    /// active; otherwise human (e.g. `info`, `list-recent`, `audit-log`).
+    Supported,
+    /// Not yet — JSON body honoring is tracked as the issue named
+    /// inside.
+    Deferred {
+        /// The follow-up issue tracking the JSON honoring for this
+        /// command (e.g. `"#210"`).
+        tracking: &'static str,
+    },
+}
+
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct EnvVar {
+    pub name: &'static str,
+    /// `(none)` when no built-in default.
+    pub default: &'static str,
+    pub help: &'static str,
+}
+
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct McpTool {
+    pub name: &'static str,
+    /// Anchor-style reference into `docs/MCP_TOOLS.md`.
+    pub schema_ref: &'static str,
+}
+
+#[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[derive(Debug, Serialize)]
+pub struct Docs {
+    pub config: &'static str,
+    pub errors: &'static str,
+    pub scope: &'static str,
+    pub mcp: &'static str,
+    pub sources: &'static str,
+    pub redirect_allowlist: &'static str,
+    pub provenance_log: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Static tables
+// ---------------------------------------------------------------------------
+
+const MODES: &[&str] = &["human", "json", "quiet", "mcp"];
+
+const ENV_VARS: &[EnvVar] = &[
+    EnvVar {
+        name: "DOIGET_STORE_ROOT",
+        default: "$HOME/papers",
+        help: "Root of the on-disk paper store. CONFIG.md §4.",
+    },
+    EnvVar {
+        name: "DOIGET_LOG_PATH",
+        default: "<config_dir>/doiget/access.jsonl",
+        help: "JSON-Lines provenance log file path (PROVENANCE_LOG.md §3).",
+    },
+    EnvVar {
+        name: "DOIGET_LOG_RETENTION_DAYS",
+        default: "90",
+        help: "Rotated-segment retention window (0 disables pruning). #140 / PROVENANCE_LOG.md §6.",
+    },
+    EnvVar {
+        name: "DOIGET_MODE",
+        default: "(none)",
+        help: "Output mode (`human`/`json`/`quiet`/`mcp`). ADR-0017 ladder rung 3.",
+    },
+    EnvVar {
+        name: "DOIGET_CONTACT_EMAIL",
+        default: "(none)",
+        help: "Contact email for polite User-Agent header (CONFIG.md §4).",
+    },
+    EnvVar {
+        name: "DOIGET_UNPAYWALL_EMAIL",
+        default: "(falls back to DOIGET_CONTACT_EMAIL)",
+        help: "Unpaywall-specific contact email.",
+    },
+    EnvVar {
+        name: "DOIGET_USER_AGENT",
+        default: "(default polite UA)",
+        help: "Override the User-Agent header for all outbound requests.",
+    },
+    EnvVar {
+        name: "DOIGET_ENABLE_OPENALEX",
+        default: "(off)",
+        help: "Enable the OpenAlex citation graph source (graph subcommand prerequisite).",
+    },
+    EnvVar {
+        name: "DOIGET_ARXIV_BASE",
+        default: "https://export.arxiv.org/",
+        help: "arXiv API base URL — primarily for testing/wiremock override.",
+    },
+    EnvVar {
+        name: "DOIGET_CROSSREF_BASE",
+        default: "https://api.crossref.org/",
+        help: "Crossref API base URL.",
+    },
+    EnvVar {
+        name: "DOIGET_UNPAYWALL_BASE",
+        default: "https://api.unpaywall.org/",
+        help: "Unpaywall API base URL.",
+    },
+];
+
+const MCP_TOOLS: &[McpTool] = &[
+    McpTool {
+        name: "doiget_resolve_paper",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_fetch_paper",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_metadata_only",
+        schema_ref: "docs/MCP_TOOLS.md#11-doiget_metadata_only-normative",
+    },
+    McpTool {
+        name: "doiget_batch_fetch",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_info",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_search_local",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_list_recent",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_paper_pdf_path",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_capability_profile",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_health",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_expand_citation_graph",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_bibtex_export",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+    McpTool {
+        name: "doiget_csl_export",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
+];
+
+const DOCS: Docs = Docs {
+    config: "docs/CONFIG.md",
+    errors: "docs/ERRORS.md",
+    scope: "docs/SCOPE.md",
+    mcp: "docs/MCP_TOOLS.md",
+    sources: "docs/SOURCES.md",
+    redirect_allowlist: "docs/REDIRECT_ALLOWLIST.md",
+    provenance_log: "docs/PROVENANCE_LOG.md",
+};
+
+/// Per-subcommand hand-maintained metadata. The clap walk provides
+/// name + summary + args + flags; this table adds examples,
+/// `json_mode` semantics, and feature-gating that clap doesn't
+/// expose. A regression unit test asserts every clap-visible
+/// subcommand has an entry here (otherwise the test fails loudly).
+struct SubcommandMeta {
+    examples: &'static [&'static str],
+    json_mode: JsonMode,
+    feature_gated: Option<&'static str>,
+}
+
+fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
+    let m = match subcommand {
+        "fetch" => SubcommandMeta {
+            examples: &[
+                "doiget fetch 10.1234/foo",
+                "doiget fetch arxiv:2401.12345",
+                "doiget fetch 10.1234/foo --dry-run",
+            ],
+            // The success summary is on stderr (ADR-0001); the
+            // dry-run plan is JSON product output (ADR-0022).
+            json_mode: JsonMode::Product,
+            feature_gated: None,
+        },
+        "batch" => SubcommandMeta {
+            examples: &[
+                "doiget batch refs.txt",
+                "doiget batch refs.txt --dry-run",
+                "doiget batch refs.txt --json",
+            ],
+            // `--json` emits the ERRORS.md §3 JSONL per-ref shape (#205).
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "info" => SubcommandMeta {
+            examples: &[
+                "doiget info 10.1234/foo",
+                "doiget info arxiv:2401.12345 --json",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "list-recent" => SubcommandMeta {
+            examples: &[
+                "doiget list-recent",
+                "doiget list-recent 20",
+                "doiget list-recent --json",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "search" => SubcommandMeta {
+            examples: &[
+                "doiget search 'quantum entanglement'",
+                "doiget search renormalization --json",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "bib" => SubcommandMeta {
+            examples: &["doiget bib 10.1234/foo", "doiget bib arxiv:2401.12345"],
+            // BibTeX output is the product; `--mode` is informational.
+            json_mode: JsonMode::Product,
+            feature_gated: None,
+        },
+        "csl" => SubcommandMeta {
+            examples: &["doiget csl 10.1234/foo"],
+            json_mode: JsonMode::Product,
+            feature_gated: None,
+        },
+        "audit-log" => SubcommandMeta {
+            examples: &[
+                "doiget audit-log --verify",
+                "doiget audit-log --verify --json",
+                "doiget --quiet audit-log --verify   # exit code only",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "provenance" => SubcommandMeta {
+            examples: &[
+                "doiget provenance migrate --dry-run",
+                "doiget provenance migrate",
+                "doiget provenance migrate --dry-run --json",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "config" => SubcommandMeta {
+            examples: &[
+                "doiget config show",
+                "doiget config show --json",
+                "doiget config path",
+                "doiget config doctor",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
+        "serve" => SubcommandMeta {
+            examples: &["doiget serve   # stdio MCP server (ADR-0001)"],
+            // serve always runs in mcp mode; the protocol output is
+            // JSON-RPC, which is product.
+            json_mode: JsonMode::Product,
+            feature_gated: None,
+        },
+        "graph" => SubcommandMeta {
+            examples: &[
+                "DOIGET_ENABLE_OPENALEX=1 doiget graph 10.1234/foo",
+                "DOIGET_ENABLE_OPENALEX=1 doiget graph 10.1234/foo --depth 2 --total 50",
+            ],
+            json_mode: JsonMode::Product,
+            feature_gated: Some("citation"),
+        },
+        "capabilities" => SubcommandMeta {
+            examples: &["doiget capabilities | jq ."],
+            // The whole point of capabilities IS JSON output.
+            json_mode: JsonMode::Product,
+            feature_gated: None,
+        },
+        // clap auto-adds `help`; we silently ignore it (it's not a
+        // domain subcommand).
+        "help" => return None,
+        _ => return None,
+    };
+    Some(m)
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+/// Build the [`Capabilities`] inventory from `cli` (the clap parser
+/// for this binary, supplied by the caller because the `Cli` struct
+/// lives in `main.rs` and is not exposed in the library crate). The
+/// caller is `commands::main::run_dispatch` via `Cli::command()`.
+pub fn build_capabilities(cli: &clap::Command) -> Capabilities {
+    let global_flags = collect_global_flags(cli);
+    let subcommands = cli
+        .get_subcommands()
+        .filter_map(|sub| build_subcommand(sub, cli))
+        .collect::<Vec<_>>();
+    Capabilities {
+        version: env!("CARGO_PKG_VERSION"),
+        features: compile_time_features(),
+        modes: MODES,
+        global_flags,
+        subcommands,
+        env_vars: ENV_VARS,
+        mcp_tools: MCP_TOOLS,
+        docs: DOCS,
+    }
+}
+
+fn compile_time_features() -> Vec<&'static str> {
+    let mut feats: Vec<&'static str> = Vec::new();
+    if cfg!(feature = "oa-only") {
+        feats.push("oa-only");
+    }
+    if cfg!(feature = "metadata") {
+        feats.push("metadata");
+    }
+    if cfg!(feature = "citation") {
+        feats.push("citation");
+    }
+    if cfg!(feature = "tdm-elsevier") {
+        feats.push("tdm-elsevier");
+    }
+    if cfg!(feature = "tdm-aps") {
+        feats.push("tdm-aps");
+    }
+    if cfg!(feature = "tdm-springer") {
+        feats.push("tdm-springer");
+    }
+    feats
+}
+
+fn collect_global_flags(cmd: &clap::Command) -> Vec<FlagSpec> {
+    cmd.get_arguments()
+        .filter(|a| a.is_global_set())
+        .map(arg_to_flag_spec)
+        .collect()
+}
+
+fn build_subcommand(sub: &clap::Command, root: &clap::Command) -> Option<SubcommandSpec> {
+    let name = sub.get_name();
+    let meta = metadata_for(name)?;
+    let (args, flags) = split_args_and_flags(sub, root);
+    Some(SubcommandSpec {
+        name: name.to_string(),
+        summary: sub.get_about().map(|s| s.to_string()),
+        args,
+        flags,
+        examples: meta.examples,
+        json_mode: meta.json_mode,
+        feature_gated: meta.feature_gated,
+    })
+}
+
+fn split_args_and_flags(
+    sub: &clap::Command,
+    root: &clap::Command,
+) -> (Vec<ArgSpec>, Vec<FlagSpec>) {
+    // The root's global args appear in every subcommand's iterator;
+    // suppress them from per-subcommand `flags` (they're already in
+    // `global_flags`).
+    let global_names: std::collections::HashSet<&str> = root
+        .get_arguments()
+        .filter(|a| a.is_global_set())
+        .map(|a| a.get_id().as_str())
+        .collect();
+    let mut args = Vec::new();
+    let mut flags = Vec::new();
+    for a in sub.get_arguments() {
+        if global_names.contains(a.get_id().as_str()) {
+            continue;
+        }
+        if a.is_positional() {
+            args.push(ArgSpec {
+                name: a.get_id().to_string(),
+                kind: "positional",
+                help: a.get_help().map(|s| s.to_string()),
+                required: a.is_required_set(),
+            });
+        } else {
+            flags.push(arg_to_flag_spec(a));
+        }
+    }
+    (args, flags)
+}
+
+fn arg_to_flag_spec(a: &clap::Arg) -> FlagSpec {
+    let name = a
+        .get_long()
+        .map(|s| format!("--{s}"))
+        .or_else(|| a.get_short().map(|c| format!("-{c}")))
+        .unwrap_or_else(|| a.get_id().to_string());
+    // Best-effort kind classification. Boolean switches show up as
+    // `bool`; value-enum flags show up as `enum` with the accepted
+    // values; everything else is `string`.
+    let kind = if matches!(
+        a.get_action(),
+        clap::ArgAction::SetTrue | clap::ArgAction::SetFalse
+    ) {
+        "bool"
+    } else if a.get_value_parser().possible_values().is_some() {
+        "enum"
+    } else {
+        "string"
+    };
+    let values: Option<&'static [&'static str]> = if kind == "enum" && name == "--mode" {
+        Some(MODES)
+    } else {
+        None
+    };
+    FlagSpec {
+        name,
+        kind,
+        help: a.get_help().map(|s| s.to_string()),
+        values,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Run the `doiget capabilities` subcommand. Honors [`super::output::OutputMode`]:
+/// `Quiet` suppresses stdout (#203); every other mode emits the same
+/// pretty-printed JSON inventory. The caller passes the live
+/// `clap::Command` so the clap walk operates on the binary's actual
+/// `Cli` tree (which the lib half of this crate can't reach
+/// directly — the `Cli` struct lives in `main.rs`).
+pub fn run(cli: &clap::Command, mode: super::output::OutputMode) -> Result<()> {
+    // `Quiet` is the one mode that suppresses (per ADR-0017 / #203).
+    // Every other mode emits the same pretty JSON: `capabilities` is a
+    // product-output command.
+    if mode == super::output::OutputMode::Quiet {
+        return Ok(());
+    }
+    let caps = build_capabilities(cli);
+    let s = serde_json::to_string_pretty(&caps).context("serialise capabilities inventory")?;
+    // `print_stdout` workspace-deny; localised allow at the
+    // sanctioned product-output sink. See `commands/csl.rs`'s pattern.
+    #[allow(clippy::print_stdout)]
+    {
+        println!("{s}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the `Cli` struct in `main.rs` for lib-test reach.
+    /// `commands::capabilities` is library-level; the binary-only
+    /// `Cli` struct can't be reached from here, so we re-derive a
+    /// shadow whose subcommand list is identical. The
+    /// `cli_shadow_matches_main_cli` integration test in
+    /// `tests/capabilities_e2e.rs` runs the real binary and asserts
+    /// the wire output matches.
+    fn test_cli() -> clap::Command {
+        use clap::{Arg, ArgAction, Command};
+        let mode_values = ["human", "json", "quiet", "mcp"];
+        Command::new("doiget")
+            .arg(
+                Arg::new("mode")
+                    .long("mode")
+                    .global(true)
+                    .value_parser(clap::builder::PossibleValuesParser::new(mode_values))
+                    .help("Output mode (human|json|quiet|mcp)."),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .global(true)
+                    .action(ArgAction::SetTrue)
+                    .help("Short for `--mode json`."),
+            )
+            .arg(
+                Arg::new("quiet")
+                    .long("quiet")
+                    .short('q')
+                    .global(true)
+                    .action(ArgAction::SetTrue)
+                    .help("Short for `--mode quiet`."),
+            )
+            .subcommand(
+                Command::new("fetch")
+                    .about("Fetch a single paper PDF")
+                    .arg(Arg::new("ref").required(true)),
+            )
+            .subcommand(Command::new("batch").about("Fetch many refs"))
+            .subcommand(Command::new("info").about("Show metadata"))
+            .subcommand(Command::new("list-recent").about("List recent"))
+            .subcommand(Command::new("search").about("Search local"))
+            .subcommand(Command::new("bib").about("BibTeX export"))
+            .subcommand(Command::new("csl").about("CSL export"))
+            .subcommand(Command::new("audit-log").about("Audit log"))
+            .subcommand(Command::new("provenance").about("Provenance ops"))
+            .subcommand(Command::new("config").about("Config"))
+            .subcommand(Command::new("serve").about("MCP server"))
+            .subcommand(Command::new("capabilities").about("Capabilities"))
+    }
+
+    fn caps() -> Capabilities {
+        build_capabilities(&test_cli())
+    }
+
+    #[test]
+    fn capabilities_serialises_to_valid_json() {
+        let s = serde_json::to_string_pretty(&caps()).expect("serialise");
+        let v: serde_json::Value = serde_json::from_str(&s).expect("parse round-trip");
+        for key in [
+            "version",
+            "features",
+            "modes",
+            "global_flags",
+            "subcommands",
+            "env_vars",
+            "mcp_tools",
+            "docs",
+        ] {
+            assert!(
+                v.get(key).is_some(),
+                "top-level key `{key}` missing from capabilities JSON: {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn modes_field_matches_output_mode_enum() {
+        // Tied to `OutputMode { Human, Json, Quiet, Mcp }`.
+        assert_eq!(caps().modes, &["human", "json", "quiet", "mcp"]);
+    }
+
+    #[test]
+    fn env_vars_all_use_doiget_prefix() {
+        for ev in ENV_VARS {
+            assert!(
+                ev.name.starts_with("DOIGET_"),
+                "env var name MUST use DOIGET_ prefix, got `{}`",
+                ev.name
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_tools_all_use_doiget_prefix() {
+        for t in MCP_TOOLS {
+            assert!(
+                t.name.starts_with("doiget_"),
+                "MCP tool name MUST use doiget_ prefix, got `{}`",
+                t.name
+            );
+        }
+    }
+
+    #[test]
+    fn subcommand_examples_reference_the_subcommand_name() {
+        for sub in &caps().subcommands {
+            for ex in sub.examples {
+                assert!(
+                    ex.starts_with("doiget "),
+                    "example `{ex}` for `{}` should start with `doiget `",
+                    sub.name
+                );
+                assert!(
+                    ex.contains(&sub.name),
+                    "example `{ex}` does not mention subcommand `{}`",
+                    sub.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn version_is_cargo_pkg_version() {
+        assert_eq!(caps().version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn every_test_cli_subcommand_has_metadata() {
+        // Regression at the lib layer: anything we add to the shadow
+        // `test_cli` must also be in `metadata_for`. The real
+        // `Cli::command()` is exercised by the e2e test in
+        // `tests/capabilities_e2e.rs`.
+        for sub in test_cli().get_subcommands() {
+            let name = sub.get_name();
+            if name == "help" {
+                continue;
+            }
+            assert!(
+                metadata_for(name).is_some(),
+                "subcommand `{name}` lacks metadata in `metadata_for`"
+            );
+        }
+    }
+}

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -21,7 +21,7 @@
 //! `doiget capabilities` is a **product-output** command per the
 //! ADR-0017 convention (`--mode` is informational; the JSON inventory
 //! is the artefact). `--mode quiet` is the one mode that suppresses
-//! stdout (#203 / CONFIG.md §3); every other mode emits the same JSON.
+//! stdout (#203 / CONFIG.md §5); every other mode emits the same JSON.
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -31,15 +31,18 @@ use serde::Serialize;
 /// any field is a semver minor with a CHANGELOG `\[BREAKING\]` callout
 /// (same discipline as `EntryInfo` / `MigrationReport` in #213).
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct Capabilities {
     /// `CARGO_PKG_VERSION` for this build.
     pub version: &'static str,
-    /// Cargo features compiled into this binary. Empty when only the
-    /// `oa-only` default is enabled.
+    /// Cargo features compiled into this binary. Contains `"oa-only"`
+    /// when the default feature set is active (which it is in stock
+    /// release builds); empty only when the crate was built with
+    /// `default-features = false`.
     pub features: Vec<&'static str>,
     /// All four [`super::output::OutputMode`] values; the parser accepts these for
-    /// `--mode`. Mirrors `CONFIG.md` §3.
+    /// `--mode`. Mirrors `CONFIG.md` §5 (CLI flags).
     pub modes: &'static [&'static str],
     /// Global flags that apply to every subcommand.
     pub global_flags: Vec<FlagSpec>,
@@ -54,22 +57,44 @@ pub struct Capabilities {
     pub docs: Docs,
 }
 
+/// What kind of value (if any) a [`FlagSpec`] carries.
+///
+/// Typed (not `&'static str`) so a typo can't slip into the wire
+/// format and the `Enum`-implies-`values`-present invariant is
+/// expressible at the type layer (#215 self-review §I10). Serialises
+/// as the lowercased variant name: `"bool"`, `"enum"`, `"string"`.
+#[non_exhaustive]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FlagKind {
+    /// Boolean switch (no value).
+    Bool,
+    /// Value-bounded flag — `values` carries the accepted set.
+    Enum,
+    /// Free-form string / path / int value.
+    String,
+}
+
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct FlagSpec {
     /// e.g. `--mode`, `--json`, `-q`.
     pub name: String,
-    /// `bool` for boolean switches, `enum` for value-bounded flags,
-    /// `string` / `path` otherwise.
-    pub kind: &'static str,
+    /// Boolean / enum / free-string discriminator. See [`FlagKind`].
+    pub kind: FlagKind,
     /// `clap` `help` text.
     pub help: Option<String>,
-    /// For `enum` kind only: accepted values.
+    /// For `kind == FlagKind::Enum`: the accepted values, harvested
+    /// from clap's `PossibleValuesParser`. Owned (not `&'static`) so
+    /// the helper works for any future enum flag, not just `--mode`
+    /// (#215 self-review §I7).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub values: Option<&'static [&'static str]>,
+    pub values: Option<Vec<String>>,
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct SubcommandSpec {
     pub name: String,
@@ -85,37 +110,67 @@ pub struct SubcommandSpec {
     pub feature_gated: Option<&'static str>,
 }
 
+/// What kind of positional argument an [`ArgSpec`] describes.
+///
+/// Currently every entry is `Positional`; the typed enum reserves
+/// space for future variants (e.g. `Stdin` markers) without breaking
+/// existing JSON consumers. Serialises as `"positional"`.
+#[non_exhaustive]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArgKind {
+    /// A required-or-optional positional argument on the subcommand.
+    Positional,
+}
+
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct ArgSpec {
     pub name: String,
-    /// `positional` | `flag-value`.
-    pub kind: &'static str,
+    /// Always [`ArgKind::Positional`] today. Kept as a discriminator
+    /// so the JSON shape can grow new arg kinds later without
+    /// renaming fields (#215 self-review §I10).
+    pub kind: ArgKind,
     pub help: Option<String>,
     /// `true` when the arg has no default and no `Option<T>` wrapper.
     pub required: bool,
 }
 
-#[allow(missing_docs)] // Variants are documented inline; the enum-level allow silences clippy.
+/// How a subcommand interacts with `--mode json`.
+///
+/// Wire shape: every variant serialises to an object with a `status`
+/// discriminant, so a consumer sees uniform `{"status":"…", …}`
+/// records (`#[serde(tag = "status")]`). Pre-#215 self-review §I6:
+/// the previous mixed string/object representation forced consumers
+/// to handle two JSON shapes for sibling variants.
+#[non_exhaustive] // Adding a future variant is non-breaking for JSON consumers.
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(tag = "status", rename_all = "lowercase")]
 pub enum JsonMode {
-    /// The command's primary output IS JSON regardless of `--mode`
-    /// (e.g. `csl`, `graph`, `*-dry-run`).
-    Product,
-    /// The command emits a structured JSON body when `--mode json` is
-    /// active; otherwise human (e.g. `info`, `list-recent`, `audit-log`).
+    /// The command's primary output IS the requested artifact, not
+    /// informational chatter. `--mode` is informational here; the
+    /// exact stdout shape (JSON for `csl` / `graph` / `capabilities`
+    /// and the JSON-RPC stream from `serve`; BibTeX for `bib`;
+    /// PDF-on-disk + stderr summary for `fetch`; a `--dry-run` JSON
+    /// plan in the dry-run variants) is fixed by the subcommand and
+    /// may vary across flags. **Consult `examples` for the per-flag
+    /// stdout form** rather than assuming JSON.
+    Artifact,
+    /// Under `--mode json` the command emits a structured JSON body
+    /// on stdout; otherwise the human form (e.g. `info`,
+    /// `list-recent`, `audit-log`, `provenance migrate`, `batch`).
     Supported,
-    /// Not yet — JSON body honoring is tracked as the issue named
-    /// inside.
+    /// JSON body honoring not yet implemented; tracked at the issue
+    /// named inside.
     Deferred {
-        /// The follow-up issue tracking the JSON honoring for this
-        /// command (e.g. `"#210"`).
+        /// The follow-up issue (e.g. `"#210"`).
         tracking: &'static str,
     },
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct EnvVar {
     pub name: &'static str,
@@ -125,6 +180,7 @@ pub struct EnvVar {
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct McpTool {
     pub name: &'static str,
@@ -133,6 +189,7 @@ pub struct McpTool {
 }
 
 #[allow(missing_docs)] // Field names ARE the schema; documented externally in #214.
+#[non_exhaustive] // Wire-format stability: adding fields is non-breaking; renames/removals are.
 #[derive(Debug, Serialize)]
 pub struct Docs {
     pub config: &'static str,
@@ -155,6 +212,11 @@ const ENV_VARS: &[EnvVar] = &[
         name: "DOIGET_STORE_ROOT",
         default: "$HOME/papers",
         help: "Root of the on-disk paper store. CONFIG.md §4.",
+    },
+    EnvVar {
+        name: "DOIGET_CACHE_ROOT",
+        default: "$HOME/.cache/doiget",
+        help: "Root of the on-disk HTTP / metadata cache. CONFIG.md §4.",
     },
     EnvVar {
         name: "DOIGET_LOG_PATH",
@@ -278,6 +340,15 @@ const DOCS: Docs = Docs {
 /// `json_mode` semantics, and feature-gating that clap doesn't
 /// expose. A regression unit test asserts every clap-visible
 /// subcommand has an entry here (otherwise the test fails loudly).
+///
+/// **Maintenance:** `feature_gated` MUST be kept in sync with the
+/// corresponding `#[cfg(feature = …)]` annotation in `main.rs`. There
+/// is no compile-time check; the `every_test_cli_subcommand_has_metadata`
+/// regression test does not cover feature-gating directly — it only
+/// asserts metadata exists. Add a CI matrix entry (`--features
+/// citation`) when introducing new gated subcommands so the e2e
+/// assertion list catches drift (#215 self-review §I5 / comment-analyzer
+/// note 4).
 struct SubcommandMeta {
     examples: &'static [&'static str],
     json_mode: JsonMode,
@@ -294,7 +365,7 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
             ],
             // The success summary is on stderr (ADR-0001); the
             // dry-run plan is JSON product output (ADR-0022).
-            json_mode: JsonMode::Product,
+            json_mode: JsonMode::Artifact,
             feature_gated: None,
         },
         "batch" => SubcommandMeta {
@@ -335,12 +406,12 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
         "bib" => SubcommandMeta {
             examples: &["doiget bib 10.1234/foo", "doiget bib arxiv:2401.12345"],
             // BibTeX output is the product; `--mode` is informational.
-            json_mode: JsonMode::Product,
+            json_mode: JsonMode::Artifact,
             feature_gated: None,
         },
         "csl" => SubcommandMeta {
             examples: &["doiget csl 10.1234/foo"],
-            json_mode: JsonMode::Product,
+            json_mode: JsonMode::Artifact,
             feature_gated: None,
         },
         "audit-log" => SubcommandMeta {
@@ -375,7 +446,7 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
             examples: &["doiget serve   # stdio MCP server (ADR-0001)"],
             // serve always runs in mcp mode; the protocol output is
             // JSON-RPC, which is product.
-            json_mode: JsonMode::Product,
+            json_mode: JsonMode::Artifact,
             feature_gated: None,
         },
         "graph" => SubcommandMeta {
@@ -383,13 +454,13 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
                 "DOIGET_ENABLE_OPENALEX=1 doiget graph 10.1234/foo",
                 "DOIGET_ENABLE_OPENALEX=1 doiget graph 10.1234/foo --depth 2 --total 50",
             ],
-            json_mode: JsonMode::Product,
+            json_mode: JsonMode::Artifact,
             feature_gated: Some("citation"),
         },
         "capabilities" => SubcommandMeta {
             examples: &["doiget capabilities | jq ."],
             // The whole point of capabilities IS JSON output.
-            json_mode: JsonMode::Product,
+            json_mode: JsonMode::Artifact,
             feature_gated: None,
         },
         // clap auto-adds `help`; we silently ignore it (it's not a
@@ -489,10 +560,24 @@ fn split_args_and_flags(
         if global_names.contains(a.get_id().as_str()) {
             continue;
         }
+        // #215 self-review §I1: clap auto-adds `--help` (and `--version`
+        // on the root) to every subcommand. They're not positional and
+        // not `is_global_set()`, so they would otherwise leak into
+        // every subcommand's `flags[]` as `kind: "string"`. Filter on
+        // the action to be robust across future clap built-ins.
+        if matches!(
+            a.get_action(),
+            clap::ArgAction::Help
+                | clap::ArgAction::HelpShort
+                | clap::ArgAction::HelpLong
+                | clap::ArgAction::Version
+        ) {
+            continue;
+        }
         if a.is_positional() {
             args.push(ArgSpec {
                 name: a.get_id().to_string(),
-                kind: "positional",
+                kind: ArgKind::Positional,
                 help: a.get_help().map(|s| s.to_string()),
                 required: a.is_required_set(),
             });
@@ -509,23 +594,23 @@ fn arg_to_flag_spec(a: &clap::Arg) -> FlagSpec {
         .map(|s| format!("--{s}"))
         .or_else(|| a.get_short().map(|c| format!("-{c}")))
         .unwrap_or_else(|| a.get_id().to_string());
-    // Best-effort kind classification. Boolean switches show up as
-    // `bool`; value-enum flags show up as `enum` with the accepted
-    // values; everything else is `string`.
-    let kind = if matches!(
+    // Boolean switches → `Bool`; value-enum flags → `Enum` with the
+    // accepted values harvested from clap directly; everything else
+    // → `String`. The `possible_values()` harvest covers any future
+    // enum flag without code change (#215 self-review §I7).
+    let possible: Option<Vec<String>> = a
+        .get_value_parser()
+        .possible_values()
+        .map(|it| it.map(|pv| pv.get_name().to_owned()).collect());
+    let (kind, values) = if matches!(
         a.get_action(),
         clap::ArgAction::SetTrue | clap::ArgAction::SetFalse
     ) {
-        "bool"
-    } else if a.get_value_parser().possible_values().is_some() {
-        "enum"
+        (FlagKind::Bool, None)
+    } else if let Some(vs) = possible {
+        (FlagKind::Enum, Some(vs))
     } else {
-        "string"
-    };
-    let values: Option<&'static [&'static str]> = if kind == "enum" && name == "--mode" {
-        Some(MODES)
-    } else {
-        None
+        (FlagKind::String, None)
     };
     FlagSpec {
         name,
@@ -582,7 +667,7 @@ mod tests {
     fn test_cli() -> clap::Command {
         use clap::{Arg, ArgAction, Command};
         let mode_values = ["human", "json", "quiet", "mcp"];
-        Command::new("doiget")
+        let cmd = Command::new("doiget")
             .arg(
                 Arg::new("mode")
                     .long("mode")
@@ -608,19 +693,66 @@ mod tests {
             .subcommand(
                 Command::new("fetch")
                     .about("Fetch a single paper PDF")
+                    .arg(Arg::new("ref").required(true))
+                    .arg(
+                        Arg::new("dry-run")
+                            .long("dry-run")
+                            .action(ArgAction::SetTrue),
+                    ),
+            )
+            .subcommand(
+                Command::new("batch")
+                    .about("Fetch many refs")
+                    .arg(Arg::new("path").required(true))
+                    .arg(
+                        Arg::new("dry-run")
+                            .long("dry-run")
+                            .action(ArgAction::SetTrue),
+                    ),
+            )
+            .subcommand(
+                Command::new("info")
+                    .about("Show metadata")
                     .arg(Arg::new("ref").required(true)),
             )
-            .subcommand(Command::new("batch").about("Fetch many refs"))
-            .subcommand(Command::new("info").about("Show metadata"))
             .subcommand(Command::new("list-recent").about("List recent"))
-            .subcommand(Command::new("search").about("Search local"))
-            .subcommand(Command::new("bib").about("BibTeX export"))
-            .subcommand(Command::new("csl").about("CSL export"))
-            .subcommand(Command::new("audit-log").about("Audit log"))
+            .subcommand(
+                Command::new("search")
+                    .about("Search local")
+                    .arg(Arg::new("query").required(true)),
+            )
+            .subcommand(
+                Command::new("bib")
+                    .about("BibTeX export")
+                    .arg(Arg::new("ref").required(true)),
+            )
+            .subcommand(
+                Command::new("csl")
+                    .about("CSL export")
+                    .arg(Arg::new("ref").required(true)),
+            )
+            .subcommand(
+                Command::new("audit-log")
+                    .about("Audit log")
+                    .arg(Arg::new("verify").long("verify").action(ArgAction::SetTrue)),
+            )
             .subcommand(Command::new("provenance").about("Provenance ops"))
-            .subcommand(Command::new("config").about("Config"))
-            .subcommand(Command::new("serve").about("MCP server"))
-            .subcommand(Command::new("capabilities").about("Capabilities"))
+            .subcommand(
+                Command::new("config")
+                    .about("Config")
+                    .arg(Arg::new("action").required(true)),
+            )
+            .subcommand(Command::new("serve").about("MCP server"));
+        // `graph` is `#[cfg(feature = "citation")]` in main.rs; mirror
+        // the gate so the shadow CLI matches the production surface
+        // (#215 self-review §I5).
+        #[cfg(feature = "citation")]
+        let cmd = cmd.subcommand(
+            Command::new("graph")
+                .about("Citation graph")
+                .arg(Arg::new("ref").required(true)),
+        );
+        cmd.subcommand(Command::new("capabilities").about("Capabilities"))
     }
 
     fn caps() -> Capabilities {
@@ -680,9 +812,11 @@ mod tests {
     fn subcommand_examples_reference_the_subcommand_name() {
         for sub in &caps().subcommands {
             for ex in sub.examples {
+                // `graph` examples carry a `DOIGET_ENABLE_OPENALEX=1`
+                // env prefix before `doiget …`. Allow either form.
                 assert!(
-                    ex.starts_with("doiget "),
-                    "example `{ex}` for `{}` should start with `doiget `",
+                    ex.starts_with("doiget ") || ex.contains(" doiget "),
+                    "example `{ex}` for `{}` must invoke `doiget` somewhere",
                     sub.name
                 );
                 assert!(
@@ -692,6 +826,71 @@ mod tests {
                 );
             }
         }
+    }
+
+    // #215 self-review §I2: exact-set parity guard against drift
+    // between CONFIG.md §4's env-var table and the static `ENV_VARS`
+    // inventory. The expected set is the SOURCE OF TRUTH at test time;
+    // adding a new DOIGET_* env var requires updating both ENV_VARS
+    // and this list in lockstep. CHANGELOG records cross-PR changes.
+    #[test]
+    fn env_vars_exact_set_matches_expected() {
+        let actual: std::collections::BTreeSet<&str> = ENV_VARS.iter().map(|ev| ev.name).collect();
+        let expected: std::collections::BTreeSet<&str> = [
+            // CONFIG.md §4 documented:
+            "DOIGET_STORE_ROOT",
+            "DOIGET_CACHE_ROOT",
+            "DOIGET_LOG_PATH",
+            "DOIGET_LOG_RETENTION_DAYS",
+            "DOIGET_USER_AGENT",
+            "DOIGET_UNPAYWALL_EMAIL",
+            "DOIGET_MODE",
+            // Code-reachable but documented in code-level docs or
+            // CAPABILITY.md (not CONFIG.md §4):
+            "DOIGET_CONTACT_EMAIL",
+            "DOIGET_ENABLE_OPENALEX",
+            // Test/wiremock-override base URLs:
+            "DOIGET_ARXIV_BASE",
+            "DOIGET_CROSSREF_BASE",
+            "DOIGET_UNPAYWALL_BASE",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            actual, expected,
+            "ENV_VARS table drifted from the expected canonical set; \
+             update both `ENV_VARS` and this test together (and CONFIG.md §4 \
+             if the new var is user-documented)."
+        );
+    }
+
+    // #215 self-review §I3: exact-set parity guard against drift
+    // between docs/MCP_TOOLS.md §1 and the static `MCP_TOOLS` array.
+    #[test]
+    fn mcp_tools_exact_set_matches_expected() {
+        let actual: std::collections::BTreeSet<&str> = MCP_TOOLS.iter().map(|t| t.name).collect();
+        let expected: std::collections::BTreeSet<&str> = [
+            "doiget_resolve_paper",
+            "doiget_fetch_paper",
+            "doiget_metadata_only",
+            "doiget_batch_fetch",
+            "doiget_info",
+            "doiget_search_local",
+            "doiget_list_recent",
+            "doiget_paper_pdf_path",
+            "doiget_capability_profile",
+            "doiget_health",
+            "doiget_expand_citation_graph",
+            "doiget_bibtex_export",
+            "doiget_csl_export",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            actual, expected,
+            "MCP_TOOLS table drifted from the expected set; update both \
+             `MCP_TOOLS` and this test together (and docs/MCP_TOOLS.md §1)."
+        );
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@
 pub mod audit_log;
 pub mod batch;
 pub mod bib;
+pub mod capabilities;
 pub mod config;
 pub mod csl;
 pub mod fetch;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -47,6 +47,8 @@ enum ProvenanceAction {
                   \x20 serve        Run as an MCP server over stdio\n\
                   \x20 graph        Expand a DOI's citation neighborhood via OpenAlex\n\
                   \x20              (requires --features citation + DOIGET_ENABLE_OPENALEX)\n\
+                  \x20 capabilities Emit a JSON inventory of the binary's full surface\n\
+                  \x20              (for LLM cold-boot; #214)\n\
                   \n\
                   See README.md and docs/ for the full specification."
 )]
@@ -142,6 +144,10 @@ enum Command {
     },
     /// Run as an MCP server over stdio.
     Serve,
+    /// Emit a single JSON inventory of the binary's full surface
+    /// (subcommands, args, env vars, modes, MCP tools, features).
+    /// Designed for LLM cold-boot in one round-trip. See #214.
+    Capabilities,
     /// Show or doctor the resolved configuration.
     Config {
         /// `show` / `path` / `doctor`
@@ -277,6 +283,15 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             debug_assert_eq!(mode, OutputMode::Mcp, "serve must resolve to Mcp");
             let profile = doiget_core::CapabilityProfile::from_env()?;
             doiget_mcp::Server::new(profile).run().await
+        }
+        // #214: single-shot inventory for LLM cold-boot. We pass the
+        // live `clap::Command` AST so the subcommand list cannot
+        // drift from the parser. `capabilities::run` honors
+        // `--mode quiet` (suppresses) and emits pretty JSON in every
+        // other mode (product-output convention).
+        Some(Command::Capabilities) => {
+            let cli_cmd = <Cli as clap::CommandFactory>::command();
+            doiget_cli::commands::capabilities::run(&cli_cmd, mode)
         }
         // Phase 4 / Slice 16. Feature-gated to keep default release
         // binaries free of the OpenAlex-only citation walker.

--- a/crates/doiget-cli/tests/capabilities_e2e.rs
+++ b/crates/doiget-cli/tests/capabilities_e2e.rs
@@ -105,6 +105,52 @@ fn capabilities_inventory_includes_every_subcommand() {
             "subcommand `{expected}` missing from capabilities inventory; got {names:?}"
         );
     }
+
+    // `graph` is `#[cfg(feature = "citation")]` in main.rs. Under
+    // that feature it MUST appear; without it, it MUST NOT. A silent
+    // drop of `graph` in a citation build would otherwise pass this
+    // test (#215 N2).
+    let has_graph = names.contains(&"graph");
+    if cfg!(feature = "citation") {
+        assert!(
+            has_graph,
+            "`citation` feature was compiled in but `graph` is missing \
+             from capabilities inventory; got {names:?}"
+        );
+    } else {
+        assert!(
+            !has_graph,
+            "`graph` appeared in capabilities inventory without the \
+             `citation` feature; got {names:?}"
+        );
+    }
+}
+
+#[test]
+fn capabilities_fetch_subcommand_carries_artifact_status() {
+    // #215 N1: the `#[serde(tag = "status")]` wire shape is part of
+    // the public contract. Pin a representative subcommand's
+    // `json_mode` so an accidental revert (removing the tag, renaming
+    // the discriminant) fails at the e2e layer.
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    let fetch = v["subcommands"]
+        .as_array()
+        .expect("subcommands array")
+        .iter()
+        .find(|s| s["name"] == "fetch")
+        .expect("fetch subcommand present");
+    assert_eq!(
+        fetch["json_mode"]["status"], "artifact",
+        "fetch.json_mode MUST carry a status discriminant, got {fetch:?}"
+    );
 }
 
 #[test]

--- a/crates/doiget-cli/tests/capabilities_e2e.rs
+++ b/crates/doiget-cli/tests/capabilities_e2e.rs
@@ -1,0 +1,194 @@
+//! End-to-end tests for `doiget capabilities` (#214).
+//!
+//! Exercises the real `doiget` binary so the clap walk uses the
+//! production `Cli` tree (not the shadow `test_cli` in the lib-level
+//! tests). The contract surface is:
+//!
+//! 1. Single valid JSON value on stdout.
+//! 2. Top-level keys: `version`, `features`, `modes`, `global_flags`,
+//!    `subcommands`, `env_vars`, `mcp_tools`, `docs`.
+//! 3. Every documented CLI subcommand (`fetch`, `batch`, `info`,
+//!    `list-recent`, `search`, `bib`, `csl`, `audit-log`,
+//!    `provenance`, `config`, `serve`, `capabilities`) is in
+//!    `subcommands[]`.
+//! 4. Honors ADR-0017: `--mode quiet` produces empty stdout.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Build a `doiget capabilities` command with env scaffolding that
+/// avoids touching the developer's real `~/.config/doiget/`.
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        // capabilities is a product-output command (JSON regardless of
+        // mode). Force `human` so the non-TTY default-to-quiet rule
+        // (#203) doesn't suppress stdout in this assert_cmd context.
+        .env("DOIGET_MODE", "human");
+    cmd
+}
+
+fn parse_capabilities(stdout: Vec<u8>) -> Value {
+    let s = String::from_utf8(stdout).expect("stdout utf-8");
+    serde_json::from_str(&s).expect("capabilities stdout parses as JSON")
+}
+
+#[test]
+fn capabilities_emits_valid_json_with_all_top_level_keys() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    for key in [
+        "version",
+        "features",
+        "modes",
+        "global_flags",
+        "subcommands",
+        "env_vars",
+        "mcp_tools",
+        "docs",
+    ] {
+        assert!(
+            v.get(key).is_some(),
+            "top-level key `{key}` missing from capabilities JSON"
+        );
+    }
+}
+
+#[test]
+fn capabilities_inventory_includes_every_subcommand() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    let subs = v["subcommands"]
+        .as_array()
+        .expect("subcommands is an array");
+    let names: Vec<&str> = subs
+        .iter()
+        .map(|s| s["name"].as_str().expect("subcommand name is a string"))
+        .collect();
+    for expected in [
+        "fetch",
+        "batch",
+        "info",
+        "list-recent",
+        "search",
+        "bib",
+        "csl",
+        "audit-log",
+        "provenance",
+        "config",
+        "serve",
+        "capabilities",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "subcommand `{expected}` missing from capabilities inventory; got {names:?}"
+        );
+    }
+}
+
+#[test]
+fn capabilities_quiet_mode_produces_no_stdout() {
+    // ADR-0017 / #203: Quiet suppresses stdout even for product-output
+    // commands. The exit is still 0 (capabilities never errors on a
+    // missing env / store; pure introspection).
+    let dir = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("locate doiget binary")
+        .env("HOME", dir.path())
+        .env("USERPROFILE", dir.path())
+        .env("APPDATA", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["--quiet", "capabilities"])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn capabilities_modes_field_matches_output_mode_enum() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    let modes = v["modes"]
+        .as_array()
+        .expect("modes is an array")
+        .iter()
+        .map(|m| m.as_str().expect("mode string").to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        modes,
+        vec!["human", "json", "quiet", "mcp"],
+        "modes field MUST mirror the OutputMode enum (ADR-0017)"
+    );
+}
+
+#[test]
+fn capabilities_env_vars_list_is_non_empty_and_doiget_prefixed() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    let env_vars = v["env_vars"].as_array().expect("env_vars is an array");
+    assert!(!env_vars.is_empty(), "env_vars MUST be non-empty");
+    for ev in env_vars {
+        let name = ev["name"].as_str().expect("env var has a name");
+        assert!(
+            name.starts_with("DOIGET_"),
+            "env var name MUST use DOIGET_ prefix, got `{name}`"
+        );
+    }
+}
+
+#[test]
+fn capabilities_mcp_tools_list_is_non_empty_and_doiget_prefixed() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    let tools = v["mcp_tools"].as_array().expect("mcp_tools is an array");
+    assert!(!tools.is_empty(), "mcp_tools MUST be non-empty");
+    for t in tools {
+        let name = t["name"].as_str().expect("mcp tool has a name");
+        assert!(
+            name.starts_with("doiget_"),
+            "MCP tool name MUST use doiget_ prefix, got `{name}`"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

\`doiget capabilities\` emits **one JSON value** describing the binary's full surface: subcommands, args, flags, modes, env vars, MCP tools, compile-time features, and doc cross-refs. Designed for **LLM cold-boot in one round-trip** — the agent reads stdout once and knows everything it can do with this build of doiget.

Closes #214.

## What it prints

\`\`\`jsonc
{
  "version": "0.2.1-beta.12",
  "features": ["oa-only"],
  "modes": ["human","json","quiet","mcp"],
  "global_flags": [{"name":"--mode","kind":"enum","values":["human","json","quiet","mcp"], ...}, ...],
  "subcommands": [
    {
      "name": "fetch",
      "summary": "Fetch a single paper PDF by DOI or arXiv id",
      "args": [{"name":"ref_","kind":"positional","required":true, ...}],
      "flags": [{"name":"--dry-run","kind":"bool", ...}],
      "examples": ["doiget fetch 10.1234/foo", "doiget fetch arxiv:2401.12345 --dry-run"],
      "json_mode": "product"
    },
    // ... 12 subcommands total
  ],
  "env_vars":   [{"name":"DOIGET_STORE_ROOT","default":"$HOME/papers","help":"..."}, ...],
  "mcp_tools":  [{"name":"doiget_fetch_paper","schema_ref":"docs/MCP_TOOLS.md#1-tool-list"}, ...],
  "docs":       {"config":"docs/CONFIG.md","errors":"docs/ERRORS.md", ...}
}
\`\`\`

## Drift-resistance

The **subcommand inventory is clap-walked from the live \`Cli::command()\` tree** — cannot drift from the parser. A new subcommand added to the \`Cli\` enum must also be registered in \`commands::capabilities::metadata_for\` (examples + \`json_mode\` + \`feature_gated\` are still hand-maintained), otherwise the \`every_test_cli_subcommand_has_metadata\` unit test fails at lib-test time.

## Honoring of ADR-0017 / #203

\`doiget capabilities\` is a **product-output** command (the JSON inventory IS the artefact). \`--mode quiet\` suppresses; every other mode (\`human\` / \`json\` / \`mcp\`) emits the same pretty JSON.

## Wire-format stability

Field names in the JSON are public API the moment a release ships. Same discipline as \`EntryInfo\` / \`MigrationReport\` (added in #213 self-review): renames are semver minor with a CHANGELOG \`[BREAKING]\` callout. The module-top doc says so inline.

## Test plan

- [x] **Lib unit (7)**: schema round-trip; top-level keys; \`modes\` matches \`OutputMode\`; \`DOIGET_*\` prefix invariant; \`doiget_*\` prefix invariant; examples reference their subcommand; \`version\` == \`CARGO_PKG_VERSION\`; every shadow-CLI subcommand has metadata.
- [x] **E2E (6)**: real-binary JSON output; every documented subcommand (\`fetch\`/\`batch\`/\`info\`/\`list-recent\`/\`search\`/\`bib\`/\`csl\`/\`audit-log\`/\`provenance\`/\`config\`/\`serve\`/\`capabilities\`) present; \`--quiet\` suppresses; \`modes\` round-trips; \`env_vars\`/\`mcp_tools\` non-empty + prefix invariants.
- [x] \`cargo test --workspace\` green; clippy clean; fmt clean; rustdoc 0 warnings; \`doiget capabilities | jq .\` smoke-tested locally.

## Follow-ups intentionally out of scope

- **MCP \`initialize.instructions\` integration** — same \`Capabilities\` payload could (and should) be returned by the MCP server's initialize handshake so MCP clients get the same inventory. Tracked alongside #212 (MCP shape alignment).
- **\`doiget-mcp\` self-registration** for the tool list — current \`mcp_tools[]\` is hand-coded against \`docs/MCP_TOOLS.md\`. A future slice can introspect the \`#[tool_router]\` macro output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)