### PR TITLE
fix(cli): capabilities emits inventory in non-TTY contexts (#219, #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.2] - 2026-05-21
+
+### Fixed
+
+- **[cli]** `doiget capabilities` no longer silently exits with empty
+  stdout in non-TTY / agent execution contexts (#219, #220 ADR-0017
+  Amendment 1). The resolver now distinguishes **explicit** Quiet
+  (`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`) from
+  **implicit** Quiet (the non-TTY default), and `capabilities` —
+  classified as an *artifact* command — suppresses stdout only on
+  explicit Quiet. Closes the LLM cold-boot deadlock where an agent
+  ran `doiget capabilities` over a captured pipe and got nothing
+  back. `OutputMode` enum wire format (`DOIGET_MODE` strings, the
+  `modes` array in capabilities JSON) is unchanged; the
+  `quiet_was_explicit` discriminator lives only in-memory on the
+  new `ResolvedOutput` returned by `commands::output::resolve()`.
+  `bib` / `csl` were already correct (they ignore mode); their
+  classification is now documented via the new
+  `is_artifact_command()` helper.
+
 ## [0.4.1-beta.1] - 2026-05-21
 
 Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.1"
+version = "0.4.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.1"
+version = "0.4.1-beta.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.1"
+version = "0.4.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.1"
+version       = "0.4.1-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -652,17 +652,39 @@ fn arg_to_flag_spec(a: &clap::Arg) -> FlagSpec {
 // Entry point
 // ---------------------------------------------------------------------------
 
-/// Run the `doiget capabilities` subcommand. Honors [`super::output::OutputMode`]:
-/// `Quiet` suppresses stdout (#203); every other mode emits the same
-/// pretty-printed JSON inventory. The caller passes the live
-/// `clap::Command` so the clap walk operates on the binary's actual
-/// `Cli` tree (which the lib half of this crate can't reach
-/// directly — the `Cli` struct lives in `main.rs`).
-pub fn run(cli: &clap::Command, mode: super::output::OutputMode) -> Result<()> {
-    // `Quiet` is the one mode that suppresses (per ADR-0017 / #203).
-    // Every other mode emits the same pretty JSON: `capabilities` is a
-    // product-output command.
-    if mode == super::output::OutputMode::Quiet {
+/// Run the `doiget capabilities` subcommand.
+///
+/// `capabilities` is an **artifact** command per ADR-0017 Amendment 1:
+/// its stdout output IS the deliverable (the inventory JSON an LLM
+/// reads on cold-boot). It honors only **explicit** Quiet —
+/// `--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet` — and emits
+/// the inventory on every other path. The `quiet_was_explicit`
+/// discriminator is what distinguishes the two cases:
+///
+/// | mode               | quiet_was_explicit | behaviour          |
+/// |--------------------|--------------------|--------------------|
+/// | non-`Quiet`        | -                  | emit               |
+/// | `Quiet` (explicit) | `true`             | suppress           |
+/// | `Quiet` (non-TTY)  | `false`            | **emit** (#219)    |
+///
+/// The non-TTY case is the one #219 / #220 report: an LLM tool
+/// executor captures stdout, so `stdout_is_tty()` is `false`, the
+/// resolver falls through to `Quiet`, but the caller wants the JSON
+/// inventory exactly because it's about to be machine-parsed. The
+/// table's bottom row is the fix.
+///
+/// The caller passes the live `clap::Command` so the clap walk
+/// operates on the binary's actual `Cli` tree (which the lib half of
+/// this crate can't reach directly — the `Cli` struct lives in
+/// `main.rs`).
+pub fn run(
+    cli: &clap::Command,
+    mode: super::output::OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
+    // ADR-0017 Amendment 1: artifact command — suppress ONLY on
+    // explicit Quiet, never on the non-TTY implicit fallback.
+    if mode == super::output::OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
     let caps = build_capabilities(cli);

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -1,4 +1,5 @@
-//! Output-mode resolution for the `doiget` CLI (ADR-0017, #144).
+//! Output-mode resolution for the `doiget` CLI (ADR-0017, #144;
+//! Amendment 1 = #219/#220).
 //!
 //! ADR-0017 specifies the precedence ladder
 //! `--mode > --json/--quiet > DOIGET_MODE env > subcommand-implicit > TTY > quiet`.
@@ -7,6 +8,14 @@
 //! CI job already enforces "MCP mode forbids non-JSON stdout"). The
 //! `forced_implicit` parameter to [`resolve`] expresses that override: when
 //! `Some(_)`, it overrides everything else.
+//!
+//! [`resolve`] returns a [`ResolvedOutput`] carrying the [`OutputMode`]
+//! plus a `quiet_was_explicit` discriminator. The distinction is
+//! load-bearing per ADR-0017 Amendment 1: artifact-producing commands
+//! (`bib` / `csl` / `capabilities` / `audit-log --verify --mode json`)
+//! suppress only on **explicit** Quiet (`--quiet` / `-q` /
+//! `DOIGET_MODE=quiet` / `--mode quiet`), not on the non-TTY default.
+//! Informational commands continue to suppress on any Quiet.
 //!
 //! Resolution is split into a pure function ([`resolve`]) plus a thin
 //! TTY-detection wrapper ([`stdout_is_tty`]) so the ladder is fully
@@ -86,19 +95,63 @@ pub enum FlagInput {
     None,
 }
 
-/// Resolve the effective [`OutputMode`] per ADR-0017.
+/// The resolved output state per ADR-0017 Amendment 1: the
+/// [`OutputMode`] the resolution ladder picked, plus a
+/// `quiet_was_explicit` discriminator that distinguishes the user's
+/// **explicit** request for silence (`--quiet` / `-q` /
+/// `DOIGET_MODE=quiet` / `--mode quiet`) from the resolver's
+/// **implicit** fallback to Quiet when stdout is not a TTY.
+///
+/// Per ADR-0017 Amendment 1, *informational* commands (audit-log Human,
+/// list-recent, search, info, config show/path, provenance migrate,
+/// fetch/batch status) suppress on any Quiet; *artifact* commands
+/// (`bib` / `csl` / `capabilities` / `audit-log --verify --mode json`)
+/// suppress only on **explicit** Quiet. The wire format of
+/// [`OutputMode`] (`DOIGET_MODE` string values, the `modes` array in
+/// `capabilities` JSON, the `--mode` clap values) is **unchanged**;
+/// this struct lives only in-memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedOutput {
+    /// The effective mode for this invocation.
+    pub mode: OutputMode,
+    /// `true` iff the user supplied an explicit Quiet signal
+    /// (`--quiet`, `-q`, `--mode quiet`, `DOIGET_MODE=quiet`).
+    /// `false` for the non-TTY fallback to Quiet, and for any
+    /// non-Quiet mode.
+    pub quiet_was_explicit: bool,
+}
+
+/// `true` if `name` identifies an artifact-producing subcommand whose
+/// stdout output IS the deliverable (per ADR-0017 Amendment 1).
+/// Artifact commands suppress only on **explicit** Quiet
+/// ([`ResolvedOutput::quiet_was_explicit`] == `true`).
+///
+/// `audit-log` is omitted on purpose: it is *informational* in Human
+/// mode and *artifact* in Json mode; the command checks the resolved
+/// mode rather than its name, so this classifier doesn't apply.
+pub fn is_artifact_command(name: &str) -> bool {
+    matches!(name, "bib" | "csl" | "capabilities")
+}
+
+/// Resolve the effective [`OutputMode`] per ADR-0017 and the
+/// `quiet_was_explicit` discriminator per ADR-0017 Amendment 1.
 ///
 /// Precedence (highest first):
 ///
 /// 1. `forced_implicit` — a subcommand-pinned mode that overrides
 ///    everything (e.g. `doiget serve` → `Mcp` per CONFIG.md §5; required
-///    for the Slice 9 stdout-purity invariant).
+///    for the Slice 9 stdout-purity invariant). Pinned modes are
+///    **never** counted as explicit user Quiet; they are system policy.
 /// 2. `flag` — `--mode` / `--json` / `--quiet` on the command line.
+///    A `Quiet` mode reached via `--mode quiet`, `--quiet`, or `-q`
+///    is **explicit**.
 /// 3. `env` — `DOIGET_MODE` (parsed by [`parse_env_mode`]; unrecognised
 ///    values are ignored, matching CONFIG.md §4's "doiget reads only the
-///    keys it knows about" posture).
+///    keys it knows about" posture). A `Quiet` mode reached via
+///    `DOIGET_MODE=quiet` is **explicit**.
 /// 4. `is_tty` — `Human` when stdout is a terminal, otherwise `Quiet`
-///    (CONFIG.md §3.b's "implicit + TTY > quiet (default)").
+///    (CONFIG.md §3.b's "implicit + TTY > quiet (default)"). A `Quiet`
+///    mode reached this way is **implicit**.
 ///
 /// This function is pure: no env reads, no I/O. The caller plumbs
 /// `env::var("DOIGET_MODE").ok()` and an `is_tty` probe in.
@@ -107,19 +160,33 @@ pub fn resolve(
     flag: FlagInput,
     env: Option<&str>,
     is_tty: bool,
-) -> OutputMode {
+) -> ResolvedOutput {
     if let Some(m) = forced_implicit {
-        return m;
+        return ResolvedOutput {
+            mode: m,
+            quiet_was_explicit: false,
+        };
     }
-    match flag {
-        FlagInput::Explicit(m) => m,
-        FlagInput::JsonShort => OutputMode::Json,
-        FlagInput::QuietShort => OutputMode::Quiet,
-        FlagInput::None => env.and_then(parse_env_mode).unwrap_or(if is_tty {
-            OutputMode::Human
-        } else {
-            OutputMode::Quiet
-        }),
+    let (mode, quiet_was_explicit) = match flag {
+        FlagInput::Explicit(OutputMode::Quiet) => (OutputMode::Quiet, true),
+        FlagInput::Explicit(m) => (m, false),
+        FlagInput::JsonShort => (OutputMode::Json, false),
+        FlagInput::QuietShort => (OutputMode::Quiet, true),
+        FlagInput::None => match env.and_then(parse_env_mode) {
+            Some(OutputMode::Quiet) => (OutputMode::Quiet, true),
+            Some(m) => (m, false),
+            None => {
+                if is_tty {
+                    (OutputMode::Human, false)
+                } else {
+                    (OutputMode::Quiet, false)
+                }
+            }
+        },
+    };
+    ResolvedOutput {
+        mode,
+        quiet_was_explicit,
     }
 }
 
@@ -156,44 +223,55 @@ mod tests {
     fn forced_mcp_wins_over_flag_env_and_tty() {
         // `doiget serve` MUST be `Mcp` even if the user passes
         // `--mode quiet` or sets `DOIGET_MODE=human` (CONFIG.md §5).
-        let m = resolve(
+        let out = resolve(
             Some(OutputMode::Mcp),
             FlagInput::Explicit(OutputMode::Quiet),
             Some("human"),
             true,
         );
-        assert_eq!(m, OutputMode::Mcp);
+        assert_eq!(out.mode, OutputMode::Mcp);
+        assert!(
+            !out.quiet_was_explicit,
+            "forced_implicit is system policy, never explicit user Quiet"
+        );
     }
 
     // ---- flag > env > tty ---------------------------------------------
 
     #[test]
     fn explicit_flag_wins_over_env_and_tty() {
-        let m = resolve(
+        let out = resolve(
             None,
             FlagInput::Explicit(OutputMode::Json),
             Some("human"),
             true,
         );
-        assert_eq!(m, OutputMode::Json);
+        assert_eq!(out.mode, OutputMode::Json);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
     fn json_short_flag_implies_json() {
-        let m = resolve(None, FlagInput::JsonShort, Some("human"), true);
-        assert_eq!(m, OutputMode::Json);
+        let out = resolve(None, FlagInput::JsonShort, Some("human"), true);
+        assert_eq!(out.mode, OutputMode::Json);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
     fn quiet_short_flag_implies_quiet() {
-        let m = resolve(None, FlagInput::QuietShort, Some("human"), true);
-        assert_eq!(m, OutputMode::Quiet);
+        let out = resolve(None, FlagInput::QuietShort, Some("human"), true);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(
+            out.quiet_was_explicit,
+            "`--quiet`/`-q` is an explicit Quiet signal"
+        );
     }
 
     #[test]
     fn env_wins_when_no_flag() {
-        let m = resolve(None, FlagInput::None, Some("json"), true);
-        assert_eq!(m, OutputMode::Json);
+        let out = resolve(None, FlagInput::None, Some("json"), true);
+        assert_eq!(out.mode, OutputMode::Json);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
@@ -208,8 +286,12 @@ mod tests {
         // `DOIGET_MODE=garbage` is ignored, ladder continues to TTY.
         let tty = resolve(None, FlagInput::None, Some("garbage"), true);
         let pipe = resolve(None, FlagInput::None, Some("garbage"), false);
-        assert_eq!(tty, OutputMode::Human);
-        assert_eq!(pipe, OutputMode::Quiet);
+        assert_eq!(tty.mode, OutputMode::Human);
+        assert_eq!(pipe.mode, OutputMode::Quiet);
+        assert!(
+            !pipe.quiet_was_explicit,
+            "pipe-default Quiet is implicit, not explicit"
+        );
     }
 
     #[test]
@@ -219,39 +301,84 @@ mod tests {
         assert_eq!(parse_env_mode(""), None);
         assert_eq!(parse_env_mode("   "), None);
         let tty = resolve(None, FlagInput::None, Some(""), true);
-        assert_eq!(tty, OutputMode::Human);
+        assert_eq!(tty.mode, OutputMode::Human);
     }
 
     // ---- TTY tail ------------------------------------------------------
 
     #[test]
     fn tty_with_no_flag_no_env_yields_human() {
-        let m = resolve(None, FlagInput::None, None, true);
-        assert_eq!(m, OutputMode::Human);
+        let out = resolve(None, FlagInput::None, None, true);
+        assert_eq!(out.mode, OutputMode::Human);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
     fn no_tty_with_no_flag_no_env_yields_quiet() {
-        let m = resolve(None, FlagInput::None, None, false);
-        assert_eq!(m, OutputMode::Quiet);
+        let out = resolve(None, FlagInput::None, None, false);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(
+            !out.quiet_was_explicit,
+            "non-TTY default to Quiet is implicit (#219 / #220 / ADR-0017 Am1)"
+        );
     }
 
     // ---- env never overrides flag, never beats forced_implicit --------
 
     #[test]
     fn env_does_not_override_explicit_flag() {
-        let m = resolve(
+        let out = resolve(
             None,
             FlagInput::Explicit(OutputMode::Quiet),
             Some("human"),
             true,
         );
-        assert_eq!(m, OutputMode::Quiet);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(
+            out.quiet_was_explicit,
+            "`--mode quiet` is an explicit Quiet signal"
+        );
     }
 
     #[test]
     fn forced_implicit_overrides_env() {
-        let m = resolve(Some(OutputMode::Mcp), FlagInput::None, Some("human"), true);
-        assert_eq!(m, OutputMode::Mcp);
+        let out = resolve(Some(OutputMode::Mcp), FlagInput::None, Some("human"), true);
+        assert_eq!(out.mode, OutputMode::Mcp);
+    }
+
+    // ---- ADR-0017 Amendment 1: explicit vs implicit Quiet ------------
+
+    #[test]
+    fn doiget_mode_quiet_env_is_explicit_quiet() {
+        // DOIGET_MODE=quiet without any flag is treated as explicit
+        // user intent — artifact commands must respect it.
+        let out = resolve(None, FlagInput::None, Some("quiet"), true);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(out.quiet_was_explicit);
+    }
+
+    #[test]
+    fn non_tty_quiet_default_is_implicit_quiet() {
+        // The TTY-driven fallback to Quiet is implicit — artifact
+        // commands (capabilities/bib/csl) MUST still emit. This is
+        // the #219/#220 LLM cold-boot fix.
+        let out = resolve(None, FlagInput::None, None, /* is_tty */ false);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(!out.quiet_was_explicit);
+    }
+
+    // ---- artifact-command classifier (ADR-0017 Am1) ------------------
+
+    #[test]
+    fn artifact_command_classifier_covers_bib_csl_capabilities() {
+        assert!(is_artifact_command("bib"));
+        assert!(is_artifact_command("csl"));
+        assert!(is_artifact_command("capabilities"));
+        // audit-log is informational-vs-artifact per resolved mode,
+        // not per name; the classifier does NOT match it.
+        assert!(!is_artifact_command("audit-log"));
+        assert!(!is_artifact_command("fetch"));
+        assert!(!is_artifact_command("info"));
+        assert!(!is_artifact_command(""));
     }
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -233,12 +233,18 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
     // Resolve the effective output mode ONCE per invocation per ADR-0017.
     // The pure resolver lives in `commands::output`; this site is the
     // single I/O-touching layer that reads env + probes the TTY.
-    let mode = output::resolve(
+    // ADR-0017 Amendment 1: the resolver returns ResolvedOutput
+    // carrying mode + quiet_was_explicit; informational commands receive
+    // `out.mode` (their existing OutputMode signature), artifact
+    // commands additionally consume `out.quiet_was_explicit` so the
+    // non-TTY fallback to Quiet does NOT silence them (#219 / #220).
+    let out = output::resolve(
         forced_implicit_for(&cli.command),
         flag_input_from(&cli),
         std::env::var("DOIGET_MODE").ok().as_deref(),
         output::stdout_is_tty(),
     );
+    let mode = out.mode;
 
     match cli.command {
         None => {
@@ -284,14 +290,18 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             let profile = doiget_core::CapabilityProfile::from_env()?;
             doiget_mcp::Server::new(profile).run().await
         }
-        // #214: single-shot inventory for LLM cold-boot. We pass the
-        // live `clap::Command` AST so the subcommand list cannot
-        // drift from the parser. `capabilities::run` honors
-        // `--mode quiet` (suppresses) and emits pretty JSON in every
-        // other mode (product-output convention).
+        // #214 / #219 (ADR-0017 Amendment 1): single-shot inventory
+        // for LLM cold-boot. We pass the live `clap::Command` AST so
+        // the subcommand list cannot drift from the parser.
+        // `capabilities` is an *artifact* command — it suppresses
+        // stdout ONLY on **explicit** Quiet (`--quiet`/`-q`/
+        // `DOIGET_MODE=quiet`/`--mode quiet`), never on the non-TTY
+        // implicit fallback. The `quiet_was_explicit` discriminator
+        // is what closes the LLM cold-boot deadlock reported in
+        // #219 / #220.
         Some(Command::Capabilities) => {
             let cli_cmd = <Cli as clap::CommandFactory>::command();
-            doiget_cli::commands::capabilities::run(&cli_cmd, mode)
+            doiget_cli::commands::capabilities::run(&cli_cmd, mode, out.quiet_was_explicit)
         }
         // Phase 4 / Slice 16. Feature-gated to keep default release
         // binaries free of the OpenAlex-only citation walker.

--- a/crates/doiget-cli/tests/capabilities_e2e.rs
+++ b/crates/doiget-cli/tests/capabilities_e2e.rs
@@ -155,9 +155,11 @@ fn capabilities_fetch_subcommand_carries_artifact_status() {
 
 #[test]
 fn capabilities_quiet_mode_produces_no_stdout() {
-    // ADR-0017 / #203: Quiet suppresses stdout even for product-output
-    // commands. The exit is still 0 (capabilities never errors on a
-    // missing env / store; pure introspection).
+    // ADR-0017 Am1: `capabilities` is an *artifact* command, so it
+    // suppresses stdout ONLY on **explicit** Quiet. Passing `--quiet`
+    // is the canonical explicit signal — output must be empty, exit 0
+    // (capabilities never errors on a missing env / store; pure
+    // introspection).
     let dir = TempDir::new().expect("tempdir");
     Command::cargo_bin("doiget")
         .expect("locate doiget binary")
@@ -169,6 +171,62 @@ fn capabilities_quiet_mode_produces_no_stdout() {
         .assert()
         .success()
         .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn capabilities_quiet_mode_via_doiget_mode_env_produces_no_stdout() {
+    // ADR-0017 Am1: `DOIGET_MODE=quiet` is an **explicit** Quiet
+    // signal (CONFIG.md §4 documents env vars as user-controlled),
+    // so `capabilities` must suppress on it just like `--quiet`.
+    let dir = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("locate doiget binary")
+        .env("HOME", dir.path())
+        .env("USERPROFILE", dir.path())
+        .env("APPDATA", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("DOIGET_MODE", "quiet")
+        .arg("capabilities")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn capabilities_non_tty_default_still_emits_inventory() {
+    // #219 / #220 + ADR-0017 Amendment 1 regression pin: under
+    // `assert_cmd`, stdout is captured (non-TTY), so the resolver
+    // falls through to `Quiet`. Before the Amendment that silenced
+    // `capabilities` — the LLM cold-boot deadlock the issues report.
+    // After the Amendment, the non-TTY fallback to Quiet is *implicit*
+    // and `capabilities` (artifact) must STILL emit the inventory.
+    //
+    // Constructs the command WITHOUT the `doiget()` helper's
+    // `DOIGET_MODE=human` override on purpose: that override was the
+    // workaround the helper applied to compensate for the bug.
+    let dir = TempDir::new().expect("tempdir");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    let out = Command::cargo_bin("doiget")
+        .expect("locate doiget binary")
+        .env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        // Intentionally NOT setting DOIGET_MODE so the resolver lands
+        // on the non-TTY implicit Quiet path.
+        .env_remove("DOIGET_MODE")
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    assert!(
+        v.get("subcommands").is_some(),
+        "capabilities MUST emit its JSON inventory on the non-TTY \
+         implicit-Quiet path (#219 / #220 regression)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**S1 = ADR-0017 Amendment 1 implementation slice.** Closes the LLM cold-boot deadlock reported in #219 / #220 where `doiget capabilities` silently emits empty stdout in non-TTY / agent execution contexts.

## Root cause (the deadlock)

The pre-Amendment resolver collapsed two distinct signals into one `OutputMode::Quiet`:

| Signal | Author | Was: | Now (Am1): |
|---|---|---|---|
| `--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet` | user intent | Quiet | Quiet, **explicit** |
| stdout is not a TTY, no other signal | resolver heuristic | Quiet | Quiet, **implicit** |

`capabilities` then suppressed on the union, so any agent capturing stdout via pipe saw empty output — the very command an LLM would call to discover how to make `doiget` talk was silenced by the TTY heuristic.

## Fix

- `commands::output::resolve()` now returns a `ResolvedOutput { mode, quiet_was_explicit }`. `OutputMode` enum + its wire format (`DOIGET_MODE` strings, the `modes` array in capabilities JSON) are **unchanged**; the bit lives only in-memory.
- `capabilities::run(cli, mode, quiet_was_explicit)` suppresses iff `mode == Quiet && quiet_was_explicit`. Every other path emits the inventory.
- New `is_artifact_command(name)` helper classifies `bib` / `csl` / `capabilities` as artifact commands. `audit-log` is omitted on purpose (it's informational in Human, artifact in Json — checks resolved mode, not name).
- `bib` / `csl` were already correct (they accept `_mode` and always emit), so this slice does not touch them.

## Behavior matrix

| Invocation | Mode resolved to | quiet_was_explicit | capabilities stdout |
|---|---|---|---|
| `doiget capabilities` (TTY) | Human | - | inventory JSON |
| `doiget capabilities` (non-TTY) | Quiet (implicit) | false | **inventory JSON** ← #219 fix |
| `doiget --quiet capabilities` | Quiet | true | empty |
| `doiget -q capabilities` | Quiet | true | empty |
| `doiget --mode quiet capabilities` | Quiet | true | empty |
| `DOIGET_MODE=quiet doiget capabilities` | Quiet | true | empty |
| `DOIGET_MODE=json doiget capabilities` | Json | - | inventory JSON |
| `doiget capabilities \| jq .` | Quiet (implicit) | false | **inventory JSON** ← #219 fix |

## Tests

- **output.rs**: 4 new unit tests (15 total pass) for explicit/implicit Quiet:
  - `doiget_mode_quiet_env_is_explicit_quiet`
  - `non_tty_quiet_default_is_implicit_quiet`
  - extended `quiet_short_flag_implies_quiet` asserts explicit-bit
  - `artifact_command_classifier_covers_bib_csl_capabilities`
- **capabilities_e2e.rs**: 2 new e2e tests (9 total pass):
  - **`capabilities_non_tty_default_still_emits_inventory`** — the direct #219/#220 regression pin (runs `doiget capabilities` under `assert_cmd` without `DOIGET_MODE=human`, asserts JSON is emitted)
  - `capabilities_quiet_mode_via_doiget_mode_env_produces_no_stdout` — covers the explicit env-var path

## Scope (S1, not the whole #220)

This PR ships the **capabilities cold-boot** half of #220. The other two items in #220 land as separate slices:

- **S2**: `http://` -> `https://` auto-upgrade in `fetch_inner` (separate small PR)
- **S3**: `network.additional_hosts` + `verified_by` provenance plumbing per ADR-0028 (separate medium PR)

## Test plan

- [ ] CI all green on `next` branch protection
- [ ] `version-check` advisory job green for `v0.4.1-beta.2` (lane: beta)
- [ ] `capabilities_non_tty_default_still_emits_inventory` passes on all three runners (ubuntu / macos / windows)
- [ ] After merge: open S2 (http upgrade) as the next slice

Closes #219.
Closes #220 (the capabilities-deadlock portion; the http:// auto-upgrade and Green-OA allowlist portions are tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)