### PR TITLE
feat(core): ADR-0029 fetch chain slice 1 — multi-candidate OA-PDF walker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.12] - 2026-05-21
+
+### Added
+
+- **[core]** ADR-0029 fetch chain slice 1 — the DOI OA-PDF leg now
+  walks a multi-candidate chain instead of trying only
+  `best_oa_location` (#222). Candidate URLs are extracted from the
+  Unpaywall envelope in priority order (best_oa_location first, then
+  every distinct entry in `oa_locations[]`); the orchestrator
+  advances past any non-PDF / 403 / network failure until either one
+  candidate yields a valid PDF or every candidate is exhausted. Each
+  attempt emits its own `oa-publisher` Fetch provenance row, so the
+  audit trail captures every external request.
+
+  Recovers the dogfood case from the finite-temperature-MPS corpus:
+  a DOI hits `link.aps.org`, the publisher WAF returns 403, but the
+  same record's arXiv preprint is in `oa_locations[]`. Pre-slice-1
+  this surfaced as `PdfLegStatus::Blocked` + metadata-only; post-
+  slice-1 the chain advances to the arXiv preprint and writes a
+  real PDF.
+
+  New helper: `doiget_core::orchestrator::extract_oa_url_chain`
+  (private). Removes the now-superseded
+  `extract_best_oa_url_from_value` helper and migrates its tests to
+  the chain extractor; net + 3 unit tests covering ordering,
+  deduplication, fallback-on-no-best, and malformed-URL tolerance.
+  New e2e test
+  `fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403`
+  exercises the WAF-block fallback flow end-to-end.
+
+### Notes
+
+- Out of scope for slice 1 (deferred follow-ups):
+  - The structured `chain: Vec<AttemptOutcome>` field on
+    `FetchError` and the new `ALL_FALLBACKS_EXHAUSTED` closed-enum
+    variant (ADR-0029 D5). Today an all-failed chain still surfaces
+    as `PdfLegStatus::Blocked` with the *last* attempt's reason on
+    `denial`; the structured per-attempt list is reserved for the
+    MCP / CLI JSON wire-shape slice that follows #212 alignment.
+  - The schema-additive `chain_attempt` / `chain_total` /
+    `chain_terminal` / `verified_by` columns on the provenance log
+    (ADR-0029 D4). Today each chain attempt is logged as a
+    standalone Fetch row indistinguishable from the pre-slice-1
+    shape; the per-attempt enrichment is deferred.
+
 ## [0.4.1-beta.11] - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.11"
+version = "0.4.1-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.11"
+version = "0.4.1-beta.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.11"
+version = "0.4.1-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.11"
+version       = "0.4.1-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.11" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.11" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.11" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.12" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.12" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.12" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -475,3 +475,137 @@ async fn fetch_doi_crossref_down_unpaywall_oa_still_yields_pdf() {
     drop(env);
     drop(td);
 }
