### PR TITLE
fix(core/http): upgrade legacy http:// URLs to https:// before send (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.7] - 2026-05-21
+
+### Fixed
+
+- **[core/http]** Legacy `http://` URLs returned by OpenAlex /
+  Unpaywall metadata (e.g. `http://link.aps.org/pdf/…` for older
+  APS records) are now transparently upgraded to `https://` before
+  the request leaves the process (#220, see ADR-0028 D3 — accept-
+  list, non-impersonating). Without this, the production
+  `https_only(true)` client refuses to send the request and the
+  fetch fails with a generic builder error even though the host
+  has supported HTTPS for years. The upgrade is total but
+  intentionally skipped for loopback hosts (`localhost`,
+  `127.0.0.0/8`, `::1`) so the `new_for_tests_allow_http*`
+  wiremock path is unchanged. TLS posture is preserved: if the
+  upgraded host doesn't serve HTTPS the connection fails at the
+  TLS handshake with a normal `NETWORK_ERROR`, never falling back
+  to plaintext.
+
 ## [0.4.1-beta.5] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
-- **[core/http]** Legacy `http://` URLs returned by OpenAlex /
-  Unpaywall metadata (e.g. `http://link.aps.org/pdf/…` for older
-  APS records) are now transparently upgraded to `https://` before
-  the request leaves the process (#220, see ADR-0028 D3 — accept-
-  list, non-impersonating). Without this, the production
-  `https_only(true)` client refuses to send the request and the
-  fetch fails with a generic builder error even though the host
-  has supported HTTPS for years. The upgrade is total but
-  intentionally skipped for loopback hosts (`localhost`,
-  `127.0.0.0/8`, `::1`) so the `new_for_tests_allow_http*`
-  wiremock path is unchanged. TLS posture is preserved: if the
-  upgraded host doesn't serve HTTPS the connection fails at the
-  TLS handshake with a normal `NETWORK_ERROR`, never falling back
-  to plaintext.
+- **[core/http]** `http://` URLs returned by OpenAlex / Unpaywall
+  metadata for publishers that have since moved to HTTPS are
+  transparently upgraded to `https://` before the request leaves
+  the process (#220). Without this, the production
+  `https_only(true)` client refused to send and the fetch failed
+  with a generic builder error. The upgrade is skipped for
+  loopback hosts (`localhost`, the RFC 6761 `.localhost` TLD,
+  `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback) so the
+  `new_for_tests_allow_http*` wiremock path is unchanged. TLS
+  posture (ADR-0020) is preserved — the upgrade turns a
+  guaranteed-reject into a real TLS handshake, never a plaintext
+  fallback. Successful upgrades log at `tracing::info!` so the
+  rewrite appears in audit-level logs.
 
 ## [0.4.1-beta.5] - 2026-05-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.5"
+version       = "0.4.1-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -722,6 +722,27 @@ impl HttpClient {
         headers: &[(&str, &str)],
         check_pdf_magic: bool,
     ) -> Result<(Bytes, Url), HttpError> {
+        // #220: legacy OpenAlex / Unpaywall metadata sometimes contains
+        // `http://` URLs for publishers that have since moved to HTTPS
+        // (`http://link.aps.org/pdf/...` is the common case). The
+        // production client is built with `https_only(true)` and would
+        // refuse to send such a request, so today the fetch fails at
+        // the reqwest layer with a generic builder error. Upgrading the
+        // scheme to `https` before send turns the failure into a
+        // legitimate fetch in 99 %+ of academic-publisher cases (APS,
+        // IOP, SciPost, Springer, Crossref, OpenAlex all serve HTTPS
+        // for years now). The upgrade is intentionally skipped for
+        // loopback hosts so the `new_for_tests_allow_http*` wiremock
+        // path still works.
+        //
+        // TLS posture unchanged: a redirected URL is still verified by
+        // the redirect-allowlist closure on the upgraded scheme; an
+        // upgraded URL whose host doesn't serve HTTPS will fail at the
+        // TLS handshake with a normal `NETWORK_ERROR`, not an insecure
+        // fallback. See ADR-0028 D3 ("non-impersonating tweaks are
+        // accept-list").
+        let url = upgrade_http_to_https(url);
+
         let client = self
             .clients
             .get(source)
@@ -1047,6 +1068,54 @@ fn ensure_crypto_provider() {
     });
 }
 
