### PR TITLE
feat(core): user-extensible capability gate via config.toml (ADR-0028, #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,21 +14,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
-- **[core]** New module `doiget_core::user_extension`: parser + merger
-  for `[[network.additional_hosts]]` entries in the user's
-  `config.toml`, per ADR-0028 D2 (#220). The orchestrator's
-  production HttpClient construction (`commands::fetch::build_http_client`)
-  now reads `<config_dir>/doiget/config.toml`, validates each entry
-  against the restricted ADR-0028 D2-1 pattern grammar (literal FQDN
-  or single-suffix wildcard `*.<suffix>` only — multi-segment globs,
-  bare wildcards, and non-host characters are parse errors), and
-  merges the user-added hosts into the `oa-publisher` allowlist
-  alongside the curated set. A missing config file is the normal case
-  ("no extensions"); a malformed file emits a `tracing::warn!` to
-  stderr but never aborts the fetch (the curated allowlist still
-  applies). Unblocks the real-world dogfood case where a Green-OA
-  paper lives on an institutional repo like `ruj.uj.edu.pl` that the
-  curated list cannot reasonably enumerate.
+- **[core]** New module `doiget_core::user_extension` per ADR-0028
+  D2 (#220). Users can extend the `oa-publisher` redirect allowlist
+  for their own deployment via `[[network.additional_hosts]]` in
+  `<config_dir>/doiget/config.toml`. Pattern grammar is restricted
+  (literal FQDN or single-suffix wildcard `*.<suffix>`); rejection
+  classes are surfaced as a closed-enum `PatternError` for
+  programmatic consumption by the future `doiget config doctor`
+  surface. The `host` field of `UserExtensionHost` is a
+  `HostPattern` newtype that runs validation through its serde
+  `Deserialize`, so the "valid pattern" invariant is type-level —
+  no `UserExtensionHost` value can exist with an invalid host. The
+  orchestrator's production HttpClient construction
+  (`commands::fetch::build_http_client`) loads and merges in one
+  pass; a missing config file is silent, a malformed config is
+  surfaced as `tracing::warn!` and the fetch continues with the
+  curated set.
 
   Example:
 
@@ -47,7 +48,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   the `doiget config doctor` surface (D2-3), the
   `capability_gate.user_extension_count` field in `doiget
   capabilities` JSON (D2-4), and the MCP-server-side merge in
-  `doiget-mcp`.
+  `doiget-mcp` (a user who configures
+  `[[network.additional_hosts]]` and invokes via `doiget serve`
+  currently sees no effect; that is the load-bearing item S3b
+  closes).
 
 ## [0.4.1-beta.7] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.8] - 2026-05-21
+
+### Added
+
+- **[core]** New module `doiget_core::user_extension`: parser + merger
+  for `[[network.additional_hosts]]` entries in the user's
+  `config.toml`, per ADR-0028 D2 (#220). The orchestrator's
+  production HttpClient construction (`commands::fetch::build_http_client`)
+  now reads `<config_dir>/doiget/config.toml`, validates each entry
+  against the restricted ADR-0028 D2-1 pattern grammar (literal FQDN
+  or single-suffix wildcard `*.<suffix>` only — multi-segment globs,
+  bare wildcards, and non-host characters are parse errors), and
+  merges the user-added hosts into the `oa-publisher` allowlist
+  alongside the curated set. A missing config file is the normal case
+  ("no extensions"); a malformed file emits a `tracing::warn!` to
+  stderr but never aborts the fetch (the curated allowlist still
+  applies). Unblocks the real-world dogfood case where a Green-OA
+  paper lives on an institutional repo like `ruj.uj.edu.pl` that the
+  curated list cannot reasonably enumerate.
+
+  Example:
+
+  ```toml
+  # ~/.config/doiget/config.toml
+  [[network.additional_hosts]]
+  host = "ruj.uj.edu.pl"
+  note = "Jagiellonian University Repository — Green OA"
+
+  [[network.additional_hosts]]
+  host = "*.uj.edu.pl"
+  ```
+
+  Out of scope for this slice (tracked as S3b): the
+  `verified_by = "user"` provenance row field (ADR-0028 D2-2),
+  the `doiget config doctor` surface (D2-3), the
+  `capability_gate.user_extension_count` field in `doiget
+  capabilities` JSON (D2-4), and the MCP-server-side merge in
+  `doiget-mcp`.
+
 ## [0.4.1-beta.7] - 2026-05-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.7"
+version = "0.4.1-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.7"
+version = "0.4.1-beta.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.7"
+version = "0.4.1-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.7"
+version       = "0.4.1-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -191,39 +191,49 @@ fn build_http_client() -> Result<HttpClient> {
         allowlists.extend(tier_2_allowlist());
 
         // ADR-0028 D2: merge user-extension hosts from
-        // `<config_dir>/doiget/config.toml`'s
-        // `[[network.additional_hosts]]` table. Pattern grammar is
-        // restricted to literal FQDN or `*.<suffix>` (ADR-0028 D2-1);
-        // anything else is rejected at parse time. A missing config
-        // file is the normal case (treated as "no extensions").
+        // `<config_dir>/doiget/config.toml`. See
+        // `doiget_core::user_extension` for the wire contract and
+        // the (deferred) S3b provenance / doctor / capabilities
+        // surfaces.
         //
-        // A malformed config is surfaced as a *warning* to stderr,
-        // never aborts the fetch — ADR-0028 D2 frames user-extension
-        // as opt-in convenience; the curated allowlist still applies.
-        // The user can then run `doiget config doctor` (S3b will add
-        // the surface) to see the offending entry.
-        if let Ok(cfg_dir) = config_dir_utf8() {
-            let path = cfg_dir.join("doiget").join("config.toml");
-            match doiget_core::user_extension::load(&path) {
-                Ok(user_hosts) if !user_hosts.is_empty() => {
-                    tracing::info!(
-                        count = user_hosts.len(),
-                        path = %path,
-                        "merging user-extension allowlist hosts (ADR-0028 D2)"
-                    );
-                    doiget_core::user_extension::merge_into_allowlists(
-                        &mut allowlists,
-                        &user_hosts,
-                    );
+        // Failure handling is opt-in-convenience: a missing config
+        // is silent (Ok-empty), a malformed config emits
+        // `tracing::warn!` and continues with the curated allowlist,
+        // and an unresolvable config dir emits `tracing::debug!`
+        // (only happens in stripped envs with no HOME / XDG /
+        // APPDATA — review pass I3 / A1).
+        match config_dir_utf8() {
+            Ok(cfg_dir) => {
+                let path = cfg_dir.join("doiget").join("config.toml");
+                match doiget_core::user_extension::load(&path) {
+                    Ok(user_hosts) if !user_hosts.is_empty() => {
+                        tracing::info!(
+                            count = user_hosts.len(),
+                            path = %path,
+                            "merging user-extension allowlist hosts (ADR-0028 D2)"
+                        );
+                        doiget_core::user_extension::merge_into_allowlists(
+                            &mut allowlists,
+                            &user_hosts,
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            path = %path,
+                            "failed to load user-extension allowlist; \
+                             falling back to curated set only"
+                        );
+                    }
                 }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        path = %path,
-                        "failed to load user-extension allowlist; falling back to curated set only"
-                    );
-                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "config dir unresolvable; \
+                     user-extension allowlist disabled (curated set only)"
+                );
             }
         }
 
@@ -824,6 +834,7 @@ fn render_blocked_error(
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn new_session_id_is_26_chars() {
@@ -837,6 +848,108 @@ mod tests {
             id.chars().all(|c| c.is_ascii_alphanumeric()),
             "ulid must be ASCII alphanumeric: {:?}",
             id
+        );
+    }
+
+    /// Review pass C2: end-to-end coverage of the user-extension
+    /// merge inside `build_http_client`. Without this test the
+    /// production path that turns a `config.toml`
+    /// `[[network.additional_hosts]]` entry into a passing
+    /// allowlist match is unexercised — every existing e2e sets
+    /// `DOIGET_*_BASE` and short-circuits into the test-mode
+    /// builder above.
+    #[test]
+    #[serial]
+    fn build_http_client_merges_user_extension_into_oa_publisher_allowlist() {
+        use std::io::Write;
+
+        // Construct a tempdir + minimal config.toml under it.
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let cfg_dir = td.path().join("doiget");
+        std::fs::create_dir_all(&cfg_dir).expect("mkdir doiget/");
+        let cfg_path = cfg_dir.join("config.toml");
+        let mut f = std::fs::File::create(&cfg_path).expect("create config.toml");
+        f.write_all(
+            br#"
+[[network.additional_hosts]]
+host = "ruj.uj.edu.pl"
+note = "Jagiellonian"
+
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+"#,
+        )
+        .expect("write config.toml");
+        drop(f);
+
+        // Save + override env so `config_dir_utf8()` lands on the
+        // tempdir. Restored on Drop by EnvGuard. We also clear the
+        // five `DOIGET_*_BASE` env vars to force the production
+        // branch of `build_http_client`.
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<String>,
+        }
+        impl EnvGuard {
+            fn save(key: &'static str) -> Self {
+                Self {
+                    key,
+                    prev: std::env::var(key).ok(),
+                }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+        let _g0 = EnvGuard::save("XDG_CONFIG_HOME");
+        let _g1 = EnvGuard::save("APPDATA");
+        let _g2 = EnvGuard::save("HOME");
+        let _g3 = EnvGuard::save("USERPROFILE");
+        let _g4 = EnvGuard::save("DOIGET_ARXIV_BASE");
+        let _g5 = EnvGuard::save("DOIGET_CROSSREF_BASE");
+        let _g6 = EnvGuard::save("DOIGET_UNPAYWALL_BASE");
+        let _g7 = EnvGuard::save("DOIGET_OA_PUBLISHER_BASE");
+        let _g8 = EnvGuard::save("DOIGET_OPENALEX_BASE");
+        std::env::set_var("XDG_CONFIG_HOME", td.path());
+        std::env::set_var("APPDATA", td.path());
+        std::env::set_var("HOME", td.path());
+        std::env::set_var("USERPROFILE", td.path());
+        std::env::remove_var("DOIGET_ARXIV_BASE");
+        std::env::remove_var("DOIGET_CROSSREF_BASE");
+        std::env::remove_var("DOIGET_UNPAYWALL_BASE");
+        std::env::remove_var("DOIGET_OA_PUBLISHER_BASE");
+        std::env::remove_var("DOIGET_OPENALEX_BASE");
+
+        let client = build_http_client().expect("HttpClient builds");
+        let oa = client
+            .source_allowlist("oa-publisher")
+            .expect("oa-publisher source registered");
+
+        // Pre-existing curated allowlist still effective.
+        assert!(
+            oa.redirect_hosts.iter().any(|p| p == "*.aps.org"),
+            "curated *.aps.org MUST still be present after merge; got {:?}",
+            oa.redirect_hosts
+        );
+        // User-added literal host passes match.
+        assert!(
+            oa.matches("ruj.uj.edu.pl"),
+            "literal `ruj.uj.edu.pl` from user config MUST match"
+        );
+        // User-added wildcard passes match for a subdomain.
+        assert!(
+            oa.matches("alpha.uj.edu.pl"),
+            "wildcard `*.uj.edu.pl` from user config MUST match alpha.uj.edu.pl"
+        );
+        // Unrelated host MUST still fail.
+        assert!(
+            !oa.matches("ruj.uj.edu.ru"),
+            "host outside the suffix MUST NOT match"
         );
     }
 

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -189,6 +189,44 @@ fn build_http_client() -> Result<HttpClient> {
         // the runtime gate; the allowlist is the transport gate.
         #[cfg(feature = "citation")]
         allowlists.extend(tier_2_allowlist());
+
+        // ADR-0028 D2: merge user-extension hosts from
+        // `<config_dir>/doiget/config.toml`'s
+        // `[[network.additional_hosts]]` table. Pattern grammar is
+        // restricted to literal FQDN or `*.<suffix>` (ADR-0028 D2-1);
+        // anything else is rejected at parse time. A missing config
+        // file is the normal case (treated as "no extensions").
+        //
+        // A malformed config is surfaced as a *warning* to stderr,
+        // never aborts the fetch — ADR-0028 D2 frames user-extension
+        // as opt-in convenience; the curated allowlist still applies.
+        // The user can then run `doiget config doctor` (S3b will add
+        // the surface) to see the offending entry.
+        if let Ok(cfg_dir) = config_dir_utf8() {
+            let path = cfg_dir.join("doiget").join("config.toml");
+            match doiget_core::user_extension::load(&path) {
+                Ok(user_hosts) if !user_hosts.is_empty() => {
+                    tracing::info!(
+                        count = user_hosts.len(),
+                        path = %path,
+                        "merging user-extension allowlist hosts (ADR-0028 D2)"
+                    );
+                    doiget_core::user_extension::merge_into_allowlists(
+                        &mut allowlists,
+                        &user_hosts,
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %path,
+                        "failed to load user-extension allowlist; falling back to curated set only"
+                    );
+                }
+            }
+        }
+
         return HttpClient::new(allowlists).context("building HTTP client");
     }
 

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod rate_limiter;
 pub mod source;
 pub mod sources;
 pub mod store;
+pub mod user_extension;
 
 // Phase 4 citation graph (ADR-0010). Compile-gated by the `citation`
 // Cargo feature, which itself enables the `metadata` feature so the

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -128,6 +128,7 @@ pub struct UserExtensionHost {
 impl UserExtensionHost {
     /// Test-only constructor. Production callers go through [`load`].
     #[cfg(test)]
+    #[allow(clippy::expect_used)]
     pub(crate) fn for_test(host: &str) -> Self {
         Self {
             host: HostPattern::new(host).expect("test host must be valid"),
@@ -473,8 +474,14 @@ mod tests {
 
     #[test]
     fn validate_pattern_rejects_whitespace() {
-        assert_eq!(validate_pattern("  example.org"), Err(PatternError::Whitespace));
-        assert_eq!(validate_pattern("example.org  "), Err(PatternError::Whitespace));
+        assert_eq!(
+            validate_pattern("  example.org"),
+            Err(PatternError::Whitespace)
+        );
+        assert_eq!(
+            validate_pattern("example.org  "),
+            Err(PatternError::Whitespace)
+        );
     }
 
     #[test]
@@ -613,12 +620,15 @@ mod tests {
     #[test]
     fn parse_rejects_unknown_field_inside_additional_hosts_entry() {
         // The [[network.additional_hosts]] table itself uses
-        // deny_unknown_fields, so typos like `hsot = "..."` surface
-        // as a parse error (review pass I5).
+        // deny_unknown_fields, so typos and stray keys surface as a
+        // parse error (review pass I5). The unknown-key string is
+        // chosen so the typos lint doesn't fight us — `notez`
+        // doesn't trip any English-word dictionary while still
+        // exercising the deny_unknown_fields code path.
         let toml = r#"
             [[network.additional_hosts]]
             host = "ruj.uj.edu.pl"
-            commet = "typo"
+            notez = "typo"
         "#;
         let err = parse_str(toml, p("config.toml")).expect_err("typo must fail");
         assert!(matches!(err, UserExtensionError::Parse { .. }));
@@ -691,11 +701,8 @@ mod tests {
 
     #[test]
     fn parse_rejects_malformed_toml() {
-        let err = parse_str(
-            "[[network.additional_hosts\nhost=\"foo\"",
-            p("config.toml"),
-        )
-        .expect_err("malformed toml must error");
+        let err = parse_str("[[network.additional_hosts\nhost=\"foo\"", p("config.toml"))
+            .expect_err("malformed toml must error");
         assert!(matches!(err, UserExtensionError::Parse { .. }));
     }
 
@@ -704,9 +711,7 @@ mod tests {
     #[test]
     fn load_returns_empty_when_file_missing() {
         let td = tempfile::TempDir::new().unwrap();
-        let path = Utf8Path::from_path(td.path())
-            .unwrap()
-            .join("missing.toml");
+        let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
         let got = load(&path).expect("missing file MUST be Ok(empty)");
         assert_eq!(got, vec![]);
     }

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -2,14 +2,14 @@
 //!
 //! Parses the `[[network.additional_hosts]]` array-of-tables from the
 //! user's `config.toml`, validates each entry against the restricted
-//! pattern grammar (literal FQDN or single-suffix wildcard `*.foo.bar`),
-//! and exposes a helper that merges the user-added hosts into the
-//! orchestrator's `oa-publisher` [`crate::http::SourceAllowlist`].
+//! ADR-0028 D2-1 pattern grammar, and merges the user-added hosts into
+//! the orchestrator's `oa-publisher` [`crate::http::SourceAllowlist`].
 //!
-//! This module is intentionally minimal: it does NOT layer config.toml
-//! with env vars or implement the full `docs/CONFIG.md` resolution
-//! ladder. The full reader is a separate slice (S3b); this slice ships
-//! only the surface needed for ADR-0028 D2 (user-extensible allowlist).
+//! This module is intentionally minimal — it does NOT layer
+//! `config.toml` with env vars or implement the full
+//! `docs/CONFIG.md` resolution ladder. The full reader is a separate
+//! slice (S3b); this slice ships only the surface needed for
+//! ADR-0028 D2 (user-extensible allowlist) to actually work end-to-end.
 //!
 //! # Wire contract (ADR-0028 D2-1)
 //!
@@ -20,73 +20,174 @@
 //!
 //! [[network.additional_hosts]]
 //! host = "*.uj.edu.pl"          # single-suffix wildcard, allowed
-//!
-//! # Rejected at parse time:
-//! # [[network.additional_hosts]]
-//! # host = "*.edu.*"            # multi-segment glob — rejected
-//! # host = "*"                  # bare wildcard — rejected
-//! # host = "user@host.com"      # `@` not in host charset
 //! ```
+//!
+//! Every rejection class enforced by [`validate_pattern`]:
+//!
+//! - empty string
+//! - leading or trailing whitespace
+//! - bare wildcard (`*`)
+//! - multi-segment glob (`*.edu.*`, `*.*`, `*.foo.*`)
+//! - mid-string wildcard (`foo.*.org`, `f*o.bar`, `*foo.bar`)
+//! - no `.` (single-label hostnames)
+//! - non-host characters (`@`, `/`, `:`, port suffixes, scheme prefix)
+//! - empty leading / inner / trailing label
+//! - label starting or ending with `-`
+//!
+//! Each rejection maps to a [`PatternError`] variant for downstream
+//! consumers (S3b `doiget config doctor`) to branch on programmatically.
 //!
 //! # Provenance & doctor (deferred to S3b)
 //!
 //! ADR-0028 D2-2 / D2-3 / D2-4 (the `verified_by = "user"` provenance
-//! field, `config doctor` surface, `capabilities` count) ship in the
-//! S3b follow-up; this slice is purely the **data path** so a user's
-//! `ruj.uj.edu.pl` actually passes the redirect-allowlist gate.
+//! field, `doiget config doctor` surface, `doiget capabilities`
+//! `user_extension_count`) ship in the S3b follow-up. The
+//! MCP-server-side merge in `doiget-mcp` is also deferred — this
+//! slice wires user extensions only through the CLI production path
+//! (`commands::fetch::build_http_client`). A user who configures
+//! `[[network.additional_hosts]]` and invokes via `doiget serve`
+//! (MCP) currently sees no effect; that is the load-bearing item
+//! S3b closes.
 
 use camino::Utf8Path;
 use serde::Deserialize;
 
 use crate::http::SourceAllowlist;
 
+/// A validated host pattern from `[[network.additional_hosts]]`.
+///
+/// Construction goes through [`HostPattern::new`] (or the
+/// `TryFrom<&str>` / `TryFrom<String>` impls), which run
+/// [`validate_pattern`] internally. The serde `Deserialize` impl
+/// also goes through `TryFrom<String>`, so any path that produces a
+/// `HostPattern` value — including TOML deserialisation — has
+/// passed validation. The invariant "this is a syntactically valid
+/// ADR-0028 D2-1 pattern" is therefore type-level.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HostPattern(String);
+
+impl HostPattern {
+    /// Construct after validation. Most callers prefer the
+    /// `TryFrom` impls.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PatternError`] for any input that fails
+    /// [`validate_pattern`].
+    pub fn new(raw: impl Into<String>) -> Result<Self, PatternError> {
+        let s: String = raw.into();
+        validate_pattern(&s)?;
+        Ok(Self(s))
+    }
+
+    /// Borrow the validated pattern as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for HostPattern {
+    type Error = PatternError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for HostPattern {
+    type Error = PatternError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HostPattern {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
 /// One user-added host entry from `[[network.additional_hosts]]`.
 ///
-/// The `note` field is free-text user documentation (e.g. "Jagiellonian
-/// University Repository — Green OA"); it is recorded in the
-/// provenance log alongside the host but never used for matching.
+/// The `note` field is free-text user documentation (e.g.
+/// "Jagiellonian University Repository — Green OA"); it is recorded
+/// in the provenance log alongside the host (S3b) but never consulted
+/// for matching.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[non_exhaustive]
 pub struct UserExtensionHost {
-    /// The host pattern. Either a literal FQDN (`example.org`) or a
-    /// single-suffix wildcard (`*.example.org`). Validated by
-    /// [`validate_pattern`] before this struct reaches a caller.
-    pub host: String,
-    /// Optional free-text note. Surfaced by `doiget config doctor`
-    /// (S3b) but never consulted for matching.
+    /// Validated host pattern (literal FQDN or single-suffix
+    /// wildcard `*.foo.bar`). Construction is type-enforced via
+    /// [`HostPattern`].
+    pub host: HostPattern,
+    /// Optional free-text note.
     #[serde(default)]
     pub note: Option<String>,
 }
 
 impl UserExtensionHost {
-    /// Construct a new entry with no note. Used by tests; production
-    /// callers go through [`load`].
-    #[doc(hidden)]
-    pub fn new(host: impl Into<String>) -> Self {
+    /// Test-only constructor. Production callers go through [`load`].
+    #[cfg(test)]
+    pub(crate) fn for_test(host: &str) -> Self {
         Self {
-            host: host.into(),
+            host: HostPattern::new(host).expect("test host must be valid"),
             note: None,
         }
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct ConfigFile {
-    #[serde(default)]
-    network: Option<NetworkSection>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct NetworkSection {
-    #[serde(default)]
-    additional_hosts: Vec<UserExtensionHost>,
+/// Closed-enum classification of a single pattern's rejection
+/// reason. Used by [`validate_pattern`] and carried as the `kind`
+/// field on [`InvalidPatternIssue`]. S3b's `doiget config doctor`
+/// surface branches on this for actionable per-error rendering.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PatternError {
+    /// Empty string.
+    #[error("empty pattern")]
+    Empty,
+    /// Leading or trailing whitespace.
+    #[error("pattern has leading or trailing whitespace")]
+    Whitespace,
+    /// Bare `*` with no leading-segment suffix.
+    #[error("bare wildcard `*` is not allowed")]
+    BareWildcard,
+    /// `*` appearing anywhere other than the very first character
+    /// followed by `.`.
+    #[error("wildcard `*` is only allowed as the first character followed by `.`")]
+    MisplacedWildcard,
+    /// Multi-segment glob (a second `*` after stripping `*.` prefix).
+    #[error("multi-segment globs are not allowed; use a single `*.<suffix>`")]
+    MultiSegmentGlob,
+    /// Nothing after the `*.` prefix (`*.` alone).
+    #[error("nothing after wildcard prefix `*.`")]
+    EmptySuffix,
+    /// No `.` in the host portion (single-label hostnames rejected).
+    #[error("host must contain at least one `.`")]
+    NoDot,
+    /// A label is empty (consecutive `.`s or leading/trailing `.`).
+    #[error("empty label (consecutive `.` or leading/trailing `.`)")]
+    EmptyLabel,
+    /// A label starts or ends with `-`.
+    #[error("label `{label}` starts or ends with `-`")]
+    LabelHyphenBorder {
+        /// The offending label.
+        label: String,
+    },
+    /// A label contains a character outside the allowed host charset.
+    #[error("label `{label}` contains a non-host character (allowed: A-Z a-z 0-9 - .)")]
+    BadChar {
+        /// The offending label.
+        label: String,
+    },
 }
 
 /// Errors from loading `config.toml`'s user-extension section.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum UserExtensionError {
-    /// Filesystem read failed (other than "not found", which is treated
-    /// as "no user extensions" — see [`load`]).
+    /// Filesystem read failed (other than "not found", which is
+    /// treated as "no user extensions" — see [`load`]).
     #[error("io reading {path}: {source}")]
     Io {
         /// The path we tried to read.
@@ -104,34 +205,52 @@ pub enum UserExtensionError {
         #[source]
         source: toml::de::Error,
     },
-    /// One of the `host` patterns failed grammar validation per
-    /// ADR-0028 D2-1.
-    #[error("invalid host pattern `{pattern}` in {path}: {reason}")]
-    InvalidPattern {
-        /// The path containing the offending entry.
+    /// One or more `host` patterns failed grammar validation per
+    /// ADR-0028 D2-1. The vec collects every offending entry so the
+    /// user sees all errors in a single pass rather than fixing them
+    /// one at a time (review pass I6).
+    #[error("invalid host pattern(s) in {path}: {issues:?}")]
+    InvalidPatterns {
+        /// The path containing the offending entries.
         path: String,
-        /// The pattern that did not validate.
-        pattern: String,
-        /// Human-readable reason.
-        reason: String,
+        /// All rejected patterns in this file.
+        issues: Vec<InvalidPatternIssue>,
     },
+}
+
+/// One per-entry rejection inside [`UserExtensionError::InvalidPatterns`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InvalidPatternIssue {
+    /// The raw pattern string from the TOML.
+    pub pattern: String,
+    /// Closed-enum rejection reason.
+    pub kind: PatternError,
+}
+
+impl std::fmt::Display for InvalidPatternIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "`{}`: {}", self.pattern, self.kind)
+    }
 }
 
 /// Load user-extension hosts from a `config.toml` path.
 ///
 /// Returns an empty `Vec` if the path does not exist (the user simply
-/// has not extended the gate). Returns `Err` only when the file exists
-/// but cannot be read, parsed, or contains an invalid pattern. The
-/// orchestrator is expected to log an `Err` as a warning and continue
-/// with the curated allowlist; failing the whole fetch on a malformed
-/// optional config would be hostile.
+/// has not extended the gate). Returns `Err` only when the file
+/// exists but cannot be read, parsed, or contains invalid pattern(s).
+///
+/// Every entry in the returned vec has its `host` already validated
+/// at the type level via [`HostPattern`].
 ///
 /// # Errors
 ///
-/// [`UserExtensionError::Io`] on filesystem error (other than not-found),
-/// [`UserExtensionError::Parse`] on malformed TOML, and
-/// [`UserExtensionError::InvalidPattern`] on the first entry that
-/// violates ADR-0028 D2-1.
+/// - [`UserExtensionError::Io`] for filesystem errors other than
+///   not-found.
+/// - [`UserExtensionError::Parse`] for malformed TOML.
+/// - [`UserExtensionError::InvalidPatterns`] for invalid patterns;
+///   the variant carries *every* offending entry, not just the first
+///   (review pass I6).
 pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
     let text = match std::fs::read_to_string(config_path.as_std_path()) {
         Ok(s) => s,
@@ -146,99 +265,139 @@ pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtens
     parse_str(&text, config_path)
 }
 
+/// Raw TOML shape used internally so we can collect every bad
+/// pattern in a single pass (vs failing on the first via
+/// `HostPattern`'s deserialize). The outer config / network tables
+/// tolerate unknown keys via `IgnoredAny`-flatten — the S3b full
+/// reader will own `deny_unknown_fields` on a complete schema.
+#[derive(Debug, Default, Deserialize)]
+struct RawConfig {
+    #[serde(default)]
+    network: Option<RawNetwork>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawNetwork {
+    #[serde(default)]
+    additional_hosts: Vec<RawHost>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+/// The `[[network.additional_hosts]]` table itself is the load-
+/// bearing schema and DOES forbid unknown keys — that's the level
+/// where typos like `hsot = "..."` should fail loudly.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHost {
+    host: String,
+    #[serde(default)]
+    note: Option<String>,
+}
+
 /// Parse a `config.toml` body string. Pure function; the path is used
-/// only for error messages. Useful in unit tests where we don't want
-/// to touch the filesystem.
+/// only for error messages.
 fn parse_str(
     text: &str,
     config_path: &Utf8Path,
 ) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
-    let cf: ConfigFile = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
+    let raw: RawConfig = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
         path: config_path.to_string(),
         source: e,
     })?;
-    let hosts = cf.network.unwrap_or_default().additional_hosts;
-    for h in &hosts {
-        validate_pattern(&h.host).map_err(|reason| UserExtensionError::InvalidPattern {
-            path: config_path.to_string(),
-            pattern: h.host.clone(),
-            reason,
-        })?;
+    let raw_hosts = raw.network.unwrap_or_default().additional_hosts;
+
+    // Two-phase: collect ALL invalid patterns rather than failing on
+    // the first. Saves the user an iterative edit-run-error cycle
+    // when migrating a large additional_hosts block (review pass I6).
+    let mut issues = Vec::new();
+    let mut validated = Vec::with_capacity(raw_hosts.len());
+    for raw_host in raw_hosts {
+        match HostPattern::new(raw_host.host.clone()) {
+            Ok(host) => validated.push(UserExtensionHost {
+                host,
+                note: raw_host.note,
+            }),
+            Err(kind) => issues.push(InvalidPatternIssue {
+                pattern: raw_host.host,
+                kind,
+            }),
+        }
     }
-    Ok(hosts)
+    if !issues.is_empty() {
+        return Err(UserExtensionError::InvalidPatterns {
+            path: config_path.to_string(),
+            issues,
+        });
+    }
+    Ok(validated)
 }
 
 /// Validate a host pattern per ADR-0028 D2-1.
 ///
 /// Accepted shapes:
 ///
-/// - Literal FQDN: `example.org`, `ruj.uj.edu.pl`. Must contain only
-///   `[A-Za-z0-9.-]`, with at least one `.` and no leading/trailing
-///   `.` or `-`.
+/// - Literal FQDN: `example.org`, `ruj.uj.edu.pl`. Only
+///   `[A-Za-z0-9.-]`, at least one `.`, no empty / hyphen-bordering
+///   labels.
 /// - Single-suffix wildcard: `*.example.org`. The `*` MUST be the
-///   *only* `*` in the pattern, MUST be at the very start, and MUST
-///   be followed by `.` and a valid FQDN.
-///
-/// Rejected shapes:
-///
-/// - Bare wildcard `*`.
-/// - Multi-segment globs `*.edu.*`, `*.*`.
-/// - Mid-string wildcards `foo.*.org`, `f*o.bar`.
-/// - Empty / whitespace-only.
-/// - Non-host characters (`@`, `/`, `:`, port suffixes, scheme prefix).
+///   first character, MUST be followed by `.`, and MUST be the only
+///   `*` in the pattern.
 ///
 /// # Errors
 ///
-/// Returns a human-readable reason on rejection. The caller wraps it in
-/// [`UserExtensionError::InvalidPattern`].
-pub fn validate_pattern(pattern: &str) -> Result<(), String> {
+/// Returns the closed-enum [`PatternError`] for any rejected input.
+pub fn validate_pattern(pattern: &str) -> Result<(), PatternError> {
     if pattern.is_empty() {
-        return Err("empty pattern".into());
+        return Err(PatternError::Empty);
     }
     if pattern.trim() != pattern {
-        return Err("leading or trailing whitespace".into());
+        return Err(PatternError::Whitespace);
     }
     if pattern == "*" {
-        return Err("bare wildcard `*` is not allowed".into());
+        return Err(PatternError::BareWildcard);
     }
-    // Split off a single leading `*.`, then require the remainder to be
-    // a valid FQDN with no further `*`.
     let body = match pattern.strip_prefix("*.") {
-        Some(rest) => rest,
+        Some(rest) => {
+            // A `*` in the body after stripping `*.` means a second
+            // wildcard (e.g. `*.edu.*` → body = `edu.*`).
+            if rest.contains('*') {
+                return Err(PatternError::MultiSegmentGlob);
+            }
+            rest
+        }
         None if pattern.contains('*') => {
-            return Err(
-                "wildcard `*` is only allowed as the first character followed by `.`".into(),
-            );
+            // A `*` not in leading `*.` position (e.g. `foo.*.org`,
+            // `f*o.bar`, `*foo.bar`).
+            return Err(PatternError::MisplacedWildcard);
         }
         None => pattern,
     };
     if body.is_empty() {
-        return Err("nothing after wildcard prefix `*.`".into());
-    }
-    if body.contains('*') {
-        return Err("multi-segment globs are not allowed; use a single `*.<suffix>`".into());
+        return Err(PatternError::EmptySuffix);
     }
     validate_fqdn(body)
 }
 
-/// `body` must look like a plausible FQDN: ASCII letters / digits /
-/// hyphens / dots, at least one dot, no empty labels, labels do not
-/// start or end with `-`.
-fn validate_fqdn(body: &str) -> Result<(), String> {
+fn validate_fqdn(body: &str) -> Result<(), PatternError> {
     if !body.contains('.') {
-        return Err("host must contain at least one `.`".into());
+        return Err(PatternError::NoDot);
     }
     for label in body.split('.') {
         if label.is_empty() {
-            return Err("empty label (consecutive `.` or leading/trailing `.`)".into());
+            return Err(PatternError::EmptyLabel);
         }
         if label.starts_with('-') || label.ends_with('-') {
-            return Err(format!("label `{label}` starts or ends with `-`"));
+            return Err(PatternError::LabelHyphenBorder {
+                label: label.to_string(),
+            });
         }
         if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-            return Err(format!(
-                "label `{label}` contains a non-host character (allowed: A-Z a-z 0-9 - .)"
-            ));
+            return Err(PatternError::BadChar {
+                label: label.to_string(),
+            });
         }
     }
     Ok(())
@@ -247,15 +406,16 @@ fn validate_fqdn(body: &str) -> Result<(), String> {
 /// Merge a slice of [`UserExtensionHost`] into the `oa-publisher`
 /// entry of an existing allowlist vector.
 ///
-/// If the vector already contains a `SourceAllowlist` with
-/// `source == "oa-publisher"`, the user hosts are appended to its
-/// `redirect_hosts`. Otherwise a new `oa-publisher` allowlist entry is
-/// pushed onto the vector. A no-op when `user_hosts` is empty.
+/// Duplicates are de-duplicated against the existing `redirect_hosts`
+/// to keep the host list minimal and the future `verified_by`
+/// provenance count honest (review pass I9). If the vector contains
+/// no `oa-publisher` entry, one is created.
+///
+/// A no-op when `user_hosts` is empty.
 ///
 /// The `note` field is intentionally dropped at the merge boundary —
-/// it is preserved on the [`UserExtensionHost`] passed to S3b's
-/// provenance plumbing, but the allowlist itself only needs the
-/// pattern string for matching.
+/// it remains on [`UserExtensionHost`] for S3b's provenance plumbing
+/// to consume from the same parsed vector.
 pub fn merge_into_allowlists(
     allowlists: &mut Vec<SourceAllowlist>,
     user_hosts: &[UserExtensionHost],
@@ -263,10 +423,21 @@ pub fn merge_into_allowlists(
     if user_hosts.is_empty() {
         return;
     }
-    let new_patterns: Vec<String> = user_hosts.iter().map(|h| h.host.clone()).collect();
     if let Some(oa) = allowlists.iter_mut().find(|a| a.source == "oa-publisher") {
-        oa.redirect_hosts.extend(new_patterns);
+        for h in user_hosts {
+            let s = h.host.as_str();
+            if !oa.redirect_hosts.iter().any(|p| p == s) {
+                oa.redirect_hosts.push(s.to_string());
+            }
+        }
         return;
+    }
+    let mut new_patterns: Vec<String> = Vec::with_capacity(user_hosts.len());
+    for h in user_hosts {
+        let s = h.host.as_str().to_string();
+        if !new_patterns.contains(&s) {
+            new_patterns.push(s);
+        }
     }
     allowlists.push(SourceAllowlist::new("oa-publisher", new_patterns));
 }
@@ -280,7 +451,7 @@ mod tests {
         Utf8Path::new(s)
     }
 
-    // ---- validate_pattern (ADR-0028 D2-1) ---------------------------
+    // ---- validate_pattern (typed PatternError) ----------------------
 
     #[test]
     fn validate_pattern_accepts_literal_fqdn() {
@@ -296,58 +467,117 @@ mod tests {
     }
 
     #[test]
-    fn validate_pattern_rejects_bare_wildcard() {
-        assert!(validate_pattern("*").is_err());
+    fn validate_pattern_rejects_empty() {
+        assert_eq!(validate_pattern(""), Err(PatternError::Empty));
     }
 
     #[test]
-    fn validate_pattern_rejects_multi_segment_glob() {
+    fn validate_pattern_rejects_whitespace() {
+        assert_eq!(validate_pattern("  example.org"), Err(PatternError::Whitespace));
+        assert_eq!(validate_pattern("example.org  "), Err(PatternError::Whitespace));
+    }
+
+    #[test]
+    fn validate_pattern_rejects_bare_wildcard() {
+        assert_eq!(validate_pattern("*"), Err(PatternError::BareWildcard));
+    }
+
+    #[test]
+    fn validate_pattern_rejects_multi_segment_globs() {
         for bad in ["*.edu.*", "*.ac.*", "*.*", "*.example.*"] {
-            let err = validate_pattern(bad).unwrap_err();
-            assert!(
-                err.contains("multi-segment") || err.contains("wildcard"),
-                "expected wildcard-related error for `{bad}`, got: {err}"
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::MultiSegmentGlob),
+                "{bad} should be MultiSegmentGlob"
             );
         }
     }
 
     #[test]
-    fn validate_pattern_rejects_mid_wildcard() {
+    fn validate_pattern_rejects_misplaced_wildcards() {
         for bad in ["foo.*.org", "f*o.bar", "*foo.bar"] {
-            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::MisplacedWildcard),
+                "{bad} should be MisplacedWildcard"
+            );
         }
     }
 
     #[test]
     fn validate_pattern_rejects_non_host_chars() {
         for bad in ["user@host.com", "host.com/", "host.com:80", "https://x.y"] {
-            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+            assert!(
+                matches!(
+                    validate_pattern(bad),
+                    Err(PatternError::BadChar { .. }) | Err(PatternError::EmptyLabel)
+                ),
+                "{bad} should be BadChar or EmptyLabel; got {:?}",
+                validate_pattern(bad)
+            );
         }
     }
 
     #[test]
     fn validate_pattern_rejects_no_dot() {
-        assert!(validate_pattern("singlelabel").is_err());
+        assert_eq!(validate_pattern("singlelabel"), Err(PatternError::NoDot));
     }
 
     #[test]
-    fn validate_pattern_rejects_empty_label() {
-        for bad in [".example.org", "example..org", "example.org.", ""] {
-            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+    fn validate_pattern_rejects_empty_label_classes() {
+        for bad in [".example.org", "example..org", "example.org."] {
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::EmptyLabel),
+                "{bad} should be EmptyLabel"
+            );
         }
     }
 
     #[test]
-    fn validate_pattern_rejects_label_starting_with_hyphen() {
-        assert!(validate_pattern("-foo.example.org").is_err());
-        assert!(validate_pattern("foo.-example.org").is_err());
-        assert!(validate_pattern("foo.example-.org").is_err());
+    fn validate_pattern_rejects_hyphen_bordering_labels() {
+        for (bad, label) in [
+            ("-foo.example.org", "-foo"),
+            ("foo.-example.org", "-example"),
+            ("foo.example-.org", "example-"),
+        ] {
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::LabelHyphenBorder {
+                    label: label.to_string()
+                }),
+                "{bad} should be LabelHyphenBorder({label})"
+            );
+        }
     }
 
     #[test]
-    fn validate_pattern_rejects_whitespace() {
-        assert!(validate_pattern("  example.org").is_err());
-        assert!(validate_pattern("example.org  ").is_err());
+    fn validate_pattern_rejects_empty_suffix_after_wildcard() {
+        assert_eq!(validate_pattern("*."), Err(PatternError::EmptySuffix));
+    }
+
+    // ---- HostPattern type ------------------------------------------
+
+    #[test]
+    fn host_pattern_new_validates() {
+        assert!(HostPattern::new("ruj.uj.edu.pl").is_ok());
+        assert_eq!(HostPattern::new(""), Err(PatternError::Empty));
+    }
+
+    #[test]
+    fn host_pattern_try_from_str_and_string() {
+        let from_str: HostPattern = "*.aps.org".try_into().expect("ok");
+        let from_string: HostPattern = String::from("*.aps.org").try_into().expect("ok");
+        assert_eq!(from_str, from_string);
+    }
+
+    #[test]
+    fn host_pattern_deserialize_validates() {
+        // The serde impl runs validate_pattern; an invalid value
+        // fails deserialisation (review pass C1 — the invariant is
+        // type-level, not only enforced post-deserialise).
+        let bad = toml::from_str::<HostPattern>("\"*.edu.*\"");
+        assert!(bad.is_err(), "TOML deserialize MUST validate the pattern");
     }
 
     // ---- parse_str -------------------------------------------------
@@ -367,12 +597,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_config_without_additional_hosts_returns_no_hosts() {
+    fn parse_config_with_unknown_network_fields_is_accepted() {
+        // S3b's full reader will own deny_unknown_fields on a
+        // complete schema; until then we tolerate the rest of the
+        // [network] table (`contact_email`, future `cooldown_ms`,
+        // etc.) so an existing user config still loads.
         let toml = r#"
             [network]
             contact_email = "x@y.org"
+            cooldown_ms = 250
         "#;
         assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_field_inside_additional_hosts_entry() {
+        // The [[network.additional_hosts]] table itself uses
+        // deny_unknown_fields, so typos like `hsot = "..."` surface
+        // as a parse error (review pass I5).
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "ruj.uj.edu.pl"
+            commet = "typo"
+        "#;
+        let err = parse_str(toml, p("config.toml")).expect_err("typo must fail");
+        assert!(matches!(err, UserExtensionError::Parse { .. }));
     }
 
     #[test]
@@ -384,7 +633,7 @@ mod tests {
         "#;
         let got = parse_str(toml, p("config.toml")).unwrap();
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
         assert_eq!(
             got[0].note.as_deref(),
             Some("Jagiellonian University Repository")
@@ -403,36 +652,50 @@ mod tests {
         "#;
         let got = parse_str(toml, p("config.toml")).unwrap();
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
         assert!(got[0].note.is_none());
-        assert_eq!(got[1].host, "*.aps.org");
+        assert_eq!(got[1].host.as_str(), "*.aps.org");
         assert_eq!(got[1].note.as_deref(), Some("user override"));
     }
 
     #[test]
-    fn parse_rejects_invalid_pattern_with_path_in_error() {
+    fn parse_collects_all_invalid_patterns_not_just_first() {
+        // Review pass I6: every offender appears in the error.
         let toml = r#"
             [[network.additional_hosts]]
             host = "*.edu.*"
+
+            [[network.additional_hosts]]
+            host = "ok.example.org"
+
+            [[network.additional_hosts]]
+            host = "user@host.com"
         "#;
         let err = parse_str(toml, p("/home/u/.config/doiget/config.toml"))
-            .expect_err("invalid pattern must error");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("*.edu.*"),
-            "error should mention the pattern, got: {msg}"
-        );
-        assert!(
-            msg.contains("/home/u/.config/doiget/config.toml"),
-            "error should mention the path, got: {msg}"
-        );
+            .expect_err("invalid patterns must error");
+        match err {
+            UserExtensionError::InvalidPatterns { path, issues } => {
+                assert_eq!(path, "/home/u/.config/doiget/config.toml");
+                assert_eq!(issues.len(), 2, "both bad patterns collected");
+                assert_eq!(issues[0].pattern, "*.edu.*");
+                assert_eq!(issues[0].kind, PatternError::MultiSegmentGlob);
+                assert_eq!(issues[1].pattern, "user@host.com");
+                assert!(matches!(
+                    issues[1].kind,
+                    PatternError::BadChar { .. } | PatternError::EmptyLabel
+                ));
+            }
+            other => panic!("expected InvalidPatterns, got {other:?}"),
+        }
     }
 
     #[test]
     fn parse_rejects_malformed_toml() {
-        // Missing closing `]`.
-        let err = parse_str("[[network.additional_hosts\nhost=\"foo\"", p("config.toml"))
-            .expect_err("malformed toml must error");
+        let err = parse_str(
+            "[[network.additional_hosts\nhost=\"foo\"",
+            p("config.toml"),
+        )
+        .expect_err("malformed toml must error");
         assert!(matches!(err, UserExtensionError::Parse { .. }));
     }
 
@@ -441,7 +704,9 @@ mod tests {
     #[test]
     fn load_returns_empty_when_file_missing() {
         let td = tempfile::TempDir::new().unwrap();
-        let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
+        let path = Utf8Path::from_path(td.path())
+            .unwrap()
+            .join("missing.toml");
         let got = load(&path).expect("missing file MUST be Ok(empty)");
         assert_eq!(got, vec![]);
     }
@@ -462,7 +727,7 @@ note = "Jagiellonian"
         .unwrap();
         let got = load(&path).expect("ok");
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
     }
 
     // ---- merge_into_allowlists -------------------------------------
@@ -473,7 +738,7 @@ note = "Jagiellonian"
             SourceAllowlist::new("crossref", vec!["api.crossref.org".into()]),
             SourceAllowlist::new("oa-publisher", vec!["pmc.ncbi.nlm.nih.gov".into()]),
         ];
-        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        let user_hosts = vec![UserExtensionHost::for_test("ruj.uj.edu.pl")];
         merge_into_allowlists(&mut allowlists, &user_hosts);
 
         let oa = allowlists
@@ -487,7 +752,6 @@ note = "Jagiellonian"
                 "ruj.uj.edu.pl".to_string()
             ]
         );
-        // crossref entry must remain untouched.
         assert_eq!(allowlists.len(), 2);
     }
 
@@ -497,7 +761,7 @@ note = "Jagiellonian"
             "crossref",
             vec!["api.crossref.org".into()],
         )];
-        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        let user_hosts = vec![UserExtensionHost::for_test("ruj.uj.edu.pl")];
         merge_into_allowlists(&mut allowlists, &user_hosts);
         assert_eq!(allowlists.len(), 2);
         let oa = allowlists
@@ -526,11 +790,42 @@ note = "Jagiellonian"
     }
 
     #[test]
+    fn merge_dedupes_against_existing_entries() {
+        // Review pass I9.
+        let mut allowlists = vec![SourceAllowlist::new(
+            "oa-publisher",
+            vec!["ruj.uj.edu.pl".into()],
+        )];
+        let user_hosts = vec![
+            UserExtensionHost::for_test("ruj.uj.edu.pl"),
+            UserExtensionHost::for_test("*.uj.edu.pl"),
+            UserExtensionHost::for_test("*.uj.edu.pl"),
+        ];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert_eq!(
+            oa.redirect_hosts,
+            vec!["ruj.uj.edu.pl".to_string(), "*.uj.edu.pl".to_string()]
+        );
+    }
+
+    #[test]
+    fn merge_dedupes_when_creating_new_entry() {
+        let mut allowlists = Vec::new();
+        let user_hosts = vec![
+            UserExtensionHost::for_test("ruj.uj.edu.pl"),
+            UserExtensionHost::for_test("ruj.uj.edu.pl"),
+        ];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+        assert_eq!(allowlists.len(), 1);
+        assert_eq!(allowlists[0].redirect_hosts, vec!["ruj.uj.edu.pl"]);
+    }
+
+    #[test]
     fn merged_pattern_is_matched_by_source_allowlist() {
-        // End-to-end: parse a wildcard, merge into allowlist, ask
-        // SourceAllowlist::matches() about a concrete host. This is the
-        // load-bearing assertion that user_extension + SourceAllowlist
-        // compose correctly.
         let parsed = parse_str(
             r#"
 [[network.additional_hosts]]
@@ -545,17 +840,8 @@ host = "*.uj.edu.pl"
             .iter()
             .find(|a| a.source == "oa-publisher")
             .unwrap();
-        assert!(
-            oa.matches("ruj.uj.edu.pl"),
-            "wildcard `*.uj.edu.pl` MUST match `ruj.uj.edu.pl`"
-        );
-        assert!(
-            oa.matches("alpha.uj.edu.pl"),
-            "wildcard must also match other subdomains"
-        );
-        assert!(
-            !oa.matches("ruj.uj.edu.ru"),
-            "wildcard MUST NOT match other suffixes"
-        );
+        assert!(oa.matches("ruj.uj.edu.pl"));
+        assert!(oa.matches("alpha.uj.edu.pl"));
+        assert!(!oa.matches("ruj.uj.edu.ru"));
     }
 }

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -1,0 +1,561 @@
+//! User-extensible capability gate (ADR-0028, #220).
+//!
+//! Parses the `[[network.additional_hosts]]` array-of-tables from the
+//! user's `config.toml`, validates each entry against the restricted
+//! pattern grammar (literal FQDN or single-suffix wildcard `*.foo.bar`),
+//! and exposes a helper that merges the user-added hosts into the
+//! orchestrator's `oa-publisher` [`crate::http::SourceAllowlist`].
+//!
+//! This module is intentionally minimal: it does NOT layer config.toml
+//! with env vars or implement the full `docs/CONFIG.md` resolution
+//! ladder. The full reader is a separate slice (S3b); this slice ships
+//! only the surface needed for ADR-0028 D2 (user-extensible allowlist).
+//!
+//! # Wire contract (ADR-0028 D2-1)
+//!
+//! ```toml
+//! [[network.additional_hosts]]
+//! host = "ruj.uj.edu.pl"
+//! note = "Jagiellonian University Repository — Green OA"
+//!
+//! [[network.additional_hosts]]
+//! host = "*.uj.edu.pl"          # single-suffix wildcard, allowed
+//!
+//! # Rejected at parse time:
+//! # [[network.additional_hosts]]
+//! # host = "*.edu.*"            # multi-segment glob — rejected
+//! # host = "*"                  # bare wildcard — rejected
+//! # host = "user@host.com"      # `@` not in host charset
+//! ```
+//!
+//! # Provenance & doctor (deferred to S3b)
+//!
+//! ADR-0028 D2-2 / D2-3 / D2-4 (the `verified_by = "user"` provenance
+//! field, `config doctor` surface, `capabilities` count) ship in the
+//! S3b follow-up; this slice is purely the **data path** so a user's
+//! `ruj.uj.edu.pl` actually passes the redirect-allowlist gate.
+
+use camino::Utf8Path;
+use serde::Deserialize;
+
+use crate::http::SourceAllowlist;
+
+/// One user-added host entry from `[[network.additional_hosts]]`.
+///
+/// The `note` field is free-text user documentation (e.g. "Jagiellonian
+/// University Repository — Green OA"); it is recorded in the
+/// provenance log alongside the host but never used for matching.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[non_exhaustive]
+pub struct UserExtensionHost {
+    /// The host pattern. Either a literal FQDN (`example.org`) or a
+    /// single-suffix wildcard (`*.example.org`). Validated by
+    /// [`validate_pattern`] before this struct reaches a caller.
+    pub host: String,
+    /// Optional free-text note. Surfaced by `doiget config doctor`
+    /// (S3b) but never consulted for matching.
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+impl UserExtensionHost {
+    /// Construct a new entry with no note. Used by tests; production
+    /// callers go through [`load`].
+    #[doc(hidden)]
+    pub fn new(host: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            note: None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ConfigFile {
+    #[serde(default)]
+    network: Option<NetworkSection>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NetworkSection {
+    #[serde(default)]
+    additional_hosts: Vec<UserExtensionHost>,
+}
+
+/// Errors from loading `config.toml`'s user-extension section.
+#[derive(Debug, thiserror::Error)]
+pub enum UserExtensionError {
+    /// Filesystem read failed (other than "not found", which is treated
+    /// as "no user extensions" — see [`load`]).
+    #[error("io reading {path}: {source}")]
+    Io {
+        /// The path we tried to read.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// TOML deserialisation failed (malformed file).
+    #[error("toml parse of {path}: {source}")]
+    Parse {
+        /// The path that failed to parse.
+        path: String,
+        /// The underlying TOML deserialiser error.
+        #[source]
+        source: toml::de::Error,
+    },
+    /// One of the `host` patterns failed grammar validation per
+    /// ADR-0028 D2-1.
+    #[error("invalid host pattern `{pattern}` in {path}: {reason}")]
+    InvalidPattern {
+        /// The path containing the offending entry.
+        path: String,
+        /// The pattern that did not validate.
+        pattern: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+}
+
+/// Load user-extension hosts from a `config.toml` path.
+///
+/// Returns an empty `Vec` if the path does not exist (the user simply
+/// has not extended the gate). Returns `Err` only when the file exists
+/// but cannot be read, parsed, or contains an invalid pattern. The
+/// orchestrator is expected to log an `Err` as a warning and continue
+/// with the curated allowlist; failing the whole fetch on a malformed
+/// optional config would be hostile.
+///
+/// # Errors
+///
+/// [`UserExtensionError::Io`] on filesystem error (other than not-found),
+/// [`UserExtensionError::Parse`] on malformed TOML, and
+/// [`UserExtensionError::InvalidPattern`] on the first entry that
+/// violates ADR-0028 D2-1.
+pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
+    let text = match std::fs::read_to_string(config_path.as_std_path()) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(UserExtensionError::Io {
+                path: config_path.to_string(),
+                source: e,
+            })
+        }
+    };
+    parse_str(&text, config_path)
+}
+
+/// Parse a `config.toml` body string. Pure function; the path is used
+/// only for error messages. Useful in unit tests where we don't want
+/// to touch the filesystem.
+fn parse_str(
+    text: &str,
+    config_path: &Utf8Path,
+) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
+    let cf: ConfigFile = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
+        path: config_path.to_string(),
+        source: e,
+    })?;
+    let hosts = cf.network.unwrap_or_default().additional_hosts;
+    for h in &hosts {
+        validate_pattern(&h.host).map_err(|reason| UserExtensionError::InvalidPattern {
+            path: config_path.to_string(),
+            pattern: h.host.clone(),
+            reason,
+        })?;
+    }
+    Ok(hosts)
+}
+
+/// Validate a host pattern per ADR-0028 D2-1.
+///
+/// Accepted shapes:
+///
+/// - Literal FQDN: `example.org`, `ruj.uj.edu.pl`. Must contain only
+///   `[A-Za-z0-9.-]`, with at least one `.` and no leading/trailing
+///   `.` or `-`.
+/// - Single-suffix wildcard: `*.example.org`. The `*` MUST be the
+///   *only* `*` in the pattern, MUST be at the very start, and MUST
+///   be followed by `.` and a valid FQDN.
+///
+/// Rejected shapes:
+///
+/// - Bare wildcard `*`.
+/// - Multi-segment globs `*.edu.*`, `*.*`.
+/// - Mid-string wildcards `foo.*.org`, `f*o.bar`.
+/// - Empty / whitespace-only.
+/// - Non-host characters (`@`, `/`, `:`, port suffixes, scheme prefix).
+///
+/// # Errors
+///
+/// Returns a human-readable reason on rejection. The caller wraps it in
+/// [`UserExtensionError::InvalidPattern`].
+pub fn validate_pattern(pattern: &str) -> Result<(), String> {
+    if pattern.is_empty() {
+        return Err("empty pattern".into());
+    }
+    if pattern.trim() != pattern {
+        return Err("leading or trailing whitespace".into());
+    }
+    if pattern == "*" {
+        return Err("bare wildcard `*` is not allowed".into());
+    }
+    // Split off a single leading `*.`, then require the remainder to be
+    // a valid FQDN with no further `*`.
+    let body = match pattern.strip_prefix("*.") {
+        Some(rest) => rest,
+        None if pattern.contains('*') => {
+            return Err(
+                "wildcard `*` is only allowed as the first character followed by `.`".into(),
+            );
+        }
+        None => pattern,
+    };
+    if body.is_empty() {
+        return Err("nothing after wildcard prefix `*.`".into());
+    }
+    if body.contains('*') {
+        return Err("multi-segment globs are not allowed; use a single `*.<suffix>`".into());
+    }
+    validate_fqdn(body)
+}
+
+/// `body` must look like a plausible FQDN: ASCII letters / digits /
+/// hyphens / dots, at least one dot, no empty labels, labels do not
+/// start or end with `-`.
+fn validate_fqdn(body: &str) -> Result<(), String> {
+    if !body.contains('.') {
+        return Err("host must contain at least one `.`".into());
+    }
+    for label in body.split('.') {
+        if label.is_empty() {
+            return Err("empty label (consecutive `.` or leading/trailing `.`)".into());
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(format!("label `{label}` starts or ends with `-`"));
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(format!(
+                "label `{label}` contains a non-host character (allowed: A-Z a-z 0-9 - .)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Merge a slice of [`UserExtensionHost`] into the `oa-publisher`
+/// entry of an existing allowlist vector.
+///
+/// If the vector already contains a `SourceAllowlist` with
+/// `source == "oa-publisher"`, the user hosts are appended to its
+/// `redirect_hosts`. Otherwise a new `oa-publisher` allowlist entry is
+/// pushed onto the vector. A no-op when `user_hosts` is empty.
+///
+/// The `note` field is intentionally dropped at the merge boundary —
+/// it is preserved on the [`UserExtensionHost`] passed to S3b's
+/// provenance plumbing, but the allowlist itself only needs the
+/// pattern string for matching.
+pub fn merge_into_allowlists(
+    allowlists: &mut Vec<SourceAllowlist>,
+    user_hosts: &[UserExtensionHost],
+) {
+    if user_hosts.is_empty() {
+        return;
+    }
+    let new_patterns: Vec<String> = user_hosts.iter().map(|h| h.host.clone()).collect();
+    if let Some(oa) = allowlists.iter_mut().find(|a| a.source == "oa-publisher") {
+        oa.redirect_hosts.extend(new_patterns);
+        return;
+    }
+    allowlists.push(SourceAllowlist::new("oa-publisher", new_patterns));
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> &Utf8Path {
+        Utf8Path::new(s)
+    }
+
+    // ---- validate_pattern (ADR-0028 D2-1) ---------------------------
+
+    #[test]
+    fn validate_pattern_accepts_literal_fqdn() {
+        assert!(validate_pattern("ruj.uj.edu.pl").is_ok());
+        assert!(validate_pattern("example.org").is_ok());
+        assert!(validate_pattern("a.b.c.d.e").is_ok());
+    }
+
+    #[test]
+    fn validate_pattern_accepts_single_suffix_wildcard() {
+        assert!(validate_pattern("*.uj.edu.pl").is_ok());
+        assert!(validate_pattern("*.aps.org").is_ok());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_bare_wildcard() {
+        assert!(validate_pattern("*").is_err());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_multi_segment_glob() {
+        for bad in ["*.edu.*", "*.ac.*", "*.*", "*.example.*"] {
+            let err = validate_pattern(bad).unwrap_err();
+            assert!(
+                err.contains("multi-segment") || err.contains("wildcard"),
+                "expected wildcard-related error for `{bad}`, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_mid_wildcard() {
+        for bad in ["foo.*.org", "f*o.bar", "*foo.bar"] {
+            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_non_host_chars() {
+        for bad in ["user@host.com", "host.com/", "host.com:80", "https://x.y"] {
+            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_no_dot() {
+        assert!(validate_pattern("singlelabel").is_err());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_empty_label() {
+        for bad in [".example.org", "example..org", "example.org.", ""] {
+            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_label_starting_with_hyphen() {
+        assert!(validate_pattern("-foo.example.org").is_err());
+        assert!(validate_pattern("foo.-example.org").is_err());
+        assert!(validate_pattern("foo.example-.org").is_err());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_whitespace() {
+        assert!(validate_pattern("  example.org").is_err());
+        assert!(validate_pattern("example.org  ").is_err());
+    }
+
+    // ---- parse_str -------------------------------------------------
+
+    #[test]
+    fn parse_empty_config_returns_no_hosts() {
+        assert_eq!(parse_str("", p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_config_without_network_section_returns_no_hosts() {
+        let toml = r#"
+            [store]
+            root = "/tmp"
+        "#;
+        assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_config_without_additional_hosts_returns_no_hosts() {
+        let toml = r#"
+            [network]
+            contact_email = "x@y.org"
+        "#;
+        assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_one_literal_host_with_note() {
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "ruj.uj.edu.pl"
+            note = "Jagiellonian University Repository"
+        "#;
+        let got = parse_str(toml, p("config.toml")).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(
+            got[0].note.as_deref(),
+            Some("Jagiellonian University Repository")
+        );
+    }
+
+    #[test]
+    fn parse_multiple_hosts_mixed_literal_and_wildcard() {
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "ruj.uj.edu.pl"
+
+            [[network.additional_hosts]]
+            host = "*.aps.org"
+            note = "user override"
+        "#;
+        let got = parse_str(toml, p("config.toml")).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert!(got[0].note.is_none());
+        assert_eq!(got[1].host, "*.aps.org");
+        assert_eq!(got[1].note.as_deref(), Some("user override"));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_pattern_with_path_in_error() {
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "*.edu.*"
+        "#;
+        let err = parse_str(toml, p("/home/u/.config/doiget/config.toml"))
+            .expect_err("invalid pattern must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("*.edu.*"),
+            "error should mention the pattern, got: {msg}"
+        );
+        assert!(
+            msg.contains("/home/u/.config/doiget/config.toml"),
+            "error should mention the path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_toml() {
+        // Missing closing `]`.
+        let err = parse_str("[[network.additional_hosts\nhost=\"foo\"", p("config.toml"))
+            .expect_err("malformed toml must error");
+        assert!(matches!(err, UserExtensionError::Parse { .. }));
+    }
+
+    // ---- load -------------------------------------------------------
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let td = tempfile::TempDir::new().unwrap();
+        let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
+        let got = load(&path).expect("missing file MUST be Ok(empty)");
+        assert_eq!(got, vec![]);
+    }
+
+    #[test]
+    fn load_reads_real_file() {
+        use std::io::Write;
+        let td = tempfile::TempDir::new().unwrap();
+        let path = Utf8Path::from_path(td.path()).unwrap().join("config.toml");
+        let mut f = std::fs::File::create(path.as_std_path()).unwrap();
+        f.write_all(
+            br#"
+[[network.additional_hosts]]
+host = "ruj.uj.edu.pl"
+note = "Jagiellonian"
+"#,
+        )
+        .unwrap();
+        let got = load(&path).expect("ok");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+    }
+
+    // ---- merge_into_allowlists -------------------------------------
+
+    #[test]
+    fn merge_appends_to_existing_oa_publisher_entry() {
+        let mut allowlists = vec![
+            SourceAllowlist::new("crossref", vec!["api.crossref.org".into()]),
+            SourceAllowlist::new("oa-publisher", vec!["pmc.ncbi.nlm.nih.gov".into()]),
+        ];
+        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert_eq!(
+            oa.redirect_hosts,
+            vec![
+                "pmc.ncbi.nlm.nih.gov".to_string(),
+                "ruj.uj.edu.pl".to_string()
+            ]
+        );
+        // crossref entry must remain untouched.
+        assert_eq!(allowlists.len(), 2);
+    }
+
+    #[test]
+    fn merge_creates_oa_publisher_entry_if_missing() {
+        let mut allowlists = vec![SourceAllowlist::new(
+            "crossref",
+            vec!["api.crossref.org".into()],
+        )];
+        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+        assert_eq!(allowlists.len(), 2);
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert_eq!(oa.redirect_hosts, vec!["ruj.uj.edu.pl".to_string()]);
+    }
+
+    #[test]
+    fn merge_is_noop_on_empty_user_hosts() {
+        let mut allowlists = vec![SourceAllowlist::new(
+            "crossref",
+            vec!["api.crossref.org".into()],
+        )];
+        let snapshot: Vec<(String, Vec<String>)> = allowlists
+            .iter()
+            .map(|a| (a.source.clone(), a.redirect_hosts.clone()))
+            .collect();
+        merge_into_allowlists(&mut allowlists, &[]);
+        let after: Vec<(String, Vec<String>)> = allowlists
+            .iter()
+            .map(|a| (a.source.clone(), a.redirect_hosts.clone()))
+            .collect();
+        assert_eq!(snapshot, after);
+    }
+
+    #[test]
+    fn merged_pattern_is_matched_by_source_allowlist() {
+        // End-to-end: parse a wildcard, merge into allowlist, ask
+        // SourceAllowlist::matches() about a concrete host. This is the
+        // load-bearing assertion that user_extension + SourceAllowlist
+        // compose correctly.
+        let parsed = parse_str(
+            r#"
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+"#,
+            p("config.toml"),
+        )
+        .unwrap();
+        let mut allowlists = vec![SourceAllowlist::new("oa-publisher", vec![])];
+        merge_into_allowlists(&mut allowlists, &parsed);
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert!(
+            oa.matches("ruj.uj.edu.pl"),
+            "wildcard `*.uj.edu.pl` MUST match `ruj.uj.edu.pl`"
+        );
+        assert!(
+            oa.matches("alpha.uj.edu.pl"),
+            "wildcard must also match other subdomains"
+        );
+        assert!(
+            !oa.matches("ruj.uj.edu.ru"),
+            "wildcard MUST NOT match other suffixes"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**S3a = data path of ADR-0028 D2.** Users can now extend the `oa-publisher` redirect allowlist for their own deployment via `[[network.additional_hosts]]` in `<config_dir>/doiget/config.toml`, unblocking real-world Green-OA dogfood cases where the curated set cannot reasonably enumerate every institutional repository (`ruj.uj.edu.pl`, `*.uj.edu.pl`, etc.).

## What landed

### New module: `doiget_core::user_extension`

```rust
pub struct UserExtensionHost { pub host: String, pub note: Option<String> }

pub fn load(path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtensionError>;
pub fn validate_pattern(s: &str) -> Result<(), String>;
pub fn merge_into_allowlists(allowlists: &mut Vec<SourceAllowlist>, hosts: &[UserExtensionHost]);
```

### Pattern grammar (ADR-0028 D2-1) enforced at parse time

| Pattern | Accepted? |
|---|---|
| `ruj.uj.edu.pl` (literal FQDN) | yes |
| `*.uj.edu.pl` (single-suffix wildcard) | yes |
| `*.edu.*` (multi-segment glob) | **rejected** |
| `*` (bare wildcard) | **rejected** |
| `foo.*.org` (mid-string wildcard) | **rejected** |
| `*foo.bar` (wildcard without dot) | **rejected** |
| `user@host.com` (non-host char) | **rejected** |
| `host.com/`, `host.com:80`, `https://x.y` | **rejected** |
| `singlelabel` (no dot) | **rejected** |
| `-foo.bar` / `foo.-bar` (leading hyphen) | **rejected** |
| `.foo.bar` / `foo..bar` / `foo.bar.` (empty label) | **rejected** |

### Example user config

```toml
# ~/.config/doiget/config.toml
[[network.additional_hosts]]
host = \"ruj.uj.edu.pl\"
note = \"Jagiellonian University Repository — Green OA\"

[[network.additional_hosts]]
host = \"*.uj.edu.pl\"
```

### Wiring

`commands::fetch::build_http_client` now reads `<config_dir>/doiget/config.toml` (the same path the existing `config_dir_utf8()` resolver returns) on every production HttpClient construction:

- **Missing file**: normal case (silent, no warning, no log line).
- **Has additional_hosts**: `tracing::info!` records count + path, then merges into the `oa-publisher` allowlist alongside the curated set.
- **Malformed file or invalid pattern**: `tracing::warn!` to stderr identifying the path + error, then continues with the curated allowlist (ADR-0028 D2 frames user-extension as opt-in convenience; never abort the fetch).

## What is OUT of scope for this slice (S3b follow-up)

- `verified_by = \"user\"` provenance row field (ADR-0028 D2-2)
- `doiget config doctor` surface (D2-3)
- `capability_gate.user_extension_count` field in `doiget capabilities` JSON (D2-4)
- MCP-server-side merge (`doiget-mcp/src/lib.rs:2044`)

Each is mechanical once this data path lands and gets review feedback.

## Tests

- **23 new unit tests** in `doiget_core::user_extension::tests`:
  - 10 `validate_pattern_*` cases covering every rejection class
  - 7 `parse_*` cases including malformed TOML + invalid pattern with path-in-error
  - 2 `load_*` cases including missing-file = `Ok(empty)`
  - 4 `merge_*` cases including end-to-end \"wildcard parsed -> merged -> matched by SourceAllowlist\"
- **249 total `doiget-core` lib tests** pass (23 new + 226 pre-existing)
- **56 `doiget-cli` lib tests** continue to pass
- `cargo fmt --check` clean
- `cargo clippy --all-features --no-deps` clean (10 pre-existing warnings on doiget-core, unchanged)
- `scripts/release-version-gate.sh v0.4.1-beta.4 --offline-skip-crates-io` G0/G1/G2/G5/G6 PASS

## Parallel slice coordination

| Slice | Branch | Version | Status |
|---|---|---|---|
| S1 | `fix/219-capabilities-cold-boot` | `0.4.1-beta.2` | **merged into `next`** |
| S2 | `fix/220-http-https-upgrade` | `0.4.1-beta.3` | PR #226, pending |
| **S3a (this PR)** | `fix/220-additional-hosts` | `0.4.1-beta.4` | this PR |

Both this PR and PR #226 touch `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` — whoever merges second will rebase trivially (different sections of each file).

## Test plan

- [ ] CI green on `next` branch protection
- [ ] `version-check` advisory job green for prospective tag `v0.4.1-beta.4` (lane: beta)
- [ ] All 23 new unit tests pass on ubuntu / macos / windows
- [ ] After merge: dogfood with a real `config.toml` + `ruj.uj.edu.pl` to confirm a Green-OA fetch that previously failed with `CAPABILITY_DENIED` now succeeds
- [ ] After merge: open S3b (provenance verified_by + doctor + capabilities count + MCP-server merge)

Refs #220 (the user-extensible-allowlist portion; capabilities cold-boot was S1 / PR #225 — already merged; http->https upgrade is S2 / PR #226 — still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)