### PR TITLE
feat(mcp/cli): S3b — user-extension allowlist surfaces (ADR-0028 D2, refs #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.10] - 2026-05-21
+
+### Added
+
+- **[mcp]** MCP-server `build_http_client_for_fetch` now merges
+  user-extension hosts from `<config_dir>/doiget/config.toml` per
+  ADR-0028 D2, mirroring the CLI path that landed in beta.8 (#220).
+  Before this slice, a user who configured
+  `[[network.additional_hosts]]` and invoked via `doiget serve`
+  saw no effect — only `doiget fetch` honored the extension. The
+  MCP merge closes that asymmetry; both surfaces now read the same
+  config file with identical failure handling (silent on
+  not-found, `tracing::warn!` on malformed, curated allowlist
+  continues regardless).
+
+- **[cli]** `doiget config doctor` adds a user-extension health
+  check (ADR-0028 D2-3): on a green run the new line reads
+  `[ ok ] user-extension hosts loaded: N`; on a malformed
+  `config.toml` it emits `[FAIL] user-extension config invalid:
+  <error>` and exits 2. A missing `config.toml` is normal (count
+  = 0, no failure) — the user simply has not extended the gate.
+
+- **[cli]** `doiget capabilities` JSON gains a top-level
+  `user_extension_count: usize` field (ADR-0028 D2-4) so an LLM
+  cold-booted into doiget can confirm at a glance whether the
+  curated allowlist has been extended on this host. The field
+  counts valid `[[network.additional_hosts]]` entries; parse
+  errors collapse to `0` (use `doiget config doctor` to
+  diagnose). `Capabilities` is `#[non_exhaustive]`, so adding the
+  field is additive for downstream Rust consumers; JSON consumers
+  should ignore unknown fields.
+
+### Changed
+
+- **[cli]** `commands::fetch::config_dir_utf8` lifted from private
+  to `pub(crate)` so sibling modules
+  (`commands::capabilities`, `commands::config`) resolve the same
+  `<config_dir>/doiget/` path the production HTTP-client builder
+  reads from. No behavior change.
+
+### Notes
+
+- Out of scope for this slice (still tracked under #220 / ADR-0028):
+  the `verified_by = "user"` provenance row field (D2-2). That
+  requires allowlist source-attribution plumbing through the
+  redirect closure and is deferred to a follow-up slice.
+
 ## [0.4.1-beta.9] - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.9"
+version = "0.4.1-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.9"
+version = "0.4.1-beta.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.9"
+version = "0.4.1-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.9"
+version       = "0.4.1-beta.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -66,6 +66,13 @@ pub struct Capabilities {
     pub mcp_tools: &'static [McpTool],
     /// Canonical doc paths an LLM can pull for deeper context.
     pub docs: Docs,
+    /// Number of user-extension allowlist hosts loaded from
+    /// `<config_dir>/doiget/config.toml` per ADR-0028 D2. `0` if the
+    /// config file is missing, contains no `[[network.additional_hosts]]`,
+    /// or fails to parse — run `doiget config doctor` to diagnose parse
+    /// failures. Exposed so an LLM can confirm at cold-boot whether the
+    /// curated allowlist has been extended on this host.
+    pub user_extension_count: usize,
 }
 
 /// What kind of value (if any) a [`FlagSpec`] carries.
@@ -515,6 +522,24 @@ pub fn build_capabilities(cli: &clap::Command) -> Capabilities {
         env_vars: ENV_VARS,
         mcp_tools: MCP_TOOLS,
         docs: DOCS,
+        user_extension_count: user_extension_count(),
+    }
+}
+
+/// Count valid `[[network.additional_hosts]]` entries in
+/// `<config_dir>/doiget/config.toml` (ADR-0028 D2). Returns `0` on any
+/// failure — missing config, parse error, unresolvable config dir.
+/// Diagnose failures via `doiget config doctor`; here we only need a
+/// best-effort cold-boot signal for the inventory.
+fn user_extension_count() -> usize {
+    let cfg_dir = match super::fetch::config_dir_utf8() {
+        Ok(p) => p,
+        Err(_) => return 0,
+    };
+    let path = cfg_dir.join("doiget").join("config.toml");
+    match doiget_core::user_extension::load(&path) {
+        Ok(hosts) => hosts.len(),
+        Err(_) => 0,
     }
 }
 
@@ -822,6 +847,7 @@ mod tests {
             "env_vars",
             "mcp_tools",
             "docs",
+            "user_extension_count",
         ] {
             assert!(
                 v.get(key).is_some(),
@@ -1008,6 +1034,94 @@ mod tests {
     #[test]
     fn version_is_cargo_pkg_version() {
         assert_eq!(caps().version, env!("CARGO_PKG_VERSION"));
+    }
+
+    /// ADR-0028 D2: `user_extension_count` must reflect the number of
+    /// `[[network.additional_hosts]]` entries actually present in
+    /// `<config_dir>/doiget/config.toml`. The test points every
+    /// config-dir env var at a tempdir, writes a 2-host config, and
+    /// asserts the inventory reports `2`. Drift here would silently
+    /// hide user-curated allowlist hosts from the cold-boot JSON.
+    #[test]
+    #[serial_test::serial]
+    fn user_extension_count_reflects_config_toml_entries() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        let config_toml = doiget_dir.join("config.toml");
+        std::fs::write(
+            config_toml.as_std_path(),
+            "[[network.additional_hosts]]\n\
+             host = \"example.org\"\n\
+             \n\
+             [[network.additional_hosts]]\n\
+             host = \"*.example.net\"\n\
+             note = \"university OA mirror\"\n",
+        )
+        .expect("write config.toml");
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let _a = EnvGuard::unset("APPDATA");
+        let _h = EnvGuard::unset("HOME");
+        let _u = EnvGuard::unset("USERPROFILE");
+
+        let cli = test_cli();
+        let caps = build_capabilities(&cli);
+        assert_eq!(
+            caps.user_extension_count, 2,
+            "expected 2 user-extension hosts, got {}",
+            caps.user_extension_count
+        );
+    }
+
+    /// Companion: with no config file (and a resolvable config dir),
+    /// the count is `0` — the curated allowlist is the entire surface.
+    /// Confirms the `Ok(vec![])` not-found path in `user_extension::load`
+    /// flows through unchanged.
+    #[test]
+    #[serial_test::serial]
+    fn user_extension_count_is_zero_without_config_toml() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let _a = EnvGuard::unset("APPDATA");
+        let _h = EnvGuard::unset("HOME");
+        let _u = EnvGuard::unset("USERPROFILE");
+
+        let caps = build_capabilities(&test_cli());
+        assert_eq!(caps.user_extension_count, 0);
+    }
+
+    /// Minimal env-guard local to this tests module; mirrors the
+    /// pattern in `commands::config::tests` (each module keeps its
+    /// own copy so they stay leaf-level cheap).
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
+        }
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -173,6 +173,25 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                 cfg.contact_email.is_some(),
                 &mut all_ok,
             );