+/// Upgrade an `http://` URL to `https://` for legacy publisher metadata
+/// (#220). Loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) are
+/// returned unchanged so the `new_for_tests_allow_http*` wiremock path
+/// continues to talk plain HTTP to the local fixture server.
+///
+/// Non-`http` schemes (including `https`, `file`, anything else) are
+/// returned unchanged. The function is total: it never panics and
+/// never returns an error — if `set_scheme` somehow refuses the change
+/// the original URL is returned, and the production client's
+/// `https_only(true)` will then reject the send with a clear network
+/// error, preserving the original posture.
+fn upgrade_http_to_https(url: Url) -> Url {
+    if url.scheme() != "http" {
+        return url;
+    }
+    // Loopback skip: `Url::host()` returns a typed `Host` enum so
+    // IPv4 (127.0.0.0/8) and IPv6 (::1) loopback can be detected
+    // structurally — `host_str()`'s bracket-stripping for IPv6 is
+    // not portable to match against. The `localhost` literal is
+    // also covered (it can resolve to either family).
+    match url.host() {
+        None => {
+            // Cannot-be-base URL (e.g. `http:foo`) — `set_scheme`
+            // would reject the conversion. Leave it untouched; the
+            // downstream client will reject it.
+            return url;
+        }
+        Some(url::Host::Domain(d)) if d.eq_ignore_ascii_case("localhost") => return url,
+        Some(url::Host::Ipv4(ip)) if ip.is_loopback() => return url,
+        Some(url::Host::Ipv6(ip)) if ip.is_loopback() => return url,
+        _ => {}
+    }
+    let mut upgraded = url.clone();
+    if upgraded.set_scheme("https").is_err() {
+        // The `url` crate documents the failure modes for `set_scheme`;
+        // `http -> https` is supported because both are "special"
+        // schemes with the same syntax. The fallback exists for
+        // defence in depth.
+        return url;
+    }
+    tracing::debug!(
+        original = %url,
+        upgraded = %upgraded,
+        "upgraded http -> https for legacy publisher metadata (#220)"
+    );
+    upgraded
+}
+
 fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
     ensure_crypto_provider();
 
