### PR TITLE
feat(core/cli): S4 — fetch_one outcome plumbing for batch JSONL (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,84 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.9] - 2026-05-21
+
+### Added
+
+- **[core]** `FetchPaperOutcome` (`doiget_core::orchestrator`) gains
+  two new fields: `safekey: String` and `canonical_digest: String`
+  (#210). Both are always populated — `safekey` from the input ref
+  (`Ref::safekey().as_str()`), `canonical_digest` from
+  `CanonicalRef::digest_hex()` under the outcome's
+  `resolver_profile`. Additive on a `#[non_exhaustive]` struct, so
+  downstream consumers continue to compile without changes.
+
+- **[cli]** `doiget batch --json` JSONL records carry the full
+  structured outcome per `docs/ERRORS.md` §3 (#210):
+  - **Success**: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`.
+    A CI consumer can now pull `safekey` to construct a store-relative
+    path and `canonical_digest` to deduplicate against an audit DB
+    without a follow-up `info` round-trip per ref.
+  - **Failure**: `{"ok":false,"ref":"...","error":{"code":"...","message":"...","denial_context":{...}}}`.
+    The `code` field is now the typed `ErrorCode` wire string (e.g.
+    `CAPABILITY_DENIED` / `NETWORK_ERROR` / `INTERNAL_ERROR`) — the
+    previous generic `FETCH_ERROR` only survives in the JoinSet
+    panic arm where no underlying `FetchError` exists. The
+    `denial_context` key is present only when the failure carries a
+    structured ADR-0023 denial; bare transport / config errors omit
+    the key entirely so consumers can use its presence as a typed-
+    denial discriminator.
+
+  A `PdfLegStatus::Blocked` outcome (an OA PDF was discovered but
+  could not be retrieved per #145) is now surfaced as a failure
+  record with the policy-class `denial_context`, rather than being
+  collapsed into the bare `{ok:true, ref}` shape that #205 left in
+  place. The `effective_blocked_code` reclassification (off-allowlist
+  / insecure-scheme / blocklisted-host → `CAPABILITY_DENIED`) is
+  shared between single-fetch and batch, so the wire code matches the
+  single-fetch CLI exit-code mapping.
+
+### Changed
+
+- **[cli]** `FetchHarness::fetch_one` signature changes from
+  `async fn (..., &Ref) -> anyhow::Result<()>` to
+  `async fn (..., &Ref) -> Result<FetchPaperOutcome, FetchError>`
+  (#210). The rendering + exit-code synthesis that used to live
+  inside `fetch_one` (Blocked-PDF reclassification, `error[CODE]:`
+  stderr, `CliExit` construction) now lives in the per-caller paths
+  (`commands::fetch::run_with_options` for single-fetch,
+  `commands::batch::classify_joined` for batch) so each surface can
+  emit its own machine-readable shape from the same typed outcome.
+  `pub(crate)`, not a public API.
+
+  - `commands::fetch::effective_blocked_code` is lifted from `fn` to
+    `pub(crate) fn` so the batch caller shares the single-fetch
+    reclassification rule.
+  - New `commands::fetch::outcome_is_clean_success` helper collapses
+    the typed `Result<FetchPaperOutcome, FetchError>` to the boolean
+    the `SessionEnd` row's `is_ok` field needs, so a Blocked PDF leg
+    never reads as a green session in the provenance log.
+
+- **[core]** New `#[doc(hidden)] pub fn FetchPaperOutcome::for_test_synthetic(...)`
+  test-only constructor in `doiget_core::orchestrator` so downstream
+  test code (`doiget-cli` batch unit tests) can drive
+  classification logic without running the full orchestrator. Not a
+  stable public API — the signature may change to fit test needs
+  without a `[BREAKING]` callout.
+
+### Notes
+
+- Out of scope (deferred to follow-up issues per #210's Out-of-scope
+  list):
+  - The MCP `doiget_fetch_paper` envelope upgrade to surface
+    `safekey` / `canonical_digest` (the FetchPaperOutcome fields
+    are populated; the envelope-side wire change is a separate
+    item).
+  - `canonical_digest` on `EntryInfo` (`info` / `list-recent` /
+    `search` JSON bodies).
+  - Single-fetch `--json` symmetric output (the CLI single-fetch JSON
+    branch mirroring batch JSONL's single record).
+
 ## [0.4.1-beta.8] - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.8"
+version       = "0.4.1-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -31,10 +31,14 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 
+use doiget_core::orchestrator::{FetchPaperOutcome, PdfLegStatus};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, RowInput};
-use doiget_core::{RateLimits, Ref, MCP_BATCH_MAX_SIZE};
+use doiget_core::source::FetchError;
+use doiget_core::{DenialContext, ErrorCode, RateLimits, Ref, MCP_BATCH_MAX_SIZE};
 
-use super::fetch::{build_fetch_plan, emit_dry_run_plan_to_stdout, CliExit, FetchHarness};
+use super::fetch::{
+    build_fetch_plan, effective_blocked_code, emit_dry_run_plan_to_stdout, CliExit, FetchHarness,
+};
 use super::resolve_store_root;
 
 /// Run the `doiget batch <path>` subcommand.
@@ -202,10 +206,15 @@ pub async fn run_with_options(
             let _permit = match sem_task.acquire_owned().await {
                 Ok(p) => p,
                 Err(_) => {
+                    // Map the semaphore-closed structural impossibility
+                    // to a typed `FetchError` (closest closed-set fit)
+                    // so `TaskOutcome::result` stays typed end-to-end.
                     return TaskOutcome {
                         input,
-                        result: Err(anyhow!("batch semaphore unexpectedly closed")),
-                    }
+                        result: Err(FetchError::SourceSchema {
+                            hint: "batch semaphore unexpectedly closed".to_string(),
+                        }),
+                    };
                 }
             };
             let result = harness_task.fetch_one(&ref_).await;
@@ -277,7 +286,7 @@ pub async fn run_with_options(
 #[derive(Debug)]
 struct TaskOutcome {
     input: String,
-    result: Result<()>,
+    result: Result<FetchPaperOutcome, FetchError>,
 }
 
 /// One-line summary written to stderr per ADR-0001 (stdio convention — the
@@ -347,16 +356,54 @@ fn classify_joined(
 ) -> JoinedOutcome {
     match joined {
         Ok(TaskOutcome { input, result }) => match result {
-            Ok(()) => JoinedOutcome {
-                is_error: false,
-                json_record: json_mode.then(|| build_jsonl_success(&input)),
-                log_breadcrumb: LogBreadcrumb::None,
-            },
+            Ok(outcome) => {
+                // #210 / `docs/ERRORS.md` §3+§6: a `Blocked` PDF leg
+                // is NOT a clean success even though the typed Result
+                // is `Ok` — surface it as a structured failure record
+                // with the `denial_context` the orchestrator carried
+                // on `PdfLegStatus::Blocked.denial`.
+                if let PdfLegStatus::Blocked {
+                    code,
+                    message,
+                    denial,
+                } = &outcome.pdf_leg
+                {
+                    let effective = effective_blocked_code(*code, denial.as_ref());
+                    let denial_value = denial.as_ref().and_then(denial_context_to_value);
+                    let record = json_mode.then(|| {
+                        build_jsonl_failure(
+                            Some(&input),
+                            effective.as_wire(),
+                            message,
+                            denial_value,
+                        )
+                    });
+                    let error_dbg =
+                        format!("pdf_leg=Blocked code={effective:?} message={message:?}");
+                    return JoinedOutcome {
+                        is_error: true,
+                        json_record: record,
+                        log_breadcrumb: LogBreadcrumb::FetchFailed { input, error_dbg },
+                    };
+                }
+                let result_value = json_mode.then(|| outcome_to_result_value(&outcome));
+                JoinedOutcome {
+                    is_error: false,
+                    json_record: json_mode
+                        .then(|| build_jsonl_success(&input, result_value.clone().flatten())),
+                    log_breadcrumb: LogBreadcrumb::None,
+                }
+            }
             Err(e) => {
                 let error_dbg = format!("{e:?}");
-                let json_msg = format!("{e:#}");
-                let record =
-                    json_mode.then(|| build_jsonl_failure(Some(&input), "FETCH_ERROR", &json_msg));
+                let json_msg = format!("{e}");
+                let code: ErrorCode = (&e).into();
+                let denial_value = Option::<DenialContext>::from(&e)
+                    .as_ref()
+                    .and_then(denial_context_to_value);
+                let record = json_mode.then(|| {
+                    build_jsonl_failure(Some(&input), code.as_wire(), &json_msg, denial_value)
+                });
                 JoinedOutcome {
                     is_error: true,
                     json_record: record,
@@ -372,7 +419,8 @@ fn classify_joined(
             // sentinel that a consumer doing `retry(rec["ref"])`
             // would mishandle. Self-review for #209 §1.
             let json_msg = format!("batch task panicked: {join_err}");
-            let record = json_mode.then(|| build_jsonl_failure(None, "FETCH_ERROR", &json_msg));
+            let record =
+                json_mode.then(|| build_jsonl_failure(None, "FETCH_ERROR", &json_msg, None));
             JoinedOutcome {
                 is_error: true,
                 json_record: record,
@@ -382,34 +430,77 @@ fn classify_joined(
     }
 }
 
-/// #205: build the JSON-Lines success record value for `ref_input`.
-/// Per ERRORS.md §3, the wire shape is `{"ok": true, "ref": "..."}`.
+/// Build the `result` sub-object for the JSONL success record per
+/// ERRORS.md §3: `{safekey, store_path, canonical_digest}`. Returns
+/// `None` if any field cannot be serialised; the caller falls back to
+/// the bare `{ok, ref}` shape so a serialisation glitch never drops
+/// the success signal.
+fn outcome_to_result_value(outcome: &FetchPaperOutcome) -> Option<serde_json::Value> {
+    Some(serde_json::json!({
+        "safekey":          outcome.safekey,
+        "store_path":       outcome.path.as_str(),
+        "canonical_digest": outcome.canonical_digest,
+    }))
+}
+
+/// Serialise a `DenialContext` to a JSON value for the `error.denial_context`
+/// field. `DenialContext: serde::Serialize` already; returns `None` on
+/// the (today unreachable) serialise-failure path rather than aborting
+/// the record.
+fn denial_context_to_value(dc: &DenialContext) -> Option<serde_json::Value> {
+    serde_json::to_value(dc).ok()
+}
+
+/// #205 + #210: build the JSON-Lines success record value for
+/// `ref_input`. Per ERRORS.md §3, the wire shape is
+/// `{"ok": true, "ref": "...", "result": {...}}` when `result` is
+/// `Some`, falling back to `{"ok": true, "ref": "..."}` when `result`
+/// is `None` (the latter is reserved for paths that don't carry a
+/// structured outcome — today every fetch path does, so `result` is
+/// `Some` in practice; the `None` arm preserves the unit-test path
+/// that asserts shape without constructing a full `FetchPaperOutcome`).
+///
 /// Returned as `serde_json::Value` so unit tests can assert the shape
 /// without a stdout-capture dance; the integration site wraps it with
 /// `println!`.
-fn build_jsonl_success(ref_input: &str) -> serde_json::Value {
-    serde_json::json!({ "ok": true, "ref": ref_input })
+fn build_jsonl_success(ref_input: &str, result: Option<serde_json::Value>) -> serde_json::Value {
+    match result {
+        Some(r) => serde_json::json!({ "ok": true, "ref": ref_input, "result": r }),
+        None => serde_json::json!({ "ok": true, "ref": ref_input }),
+    }
 }
 
-/// #205: build the JSON-Lines failure record value with `code` and
-/// `message`. The wire shape is
-/// `{"ok": false, "ref": "<ref>"|null, "error": {"code": "...", "message": "..."}}`.
+/// #205 + #210: build the JSON-Lines failure record value with `code`,
+/// `message`, and an optional `denial_context` (ADR-0023). The wire
+/// shape is `{"ok": false, "ref": "<ref>"|null, "error": {"code": "...",
+/// "message": "..."[, "denial_context": {...}]}}`.
+///
+/// `denial_context` is omitted from the record entirely when `None` —
+/// fields are not present rather than `null` — so consumers can use the
+/// `denial_context` key's presence as a discriminator between a typed
+/// policy denial and a bare transport / config error.
 ///
 /// `ref_input` is `Option<&str>` because the JoinSet panic arm has lost
 /// the originating input by the time the panic surfaces: serialising
 /// `null` is more honest than a sentinel string like `"<task-panic>"`
 /// (which a consumer doing `retry(rec["ref"])` would mishandle by
 /// trying to refetch the literal sentinel — self-review for #209 §1).
-///
-/// `denial_context` (ADR-0023 closed enum) is intentionally omitted in
-/// this PR — surfacing it requires `fetch_one` to return the structured
-/// outcome instead of `Result<()>`; tracked in #210 to keep this PR's
-/// diff focused on the contract surface.
-fn build_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) -> serde_json::Value {
+fn build_jsonl_failure(
+    ref_input: Option<&str>,
+    code: &str,
+    message: &str,
+    denial_context: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut error = serde_json::json!({ "code": code, "message": message });
+    if let Some(dc) = denial_context {
+        if let Some(obj) = error.as_object_mut() {
+            obj.insert("denial_context".to_string(), dc);
+        }
+    }
     serde_json::json!({
         "ok":    false,
         "ref":   ref_input,
-        "error": { "code": code, "message": message },
+        "error": error,
     })
 }
 
@@ -417,10 +508,12 @@ fn build_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) -> se
 /// (Step 7's `Ref::parse` branch); the JoinSet-drain site now uses
 /// [`classify_joined`] + an inline `println!`, so the matching
 /// `emit_jsonl_success` thin wrapper is no longer needed and was
-/// removed alongside the drain refactor.
+/// removed alongside the drain refactor. The `denial_context` slot is
+/// always `None` here — `INVALID_REF` is a pre-guard parse error, not
+/// a policy denial (`docs/ERRORS.md` §3.1).
 #[allow(clippy::print_stdout)]
 fn emit_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) {
-    println!("{}", build_jsonl_failure(ref_input, code, message));
+    println!("{}", build_jsonl_failure(ref_input, code, message, None));
 }
 
 // ---------------------------------------------------------------------------
@@ -435,29 +528,94 @@ mod tests {
     // ---- #205 JSON-Lines record shape (unit-level) ---------------------
 
     #[test]
-    fn jsonl_success_shape() {
-        let v = build_jsonl_success("10.1234/foo");
+    fn jsonl_success_shape_no_result() {
+        // Without a structured payload, the record falls back to the
+        // bare `{ok, ref}` shape — guards the `None` arm of
+        // `build_jsonl_success` (the unit-test path; production paths
+        // always pass `Some`).
+        let v = build_jsonl_success("10.1234/foo", None);
         assert_eq!(v["ok"], true);
         assert_eq!(v["ref"], "10.1234/foo");
         assert!(v.get("error").is_none(), "no error field on success");
+        assert!(
+            v.get("result").is_none(),
+            "no `result` key when caller passed None"
+        );
+    }
+
+    #[test]
+    fn jsonl_success_shape_with_result() {
+        // #210: the success record carries `result.{safekey, store_path,
+        // canonical_digest}`. The keys are part of the public wire format.
+        let payload = serde_json::json!({
+            "safekey":          "arxiv__2401.12345",
+            "store_path":       "/papers/arxiv__2401.12345.pdf",
+            "canonical_digest": "deadbeef".repeat(8),
+        });
+        let v = build_jsonl_success("arxiv:2401.12345", Some(payload));
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["ref"], "arxiv:2401.12345");
+        assert_eq!(v["result"]["safekey"], "arxiv__2401.12345");
+        assert_eq!(v["result"]["store_path"], "/papers/arxiv__2401.12345.pdf");
+        assert!(
+            v["result"]["canonical_digest"]
+                .as_str()
+                .map(|s| s.len() == 64)
+                .unwrap_or(false),
+            "canonical_digest MUST be a 64-char hex string: {v}"
+        );
     }
 
     #[test]
     fn jsonl_failure_shape_invalid_ref() {
-        let v = build_jsonl_failure(Some("not-a-doi"), "INVALID_REF", "bad ref");
+        let v = build_jsonl_failure(Some("not-a-doi"), "INVALID_REF", "bad ref", None);
         assert_eq!(v["ok"], false);
         assert_eq!(v["ref"], "not-a-doi");
         assert_eq!(v["error"]["code"], "INVALID_REF");
         assert_eq!(v["error"]["message"], "bad ref");
+        assert!(
+            v["error"].get("denial_context").is_none(),
+            "no denial_context on INVALID_REF (pre-guard parse error): {v}"
+        );
     }
 
     #[test]
     fn jsonl_failure_shape_fetch_error() {
-        let v = build_jsonl_failure(Some("arxiv:2401.12345"), "FETCH_ERROR", "boom");
+        let v = build_jsonl_failure(Some("arxiv:2401.12345"), "NETWORK_ERROR", "boom", None);
         assert_eq!(v["ok"], false);
         assert_eq!(v["ref"], "arxiv:2401.12345");
-        assert_eq!(v["error"]["code"], "FETCH_ERROR");
+        assert_eq!(v["error"]["code"], "NETWORK_ERROR");
         assert_eq!(v["error"]["message"], "boom");
+    }
+
+    #[test]
+    fn jsonl_failure_shape_with_denial_context() {
+        // #210: the structured `denial_context` carries the closed-enum
+        // `reason` + per-source detail when a CAPABILITY_DENIED failure
+        // surfaces. Hand-craft the value to pin the wire shape — the
+        // serializer is `DenialContext`'s own `Serialize` impl (ADR-0023).
+        let dc = serde_json::json!({
+            "reason":    "redirect_not_in_allowlist",
+            "source":    "oa-publisher",
+            "attempted": "evil.example.com",
+            "expected":  ["good-publisher.example.org"],
+        });
+        let v = build_jsonl_failure(
+            Some("10.1234/foo"),
+            "CAPABILITY_DENIED",
+            "redirect not in allowlist",
+            Some(dc),
+        );
+        assert_eq!(v["error"]["code"], "CAPABILITY_DENIED");
+        assert_eq!(
+            v["error"]["denial_context"]["reason"],
+            "redirect_not_in_allowlist"
+        );
+        assert_eq!(v["error"]["denial_context"]["source"], "oa-publisher");
+        assert_eq!(
+            v["error"]["denial_context"]["attempted"],
+            "evil.example.com"
+        );
     }
 
     #[test]
@@ -465,7 +623,7 @@ mod tests {
         // Self-review for #209 §1: a JoinSet panic loses the input, so
         // the record carries `ref: null` rather than a sentinel string
         // that a consumer doing `retry(rec["ref"])` would mishandle.
-        let v = build_jsonl_failure(None, "FETCH_ERROR", "batch task panicked: ...");
+        let v = build_jsonl_failure(None, "FETCH_ERROR", "batch task panicked: ...", None);
         assert_eq!(v["ok"], false);
         assert!(v["ref"].is_null(), "panic record's ref MUST be null: {v}");
         assert_eq!(v["error"]["code"], "FETCH_ERROR");
@@ -478,7 +636,11 @@ mod tests {
         let outcome = classify_joined(
             Ok(TaskOutcome {
                 input: "10.1234/foo".to_string(),
-                result: Ok(()),
+                result: Ok(FetchPaperOutcome::for_test_synthetic(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    PdfLegStatus::Fetched,
+                )),
             }),
             true,
         );
@@ -486,6 +648,10 @@ mod tests {
         let rec = outcome.json_record.expect("json_mode → record");
         assert_eq!(rec["ok"], true);
         assert_eq!(rec["ref"], "10.1234/foo");
+        // #210: structured `result` body present on success.
+        assert_eq!(rec["result"]["safekey"], "doi__10_1234_foo");
+        assert!(rec["result"]["store_path"].is_string());
+        assert!(rec["result"]["canonical_digest"].is_string());
         assert!(matches!(outcome.log_breadcrumb, LogBreadcrumb::None));
     }
 
@@ -494,7 +660,11 @@ mod tests {
         let outcome = classify_joined(
             Ok(TaskOutcome {
                 input: "10.1234/foo".to_string(),
-                result: Ok(()),
+                result: Ok(FetchPaperOutcome::for_test_synthetic(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    PdfLegStatus::Fetched,
+                )),
             }),
             false,
         );
@@ -503,11 +673,17 @@ mod tests {
     }
 
     #[test]
-    fn classify_joined_fetch_failure_emits_fetch_error() {
+    fn classify_joined_fetch_failure_emits_typed_code() {
+        // #210: the failure record now carries the typed ErrorCode wire
+        // string from `FetchError → ErrorCode`, not the generic
+        // `FETCH_ERROR`. `FetchError::SourceSchema` collapses to
+        // `INTERNAL_ERROR` (per `source.rs`'s closed-set mapping).
         let outcome = classify_joined(
             Ok(TaskOutcome {
                 input: "arxiv:2401.99999".to_string(),
-                result: Err(anyhow!("connection refused")),
+                result: Err(doiget_core::source::FetchError::SourceSchema {
+                    hint: "synthetic schema failure".to_string(),
+                }),
             }),
             true,
         );
@@ -515,11 +691,61 @@ mod tests {
         let rec = outcome.json_record.expect("json_mode → record");
         assert_eq!(rec["ok"], false);
         assert_eq!(rec["ref"], "arxiv:2401.99999");
-        assert_eq!(rec["error"]["code"], "FETCH_ERROR");
+        assert_eq!(rec["error"]["code"], "INTERNAL_ERROR");
         assert!(matches!(
             outcome.log_breadcrumb,
             LogBreadcrumb::FetchFailed { .. }
         ));
+    }
+
+    #[test]
+    fn classify_joined_blocked_pdf_emits_failure_with_denial_context() {
+        // #210: a `PdfLegStatus::Blocked` outcome is reported as a
+        // structured failure record carrying the `denial_context` the
+        // orchestrator captured at the policy-denial site. The
+        // `effective_blocked_code` reclassification promotes a
+        // redirect-not-in-allowlist denial from `NETWORK_ERROR` to
+        // `CAPABILITY_DENIED` so consumers see the policy class.
+        use doiget_core::{DenialContext, DenialReason, ErrorCode as Ec};
+        let blocked = PdfLegStatus::Blocked {
+            code: Ec::NetworkError,
+            message: "redirect not in allowlist".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some("oa-publisher".to_string()),
+                attempted: Some("evil.example.com".to_string()),
+                expected: Some(vec!["good-publisher.example.org".to_string()]),
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+        };
+        let outcome = classify_joined(
+            Ok(TaskOutcome {
+                input: "10.1234/foo".to_string(),
+                result: Ok(FetchPaperOutcome::for_test_synthetic(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    blocked,
+                )),
+            }),
+            true,
+        );
+        assert!(
+            outcome.is_error,
+            "Blocked PDF leg MUST be reported as error"
+        );
+        let rec = outcome.json_record.expect("json_mode → record");
+        assert_eq!(rec["ok"], false);
+        assert_eq!(rec["error"]["code"], "CAPABILITY_DENIED");
+        assert_eq!(
+            rec["error"]["denial_context"]["reason"],
+            "redirect_not_in_allowlist"
+        );
+        assert_eq!(
+            rec["error"]["denial_context"]["attempted"],
+            "evil.example.com"
+        );
     }
 
     #[test]
@@ -586,17 +812,17 @@ mod tests {
         // no embedded newlines) — required for the JSONL contract since
         // the production emitter wraps it with a single `println!` and
         // CI consumers split stdout by `\n`.
-        let s = build_jsonl_success("10.1/x").to_string();
+        let s = build_jsonl_success("10.1/x", None).to_string();
         assert!(
             !s.contains('\n'),
             "JSONL success must be single-line: {s:?}"
         );
-        let s2 = build_jsonl_failure(Some("10.1/x"), "FETCH_ERROR", "msg").to_string();
+        let s2 = build_jsonl_failure(Some("10.1/x"), "FETCH_ERROR", "msg", None).to_string();
         assert!(
             !s2.contains('\n'),
             "JSONL failure must be single-line: {s2:?}"
         );
-        let s3 = build_jsonl_failure(None, "FETCH_ERROR", "msg").to_string();
+        let s3 = build_jsonl_failure(None, "FETCH_ERROR", "msg", None).to_string();
         assert!(
             !s3.contains('\n'),
             "null-ref JSONL must be single-line: {s3:?}"

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -431,63 +431,31 @@ impl FetchHarness {
     /// [`doiget_core::orchestrator::fetch_paper`] for the actual work
     /// (which both CLI and MCP now share). This function keeps the
     /// CLI-only stderr success-line print.
-    pub(crate) async fn fetch_one(&self, ref_: &Ref) -> Result<()> {
+    pub(crate) async fn fetch_one(&self, ref_: &Ref) -> Result<FetchPaperOutcome, FetchError> {
+        // Pure data path: return the typed outcome (or typed error)
+        // without any CLI-only rendering or exit-code synthesis. The
+        // single-fetch caller (`run_with_options`) and the batch
+        // caller (`commands::batch::classify_joined`) each render the
+        // human / JSON surface and map to `CliExit` themselves — see
+        // #210 for the rationale (batch's `--json` JSONL needs the
+        // structured `FetchPaperOutcome` to emit `result.{safekey,
+        // store_path, canonical_digest}` on success and
+        // `denial_context` on a `PdfLegStatus::Blocked` outcome, which
+        // was unreachable through the previous `Result<()>`
+        // signature).
         let ctx = self.fetch_context();
-        match core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await {
-            Ok(outcome) => {
-                // Issue #145 / `docs/ERRORS.md` §3 + §6: a `Blocked` PDF
-                // leg means an OA PDF *was* discovered but could not be
-                // retrieved. Metadata was written, but this is NOT a
-                // clean success — emitting only `print_success` here made
-                // a denied PDF visually indistinguishable from a genuine
-                // metadata-only result and exited 0 (a silent failure).
-                // Route it through the SAME `error[CODE]:` stderr channel
-                // + `cli_exit_code(...)` mapping `fetch` already uses for
-                // `CapabilityDenied`, using the structured code the
-                // orchestrator mapped from the underlying transport error.
-                if let PdfLegStatus::Blocked {
-                    code,
-                    message,
-                    denial,
-                } = &outcome.pdf_leg
-                {
-                    // Issue #145 / `docs/ERRORS.md` §2 + §3: the core
-                    // collapses *every* `FetchError::Http(_)` to
-                    // `ErrorCode::NetworkError` (see
-                    // `doiget_core::source.rs`'s `From<&FetchError> for
-                    // ErrorCode`). For a genuine transport/DNS/TLS fault
-                    // that is correct ("retry usually fine"). But an
-                    // off-allowlist / redirect-denied / insecure-scheme OA
-                    // PDF leg is a DELIBERATE policy block — retrying never
-                    // helps — yet it would otherwise surface as
-                    // `NETWORK_ERROR` → generic exit 1, misrepresenting a
-                    // flaky network. The orchestrator already preserves the
-                    // real reason on `denial` (the `From<&HttpError> for
-                    // Option<DenialContext>` impl walks reqwest's source
-                    // chain, so even a redirect denial wrapped as
-                    // `HttpError::Network` still yields
-                    // `DenialReason::RedirectNotInAllowlist`). Reclassify
-                    // the *policy* denials here at the CLI layer to
-                    // `CapabilityDenied` → `error[CAPABILITY_DENIED]:` →
-                    // exit 3 (the same code `fetch`/`graph` already use for
-                    // `ErrorCode::CapabilityDenied`).
-                    let effective = effective_blocked_code(*code, denial.as_ref());
-                    render_blocked_error(ref_, &outcome, effective, message, denial.as_ref());
-                    return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
-                }
-                emit_success_line(ref_, &outcome);
-                Ok(())
-            }
-            Err(e) => {
-                // Issue #119: render the cargo-style `error[CODE]:`
-                // line + denial note HERE (while the error is still
-                // typed), then carry only the exit code to `main`.
-                render_fetch_error(&e);
-                let code: ErrorCode = (&e).into();
-                Err(anyhow::Error::new(CliExit(cli_exit_code(code))))
-            }
-        }
+        core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await
     }
+}
+
+/// `true` iff the outcome represents a clean fetch: `Fetched` (full
+/// PDF) or `NoOaUrl` (metadata-only by design). A `Blocked` PDF leg
+/// is a failure for SessionEnd / exit-code purposes — an OA PDF was
+/// discovered but could not be retrieved — even though the metadata
+/// TOML did land on disk. Pulled out so both `run_with_options` and
+/// `commands::batch` agree on the failure boundary.
+pub(crate) fn outcome_is_clean_success(outcome: &FetchPaperOutcome) -> bool {
+    !matches!(outcome.pdf_leg, PdfLegStatus::Blocked { .. })
 }
 
 /// CLI-only one-line success message on stderr (ADR-0001 stdio
@@ -623,15 +591,47 @@ pub async fn run_with_options(
     // surrounding fetch MUST NOT proceed (`docs/PROVENANCE_LOG.md` §5).
     harness.log_session_start(Some(ref_.as_input_str()))?;
 
-    // Step 4: dispatch on ref kind.
+    // Step 4: dispatch on ref kind. `fetch_one` now returns the
+    // typed `FetchPaperOutcome` / `FetchError` per #210; the
+    // single-fetch caller (this fn) owns rendering + exit code.
     let result = harness.fetch_one(&ref_).await;
 
-    // Step 5: emit SessionEnd regardless of outcome. Best-effort: if this
-    // append also fails, surface the underlying fetch error (or a fresh one
-    // if the fetch was Ok).
-    harness.log_session_end(result.is_ok(), Some(ref_.as_input_str()));
+    // Step 5: emit SessionEnd regardless of outcome. A `Blocked` PDF
+    // leg is NOT a clean success even though the typed `Result` is
+    // `Ok` — `outcome_is_clean_success` collapses both halves so the
+    // SessionEnd `is_ok` field matches the user-facing exit code.
+    let session_ok = match &result {
+        Ok(o) => outcome_is_clean_success(o),
+        Err(_) => false,
+    };
+    harness.log_session_end(session_ok, Some(ref_.as_input_str()));
 
-    result
+    // Step 6: render the user-facing surface and map to `CliExit`.
+    // The Blocked-PDF reclassification logic that used to live inside
+    // `fetch_one` was lifted here verbatim so the batch caller can
+    // share the same `effective_blocked_code` / `render_blocked_error`
+    // helpers (issue #210 / #145).
+    match result {
+        Ok(outcome) => {
+            if let PdfLegStatus::Blocked {
+                code,
+                message,
+                denial,
+            } = &outcome.pdf_leg
+            {
+                let effective = effective_blocked_code(*code, denial.as_ref());
+                render_blocked_error(&ref_, &outcome, effective, message, denial.as_ref());
+                return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
+            }
+            emit_success_line(&ref_, &outcome);
+            Ok(())
+        }
+        Err(e) => {
+            render_fetch_error(&e);
+            let code: ErrorCode = (&e).into();
+            Err(anyhow::Error::new(CliExit(cli_exit_code(code))))
+        }
+    }
 }
 
 /// Single-line user-visible success message, written to stderr per ADR-0001
@@ -694,7 +694,7 @@ impl std::error::Error for CliExit {}
 /// Non-policy blocks (no `denial`, or a non-policy reason such as
 /// `SizeCapExceeded` / `ContentTypeMismatch`) keep the core's code so a
 /// genuine transport failure still reads as `NETWORK_ERROR`.
-fn effective_blocked_code(code: ErrorCode, denial: Option<&DenialContext>) -> ErrorCode {
+pub(crate) fn effective_blocked_code(code: ErrorCode, denial: Option<&DenialContext>) -> ErrorCode {
     match denial.map(|d| d.reason) {
         Some(
             DenialReason::RedirectNotInAllowlist

--- a/crates/doiget-cli/tests/batch_jsonl_e2e.rs
+++ b/crates/doiget-cli/tests/batch_jsonl_e2e.rs
@@ -1,14 +1,15 @@
-//! End-to-end tests for `batch --mode json` (#205, ERRORS.md §3 CI persona).
+//! End-to-end tests for `batch --mode json` (#205 + #210, ERRORS.md §3
+//! CI persona).
 //!
-//! Validates the per-ref JSON-Lines wire shape: one record per input
-//! line, success `{"ok":true,"ref":"..."}` or failure
-//! `{"ok":false,"ref":"...","error":{"code":"...","message":"..."}}`.
+//! Validates the per-ref JSON-Lines wire shape:
+//!
+//! - Success: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`
+//!   (#210 structured outcome plumbing).
+//! - Failure: `{"ok":false,"ref":"...","error":{"code":"...","message":"..."[,"denial_context":{...}]}}`
+//!   with `denial_context` per ADR-0023 when the underlying
+//!   [`doiget_core::source::FetchError`] carries one.
+//!
 //! The exit code is the failure count (capped at 255, ERRORS.md §4).
-//!
-//! Only the parse-failure path is exercised here — it requires no
-//! network mocking and exercises both the JSONL emit and the exit
-//! code. A network-mocked success path lands together with the
-//! `fetch_one` outcome-plumbing follow-up.
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
@@ -100,13 +101,91 @@ fn batch_json_fetch_failure_emits_fetch_error_jsonl() {
     let v: Value = serde_json::from_str(lines[0]).expect("line parses as JSON");
     assert_eq!(v["ok"], Value::Bool(false));
     assert_eq!(v["ref"], "arxiv:2401.99999");
-    // Code is FETCH_ERROR (generic) per the #205 contract — the
-    // structured `denial_context` / source-specific code lands with the
-    // FetchPaperOutcome plumbing follow-up.
-    assert_eq!(v["error"]["code"], "FETCH_ERROR");
+    // #210: the typed `FetchError → ErrorCode` mapping now surfaces the
+    // closed-set wire code (`NETWORK_ERROR` for a transport-layer
+    // connect-refused) instead of the previous generic `FETCH_ERROR`.
+    assert_eq!(
+        v["error"]["code"], "NETWORK_ERROR",
+        "connect-refused at the transport layer MUST surface as NETWORK_ERROR"
+    );
     assert!(
         v["error"]["message"].is_string() && !v["error"]["message"].as_str().unwrap().is_empty(),
         "error.message MUST be a non-empty string"
+    );
+}
+
+/// #210: a successful single-arxiv batch produces a structured success
+/// JSONL record carrying `result.{safekey, store_path, canonical_digest}`.
+/// Wiremock-driven so no real network traffic; the subprocess inherits
+/// `DOIGET_ARXIV_BASE` pointing at the in-process mock.
+///
+/// Acceptance for #210: a CI consumer pipelining `batch --json` can
+/// pull `result.safekey` to construct a store-relative path and
+/// `result.canonical_digest` to deduplicate against an audit DB, all
+/// without a follow-up `info` round-trip per ref.
+#[tokio::test]
+async fn batch_json_success_emits_structured_result_record() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let body = b"%PDF-1.7\n%fixture-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let refs = dir.path().join("refs.txt");
+    std::fs::File::create(&refs)
+        .expect("create refs file")
+        .write_all(b"arxiv:2401.12345\n")
+        .expect("write refs");
+
+    let output = doiget(&dir)
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .args(["--json", "batch", refs.to_str().unwrap()])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("stdout utf-8");
+    let lines: Vec<&str> = stdout.lines().filter(|s| !s.trim().is_empty()).collect();
+    assert_eq!(lines.len(), 1, "exactly one JSONL record, got: {stdout}");
+
+    let v: Value = serde_json::from_str(lines[0]).expect("line parses as JSON");
+    assert_eq!(v["ok"], Value::Bool(true));
+    assert_eq!(v["ref"], "arxiv:2401.12345");
+    let result = v.get("result").expect("success record carries `result`");
+    assert!(
+        result["safekey"]
+            .as_str()
+            .map(|s| s.contains("2401.12345"))
+            .unwrap_or(false),
+        "result.safekey must echo the input id: {result}"
+    );
+    assert!(
+        result["store_path"]
+            .as_str()
+            .map(|s| s.ends_with(".pdf"))
+            .unwrap_or(false),
+        "result.store_path must be the on-disk PDF path: {result}"
+    );
+    let digest = result["canonical_digest"]
+        .as_str()
+        .expect("canonical_digest is a string");
+    assert_eq!(
+        digest.len(),
+        64,
+        "canonical_digest MUST be 64-char lowercase hex (ADR-0021 §1): got {digest:?}"
+    );
+    assert!(
+        digest
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+        "canonical_digest MUST be lowercase hex only: got {digest:?}"
     );
 }
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -604,6 +604,54 @@ pub struct FetchPaperOutcome {
     /// reason an OA PDF existed but could not be retrieved, so the
     /// CLI / MCP surface it instead of a silent metadata-only success.
     pub pdf_leg: PdfLegStatus,
+    /// Per-ref [`crate::Safekey`] stringified (`Ref::safekey().as_str()`).
+    /// Exposed on the outcome so JSON-mode CLI / MCP callers can
+    /// emit a structured success body without re-parsing the input
+    /// ref (#210 / `docs/ERRORS.md` §3). Always populated.
+    pub safekey: String,
+    /// ADR-0021 §1 canonical-digest as 64-char lowercase hex for the
+    /// resolver_profile that produced this outcome's audit identity.
+    /// For an arXiv fetch this is the digest under `"arxiv"`; for a
+    /// DOI OA PDF leg this is under `"oa-publisher"`; for the DOI
+    /// metadata-only fallback this is under the metadata source key
+    /// (`"crossref"` / `"unpaywall"`). Always populated.
+    pub canonical_digest: String,
+}
+
+impl FetchPaperOutcome {
+    /// Test-only constructor for downstream crates (`doiget-cli`,
+    /// `doiget-mcp`) that need to drive classification / rendering
+    /// logic without running the full orchestrator. Produces a
+    /// minimal but structurally-valid outcome — all required fields
+    /// populated with defensible stubs — so unit tests can assert
+    /// the surrounding behavior (JSONL shape, exit-code mapping,
+    /// PDF-leg branching) in isolation.
+    ///
+    /// `#[doc(hidden)]` because this is not a stable public API; the
+    /// signature may change to fit test needs without a CHANGELOG
+    /// `[BREAKING]` callout.
+    #[doc(hidden)]
+    pub fn for_test_synthetic(
+        safekey: impl Into<String>,
+        source: impl Into<String>,
+        pdf_leg: PdfLegStatus,
+    ) -> Self {
+        let safekey: String = safekey.into();
+        let source: String = source.into();
+        Self {
+            source: source.clone(),
+            resolver_profile: source.clone(),
+            license: "unknown".to_string(),
+            path: Utf8PathBuf::from(format!("/tmp/{safekey}.pdf")),
+            size_bytes: 0,
+            schema_version: SCHEMA_VERSION.to_string(),
+            pdf_leg,
+            safekey: safekey.clone(),
+            // 32 bytes of `0x00` → a stable, non-secret digest stub
+            // that's still 64 chars of lowercase hex.
+            canonical_digest: "00".repeat(32),
+        }
+    }
 }
 
 /// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it
@@ -751,6 +799,8 @@ async fn fetch_paper_arxiv(
     drop(tmp);
 
     let path = store_root.join(format!("{}.pdf", safekey.as_str()));
+    let canonical_digest =
+        crate::CanonicalRef::new(crate::SourceType::Arxiv, id.as_str(), "arxiv", None).digest_hex();
     Ok(FetchPaperOutcome {
         source: "arxiv".to_string(),
         resolver_profile: "arxiv".to_string(),
@@ -761,6 +811,8 @@ async fn fetch_paper_arxiv(
         // arXiv always delivers the PDF (or the whole fn already
         // returned Err above) — there is no metadata-only fallback.
         pdf_leg: PdfLegStatus::Fetched,
+        safekey: safekey.as_str().to_string(),
+        canonical_digest,
     })
 }
 
@@ -918,6 +970,13 @@ async fn fetch_paper_doi(
             .join(".metadata")
             .join(format!("{}.toml", safekey.as_str()))
     };
+    let canonical_digest = crate::CanonicalRef::new(
+        crate::SourceType::Doi,
+        doi.as_str(),
+        &final_source_label,
+        None,
+    )
+    .digest_hex();
     Ok(FetchPaperOutcome {
         source: final_source_label.clone(),
         resolver_profile: final_source_label,
@@ -926,6 +985,8 @@ async fn fetch_paper_doi(
         size_bytes,
         schema_version: SCHEMA_VERSION.to_string(),
         pdf_leg,
+        safekey: safekey.as_str().to_string(),
+        canonical_digest,
     })
 }
 


### PR DESCRIPTION
## Summary

Surface the structured `FetchPaperOutcome` end-to-end so
`doiget batch --json` emits the documented `docs/ERRORS.md` §3 wire
shape with typed codes and structured payloads.

- **doiget-core**: `FetchPaperOutcome` gains `safekey: String` and
  `canonical_digest: String` (additive on `#[non_exhaustive]`).
- **doiget-cli `FetchHarness::fetch_one`**: returns
  `Result<FetchPaperOutcome, FetchError>`; rendering / `CliExit` moves
  into the per-caller paths.
- **`batch --json` JSONL**:
  - Success: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`
  - Failure: `{"ok":false,"ref":"...","error":{"code":"...","message":"..."[,"denial_context":{...}]}}`
    — `code` is the typed `ErrorCode` wire string; `denial_context`
    appears only when the failure carries an ADR-0023 denial.
  - `PdfLegStatus::Blocked` outcomes surface as failure records via
    the shared `effective_blocked_code` reclassification.
- `commands::fetch::effective_blocked_code` lifted to `pub(crate)`.
- `#[doc(hidden)] FetchPaperOutcome::for_test_synthetic` in doiget-core
  so downstream tests drive classification without the full orchestrator.

## Out of scope (per #210's Out-of-scope list)

- MCP `doiget_fetch_paper` envelope surfacing safekey/canonical_digest
- `EntryInfo.canonical_digest` on info / list-recent / search bodies
- Single-fetch `--json` symmetric output

## Test plan

- [x] workspace lib 333/333 green (60 cli, 271 core, 2 mcp)
- [x] `batch_jsonl_e2e.rs` extended:
  - new wiremock-driven `batch_json_success_emits_structured_result_record`
    asserting `result.{safekey, store_path, canonical_digest}` shape
    + 64-char lowercase hex digest
  - existing transport-failure test updated to assert typed
    `NETWORK_ERROR` instead of generic `FETCH_ERROR`
- [x] new unit tests:
  - `jsonl_success_shape_with_result`
  - `jsonl_failure_shape_with_denial_context`
  - `classify_joined_blocked_pdf_emits_failure_with_denial_context`
  - `classify_joined_fetch_failure_emits_typed_code`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Refs #210.