+            // ADR-0028 D2: surface user-extension allowlist health. A
+            // missing config.toml is normal (curated set only); a
+            // present-but-malformed config.toml is a doctor failure so
+            // the operator finds out before fetch attempts silently
+            // skip the extension path. `user_extension::load` returns
+            // `Ok(vec![])` for not-found, so the OK arm always reports
+            // a count.
+            match doiget_core::user_extension::load(&cfg.config_path) {
+                Ok(hosts) => check(
+                    &format!("user-extension hosts loaded: {}", hosts.len()),
+                    true,
+                    &mut all_ok,
+                ),
+                Err(e) => check(
+                    &format!("user-extension config invalid: {e}"),
+                    false,
+                    &mut all_ok,
+                ),
+            }
             // Trying to actually create the dirs would have side-effects;
             // keep doctor read-only and just check existence of parents.
             if !all_ok {
@@ -351,6 +370,49 @@ mod tests {
         // every supported test host (CI runners always have $HOME).
         run("doctor".into(), crate::commands::output::OutputMode::Human)
             .expect("doctor should pass with contact email + real home dir");
+    }
+
+    /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`
+    /// causes `doiget config doctor` to FAIL (exit 2). POSIX-only
+    /// because `dirs::config_dir()` on Windows queries the Known
+    /// Folder API directly (ignores APPDATA env), so the test can't
+    /// redirect the config path in a child process the way it can
+    /// via `XDG_CONFIG_HOME` on POSIX. The malformed-config FAIL
+    /// path is platform-independent; this test covers the wiring
+    /// on the platform where it CAN be exercised.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn doctor_fails_with_malformed_user_extension_config() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        let config_toml = doiget_dir.join("config.toml");
+        // Empty `host` value triggers `PatternError::Empty`, which
+        // the doctor surfaces as a FAIL. `note` is valid TOML so the
+        // top-level parse succeeds — only the pattern validation
+        // path produces the error we're pinning.
+        std::fs::write(
+            config_toml.as_std_path(),
+            "[[network.additional_hosts]]\nhost = \"\"\n",
+        )
+        .expect("write config.toml");
+
+        // POSIX `dirs::config_dir()` honors `XDG_CONFIG_HOME` first,
+        // so pointing it at our tempdir routes `cfg.config_path` to
+        // our crafted file.
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+
+        let err = run("doctor".into(), crate::commands::output::OutputMode::Human)
+            .expect_err("doctor should fail when user-extension config is malformed");
+        let cli_exit = err
+            .downcast_ref::<CliExit>()
+            .expect("failing doctor must carry a CliExit");
+        assert_eq!(cli_exit.0, 2);
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -134,7 +134,14 @@ fn home_dir_utf8() -> Result<Utf8PathBuf> {
 
 /// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
 /// (POSIX), then `APPDATA` (Windows), then falls back to `$HOME/.config`.
-fn config_dir_utf8() -> Result<Utf8PathBuf> {
+///
+/// Crate-visible so sibling modules (`commands::capabilities`,
+/// `commands::config`) can resolve the same `<config_dir>/doiget/`
+/// path the production HTTP-client builder reads from. Keep the
+/// signature stable: any divergence between this and the MCP-side
+/// copy (`crates/doiget-mcp/src/lib.rs::config_dir_utf8`) would
+/// silently desync the user-extension allowlist surfaces.
+pub(crate) fn config_dir_utf8() -> Result<Utf8PathBuf> {
     if let Some(s) = read_env_utf8("XDG_CONFIG_HOME")? {
         return Ok(Utf8PathBuf::from(s));
     }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2050,6 +2050,51 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
         // including the hosts here cannot widen the network surface
         // beyond what the CapabilityProfile already permits.
         allowlists.extend(tier_2_allowlist());
+
+        // ADR-0028 D2: merge user-extension hosts from
+        // `<config_dir>/doiget/config.toml`. Mirrors the CLI path in
+        // `crates/doiget-cli/src/commands/fetch.rs::build_http_client`
+        // so the MCP server sees the same user-curated allowlist
+        // additions. Failure handling matches the CLI:
+        //   - missing config (file not found) is silent (Ok-empty);
+        //   - malformed config emits `tracing::warn!` and continues
+        //     with the curated allowlist;
+        //   - unresolvable config dir emits `tracing::debug!`.
+        match config_dir_utf8() {
+            Ok(cfg_dir) => {
+                let path = cfg_dir.join("doiget").join("config.toml");
+                match doiget_core::user_extension::load(&path) {
+                    Ok(user_hosts) if !user_hosts.is_empty() => {
+                        tracing::info!(
+                            count = user_hosts.len(),
+                            path = %path,
+                            "merging user-extension allowlist hosts (ADR-0028 D2)"
+                        );
+                        doiget_core::user_extension::merge_into_allowlists(
+                            &mut allowlists,
+                            &user_hosts,
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            path = %path,
+                            "failed to load user-extension allowlist; \
+                             falling back to curated set only"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "config dir unresolvable; \
+                     user-extension allowlist disabled (curated set only)"
+                );
+            }
+        }
+
         return HttpClient::new(allowlists)
             .map_err(|e| anyhow::anyhow!("building production HTTP client: {e}"));
     }
@@ -2076,6 +2121,34 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
         .map(|(s, h)| (s.as_str(), h.as_str()))
         .collect();
     Ok(HttpClient::new_for_tests_allow_http_multi(&entries))
+}
+
+/// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
+/// (POSIX), then `APPDATA` (Windows), then falls back to
+/// `$HOME/.config` (or `%USERPROFILE%\.config` on Windows). Mirrors
+/// `crates/doiget-cli/src/commands/fetch.rs::config_dir_utf8` so the
+/// MCP server reads `<config_dir>/doiget/config.toml` from the same
+/// location the CLI writes it.
+///
+/// Returns `Err` only when none of `XDG_CONFIG_HOME` / `APPDATA` /
+/// `HOME` / `USERPROFILE` are set (or all set to empty), in which
+/// case the caller downgrades to "user extension disabled" rather
+/// than failing the whole request.
+fn config_dir_utf8() -> anyhow::Result<Utf8PathBuf> {
+    if let Ok(s) = std::env::var("XDG_CONFIG_HOME") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s));
+        }
+    }
+    if let Ok(s) = std::env::var("APPDATA") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s));
+        }
+    }
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| anyhow::anyhow!("neither HOME nor USERPROFILE is set"))?;
+    Ok(Utf8PathBuf::from(home).join(".config"))
 }
 
 /// Resolve the provenance log path. Mirrors the CLI's precedence
@@ -2276,6 +2349,95 @@ mod tests {
         // (the test process is shared with other tests).
         if std::env::var_os("HOME").is_some() || std::env::var_os("USERPROFILE").is_some() {
             assert!(resolve_store_root().is_some());
+        }
+    }
+
+    /// ADR-0028 D2: `build_http_client_for_fetch` MUST merge user-
+    /// extension allowlist hosts from `<config_dir>/doiget/config.toml`
+    /// into the oa-publisher allowlist before returning, mirroring the
+    /// CLI's `commands::fetch::build_http_client`. Drift here would
+    /// silently disable user-curated allowlist additions for the MCP
+    /// server while the CLI honors them.
+    ///
+    /// We can't read the HttpClient's internal allowlists directly
+    /// (the field is private), so we drive an end-to-end probe: write
+    /// a config.toml that adds `host = "ruj.uj.edu.pl"` to the user
+    /// extension, build the client, and call
+    /// `oa_publisher_allowlist_hosts` — the same helper the CLI test
+    /// uses (review pass M3). The function exposes the merged host
+    /// list without leaking client internals.
+    #[test]
+    #[serial_test::serial]
+    fn build_http_client_for_fetch_merges_user_extension_hosts() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        std::fs::write(
+            doiget_dir.join("config.toml").as_std_path(),
+            "[[network.additional_hosts]]\nhost = \"ruj.uj.edu.pl\"\n",
+        )
+        .expect("write config.toml");
+
+        let _guards = scoped_env_for_user_extension(cfg_root.as_str());
+
+        // No DOIGET_*_BASE overrides → takes the production branch
+        // that performs the user-extension merge.
+        let client = build_http_client_for_fetch().expect("build http client");
+        let oa = client
+            .source_allowlist("oa-publisher")
+            .expect("oa-publisher source must be registered");
+        assert!(
+            oa.redirect_hosts.iter().any(|h| h == "ruj.uj.edu.pl"),
+            "user-extension host must appear in the oa-publisher allowlist; \
+             got: {:?}",
+            oa.redirect_hosts
+        );
+    }
+
+    /// Set XDG_CONFIG_HOME / APPDATA / HOME / USERPROFILE so
+    /// `config_dir_utf8()` resolves to the supplied directory on
+    /// every supported test host. Returns guards that restore prior
+    /// values on drop.
+    fn scoped_env_for_user_extension(dir: &str) -> Vec<EnvGuard> {
+        vec![
+            EnvGuard::set("XDG_CONFIG_HOME", dir),
+            EnvGuard::set("APPDATA", dir),
+            EnvGuard::set("HOME", dir),
+            EnvGuard::set("USERPROFILE", dir),
+            EnvGuard::unset("DOIGET_ARXIV_BASE"),
+            EnvGuard::unset("DOIGET_CROSSREF_BASE"),
+            EnvGuard::unset("DOIGET_UNPAYWALL_BASE"),
+            EnvGuard::unset("DOIGET_OA_PUBLISHER_BASE"),
+            EnvGuard::unset("DOIGET_OPENALEX_BASE"),
+        ]
+    }
+
+    /// RAII env guard local to this tests module.
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Close out the ADR-0028 D2 follow-ups that beta.8 (#227) deferred to S3b:

- **doiget-mcp**: `build_http_client_for_fetch` now merges
  `[[network.additional_hosts]]` from
  `<config_dir>/doiget/config.toml` into the oa-publisher allowlist,
  mirroring the CLI path (`commands::fetch::build_http_client`).
  Both surfaces now read the same config with identical failure
  handling. Closes the asymmetry where a user who configured
  `additional_hosts` and ran `doiget serve` saw no effect.

- **`doiget config doctor`** adds a user-extension health check:

  ```
  [ ok ] user-extension hosts loaded: 2
  ```

  on a green load, or

  ```
  [FAIL] user-extension config invalid: invalid host pattern …
  ```

  (exit 2) on a malformed config. Missing `config.toml` is normal
  (`N = 0`, no failure) — the user simply has not extended the gate.

- **`doiget capabilities`** JSON gains a top-level
  `user_extension_count: usize` (additive on a `#[non_exhaustive]`
  struct) so an LLM cold-booted into doiget can confirm at a glance
  whether the curated allowlist has been extended on this host.

- `commands::fetch::config_dir_utf8` lifted to `pub(crate)` so
  sibling modules resolve the same path.

D2-2 (`verified_by = "user"` provenance row field) stays deferred —
requires allowlist source-attribution plumbing through the redirect
closure and is not gating user-visible behavior.

## Test plan

- [x] `cargo test --workspace --lib` — 333/333 green
  (271 core, 59 cli, 3 mcp)
- [x] New unit tests:
  - `commands::capabilities::tests::user_extension_count_reflects_config_toml_entries`
  - `commands::capabilities::tests::user_extension_count_is_zero_without_config_toml`
  - `commands::config::tests::doctor_fails_with_malformed_user_extension_config`
    (POSIX-only — dirs::config_dir() on Windows queries Known Folder
    API and can't be redirected via env in-process)
  - `tests::build_http_client_for_fetch_merges_user_extension_hosts`
    (doiget-mcp)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Smoke: `doiget capabilities | tail` shows
  `"user_extension_count": 0` on a fresh host

Refs #220.