+
+/// ADR-0029 fetch chain: when `best_oa_location` returns a non-PDF
+/// failure (here: HTTP 403 simulating a publisher WAF block) and
+/// `oa_locations[]` contains an alternate URL that DOES yield a
+/// PDF, the orchestrator must advance through the chain and write
+/// the fallback PDF.
+///
+/// The dogfood case this exists for: a DOI hits `link.aps.org` and
+/// is WAF-blocked (403), but the same OpenAlex / Unpaywall record
+/// already names an arXiv preprint that resolves under
+/// `oa-publisher` rate-limit posture. Pre-ADR-0029, the user had to
+/// discover that URL manually; post-ADR-0029, the chain walker
+/// recovers automatically.
+#[tokio::test]
+#[serial]
+async fn fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403() {
+    let server = MockServer::start().await;
+    let base_uri = server.uri();
+    let blocked_url = format!("{}/oa/blocked.pdf", base_uri);
+    let fallback_url = format!("{}/oa/fallback.pdf", base_uri);
+
+    // Crossref happy path.
+    Mock::given(method("GET"))
+        .and(path(format!("/works/{}", TEST_DOI)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(crossref_body()))
+        .mount(&server)
+        .await;
+
+    // Unpaywall envelope: best_oa_location names the (about-to-fail)
+    // publisher URL; oa_locations[] carries an alternate that the
+    // chain walker advances to after the first attempt fails.
+    let upw_body = serde_json::json!({
+        "doi": TEST_DOI,
+        "is_oa": true,
+        "title": "E2E chain test paper",
+        "best_oa_location": {
+            "url":         blocked_url,
+            "url_for_pdf": blocked_url,
+            "license":     "cc-by"
+        },
+        "oa_locations": [
+            { "url_for_pdf": blocked_url },
+            { "url_for_pdf": fallback_url }
+        ]
+    });
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(upw_body))
+        .mount(&server)
+        .await;
+
+    // First candidate: 403 (publisher WAF stand-in). Empty body.
+    Mock::given(method("GET"))
+        .and(path("/oa/blocked.pdf"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    // Second candidate: valid PDF. The chain walker MUST land here.
+    let pdf_body = b"%PDF-fallback-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/oa/fallback.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(pdf_body.clone()))
+        .mount(&server)
+        .await;
+
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CROSSREF_BASE", &base_uri);
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", base_uri));
+    env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
+
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
+        .await
+        .expect("chain walker must succeed on the fallback candidate");
+
+    // The PDF on disk MUST be the fallback body, not the blocked URL's
+    // empty 403 body — confirms the chain advanced past the first hit.
+    let pdf_path = store_root.join("doi_10.1234_test.pdf");
+    let pdf_bytes = std::fs::read(pdf_path.as_std_path()).expect("read pdf");
+    assert_eq!(
+        pdf_bytes, pdf_body,
+        "stored PDF MUST be the fallback candidate's body"
+    );
+    assert!(pdf_bytes.starts_with(b"%PDF-"));
+
+    // Provenance log MUST show two oa-publisher Fetch rows — the first
+    // an Err (403), the second an Ok (fallback success). Pre-ADR-0029
+    // there was only one oa-publisher row (the err) and a blocked
+    // metadata-only fallback.
+    let rows = read_log_rows(&log_path);
+    let oa_rows: Vec<&LogRow> = rows
+        .iter()
+        .filter(|r| r.event == LogEvent::Fetch && r.source.as_deref() == Some("oa-publisher"))
+        .collect();
+    assert_eq!(
+        oa_rows.len(),
+        2,
+        "expected 2 oa-publisher Fetch rows (one per chain candidate), got {}: {:?}",
+        oa_rows.len(),
+        oa_rows.iter().map(|r| &r.result).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        oa_rows[0].result,
+        LogResult::Err,
+        "first chain attempt is the 403"
+    );
+    assert_eq!(
+        oa_rows[1].result,
+        LogResult::Ok,
+        "second chain attempt is the fallback PDF success"
+    );
+
+    // Hash chain stays intact across the multi-attempt OA leg.
+    assert_eq!(rows[0].prev_hash, "GENESIS");
+    for i in 1..rows.len() {
+        assert_eq!(
+            rows[i].prev_hash,
+            rows[i - 1].this_hash,
+            "hash chain break at row {i}"
+        );
+    }
+
+    drop(env);
+    drop(td);
+}

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -852,43 +852,85 @@ async fn fetch_paper_doi(
         .unwrap_or(Value::Null);
     let extracted = extract_crossref_fields(&crossref_meta);
 
-    // Unpaywall second — license enrichment + OA URL discovery. A
-    // failure here is non-fatal: we still write the Crossref-derived
-    // metadata.
+    // Unpaywall second — license enrichment + OA URL chain discovery.
+    // A failure here is non-fatal: we still write the Crossref-
+    // derived metadata.
     let unpaywall = unpaywall_source_from_env(&unpaywall_contact);
     let upw_result = unpaywall.fetch(ref_, profile, ctx).await;
-    let (license, source_label, oa_url) = match upw_result {
+    let (license, source_label, oa_chain) = match upw_result {
         Ok(r) => {
-            let oa = extract_best_oa_url_from_value(r.metadata_json.as_ref());
+            let chain = extract_oa_url_chain(r.metadata_json.as_ref());
             let label = if r.license != "unknown" {
                 "unpaywall".to_string()
             } else {
                 "crossref".to_string()
             };
-            (r.license, label, oa)
+            (r.license, label, chain)
         }
         Err(e) => {
             tracing::warn!(
                 error = %e,
                 "unpaywall fetch failed; continuing with crossref-only metadata"
             );
-            ("unknown".to_string(), "crossref".to_string(), None)
+            ("unknown".to_string(), "crossref".to_string(), Vec::new())
         }
     };
 
-    // OA PDF leg. Try the URL Unpaywall returned via the `oa-publisher`
-    // source allowlist. Magic-byte check is enforced inside
-    // `HttpClient::fetch_pdf`. Issue #118: a failure here is NEVER
-    // silently turned into a clean metadata-only success — the
-    // structured reason is carried out on `PdfLegStatus::Blocked` so
-    // the CLI / MCP can explain WHY the PDF could not be fetched.
-    let (pdf_leg, pdf_bytes) = match oa_url {
-        None => (PdfLegStatus::NoOaUrl, None),
-        Some(url) => match try_fetch_oa_pdf(doi, &url, ctx).await {
-            Ok((bytes, _final_url)) => (PdfLegStatus::Fetched, Some(bytes)),
-            Err(e) => {
-                // Borrow for the denial side-channel + human message,
-                // then consume into the closed ErrorCode last.
+    // OA PDF leg — ADR-0029 fetch chain. Walk the candidate URL list
+    // in order; first successful PDF wins, all-failed surfaces as
+    // `PdfLegStatus::Blocked` with the LAST attempt's error (the most
+    // informative for the operator — typically the network /
+    // allowlist reason the chain could not be exhausted). Each
+    // `try_fetch_oa_pdf` call already emits its own per-attempt
+    // provenance row (`oa-publisher` Fetch ok / err), so the audit
+    // trail captures every external request without orchestrator-
+    // side bookkeeping.
+    //
+    // Issue #118: a failure here is NEVER silently turned into a
+    // clean metadata-only success — the structured reason is carried
+    // out on `PdfLegStatus::Blocked`.
+    let (pdf_leg, pdf_bytes) = if oa_chain.is_empty() {
+        (PdfLegStatus::NoOaUrl, None)
+    } else {
+        let mut succeeded: Option<Vec<u8>> = None;
+        let mut last_err: Option<HttpError> = None;
+        let total = oa_chain.len();
+        for (idx, candidate) in oa_chain.iter().enumerate() {
+            let attempt = idx + 1;
+            tracing::debug!(
+                attempt,
+                total,
+                url = %candidate,
+                "trying OA PDF candidate (ADR-0029 chain)"
+            );
+            match try_fetch_oa_pdf(doi, candidate, ctx).await {
+                Ok((bytes, _final_url)) => {
+                    if attempt > 1 {
+                        tracing::info!(
+                            attempt,
+                            total,
+                            url = %candidate,
+                            "OA PDF chain succeeded on fallback candidate (ADR-0029)"
+                        );
+                    }
+                    succeeded = Some(bytes);
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        attempt,
+                        total,
+                        url = %candidate,
+                        error = %e,
+                        "OA PDF candidate failed; advancing to next (ADR-0029 chain)"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        match (succeeded, last_err) {
+            (Some(bytes), _) => (PdfLegStatus::Fetched, Some(bytes)),
+            (None, Some(e)) => {
                 let fe = FetchError::Http(e);
                 let denial: Option<crate::DenialContext> = (&fe).into();
                 let message = fe.to_string();
@@ -902,7 +944,12 @@ async fn fetch_paper_doi(
                     None,
                 )
             }
-        },
+            // Unreachable: `oa_chain` is non-empty in this branch, so
+            // at least one iteration set either `succeeded` or
+            // `last_err`. Conservative fallback if a future refactor
+            // breaks the invariant.
+            (None, None) => (PdfLegStatus::NoOaUrl, None),
+        }
     };
 
     // Issue #120: Crossref is non-fatal, but if it failed AND the OA
@@ -1303,12 +1350,60 @@ fn extract_crossref_fields(msg: &Value) -> CrossrefFields {
     }
 }
 
-/// Pull the preferred OA URL out of an Unpaywall `metadata_json`
-/// envelope. Tries `best_oa_location.url_for_pdf` first (direct PDF
-/// link), falling back to `best_oa_location.url`.
-fn extract_best_oa_url_from_value(meta: Option<&Value>) -> Option<url::Url> {
-    let meta = meta?;
-    let loc = meta.get("best_oa_location")?;
+/// Pull the ordered chain of candidate OA URLs out of an Unpaywall
+/// `metadata_json` envelope per ADR-0029 D2.
+///
+/// Order is `best_oa_location` first (when present), then every
+/// distinct entry in `oa_locations[]`. Duplicate URLs are deduped by
+/// exact string match so a candidate that appears as both the "best"
+/// entry and an array element is fetched at most once.
+///
+/// Each location's URL is resolved via the same `url_for_pdf` →
+/// `url` fallback the single-URL extractor uses.
+///
+/// Returns `Vec::new()` when no OA location was reported (the chain
+/// is empty and the caller surfaces [`PdfLegStatus::NoOaUrl`]).
+fn extract_oa_url_chain(meta: Option<&Value>) -> Vec<url::Url> {
+    let meta = match meta {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+    let mut out: Vec<url::Url> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut push_unique = |u: url::Url| {
+        let key = u.as_str().to_string();
+        if seen.insert(key) {
+            out.push(u);
+        }
+    };
+
+    // Priority 1: best_oa_location (Unpaywall's own quality-ordered
+    // pick — ADR-0029 D2 NORMATIVE: defer to the metadata source's
+    // ordering).
+    if let Some(best) = meta.get("best_oa_location") {
+        if let Some(u) = pull_oa_url_from_location(best) {
+            push_unique(u);
+        }
+    }
+    // Priority 2: every entry in oa_locations[] after the best one.
+    // The fallback target this ADR exists to enable is precisely the
+    // arXiv preprint that lives here when `best_oa_location` is a
+    // WAF-blocked publisher URL.
+    if let Some(arr) = meta.get("oa_locations").and_then(|v| v.as_array()) {
+        for loc in arr {
+            if let Some(u) = pull_oa_url_from_location(loc) {
+                push_unique(u);
+            }
+        }
+    }
+    out
+}
+
+/// Resolve a single OA location object to a `url::Url`. Tries
+/// `url_for_pdf` first (the direct PDF link Unpaywall annotates when
+/// it knows one), falling back to `url` (the landing page). Returns
+/// `None` if neither field is present or parses.
+fn pull_oa_url_from_location(loc: &Value) -> Option<url::Url> {
     let candidate = loc
         .get("url_for_pdf")
         .and_then(|v| v.as_str())
@@ -1531,33 +1626,111 @@ mod tests {
     }
 
     #[test]
-    fn extract_best_oa_url_from_value_prefers_url_for_pdf() {
+    fn extract_oa_url_chain_prefers_best_url_for_pdf() {
+        // `best_oa_location.url_for_pdf` is the highest-priority
+        // candidate (ADR-0029 D2 — defer to the metadata source's
+        // ordering). Falls back to `best_oa_location.url` only when
+        // no PDF link is annotated.
         let meta = serde_json::json!({
             "best_oa_location": {
                 "url_for_pdf": "https://example.org/pdf",
                 "url": "https://example.org/landing"
             }
         });
-        let url = extract_best_oa_url_from_value(Some(&meta)).expect("Some(Url)");
-        assert_eq!(url.as_str(), "https://example.org/pdf");
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].as_str(), "https://example.org/pdf");
     }
 
     #[test]
-    fn extract_best_oa_url_from_value_falls_back_to_url() {
+    fn extract_oa_url_chain_falls_back_to_url_when_url_for_pdf_absent() {
         let meta = serde_json::json!({
             "best_oa_location": {
                 "url": "https://example.org/landing"
             }
         });
-        let url = extract_best_oa_url_from_value(Some(&meta)).expect("Some(Url)");
-        assert_eq!(url.as_str(), "https://example.org/landing");
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].as_str(), "https://example.org/landing");
     }
 
     #[test]
-    fn extract_best_oa_url_from_value_none_on_missing() {
+    fn extract_oa_url_chain_is_empty_when_no_locations() {
         let meta = serde_json::json!({});
-        assert!(extract_best_oa_url_from_value(Some(&meta)).is_none());
-        assert!(extract_best_oa_url_from_value(None).is_none());
+        assert!(extract_oa_url_chain(Some(&meta)).is_empty());
+        assert!(extract_oa_url_chain(None).is_empty());
+    }
+
+    #[test]
+    fn extract_oa_url_chain_appends_oa_locations_after_best() {
+        // ADR-0029 D2: best_oa_location first, then the rest of
+        // oa_locations in metadata-source order. This is the load-
+        // bearing test: it pins the fact that an arXiv preprint
+        // listed *after* a WAF-blocked publisher in oa_locations[]
+        // becomes a fallback candidate the chain walker can reach.
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://publisher.example.org/pdf"
+            },
+            "oa_locations": [
+                {"url_for_pdf": "https://publisher.example.org/pdf"},
+                {"url_for_pdf": "https://arxiv.org/pdf/2401.12345"},
+                {"url": "https://repo.example.edu/handle/123"}
+            ]
+        });
+        let chain = extract_oa_url_chain(Some(&meta));
+        let strs: Vec<&str> = chain.iter().map(|u| u.as_str()).collect();
+        assert_eq!(
+            strs,
+            vec![
+                "https://publisher.example.org/pdf",
+                "https://arxiv.org/pdf/2401.12345",
+                "https://repo.example.edu/handle/123",
+            ],
+            "chain ordering MUST be best_oa_location first, oa_locations[] verbatim after"
+        );
+    }
+
+    #[test]
+    fn extract_oa_url_chain_dedupes_repeated_urls() {
+        // A URL that appears as both `best_oa_location` and an entry
+        // in `oa_locations[]` is fetched at most once. Without this,
+        // a publisher whose record has the same URL in both slots
+        // would consume two HTTP requests + two rate-limit ticks.
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/pdf"
+            },
+            "oa_locations": [
+                {"url_for_pdf": "https://example.org/pdf"},
+                {"url_for_pdf": "https://example.org/pdf"},
+                {"url_for_pdf": "https://arxiv.org/pdf/2401.12345"}
+            ]
+        });
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].as_str(), "https://example.org/pdf");
+        assert_eq!(chain[1].as_str(), "https://arxiv.org/pdf/2401.12345");
+    }
+
+    #[test]
+    fn extract_oa_url_chain_skips_unparseable_urls() {
+        // A malformed URL in oa_locations[] is dropped silently
+        // rather than aborting the chain — the metadata source can
+        // emit a stray entry without poisoning the whole fetch.
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://good.example.org/pdf"
+            },
+            "oa_locations": [
+                {"url_for_pdf": "not a url"},
+                {"url_for_pdf": "https://arxiv.org/pdf/2401.12345"}
+            ]
+        });
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].as_str(), "https://good.example.org/pdf");
+        assert_eq!(chain[1].as_str(), "https://arxiv.org/pdf/2401.12345");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The DOI orchestrator's OA-PDF leg now walks a multi-candidate chain
extracted from Unpaywall's \`best_oa_location\` + \`oa_locations[]\`
instead of trying only the single \"best\" URL. On any non-PDF / 403
/ network failure the chain advances; first successful candidate
wins.

