### PR TITLE
docs(adr) + chore(next): v0.4 design + open v0.4.1-beta.1 beta lane

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,11 @@
 # `flate`: substring of the gzip crate name `flate2` (provenance §6
 # rotation, #140) — a real crate identifier, not a misspelling of "flat".
 flate = "flate"
+# `rquest`: actively-maintained reqwest fork
+# (https://crates.io/crates/rquest); referenced in ADR-0028 (D3)
+# as one of the impersonation libraries explicitly out-of-scope.
+# Not a misspelling of "request" or "quest".
+rquest = "rquest"
 
 [files]
 # Generated / vendored / fixture files where typo enforcement is not useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.1] - 2026-05-21
+
+Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +
+ADR-0028 / 0029 / 0030, design-only — no code change yet).
+Workspace version is bumped to satisfy the version-gate G5
+(non-empty CHANGELOG section for the prospective tag) while the
+implementation slices S1-S8 land separately.
+
+### Added
+
+- **[design]** ADR-0017 Amendment 1: distinguish *explicit* vs
+  *implicit* `Quiet`, classify commands as artifact vs
+  informational. Closes the LLM cold-boot deadlock reported in
+  #219 / #220 once the implementation slice (S1) lands.
+- **[design]** ADR-0028: the capability gate's purpose is
+  **ToS compliance + verified curation**; users may extend it via
+  `config.toml` (literal hosts or single-suffix wildcards) with
+  per-attempt `verified_by = "user"` recorded in the provenance
+  log. Impersonation / WAF bypass / embedded headless browser
+  (#223) are permanently out-of-scope.
+- **[design]** ADR-0029: `fetch_one` resolves to an ordered chain
+  of candidate URLs (OpenAlex `oa_locations[]` order); each
+  attempt becomes its own provenance row (schema-additive on v2).
+  New closed-enum `FetchError` variant `ALL_FALLBACKS_EXHAUSTED`
+  carries `Vec<AttemptOutcome>`.
+- **[design]** ADR-0030: bibliography input adapters
+  (`.bib` / CSL-JSON) live in `doiget-core`; new MCP tool
+  `doiget_batch_from_bibliography` enables the Zotero plugin
+  distribution path. One identifier per entry
+  (DOI > arXiv > PMID); skip-and-warn on parse error by default.
+
 ## [0.3.0] - 2026-05-20
 
 Promotion of the `0.2.1-beta.1..beta.12` integration line on `next` to a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.3.0"
+version = "0.4.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.3.0"
+version = "0.4.1-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.3.0"
+version = "0.4.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.3.0"
+version       = "0.4.1-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.3.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.3.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.3.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/DECISIONS/0017-output-mode-resolution.md
+++ b/docs/DECISIONS/0017-output-mode-resolution.md
@@ -1,7 +1,7 @@
 # 0017 - Output mode resolution (flag > env > implicit > TTY > quiet)
 
 - **Date:** 2026-05-05
-- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205.
+- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205. Amendment 1 (2026-05-21) distinguishes **explicit** vs **implicit** Quiet and adds an artifact-command classification so commands whose output is the product (`bib`/`csl`/`capabilities`/`audit-log --verify --mode json`) honor only explicit Quiet, fixing the LLM cold-boot deadlock reported in #219 / #220.
 - **Supersedes:** -
 - **Source:** Discussion #14
 
@@ -24,3 +24,132 @@ NORMATIVE doc(s) under docs/.
 
 To revise this decision, write a new ADR with Status: Accepted and Supersedes: 0017,
 and update this file's Status to Superseded by NNNN per CONTRIBUTING.md.
+
+## Amendment — 2026-05-21 (1): bifurcate Quiet into explicit vs implicit; classify commands as artifact vs informational
+
+**Diagnosis (LLM cold-boot deadlock, #219 / #220).** ADR-0017 collapses
+two distinct signals into a single `OutputMode::Quiet`:
+
+1. **Explicit Quiet** — the user *asks* for silence:
+   `--quiet`, `-q`, `--mode quiet`, `DOIGET_MODE=quiet`.
+2. **Implicit Quiet** — the resolver *infers* silence from a display
+   heuristic: stdout is not a TTY and no other signal was given.
+   The intent here is "don't dump ANSI into a pipe," not "be silent."
+
+These two signals collapse to the same enum value but have different
+authorities. Conflating them silently breaks artifact-output commands
+in agent / pipe contexts:
+
+```text
+$ doiget capabilities | jq .    # non-TTY -> implicit Quiet
+                                # capabilities suppresses stdout
+                                # exit code 0, empty output
+                                # LLM cannot discover anything.
+```
+
+The chicken-and-egg: the very command an LLM would call to discover
+how to make `doiget` talk (`capabilities`) is the one silenced by the
+TTY heuristic. `bib` / `csl` exhibit the same class of failure — both
+are artifact-producing commands and both go silent when piped.
+
+**Decision.** Distinguish explicit Quiet from implicit Quiet at the
+resolution boundary, and classify every command as either *artifact*
+(output IS the product) or *informational* (output is a status report,
+silenceable on display heuristic). The classification dictates which
+Quiet a command honors:
+
+```text
+                       | informational   | artifact
+                       |  cmd  silenced? |  cmd  silenced?
+-----------------------+-----------------+------------------
+explicit  Quiet        |       yes       |       yes
+  (--quiet / -q /      |                 |
+   DOIGET_MODE=quiet / |                 |
+   --mode quiet)       |                 |
+-----------------------+-----------------+------------------
+implicit  Quiet        |       yes       |       NO
+  (non-TTY default)    |                 |
+```
+
+### Implementation shape (illustrative; binding contract is the table above)
+
+1. **Resolver surface.** Promote the return type of
+   `commands::output::resolve(..)` from `OutputMode` to a small
+   `ResolvedOutput` value carrying the `mode` plus an
+   explicit-quiet bit:
+
+   ```rust
+   pub struct ResolvedOutput {
+       pub mode: OutputMode,           // unchanged (4 variants)
+       pub quiet_was_explicit: bool,   // true iff user asked for it
+   }
+   ```
+
+   The wire surface (`DOIGET_MODE` string values, the `modes` array
+   in `capabilities` JSON, the `--mode` clap values) is **unchanged**;
+   the bit lives only in the in-memory resolved value.
+
+2. **Per-command honoring.** Each command receives `ResolvedOutput`
+   instead of bare `OutputMode`:
+
+   ```rust
+   // Informational commands (audit-log Human, list-recent, search,
+   // info, config show/path, provenance migrate, fetch/batch status):
+   if out.mode == OutputMode::Quiet { return suppress(); }
+
+   // Artifact commands (bib, csl, capabilities,
+   // audit-log --verify --mode json):
+   if out.mode == OutputMode::Quiet && out.quiet_was_explicit {
+       return suppress();
+   }
+   ```
+
+3. **Classification table.** A single source of truth in
+   `commands::output` (e.g. a `is_artifact_command(name: &str) -> bool`
+   helper) lists artifact commands; the lib-level parity test
+   asserting every `Cli` enum variant has a `SubcommandMeta` entry
+   (#214) is extended to also assert the classification matches the
+   command's documented behavior.
+
+4. **`audit-log --verify`** is the boundary case: **informational in
+   Human mode, artifact in Json mode**. The split is natural since
+   the `--mode json` request is itself an explicit signal; the
+   command checks the mode it resolved into rather than its name.
+
+### Binding properties
+
+1. **`OutputMode` enum shape is unchanged** — 4 variants, same serde,
+   same `capabilities` `modes` array. No wire-format break.
+2. **`DOIGET_MODE=quiet` semantics are unchanged** — still suppresses
+   *every* command including artifact ones (it is explicit).
+3. **TTY detection semantics are unchanged** — still produces
+   `OutputMode::Quiet` for non-TTY when no other signal is given,
+   but now carries `quiet_was_explicit = false`.
+4. **`serve → forced Mcp`** override (Slice 9 / Slice 1 stdout-purity
+   invariant) is unchanged and orthogonal to this bit.
+5. **`--mode quiet` is explicit** — passing the flag, even though it
+   is the *same mode* the TTY heuristic might pick, signals intent
+   and silences artifact commands.
+
+### Test plan
+
+- Unit (`output.rs`): `resolve(..)` returns `quiet_was_explicit = true`
+  for each of `{--quiet, -q, --mode quiet, DOIGET_MODE=quiet}` and
+  `false` for non-TTY default.
+- E2E (`capabilities_e2e.rs`): `doiget capabilities` (non-TTY, no
+  flags) emits the full JSON inventory — closes #219. The existing
+  `--quiet capabilities` test (#203 follow-up) keeps the empty-stdout
+  assertion to lock the explicit-quiet path.
+- E2E (`output_mode_e2e.rs`): `bib` / `csl` emit their artifact on
+  non-TTY default; `bib --quiet` / `csl --quiet` emit empty.
+- E2E (audit-log boundary): `audit-log --verify --mode json` emits
+  the JSON report regardless of TTY; `audit-log --verify` (Human)
+  is still silenced on non-TTY.
+
+### Migration
+
+The implementation slice is a CLI-internal refactor; consumers
+(scripts, agents, `capabilities` JSON consumers) see a behavior
+*restoration* for artifact commands in pipes — no API change.
+The 0.3.0 non-TTY-default callout in CHANGELOG remains in force
+for informational commands.

--- a/docs/DECISIONS/0028-user-extensible-capability-gate.md
+++ b/docs/DECISIONS/0028-user-extensible-capability-gate.md
@@ -1,0 +1,218 @@
+# 0028 - User-extensible capability gate; ToS + verified-curation posture; impersonation out-of-scope
+
+- **Date:** 2026-05-21
+- **Status:** Accepted (design; implementation slice tracked separately).
+  This ADR sets the semantic frame for the redirect / fetch-host
+  allowlist (the *capability gate*). It does not modify the default
+  curated host set; that continues to live in
+  `docs/REDIRECT_ALLOWLIST.md` §3 + `crates/doiget-core/src/http.rs`
+  and is grown by individual ADRs per cluster (e.g. ADR-0027).
+- **Supersedes:** -
+- **Source:** #220 (user-extension request: Green-OA at `ruj.uj.edu.pl`);
+  #223 (rejected: WAF / TLS-impersonation bypass);
+  dogfood of finite-temperature-MPS corpus (2026-05-20).
+
+## Context
+
+The capability gate (`oa_publisher_allowlist()` /
+`tier_2_allowlist()` + the redirect-allowlist enforcement in the
+orchestrator) is the load-bearing primitive that keeps `doiget` a
+**legitimate, auditable, official-channel** academic fetch tool
+rather than a generic scraper. Until now its purpose has been only
+*implicitly* defined — the codebase encodes "what" (a static list),
+not "why" (the policy the list enforces).
+
+Two recent issues exposed the absence of a stated policy:
+
+1. **#220 (user-extension).** A real dogfood batch was blocked at
+   `ruj.uj.edu.pl` (Jagiellonian University Repository — a Green-OA
+   institutional repo). The user could not extend the allowlist
+   locally without forking the codebase. The natural response —
+   "let users add hosts via config" — has no documented constraint,
+   so it could degrade into an arbitrary opt-out of the gate.
+2. **#223 (impersonation).** A request for TLS-fingerprint
+   impersonation (`reqwest-impersonate`) and cookie-import paths to
+   bypass Cloudflare / Akamai WAF challenges on publisher hosts.
+   Without a stated posture this would be a judgement call; with
+   one, it is mechanically out of scope.
+
+The ADR has to answer three questions: **why does the gate exist,
+how may users widen it, and which proposals are mechanically
+out-of-scope?**
+
+### Three competing semantics for "why the gate exists"
+
+```mermaid
+flowchart TB
+  Q["allowlist の存在理由"]
+  Q --> A["A. TLS / 改ざん対策<br/>(技術的信頼境界)"]
+  Q --> B["B. ToS 遵守<br/>(法的信頼境界)"]
+  Q --> C["C. 既知の良い source 集合<br/>(品質キュレーション)"]
+  A --> AC["静的 list、user 拡張不可<br/>WAF bypass 議論不能"]
+  B --> BC["publisher 単位の policy file<br/>WAF bypass は posture 違反"]
+  C --> CC["user 拡張 OK、検証込み<br/>WAF bypass はスコープ外"]
+```
+
+`doiget` already enforces TLS-only at the transport layer
+(`rustls-no-provider` + `ring`; ADR-0020 Am1), so the gate is **not
+needed for TLS safety** — that is settled lower in the stack.
+Interpretation A is therefore not load-bearing on its own. The gate's
+real load is **B + C**: it filters to hosts that (1) permit automated
+access under their terms and (2) have been empirically observed to
+return well-formed PDFs in a doiget run.
+
+## Decision
+
+The capability gate is governed by the union of **ToS compliance
+(B)** and **verified curation (C)**. This frame produces deterministic
+answers to the three open questions:
+
+### D1 — Default allowlist remains curated; entries require empirical evidence
+
+`oa_publisher_allowlist()` and `tier_2_allowlist()` continue to grow
+**only** through ADRs that:
+
+1. Document the host (or single-suffix host pattern).
+2. Cite ToS evidence that automated PDF fetch is permitted (e.g.
+   APS green OA policy, SciPost diamond OA terms, arXiv API terms).
+3. Cite at least one empirical fetch that produced a well-formed PDF
+   with a sane `Content-Type` and an HTTP/2 200 (or 200 after a
+   permitted redirect).
+
+ADR-0027 is the canonical template for this growth path (the
+empirical-evidence comment lives in `http.rs` next to each added
+host). Hosts added without (1)+(2)+(3) are rejected.
+
+### D2 — User-extensible allowlist via `config.toml`, opt-in, audited
+
+Users SHALL be able to extend the gate for their own deployment via
+`config.toml`, **literal hosts or single-suffix wildcards only**, and
+each extension is recorded in the provenance log so the audit trail
+remains intact:
+
+```toml
+[network]
+contact_email = "researcher@institution.edu"
+
+[[network.additional_hosts]]
+host = "ruj.uj.edu.pl"
+note = "Jagiellonian University Repository — Green OA (verified 2026-05-21)"
+
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+note = "all Jagiellonian subdomains; single-suffix wildcard"
+
+# REJECTED at parse time:
+# [[network.additional_hosts]]
+# host = "*.edu.*"        # multi-segment glob — rejected
+# host = "*"              # bare wildcard — rejected
+# host = "user@host.com"  # not a host — rejected
+```
+
+Binding properties of the user-extension surface:
+
+1. **Pattern grammar is restricted.** Literal host (`foo.example.org`)
+   or single leading-segment wildcard (`*.example.org`, meaning
+   "any subdomain of `example.org`"). Multi-segment globs (`*.edu.*`,
+   `*.ac.*`), bare wildcards (`*`), and full glob (`*.example.*`) are
+   parse errors. The orchestrator's pattern matcher is the same
+   single-suffix logic ADR-0027 already uses (e.g. `*.aps.org`).
+2. **Provenance log marks the path taken.** Every fetch that hit a
+   user-added host MUST record `verified_by = "user"` in the
+   provenance row (alongside the existing `safekey` / `canonical_digest`
+   fields). Default-list fetches record `verified_by = "curated"`
+   (or omit the field for backward compatibility — schema-additive).
+3. **`doiget config doctor` surfaces extensions.** A `doctor` line
+   reports the count of user-added hosts and warns that they are not
+   part of the project-verified set. Names are NOT printed by default
+   (privacy on shared logs); `--verbose` opts in.
+4. **`doiget capabilities` reports the count, not the contents.** The
+   `env_vars` / `docs` blocks already exist; a new field
+   `capability_gate.user_extension_count` reports a non-negative
+   integer. Field names are part of the wire format
+   (`#[non_exhaustive]` discipline from #215).
+5. **No env-var equivalent.** Extensions live only in
+   `config.toml`. The reason: env vars are usually un-audited
+   (CI scripts, parent processes); requiring a config file makes the
+   extension a deliberate, reviewable artifact.
+
+### D3 — Impersonation, WAF bypass, and credential-borrowing are out of scope
+
+The gate's purpose includes the ToS-compliance leg (D1, point 2).
+Proposals that route around publisher access controls
+*by making automated requests appear human-driven* are mechanically
+incompatible with that leg:
+
+| Proposal (from #223) | Disposition |
+|---|---|
+| Detect Cloudflare / Akamai WAF blocks and surface as a structured `HttpError::BlockedByFirewall` variant | **Accept** — the detection itself is honest classification of a failure (not a bypass) and aligns with the structured-denial-context discipline of ADR-0023; tracked under Q6 / a future error-taxonomy ADR. |
+| `reqwest-impersonate` / `rquest` (TLS JA3 fingerprint spoofing, HTTP/2 frame mimicry) | **Reject (out of scope; won't fix).** The crate's stated purpose is to misrepresent the client to publisher WAFs. This contradicts D1 point 2 directly. |
+| `--cookies` flag importing user's authenticated browser session (Netscape `cookies.txt`) | **Reject for v0.4** (re-evaluate only on explicit maintainer review). Even if user-provided, the cookies represent the *user's* authenticated session being driven programmatically; many publisher ToS treat that as automated access by an unauthorized agent. The provenance / audit story is also unclear. |
+| Embedded headless browser (`chromiumoxide`, `headless_chrome`, Playwright sidecar) | **Reject (permanent out of scope).** Brings a 100+MB Chromium dependency, an exec-arbitrary-JS execution surface, and is fundamentally an impersonation pipeline. Incompatible with the static-musl portability story (ADR-0020 Am1) and with the gate's ToS leg. |
+| Per-host configurable `User-Agent` override (`network.user_agent`) | **Defer.** Setting a contact-bearing UA per `contact_email` policy (RFC compliance) is fine; setting a UA *to look like a browser* is impersonation. The current single-UA model honoring `contact_email` already covers the legitimate use case; a per-host UA table is reserved until a real legitimate need (e.g. publisher requiring a registered application UA) emerges. |
+| Per-host configurable delay / cooldown (`network.cooldown_ms`) | **Accept** — separate, non-impersonating rate-limit tuning; tracked under #222, not blocked by this ADR. |
+
+The `won't fix` items get a written response on their respective
+issues citing this ADR; this is the canonical reference.
+
+## Consequences
+
+### Positive
+
+1. The gate's purpose is now stated. Future allowlist-growth requests
+   can be evaluated against D1; future impersonation requests can be
+   declined against D3 without re-litigating the posture each time.
+2. Real-world dogfood blockers like `ruj.uj.edu.pl` (#220) become
+   solvable for the affected user in 30 seconds (edit `config.toml`)
+   without forking, while keeping the default set verified.
+3. `provenance.verified_by` provides the audit signal needed to
+   distinguish "doiget vouched for this host" from "the operator
+   accepted responsibility for this host" — important for
+   institutional users.
+4. The ADR makes #223 a one-comment close (link here) rather than
+   a recurring design debate.
+
+### Negative
+
+1. The `config.toml` surface grows; the `additional_hosts` parser
+   becomes a small but non-trivial new code path with its own
+   tests (pattern validation, `verified_by` plumbing, doctor
+   surfacing).
+2. Users will sometimes add hosts that don't actually serve OA PDFs
+   (legacy URLs, paywalled HTML, etc.). The fetch then fails with a
+   *different* error code (`NETWORK_ERROR` / unexpected
+   `Content-Type`) rather than `CAPABILITY_DENIED`; the failure
+   digest must make this distinguishable.
+3. The "single-suffix wildcard" rule is a usability compromise — a
+   user who wants to whitelist three sibling subdomains of
+   `example.org` must either list all three, or whitelist the parent
+   suffix (which is broader than they may have intended). This is
+   deliberate: the rule biases toward least-privilege per-host
+   grants.
+4. The `won't fix` posture for impersonation closes the door on a
+   subset of real publishers (those that block all non-browser TLS
+   fingerprints). doiget cannot reach those papers via automated
+   official-channel fetch; the documented workflow there is *manual
+   download → `doiget import <pdf>`* (a future facility tracked
+   separately), not impersonation.
+
+### Migration
+
+- No default-list change. The implementation slice introduces the
+  `network.additional_hosts` parser, the `verified_by` provenance
+  field (schema-additive), the `doctor` line, and the
+  `capabilities.capability_gate.user_extension_count` field.
+  None of these break existing consumers.
+- The `won't fix` issues (#223 items D3) get a maintainer comment
+  pointing at this ADR and are closed with `state_reason: not_planned`.
+
+## References
+
+- `docs/REDIRECT_ALLOWLIST.md` §3 — the default curated host set
+- ADR-0023 (structured `denial_context` on error envelopes; the
+  failure-shape this ADR's `CAPABILITY_DENIED` continues to honor)
+- ADR-0027 (allowlist-growth template; the canonical "add a host"
+  procedure under D1)
+- #220 (user-extension motivation)
+- #223 (impersonation proposals; rejected under D3)
+- #222 (`network.cooldown_ms` — separate, accepted)

--- a/docs/DECISIONS/0029-fetch-chain-attempt-provenance.md
+++ b/docs/DECISIONS/0029-fetch-chain-attempt-provenance.md
@@ -1,0 +1,280 @@
+# 0029 - Fetch chain: per-Ref multi-attempt resolution with attempt-level provenance
+
+- **Date:** 2026-05-21
+- **Status:** Accepted (design; implementation slice tracked separately
+  and gated by ADR-0028 — the chain composes with the curated +
+  user-extension allowlist semantics, not around them).
+- **Supersedes:** -
+- **Source:** #222 (auto-preprint / alternative-OA fallback);
+  dogfood of finite-temperature-MPS corpus where DOI-publisher
+  fetches returned 403 but arXiv preprints were present in OpenAlex
+  metadata.
+
+## Context
+
+The current fetch pipeline resolves a `Ref` (DOI / arXiv ID / PMID)
+to **exactly one** PDF URL via the metadata source's *best* OA
+location:
+
+```text
+Ref -> Source.lookup -> single URL -> fetch -> PDF | error
+                       (best_oa_location)
+```
+
+This is wasteful in two directions:
+
+1. **Wasted information.** OpenAlex returns *multiple*
+   `oa_locations[]` per work (publisher OA, arXiv preprint, repo
+   mirror, …). Today only the first is tried; if it fails, the
+   remaining locations are discarded even though they're already in
+   the metadata response.
+2. **Wasted recovery.** In the dogfood batch, a `doi:` lookup hit
+   `link.aps.org` and was blocked by a publisher WAF (HTTP 403). The
+   *same* paper's arXiv preprint was already listed by OpenAlex with
+   a valid, allowlisted URL. The user had to discover this manually
+   and re-issue a separate fetch.
+
+The natural fix is to **try the OA locations in priority order until
+one succeeds**, and to record the chain in the provenance log so the
+audit trail captures every external request, not just the final
+outcome.
+
+This ADR pins the chain semantics, the per-attempt provenance shape,
+and the new closed-enum error variant for the "all attempts failed"
+terminal state.
+
+### Why this is not a CLI retry policy
+
+A retry policy is a *temporal* loop ("try again after T") on the
+*same* URL; a fetch chain is a *spatial* search across alternative
+sources of the same logical paper. The two are orthogonal:
+
+| | Retry policy | Fetch chain (this ADR) |
+|---|---|---|
+| Loop dimension | time | source / URL |
+| Triggered by | transient error (5xx, timeout) | non-transient on a given URL |
+| Cardinality of requests | 1 ref × N retries | 1 ref × N alternative sources |
+| Authoritative shape | retry policy (host-level) | metadata source (`oa_locations[]` order) |
+
+The chain belongs in `doiget-core` because every consumer of the
+core API — CLI, MCP, future bindings — wants the same multi-source
+search semantics. Putting it in `doiget-cli` as a retry policy would
+duplicate it for every consumer and would make MCP tools weaker than
+the CLI for no good reason (the #212 alignment ADR exists precisely
+to prevent this kind of drift).
+
+## Decision
+
+### D1 — Chain lives in `doiget-core` as the canonical fetch primitive
+
+The orchestrator's `fetch_one` function is generalized from
+"resolve to one URL then fetch" to "resolve to an ordered chain of
+candidate URLs and walk it until one succeeds." MCP tools and the
+CLI both consume this new shape.
+
+```mermaid
+flowchart LR
+  R["Ref<br/>doi:10.1103/PhysRevB.109.045136"] --> META[Resolve metadata via Source]
+  META --> CHAIN["fetch_chain: Vec&lt;Candidate&gt;<br/>(source-priority order)"]
+  CHAIN --> A1[attempt 1<br/>publisher OA URL]
+  A1 -->|ok 200 PDF| P[PDF + canonical_digest]
+  A1 -->|allowlist deny<br/>or HTTP 403/5xx<br/>or non-PDF body| A2[attempt 2<br/>arXiv preprint URL]
+  A2 -->|ok| P
+  A2 -->|fail| A3[attempt 3<br/>institutional repo]
+  A3 -->|all fail| ERR["ALL_FALLBACKS_EXHAUSTED<br/>{ attempts: [...] }"]
+  A1 -.attempt 1 row.-> PROV[(provenance log)]
+  A2 -.attempt 2 row.-> PROV
+  A3 -.attempt 3 row.-> PROV
+```
+
+### D2 — Chain ordering is the metadata source's `oa_locations[]` order
+
+In v0.4, doiget honors the order returned by the metadata source
+(OpenAlex / Unpaywall) verbatim. Rationale:
+
+- OpenAlex already encodes a quality ordering: `best_oa_location`
+  first, then sorted by `location.is_oa` and version (published >
+  accepted > submitted).
+- The metadata source is the operator of the catalog, not doiget;
+  imposing a *second* ordering layer in doiget adds policy that
+  needs justification.
+- User-configurable priority (e.g. `[fetch_chain] prefer = ["arxiv",
+  "publisher_oa", "institutional"]`) is deferred until at least one
+  empirical case shows the default ordering is wrong for legitimate
+  workflows. This keeps v0.4 surface area minimal.
+
+### D3 — Per-attempt rules — when to advance, when to stop
+
+The chain advances on **retryable failures** and stops on
+**terminal failures**:
+
+| Outcome | Action |
+|---|---|
+| HTTP 200 with `Content-Type: application/pdf` (or sniffed PDF magic bytes) | **Success** — record the attempt as `ok`, stop the chain, return the PDF + canonical_digest. |
+| HTTP 403 / 429 / 5xx | Advance to next candidate. (Honest WAF-block detection from a future taxonomy slice may yield a more specific code; the *chain* behavior is unchanged — still advances.) |
+| HTTP 200 with non-PDF body (HTML challenge page, paywall splash) | Advance. The fetched body is discarded; provenance records the response shape. |
+| `CAPABILITY_DENIED` (the host failed the allowlist gate from ADR-0028) | Advance. The denial is honest and structured (ADR-0023). |
+| Network error (DNS / connect timeout / TLS) | Advance. |
+| `INVALID_REF` at the metadata stage | **Terminal.** No candidates exist; chain never starts. |
+| `RATE_LIMITED` (per-host cooldown enforced) | **Terminal for the chain** but the *ref* is queued for a future re-attempt (chain re-walks from candidate 1 on the next batch run; cache-hit logic from ADR-0023's content-addressed store ensures successful past attempts are not re-issued). |
+| `STORE_ERROR` (disk / quota / permissions) | **Terminal.** Local failure, not a remote one; trying another remote candidate won't help. |
+
+The advance/stop classification is a closed set; new outcomes added
+in future ADRs must be classified explicitly.
+
+### D4 — Per-attempt provenance — one log row per remote request
+
+Every attempt is recorded in the provenance log as its own row, even
+if a later attempt in the chain succeeds. This is a deliberate
+expansion of "1 ref = 1 row" to "1 ref = N rows (one per attempt)"
+under the existing hash-chained schema.
+
+Row shape (schema-additive over the existing ADR-0024 v2):
+
+```jsonc
+{
+  // Existing fields (unchanged)
+  "v": 2,
+  "ts": "2026-05-21T03:14:15Z",
+  "ref": "doi:10.1103/PhysRevB.109.045136",
+  "safekey": "doi-10.1103-PhysRevB.109.045136",
+  "host": "link.aps.org",
+  "outcome": "fetch_blocked",
+  "code": "NETWORK_ERROR",
+  "prev_hash": "…",
+  "this_hash": "…",
+
+  // New fields (ADR-0029 additive)
+  "chain_attempt": 1,        // 1-based index of this attempt
+  "chain_total":   3,        // total candidates in the chain at time of attempt
+  "chain_terminal": false,   // true iff this attempt ended the chain (success or terminal-failure)
+  "verified_by": "curated"   // from ADR-0028; tagged per-attempt because hosts differ
+}
+```
+
+For a 3-attempt ref ending in success-on-attempt-2, the log carries
+two rows: `chain_attempt = 1` is the publisher OA failure;
+`chain_attempt = 2` is the arXiv success (`chain_terminal: true,
+outcome: "ok"`). The chain stops at success — attempt 3 is never
+issued and no row is written for it.
+
+The hash chain is per-row as before; the relationship "these N rows
+belong to the same Ref attempt" is reconstructed by readers from
+`ref` + a monotonically increasing per-ref attempt counter (the
+read-side helper is part of the implementation slice).
+
+### D5 — New closed-enum error variant: `ALL_FALLBACKS_EXHAUSTED`
+
+When every candidate in the chain has failed with an advancing
+outcome, the orchestrator returns a structured error:
+
+```rust
+pub enum FetchErrorCode {
+    // existing variants...
+    AllFallbacksExhausted,
+}
+
+pub struct FetchError {
+    pub code: FetchErrorCode,
+    pub message: String,
+    pub denial_context: Option<DenialContext>,  // ADR-0023, unchanged
+    pub chain: Vec<AttemptOutcome>,             // new, ADR-0029
+}
+
+pub struct AttemptOutcome {
+    pub source: String,           // e.g. "openalex.oa_locations[0]"
+    pub url: String,
+    pub code: FetchErrorCode,     // the *per-attempt* failure code
+    pub status: Option<u16>,      // HTTP status if reached
+    pub host: String,
+}
+```
+
+The `chain` field is part of the wire format on the
+`--mode json` / MCP / batch-JSONL surfaces (consistent with #212's
+alignment goal). Renaming `AttemptOutcome` fields is a semver-minor
++ `[BREAKING]` callout, per the existing wire-stability discipline
+(#208 self-review §1; `EntryInfo` / `MigrationReport` precedent).
+
+### D6 — Allowlist and rate-limit composition
+
+Each candidate URL passes through the ADR-0028 capability gate
+*independently*. A user who has not extended the allowlist will see
+candidates on institutional-repo hosts produce `CAPABILITY_DENIED`
+and the chain will advance. A user who has added
+`*.uj.edu.pl` to `additional_hosts` will see attempts on that host
+succeed (modulo network), with `verified_by = "user"` recorded per
+ADR-0028 D2-2.
+
+Per-host rate-limit (`network.cooldown_ms` from #222, accepted under
+ADR-0028 D3) applies per-attempt. A chain that walks three hosts
+incurs three host-scoped cooldowns. The cooldown is not amortized
+across the chain.
+
+## Consequences
+
+### Positive
+
+1. The dogfood case (publisher WAF block → arXiv recovery) is
+   handled automatically; no manual re-issue, no script glue.
+2. The provenance log gains the resolution shown above — every
+   external request is captured, enabling honest "we tried N hosts"
+   answers in audits and post-mortems.
+3. MCP and CLI gain the chain semantics together (#212 alignment is
+   preserved by construction; the surface is the same shape).
+4. Composes cleanly with ADR-0028: a user-extension that makes the
+   institutional repo allowlist-pass is reflected per-attempt in
+   `verified_by`.
+
+### Negative
+
+1. **Request multiplication.** A pathological ref hits every host
+   in `oa_locations[]` before failing terminally. Worst-case
+   per-ref cost rises from 1 request to `len(oa_locations[])`.
+   In practice OpenAlex returns ~1-4 locations per work; the
+   amplification is bounded.
+2. **Provenance log volume grows.** Same factor as the request
+   amplification. Log rotation (#140, already shipped) absorbs this,
+   but the retention math changes — the implementation slice
+   updates `docs/PROVENANCE_LOG.md` §6 accordingly.
+3. **`oa_locations[0]` is no longer a contract.** Today a downstream
+   consumer might (mistakenly) read only the first row per ref;
+   under D4 that semantics is wrong — the first row may be a
+   *failed* attempt and the final outcome row carries
+   `chain_terminal: true`. The implementation slice documents the
+   read-side helper and updates `MCP_TOOLS.md` §11.
+4. **Wire-format surface grew.** `FetchError.chain` and
+   `AttemptOutcome` are new public types; once shipped they are
+   covered by the wire-stability discipline. This is intentional —
+   the chain is a primitive, not an implementation detail.
+
+### Migration
+
+- v0.3 callers see no breaking change. The chain runs whenever
+  `oa_locations[]` has ≥ 1 entry; a 1-entry chain is byte-equivalent
+  to today's "single URL fetch" path.
+- The provenance schema is additive: new fields (`chain_attempt`,
+  `chain_total`, `chain_terminal`, `verified_by`) default to
+  `1 / 1 / true / "curated"` for backward compatibility with v2 rows
+  written before this slice. `doiget audit-log --verify` accepts
+  both shapes.
+- The new `ALL_FALLBACKS_EXHAUSTED` code is added to `ERRORS.md`'s
+  closed set and to the `capabilities` JSON inventory's
+  `subcommands[].errors[]` (the same #214 surface). MCP tool spec
+  (`docs/MCP_TOOLS.md` §11) gets a matching update.
+
+## References
+
+- ADR-0023 (structured denial context; the `denial_context` per
+  attempt continues to follow that shape)
+- ADR-0024 (provenance log v2 schema; this ADR is schema-additive
+  on top of v2, no v3 bump)
+- ADR-0027 (curated host list — the source of "host is reachable
+  under doiget's posture")
+- ADR-0028 (the gate semantics this chain composes with;
+  `verified_by` per attempt is from there)
+- #210 (`fetch_one` outcome plumbing — the consumer-side wire
+  surface this ADR's `AttemptOutcome` feeds into)
+- #212 (MCP/CLI shape alignment — the principle that motivates
+  putting the chain in core)
+- #222 (auto-preprint fallback — the user-facing requirement)

--- a/docs/DECISIONS/0030-bibliography-input-adapters.md
+++ b/docs/DECISIONS/0030-bibliography-input-adapters.md
@@ -1,0 +1,274 @@
+# 0030 - Bibliography input adapters (.bib / CSL-JSON) in doiget-core; new MCP tool `doiget_batch_from_bibliography`
+
+- **Date:** 2026-05-21
+- **Status:** Accepted (design; implementation slice tracked
+  separately).
+- **Supersedes:** -
+- **Source:** #222 §2B (BibTeX / CSL-JSON batch input);
+  Zotero-as-distribution-channel framing (maintainer review
+  2026-05-20).
+
+## Context
+
+`doiget batch` today accepts only the plain-refs format: one
+identifier per line in `doi:…` / `arxiv:…` / `pmid:…` shape. Real
+researchers do not maintain such files — they export reference
+libraries from Zotero / Mendeley / EndNote as **`.bib`** (BibLaTeX)
+or **CSL-JSON**. The current friction is:
+
+```text
+Zotero library → export .bib → user writes custom regex parser
+                            → grep/sed to extract DOIs
+                            → pipe into doiget batch
+```
+
+Every researcher writes a different parser; mistakes silently drop
+papers. This is exactly the kind of paper-cuts that prevents `doiget`
+from being adopted via the Zotero distribution path discussed in the
+2026-05-20 review (Zotero plugin → MCP server → doiget pipeline).
+
+### Two related-but-distinct surfaces are being added
+
+1. **CLI batch input**: `doiget batch library.bib` accepts a `.bib`
+   file directly, replacing the user-written parser.
+2. **MCP tool**: a new `doiget_batch_from_bibliography(path)` tool
+   so a Zotero plugin (or any other MCP client) can hand a `.bib`
+   file path to `doiget serve` and receive structured per-entry
+   results, without shelling out.
+
+Both consume the same parser. Choosing where that parser lives
+(core vs cli) is the load-bearing decision in this ADR.
+
+## Decision
+
+### D1 — Parser lives in `doiget-core` as a new `refs::parse` module
+
+The bibliography parser is a core capability, not a CLI affordance.
+Putting it in `doiget-cli` would make the MCP tool (#212-aligned
+with the CLI) weaker than the CLI for no good reason — a Zotero
+plugin handing a `.bib` path to MCP would force the plugin author
+to either re-implement BibTeX parsing in JavaScript (the
+distribution path's whole point is to avoid this) or shell out to
+the CLI just for the parser (which negates the structural advantage
+of MCP).
+
+```mermaid
+flowchart LR
+  subgraph IN["input surfaces"]
+    A["library.bib"]
+    B["library.json (CSL)"]
+    C["plain.refs (one per line)"]
+    D["stdin"]
+  end
+  IN --> SNIFF{"format detect"}
+  SNIFF -->|.bib + content fingerprint| BIB["biblatex parser"]
+  SNIFF -->|.json + CSL-JSON shape| CSL["serde_json parser"]
+  SNIFF -->|else| PLAIN["plain-refs parser"]
+  BIB --> PICK["per entry: pick<br/>DOI > arXiv ID > PMID"]
+  CSL --> PICK
+  PLAIN --> PICK
+  PICK --> REFS["Iterator&lt;Item = Result&lt;Ref, ParseError&gt;&gt;"]
+  REFS --> CLI["doiget batch (CLI)"]
+  REFS --> MCP["doiget_batch_from_bibliography (MCP)"]
+```
+
+### D2 — Dependency: `biblatex` crate, enabled by default
+
+The parser adds the `biblatex` crate (~500 KB compiled) to
+`doiget-core`. It is enabled in the **default feature set**, not
+behind an opt-in flag. Reasoning:
+
+- The musl-static release binary currently weighs ~10 MB; +500 KB is
+  a 5 % footprint increase, which is acceptable.
+- Putting it behind a feature flag would mean the default
+  `cargo install doiget-cli` lacks `.bib` support — exactly the
+  friction this ADR exists to remove.
+- A lean `oa-only-no-bib` minimal build can still be produced by
+  consumers via `default-features = false`; the `biblatex` dep
+  joins the feature graph that already includes `oa-only`.
+
+CSL-JSON is parsed via the existing `serde_json` (no new
+dependency).
+
+### D3 — One entry produces one `Ref`; priority is DOI > arXiv ID > PMID
+
+A single bibliography entry may carry multiple identifiers:
+
+```bibtex
+@article{example2024,
+  author = {…},
+  title  = {…},
+  doi    = {10.1103/PhysRevB.109.045136},
+  eprint = {2204.12345},          % arXiv
+  pmid   = {12345678},
+  url    = {https://link.aps.org/…}
+}
+```
+
+The parser picks **one** identifier per entry, in priority order:
+
+1. `doi` field (or `doi` in `note`, recognised by the
+   `^doi:\s*(.+)$` shape used by Zotero exports);
+2. `eprint` + (`archiveprefix = "arXiv"` OR `eprinttype = "arxiv"`)
+   → `arxiv:<id>`;
+3. `pmid` field → `pmid:<id>`.
+
+Entries with none of the above yield a `ParseError::NoIdentifier`
+which is **skipped + counted** in the default mode and **aborts** in
+`--strict`. The skip is reported in human-mode stderr and as a
+JSONL parse-error record in `--mode json` (consistent with #205's
+batch JSONL shape).
+
+The "pick one" rule prevents accidental N-fold fetch
+amplification — fetching the publisher OA, the arXiv preprint, AND
+the PMID record for the same paper would triple-charge rate limits
+and produce three near-duplicate store entries. The fetch chain
+(ADR-0029) already handles the "publisher OA failed → fall back to
+arXiv" recovery path *within* the resolution of a single Ref; the
+adapter does not need to fan out.
+
+### D4 — Format auto-detection by extension, overridable
+
+Detection precedence:
+
+1. **`--format` CLI flag** if given (`bibtex` / `csl-json` / `refs`).
+2. **File extension** if reading from a path: `.bib` / `.biblatex`
+   → `bibtex`; `.json` / `.yaml` / `.csl` → `csl-json`; otherwise
+   `refs`.
+3. **Content fingerprint** for stdin or unknown extensions: peek
+   the first non-blank line and test for `@<entrytype>{` (BibTeX),
+   `[` followed by `{"id":` or `"DOI":` (CSL-JSON), or
+   `^[a-z]+:` (plain refs).
+4. **Fallback**: `refs`. On the very first parse failure, emit a
+   helpful error message naming the detected format and suggesting
+   `--format` overrides.
+
+### D5 — Parse-error policy: skip + warn by default; `--strict` aborts
+
+Real-world `.bib` files have one in every couple-dozen entries that
+fails to parse (escaping issues, encoding, exotic BibLaTeX
+extensions). Aborting the whole batch on the first parse error is
+hostile to the actual user workflow.
+
+- Default mode: parse errors yield a stderr warning + a counted
+  `parse_errors` summary at end of batch + are recorded in the
+  per-ref JSONL stream (`{"ok": false, "ref": null,
+  "error": {"code": "INVALID_REF", "message": "...", "entry_key":
+  "example2024"}}`).
+- `--strict` mode: the first parse error aborts; existing successes
+  are flushed.
+
+The `entry_key` field carries the BibTeX citation key (or CSL `id`)
+so the operator can locate the offending entry in their library.
+
+### D6 — New MCP tool: `doiget_batch_from_bibliography`
+
+```jsonc
+// Tool spec sketch — full schema lands in docs/MCP_TOOLS.md §N
+{
+  "name": "doiget_batch_from_bibliography",
+  "description": "Parse a BibTeX/.bib or CSL-JSON file and fetch each entry. Returns one structured outcome per resolvable entry.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "path":   { "type": "string", "description": "Absolute path to .bib or CSL-JSON file" },
+      "format": { "type": "string", "enum": ["auto", "bibtex", "csl-json"], "default": "auto" },
+      "strict": { "type": "boolean", "default": false }
+    },
+    "required": ["path"]
+  },
+  "outputShape": {
+    "summary": { "total": "int", "ok": "int", "failed": "int", "parse_errors": "int" },
+    "entries": [
+      { "ok": true,  "ref": "...", "entry_key": "...", "result": { /* AttemptOutcome.chain final, ADR-0029 */ } },
+      { "ok": false, "ref": "...", "entry_key": "...", "error":  { "code": "...", "message": "...", "chain": [...] } },
+      { "ok": false, "ref": null,  "entry_key": "...", "error":  { "code": "INVALID_REF", "message": "no identifier" } }
+    ]
+  }
+}
+```
+
+The tool's structured output mirrors `batch --mode json` per
+ADR-0029 D5 / #212 alignment — same `AttemptOutcome.chain`, same
+`FetchError` shape, plus an `entry_key` to bridge back to the
+operator's library entry. A Zotero plugin can use `entry_key` to
+update the right reference with the fetched PDF.
+
+### D7 — CLI surface: `doiget batch library.bib` (no separate subcommand)
+
+The CLI extension is *not* a new subcommand. `doiget batch <input>`
+already takes one positional argument; the parser detects the
+format. Adding `doiget batch-bibliography` would be a redundant
+subcommand whose only difference from `batch` is the parser — and
+the parser is what's now in core. The CLI command stays single.
+
+`--format` is a new global / subcommand flag introduced alongside;
+it is mutually compatible with the `--store-root` / `--log-path` /
+`--color` / `--progress` set being added under #211 (independent
+slice).
+
+## Consequences
+
+### Positive
+
+1. The Zotero distribution path's structural friction (every user
+   writes their own parser) is removed. The MCP tool unblocks the
+   Zotero-plugin design discussed in the maintainer review on
+   2026-05-20.
+2. `.bib` and CSL-JSON ingestion lives next to the actual fetch
+   pipeline; the per-entry path through #205 batch JSONL is the
+   same regardless of input shape — only the head of the pipeline
+   differs.
+3. `entry_key` is the missing link for downstream "write the fetched
+   PDF back into Zotero / Mendeley" automations.
+
+### Negative
+
+1. **+500 KB on the default binary.** The musl-static release grows
+   from ~10 MB to ~10.5 MB. Acceptable but worth recording.
+2. **Parser bug surface.** `biblatex` is a third-party crate that
+   has known rough edges with exotic BibLaTeX usage (e.g.,
+   `@string` macros, custom field syntaxes). The skip-and-warn
+   policy means *some* of these surface as warnings, not panics;
+   the implementation slice ships a corpus of "weird `.bib`" cases
+   in the test suite.
+3. **Identifier-picking ambiguity.** A `.bib` entry without DOI but
+   with both `eprint` (arXiv) and `url` (a publisher link) is
+   resolved to the arXiv id — never the URL — because URLs are not
+   in the priority list. A subset of users may consider this
+   surprising; the priority list is documented in `docs/CONFIG.md`
+   and surfaced via `doiget capabilities` (the inventory JSON gains
+   a `bibliography_identifier_priority` field).
+4. **No fan-out by design.** Power users wanting "fetch DOI AND
+   arXiv version" cannot get it through the adapter. The documented
+   workflow is to ship the same entry twice through the plain-refs
+   pipe; ADR-0029's chain already does what they probably actually
+   wanted.
+
+### Migration
+
+- v0.3 callers (plain refs) are unaffected: the auto-detection
+  falls through to the `refs` parser on stdin / unrecognised
+  extensions.
+- `--format` flag is additive; missing flag means `auto`.
+- `docs/MCP_TOOLS.md` gains the new tool section; the `mcp_tools`
+  array in `doiget capabilities` JSON (#214 surface) gains the
+  `doiget_batch_from_bibliography` entry.
+- `docs/CONFIG.md` §5 documents the new
+  `bibliography_identifier_priority` (currently a hard-coded list,
+  may be made user-configurable in a later slice if demand exists).
+
+## References
+
+- ADR-0029 (the fetch chain; the `batch_from_bibliography` per-entry
+  output is exactly the chain's `AttemptOutcome`)
+- ADR-0024 (`Ref` canonical form — what the parser must produce)
+- #205 (batch JSONL shape; this ADR's adapter feeds the same shape)
+- #210 (`fetch_one` outcome plumbing; the per-entry `result` field
+  is the same plumbing's output)
+- #212 (MCP/CLI alignment — the principle that motivates putting
+  the parser in core and exposing both the CLI and MCP tool)
+- #214 (`capabilities` inventory; this ADR adds a tool and a
+  priority-list field to that inventory)
+- #222 (the user-facing motivation)
+- 2026-05-20 maintainer review (Zotero distribution path framing)

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -44,6 +44,9 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
 | 0026 | DOI suffix charset extension: permit `:` (SECURITY.md §1.1) | Accepted | #194 | #194 dogfood |
 | 0027 | redirect-allowlist: add physics-society / diamond-OA hosts to `oa-publisher` | Accepted | #193 | #193 dogfood |
+| 0028 | User-extensible capability gate (ToS+verified-curation posture; impersonation out-of-scope) | Accepted (design; slice TBD) | TBD | #220 / #223 |
+| 0029 | Fetch chain: per-Ref multi-attempt resolution with attempt-level provenance | Accepted (design; slice TBD) | TBD | #222 / dogfood 2026-05-20 |
+| 0030 | Bibliography input adapters (.bib / CSL-JSON) in `doiget-core`; new MCP tool `doiget_batch_from_bibliography` | Accepted (design; slice TBD) | TBD | #222 / Zotero distribution review 2026-05-20 |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Two-part PR opening the v0.4 lane on `next`:

1. **Design (ADRs)** — four architectural decisions that frame v0.4.0 (no code change):
   - **ADR-0017 Amendment 1** — bifurcate `Quiet` into *explicit* vs *implicit*; classify commands as **artifact** (`bib`/`csl`/`capabilities`/`audit-log --verify --mode json`) vs **informational**. Artifact commands honor only explicit Quiet → fixes the LLM cold-boot deadlock in #219 / #220.
   - **ADR-0028** (new) — the capability gate's purpose is **ToS compliance + verified curation**. Users may extend it via `config.toml` (literal hosts or single-suffix wildcards); each extension is recorded as `verified_by = \"user\"` in the provenance log. Impersonation, WAF bypass, embedded headless browsers (#223) are **permanently out-of-scope**.
   - **ADR-0029** (new) — `fetch_one` resolves to an ordered chain of candidate URLs (OpenAlex `oa_locations[]` order); the chain walks on retryable failures, stops on terminal ones, and each attempt is recorded as its own provenance row (schema-additive on v2). New closed-enum `FetchError` variant `ALL_FALLBACKS_EXHAUSTED` carries `Vec<AttemptOutcome>`.
   - **ADR-0030** (new) — bibliography input adapters live in `doiget-core`; the same parser feeds both `doiget batch library.bib` and a new MCP tool `doiget_batch_from_bibliography` (the structural enabler for the **Zotero plugin distribution path**). One identifier per entry (DOI > arXiv > PMID); skip-and-warn on parse error.

2. **Beta-lane open + CI green** — mechanical post-release housekeeping:
   - Workspace version `0.3.0` → **`0.4.1-beta.1`** on `next` (ADR-0025 D6); `CHANGELOG.md` gains the matching `[0.4.1-beta.1]` section so version-gate G5 / the advisory `version-check` CI both go green.
   - `.typos.toml` exempts `rquest` (the actively-maintained reqwest fork referenced in ADR-0028 D3 as one of the impersonation libraries out-of-scope) — same pattern as the existing `flate` exemption.

## Cross-references between the ADRs

```mermaid
flowchart LR
  A17[\"ADR-0017 Amend 1<br/>Quiet bifurcation\"]
  A28[\"ADR-0028<br/>Capability gate posture\"]
  A29[\"ADR-0029<br/>Fetch chain\"]
  A30[\"ADR-0030<br/>Biblio adapters\"]
  A28 --> A29
  A29 --> A30
  A17 -.independent.-> A30
```

The 0028 → 0029 → 0030 chain forms a coherent v0.4 surface. ADR-0017 Amendment 1 is independent and lands first as the smallest implementation slice (the bug-fix design).

## Issue resolution map

| Issue | ADR(s) | Disposition |
|---|---|---|
| #219 capabilities non-TTY deadlock | 0017 Amend 1 | Fixed by artifact-command classification |
| #220 capabilities deadlock + http upgrade + Green-OA allowlist | 0017 Amend 1, 0028 | Fixed |
| #210 fetch_one outcome plumbing | 0029 | Composes (`AttemptOutcome` is the outcome shape) |
| #211 remaining CLI flags | (independent) | Tracked separately as S5 |
| #212 MCP/CLI alignment | 0029, 0030 | Both new surfaces (chain + biblio tool) align by construction |
| #222 batch resumability | (no ADR) | Already correct: content-addressed store skips successes |
| #222 failure digest | (no ADR) | Implementation detail; lands with S6 |
| #222 auto preprint fallback | 0029 | Core mechanism |
| #222 BibTeX / CSL-JSON input | 0030 | Core mechanism |
| #222 `network.cooldown_ms` | 0028 D3 (accept-list) | Non-impersonating; tracked separately |
| #223 WAF detection (error variant) | 0028 D3 (accept-list) | Composes with chain |
| #223 TLS impersonation, cookies, headless | 0028 D3 (reject-list) | **Permanently out-of-scope** |

## Implementation slices (separate PRs after this lands)

```
S1 (#219/#220 cold-boot):    ResolvedOutput { mode, quiet_was_explicit } + classification
S2 (#220 http -> https):     scheme normalisation in fetch_inner
S3 (#220 user-extension):    network.additional_hosts + verified_by + doctor surface
S4 (#210 outcome plumbing):  FetchPaperOutcome + structured JSONL bodies
S5 (#211 remaining flags):   --store-root / --log-path / --color / --progress
S6 (#222 chain):             orchestrator chain walk + ALL_FALLBACKS_EXHAUSTED
S7 (#222 biblio):            refs::parse + biblatex dep + format auto-detect
S8 (#212 MCP alignment):     tool shapes -> AttemptOutcome + doiget_batch_from_bibliography
```

S1 + S2 + S3 are independent and small (good first slices). S6 is the heavy one (new core primitive). S7 and S8 depend on S6.

## Local verification

- `scripts/release-version-gate.sh v0.4.1-beta.1 --offline-skip-crates-io` — G0/G1/G2/G5/G6 PASS; G3/G4 deferred to live CI; G7 pre-tag SKIP.
- `~/.cargo/bin/typos docs/DECISIONS/` — clean (with the `rquest` exemption).
- `cargo update --workspace` — three workspace crates locked to `0.4.1-beta.1`.

## Test plan

- [ ] Maintainer reads the four ADRs and validates the cross-references resolve correctly
- [ ] `typos` CI passes with the `rquest` exemption
- [ ] `version-check` advisory CI shows green for prospective tag `v0.4.1-beta.1` (lane: beta)
- [ ] Mermaid diagrams render in GitHub's preview
- [ ] After merge: open S1 (#219/#220 cold-boot fix) as the first implementation slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)