@@ -1133,6 +1202,69 @@ mod tests {
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ---------------------------------------------------------------
+    // http -> https scheme upgrade (#220) — pure unit tests, no network.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn upgrade_http_to_https_rewrites_public_http_url() {
+        let input = Url::parse("http://link.aps.org/pdf/10.1103/PhysRev.123.456").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out.scheme(), "https");
+        assert_eq!(out.host_str(), Some("link.aps.org"));
+        assert_eq!(out.path(), "/pdf/10.1103/PhysRev.123.456");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_preserves_port_path_query_fragment() {
+        let input = Url::parse("http://example.org:8080/a/b?q=1#frag").unwrap();
+        let out = upgrade_http_to_https(input);
+        assert_eq!(out.as_str(), "https://example.org:8080/a/b?q=1#frag");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_is_idempotent_on_https() {
+        let input = Url::parse("https://api.crossref.org/works/10.1234/foo").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_localhost() {
+        // wiremock binds to `127.0.0.1:PORT`; the loopback exception
+        // is the load-bearing rule that keeps `new_for_tests_allow_http*`
+        // working alongside the production fetch path.
+        let input = Url::parse("http://localhost:7878/pdf").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out, input, "localhost MUST NOT be upgraded");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_127_loopback_block() {
+        for host in ["127.0.0.1", "127.0.0.42", "127.255.255.254"] {
+            let raw = format!("http://{host}:1234/x");
+            let input = Url::parse(&raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "host `{host}` MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_ipv6_loopback() {
+        let input = Url::parse("http://[::1]:9000/path").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out, input, "IPv6 loopback MUST NOT be upgraded");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_preserves_case_in_path() {
+        // Some publishers (e.g. APS legacy redirects) use mixed-case
+        // path segments; upgrade must NOT lowercase or canonicalise.
+        let input = Url::parse("http://link.aps.org/PDF/10.1103/PhysRevB.109.045136").unwrap();
+        let out = upgrade_http_to_https(input);
+        assert_eq!(out.path(), "/PDF/10.1103/PhysRevB.109.045136");
+    }
 
     // ---------------------------------------------------------------
     // Allowlist matching — pure unit tests, no network.

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -722,25 +722,10 @@ impl HttpClient {
         headers: &[(&str, &str)],
         check_pdf_magic: bool,
     ) -> Result<(Bytes, Url), HttpError> {
-        // #220: legacy OpenAlex / Unpaywall metadata sometimes contains
-        // `http://` URLs for publishers that have since moved to HTTPS
-        // (`http://link.aps.org/pdf/...` is the common case). The
-        // production client is built with `https_only(true)` and would
-        // refuse to send such a request, so today the fetch fails at
-        // the reqwest layer with a generic builder error. Upgrading the
-        // scheme to `https` before send turns the failure into a
-        // legitimate fetch in 99 %+ of academic-publisher cases (APS,
-        // IOP, SciPost, Springer, Crossref, OpenAlex all serve HTTPS
-        // for years now). The upgrade is intentionally skipped for
-        // loopback hosts so the `new_for_tests_allow_http*` wiremock
-        // path still works.
-        //
-        // TLS posture unchanged: a redirected URL is still verified by
-        // the redirect-allowlist closure on the upgraded scheme; an
-        // upgraded URL whose host doesn't serve HTTPS will fail at the
-        // TLS handshake with a normal `NETWORK_ERROR`, not an insecure
-        // fallback. See ADR-0028 D3 ("non-impersonating tweaks are
-        // accept-list").
+        // Normalise legacy `http://` URLs returned by OpenAlex /
+        // Unpaywall metadata before send. See `upgrade_http_to_https`
+        // for the rationale (TLS posture preserved per ADR-0020) and
+        // the loopback carve-out.
         let url = upgrade_http_to_https(url);
 
         let client = self
@@ -1068,52 +1053,96 @@ fn ensure_crypto_provider() {
     });
 }
 
-/// Upgrade an `http://` URL to `https://` for legacy publisher metadata
-/// (#220). Loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) are
-/// returned unchanged so the `new_for_tests_allow_http*` wiremock path
-/// continues to talk plain HTTP to the local fixture server.
+/// Upgrade an `http://` URL to `https://` for legacy publisher
+/// metadata. Loopback hosts (`localhost`, any RFC 6761 `.localhost`
+/// TLD subdomain, `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback)
+/// are returned unchanged so the `new_for_tests_allow_http*` wiremock
+/// path continues to talk plain HTTP to the local fixture server.
 ///
-/// Non-`http` schemes (including `https`, `file`, anything else) are
-/// returned unchanged. The function is total: it never panics and
-/// never returns an error — if `set_scheme` somehow refuses the change
-/// the original URL is returned, and the production client's
-/// `https_only(true)` will then reject the send with a clear network
-/// error, preserving the original posture.
+/// Non-`http` schemes (`https`, `file`, anything else) and cannot-be-
+/// base URLs are returned unchanged. The function is total: it never
+/// panics and never returns an error.
+///
+/// # Audit / posture
+///
+/// On a successful upgrade the function emits a `tracing::info!` event
+/// so the rewrite appears in the operator's default-level structured
+/// log. On the (in-practice unreachable) `set_scheme` failure path a
+/// `tracing::warn!` event is emitted before returning the original
+/// URL; the production client's `https_only(true)` then rejects the
+/// send with a clear network error, preserving the TLS posture
+/// established by ADR-0020.
+///
+/// # `Domain("localhost")` arm subtlety
+///
+/// The url crate resolves the bare host `localhost` to `127.0.0.1`
+/// (Ipv4 variant) when parsing an `http://` URL, so the `Domain` arm
+/// does NOT fire for that case (the `Ipv4` arm catches it). The arm
+/// IS load-bearing for the RFC 6761 `.localhost` TLD (e.g.
+/// `myservice.localhost`, `api.localhost`), which the url crate does
+/// NOT auto-resolve to an IP and keeps as `Host::Domain`.
 fn upgrade_http_to_https(url: Url) -> Url {
     if url.scheme() != "http" {
         return url;
     }
-    // Loopback skip: `Url::host()` returns a typed `Host` enum so
-    // IPv4 (127.0.0.0/8) and IPv6 (::1) loopback can be detected
-    // structurally — `host_str()`'s bracket-stripping for IPv6 is
-    // not portable to match against. The `localhost` literal is
-    // also covered (it can resolve to either family).
     match url.host() {
         None => {
             // Cannot-be-base URL (e.g. `http:foo`) — `set_scheme`
-            // would reject the conversion. Leave it untouched; the
-            // downstream client will reject it.
+            // would reject the conversion.
             return url;
         }
-        Some(url::Host::Domain(d)) if d.eq_ignore_ascii_case("localhost") => return url,
+        Some(url::Host::Domain(d)) if is_localhost_domain(d) => return url,
         Some(url::Host::Ipv4(ip)) if ip.is_loopback() => return url,
-        Some(url::Host::Ipv6(ip)) if ip.is_loopback() => return url,
-        _ => {}
+        Some(url::Host::Ipv6(ip)) if is_ipv6_loopback(ip) => return url,
+        Some(_) => {}
     }
     let mut upgraded = url.clone();
     if upgraded.set_scheme("https").is_err() {
-        // The `url` crate documents the failure modes for `set_scheme`;
+        // url-crate `set_scheme` is documented to fail only for
+        // cannot-be-base URLs and a few cross-family transitions;
         // `http -> https` is supported because both are "special"
-        // schemes with the same syntax. The fallback exists for
-        // defence in depth.
+        // schemes. The fallback below is defence-in-depth.
+        tracing::warn!(
+            url = %url,
+            "set_scheme(http -> https) failed unexpectedly; \
+             sending original URL — https_only(true) will reject",
+        );
         return url;
     }
-    tracing::debug!(
+    tracing::info!(
         original = %url,
         upgraded = %upgraded,
-        "upgraded http -> https for legacy publisher metadata (#220)"
+        "upgraded http -> https for legacy publisher metadata"
     );
     upgraded
+}
+
+/// `true` for the `localhost` literal and any RFC 6761 `.localhost`
+/// TLD subdomain (`myservice.localhost`, `api.localhost`, etc.).
+/// ASCII-case-insensitive per host-name conventions.
+fn is_localhost_domain(d: &str) -> bool {
+    if d.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    let suffix = ".localhost";
+    let d_bytes = d.as_bytes();
+    let s_bytes = suffix.as_bytes();
+    if d_bytes.len() <= s_bytes.len() {
+        return false;
+    }
+    let tail = &d_bytes[d_bytes.len() - s_bytes.len()..];
+    tail.eq_ignore_ascii_case(s_bytes)
+}
+
+/// `true` for `::1` and any IPv4-mapped loopback
+/// (`::ffff:127.0.0.0/8`). `Ipv6Addr::is_loopback()` covers only `::1`,
+/// so dual-stack callers that hit `[::ffff:127.0.0.1]` would otherwise
+/// be silently upgraded.
+fn is_ipv6_loopback(ip: std::net::Ipv6Addr) -> bool {
+    if ip.is_loopback() {
+        return true;
+    }
+    matches!(ip.to_ipv4_mapped(), Some(v4) if v4.is_loopback())
 }
 
 fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
@@ -1264,6 +1293,118 @@ mod tests {
         let input = Url::parse("http://link.aps.org/PDF/10.1103/PhysRevB.109.045136").unwrap();
         let out = upgrade_http_to_https(input);
         assert_eq!(out.path(), "/PDF/10.1103/PhysRevB.109.045136");
+    }
+
+    // ---- Review-pass extensions ------------------------------------
+
+    #[test]
+    fn upgrade_http_to_https_skips_dot_localhost_tld() {
+        // RFC 6761 reserves the entire `.localhost` TLD for loopback.
+        // A developer running `http://myservice.localhost:8080/` MUST
+        // NOT see their URL silently upgraded to https.
+        for raw in [
+            "http://myservice.localhost/",
+            "http://api.localhost:8080/x",
+            "http://a.b.LOCALHOST/y",
+        ] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "{raw} MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_ipv4_mapped_ipv6_loopback() {
+        // `::ffff:127.0.0.1` is the IPv4-mapped IPv6 form of 127.0.0.1.
+        // `Ipv6Addr::is_loopback()` alone returns false for this form,
+        // so dual-stack callers binding wiremock to it would be
+        // silently upgraded without the `to_ipv4_mapped()` check.
+        for raw in [
+            "http://[::ffff:127.0.0.1]:9000/x",
+            "http://[::ffff:127.0.0.42]/y",
+        ] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "{raw} MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_is_noop_on_non_http_schemes() {
+        // The first guard (`url.scheme() != "http"`) covers everything
+        // that isn't http: https (idempotent), file, data, ftp...
+        for raw in [
+            "https://api.crossref.org/works/10.1234/foo",
+            "file:///etc/passwd",
+            "data:text/plain,hello",
+            "ftp://ftp.example.org/papers/",
+        ] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(
+                out, input,
+                "{raw} non-http scheme MUST be returned unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_http_url_always_has_host() {
+        // The url crate's parser enforces authority for "special"
+        // schemes (`http`, `https`, `ws`, `wss`, `ftp`, `file`).
+        // `Url::parse("http:foo")` synthesises a Domain("foo")
+        // authority, so an http URL with `host() == None` is
+        // unreachable from `Url::parse`. The `None` arm in
+        // `upgrade_http_to_https` is defence-in-depth only — pinned
+        // here so a future url-crate behavior change is caught.
+        let url = Url::parse("http:foo").expect("parse");
+        assert!(
+            url.host().is_some(),
+            "http URLs always carry a host per WHATWG URL spec"
+        );
+        // The fn still produces a sensible result (upgrade applies).
+        let out = upgrade_http_to_https(url.clone());
+        assert_eq!(out.scheme(), "https");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_localhost_case_insensitive() {
+        // The literal `localhost` is resolved by the url crate to
+        // `127.0.0.1` (Ipv4) at parse time for `http://` URLs, so the
+        // Ipv4 arm catches lowercase. The Domain-arm coverage is
+        // load-bearing only for the `.localhost` TLD case, but we
+        // still pin the casefold semantics in case the url crate
+        // changes its parsing rules.
+        for raw in ["http://LOCALHOST/", "http://Localhost:8080/x"] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "{raw} MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn is_localhost_domain_matches_literal_and_tld_suffix() {
+        assert!(is_localhost_domain("localhost"));
+        assert!(is_localhost_domain("LOCALHOST"));
+        assert!(is_localhost_domain("api.localhost"));
+        assert!(is_localhost_domain("nested.api.localhost"));
+        assert!(is_localhost_domain("X.LocalHost"));
+        assert!(!is_localhost_domain("localhost.example.org"));
+        assert!(!is_localhost_domain("notlocalhost"));
+        assert!(!is_localhost_domain(""));
+        assert!(!is_localhost_domain(".localhost")); // empty label not valid
+    }
+
+    #[test]
+    fn is_ipv6_loopback_covers_both_pure_and_mapped() {
+        use std::net::Ipv6Addr;
+        assert!(is_ipv6_loopback(Ipv6Addr::LOCALHOST)); // ::1
+        assert!(is_ipv6_loopback("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_ipv6_loopback("::ffff:127.0.0.42".parse().unwrap()));
+        assert!(!is_ipv6_loopback("::".parse().unwrap()));
+        assert!(!is_ipv6_loopback("2001:db8::1".parse().unwrap()));
+        // IPv4-mapped non-loopback must NOT be considered loopback.
+        assert!(!is_ipv6_loopback("::ffff:1.2.3.4".parse().unwrap()));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

**S2 = http -> https upgrade portion of #220.** Transparently upgrades the scheme of incoming `http://` URLs to `https://` in `fetch_inner` before reqwest dispatches the request, so legacy OpenAlex / Unpaywall metadata (\`http://link.aps.org/pdf/...\` etc.) no longer triggers a guaranteed builder-error reject.

Sits parallel to PR #225 (S1 capabilities cold-boot fix) — both are independent #220 sub-slices.

## The problem

OpenAlex / Unpaywall sometimes return `http://` URLs for publishers that have since moved to HTTPS. The production reqwest client is built with \`https_only(true)\` per ADR-0020, so:

```text
Ref doi:10.1103/...
  -> OpenAlex returns "http://link.aps.org/pdf/..."
  -> orchestrator hands the URL to client.get()
  -> reqwest refuses to send (https_only(true))
  -> NETWORK_ERROR / builder error
```

The metadata is good, the host serves HTTPS, but we never try.

## The fix

`fetch_inner` now calls a small pure helper `upgrade_http_to_https()` on the URL right at entry:

```rust
fn upgrade_http_to_https(url: Url) -> Url {
    if url.scheme() != "http" { return url; }
    match url.host() {
        None => return url,
        Some(Host::Domain(d)) if d.eq_ignore_ascii_case("localhost") => return url,
        Some(Host::Ipv4(ip)) if ip.is_loopback() => return url,
        Some(Host::Ipv6(ip)) if ip.is_loopback() => return url,
        _ => {}
    }
    let mut upgraded = url.clone();
    if upgraded.set_scheme("https").is_err() { return url; }
    upgraded
}
```

| URL                              | Upgraded? |
|----------------------------------|-----------|
| `http://link.aps.org/pdf/...`    | yes -> `https://link.aps.org/pdf/...` |
| `https://api.crossref.org/...`   | no (already https; idempotent) |
| `http://localhost:7878/x`        | no (wiremock test fixture) |
| `http://127.0.0.1:RANDOM/y`      | no (wiremock binds here) |
| `http://127.0.0.42:1234/z`       | no (full 127.0.0.0/8 block) |
| `http://[::1]:9000/w`            | no (IPv6 loopback) |

## TLS posture

Unchanged. \`https_only(true)\` remains set on the production client; the upgrade just turns a guaranteed reject into a real TLS handshake. If the upgraded host doesn't serve HTTPS, the handshake fails with a normal `NETWORK_ERROR` — no plaintext fallback. The redirect-allowlist closure (load-bearing security check) operates on the post-upgrade URL.

Per ADR-0028 D3, this fix is in the **accept-list** category: non-impersonating, no fingerprint spoofing, no UA mutation. Contrast #223's rejected `reqwest-impersonate` proposal which would deliberately misrepresent the client to publisher WAFs.

## Tests

- 7 new unit tests in `http::tests::upgrade_http_to_https_*`:
  - `_rewrites_public_http_url`
  - `_preserves_port_path_query_fragment`
  - `_is_idempotent_on_https`
  - `_skips_localhost`
  - `_skips_127_loopback_block` (covers 3 different 127.x addresses)
  - `_skips_ipv6_loopback`
  - `_preserves_case_in_path`
- All 233 existing `doiget-core` lib tests continue to pass — the wiremock-backed integration tests stay green because `127.0.0.1:RANDOM_PORT` is caught by the loopback skip.

## Coordination with PR #225 (S1)

| Slice | Branch | Version | Touches |
|---|---|---|---|
| S1 | `fix/219-capabilities-cold-boot` | `0.4.1-beta.2` | CLI: output / capabilities + e2e |
| **S2 (this PR)** | `fix/220-http-https-upgrade` | `0.4.1-beta.3` | core: http.rs |

Both are independent on disjoint file sets except for `Cargo.toml` / `Cargo.lock` / `CHANGELOG.md`. Whoever merges second will rebase against the updated `next` (trivial — different sections of each file).

## Test plan

- [ ] CI green on `next` branch protection
- [ ] `version-check` advisory job green for prospective tag `v0.4.1-beta.3` (lane: beta)
- [ ] All 7 new upgrade unit tests pass on ubuntu / macos / windows runners
- [ ] After merge: open S3 (\`network.additional_hosts\` per ADR-0028) as the next slice

Refs #220 (the http-upgrade half; the capabilities cold-boot half is S1 / PR #225, the user-extensible allowlist is the upcoming S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)