Recovers the dogfood case from the finite-temperature-MPS corpus: a
DOI hits \`link.aps.org\`, the publisher WAF returns 403, but the
same record's arXiv preprint is in \`oa_locations[]\`. Pre-slice-1
this surfaced as \`PdfLegStatus::Blocked\` + metadata-only;
post-slice-1 the chain advances to the arXiv preprint and writes a
real PDF.

## What's in

- **doiget-core**: new private helper
  \`orchestrator::extract_oa_url_chain\` returns the ordered, deduped
  URL chain. \`fetch_paper_doi\` replaces the single
  \`try_fetch_oa_pdf\` call with a chain walker. Each attempt emits
  its own \`oa-publisher\` Fetch provenance row via the existing
  machinery — no schema changes.
- Removed superseded \`extract_best_oa_url_from_value\` helper; 3
  prior tests migrated to the chain extractor; net + 3 new unit
  tests cover ordering / dedup / malformed-URL tolerance.
- New e2e test
  \`fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403\`
  exercises the WAF-block fallback through the full wiremock
  fixture (2 oa-publisher Fetch rows: err → ok).

## Out of scope (ADR-0029 follow-up slices)

- The structured \`chain: Vec<AttemptOutcome>\` field on
  \`FetchError\` and the new \`ALL_FALLBACKS_EXHAUSTED\` closed-enum
  variant (ADR-0029 D5).
- The schema-additive \`chain_attempt\` / \`chain_total\` /
  \`chain_terminal\` / \`verified_by\` columns on the provenance log
  (ADR-0029 D4).

The chain *runs* in slice 1; the structured wire / log shape lands
in slice 2 (alongside #212 MCP/CLI alignment).

## Test plan

- [x] workspace lib 333 tests green (57 cli, 274 core, 2 mcp)
- [x] 6 unit tests on \`extract_oa_url_chain\` (ordering / dedup /
      malformed-URL tolerance / fallback-on-no-best)
- [x] new e2e test for WAF-block fallback flow
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

Refs ADR-0029, #222.