### PR TITLE
chore(release): bless next as v0.4.0 (promotion to main)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,11 @@
 # `flate`: substring of the gzip crate name `flate2` (provenance §6
 # rotation, #140) — a real crate identifier, not a misspelling of "flat".
 flate = "flate"
+# `rquest`: actively-maintained reqwest fork
+# (https://crates.io/crates/rquest); referenced in ADR-0028 (D3)
+# as one of the impersonation libraries explicitly out-of-scope.
+# Not a misspelling of "request" or "quest".
+rquest = "rquest"
 
 [files]
 # Generated / vendored / fixture files where typo enforcement is not useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.7] - 2026-05-21
+
+### Fixed
+
+- **[core/http]** Legacy `http://` URLs returned by OpenAlex /
+  Unpaywall metadata (e.g. `http://link.aps.org/pdf/…` for older
+  APS records) are now transparently upgraded to `https://` before
+  the request leaves the process (#220, see ADR-0028 D3 — accept-
+  list, non-impersonating). Without this, the production
+  `https_only(true)` client refuses to send the request and the
+  fetch fails with a generic builder error even though the host
+  has supported HTTPS for years. The upgrade is total but
+  intentionally skipped for loopback hosts (`localhost`,
+  `127.0.0.0/8`, `::1`) so the `new_for_tests_allow_http*`
+  wiremock path is unchanged. TLS posture is preserved: if the
+  upgraded host doesn't serve HTTPS the connection fails at the
+  TLS handshake with a normal `NETWORK_ERROR`, never falling back
+  to plaintext.
+
 ## [0.4.1-beta.5] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,62 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.11] - 2026-05-21
+
+### Added
+
+- **[core]** New `doiget_core::refs` module per ADR-0030 slice 1 —
+  bibliography input adapters. Exposes
+  `Format { Auto, Refs, CslJson, Bibtex }`,
+  `ParsedEntry { ref_, entry_key }`,
+  `ParseError { NoIdentifier, InvalidRef, Decode,
+  UnsupportedFormat }` (closed-enum, `#[non_exhaustive]`), and
+  `parse_input(text, format, path) -> Vec<Result<ParsedEntry,
+  ParseError>>` plus per-format helpers. Honors the ADR-0030 D3
+  identifier-pick priority: `DOI` > arXiv (`archivePrefix == "arXiv"`
+  + `eprint`, or `note: "arXiv:…"`) > (PMID parking). 23 unit tests
+  cover format detection, all parser branches, the priority rule,
+  case-insensitive field matching, and Zotero / Mendeley wire shape
+  quirks.
+
+- **[cli]** `doiget batch library.json` accepts a CSL-JSON export
+  directly. The format is auto-detected from the path extension
+  (`.json` / `.csl`) and the file's leading non-comment character;
+  callers writing plain refs files (`.txt`) keep working with no
+  change. A malformed CSL-JSON document aborts the batch with a
+  loud whole-input error rather than silently behaving as an empty
+  batch. New e2e tests
+  `batch_json_csl_input_yields_one_record_per_entry` and
+  `batch_malformed_csl_json_aborts_with_decode_error`.
+
+### Changed
+
+- **[cli]** `batch` JSONL `ref` field is now the bare identifier per
+  `docs/PROVENANCE_LOG.md` §3 — `Ref::as_input_str()`'s canonical
+  form — rather than the raw file line. For an input line
+  `arxiv:2401.99999`, the failure record's `ref` is now
+  `"2401.99999"` (no URI scheme). DOI inputs were already in this
+  form. Wire-format-visible: CI consumers parsing the `ref` field
+  should switch from "string match input line" to "regex / parse as
+  DOI or arXiv id". Surfaced because the new `refs::parse_input`
+  pipeline normalises every entry through `Ref::parse` before
+  emitting; the pre-ADR-0030 flow echoed raw lines verbatim.
+
+### Notes
+
+- Out of scope for slice 1 (deferred to follow-up slices):
+  - BibTeX / `.bib` parsing — requires the `biblatex` crate
+    (+500 KB) and its cargo-vet transitive exemptions. Until that
+    ships, `Format::Bibtex` returns `ParseError::UnsupportedFormat`
+    with a helpful "re-export as CSL-JSON" hint, and `.bib` file
+    extensions surface that error on the first batch invocation.
+  - `--format` / `--strict` CLI flags.
+  - New MCP tool `doiget_batch_from_bibliography`.
+  - Plumbing `entry_key` into the JSONL `error` object as a typed
+    field (today the citation key is embedded in placeholder
+    `<no-identifier:KEY>` strings that the existing JSONL `ref`
+    surfaces verbatim).
+
 ## [0.4.1-beta.10] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,49 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+<<<<<<< HEAD
+=======
+## [0.4.1-beta.13] - 2026-05-21
+
+### Added
+
+- **[mcp]** New MCP tool `doiget_batch_from_bibliography` per
+  ADR-0030 D6 — accepts an absolute `path` to a CSL-JSON file
+  (BibTeX coming in the biblatex slice), parses it via
+  `doiget_core::refs::parse_input`, and fetches every resolvable
+  entry through the existing batch orchestrator. Each result row
+  carries the source bibliography's `entry_key` so a Zotero /
+  Mendeley plugin can bridge the fetched PDF back to the originating
+  reference.
+
+  Output shape (ADR-0030 D6):
+  ```json
+  {
+    "ok": true,
+    "summary": {"total": 12, "ok": 10, "failed": 1, "parse_errors": 1},
+    "results": [
+      {"entry_key":"Foo2024","ref":"10.1234/foo","ok":true,"path":"...","license":"cc-by",...},
+      {"entry_key":"NoId2025","ref":null,"ok":false,
+       "error":{"code":"INVALID_REF","message":"entry has no DOI / arXiv id"}}
+    ]
+  }
+  ```
+
+  `strict` input field (default `false`) controls whether the FIRST
+  per-entry parse error aborts the whole call (`true`) or surfaces
+  as a row next to successful siblings (`false`). A whole-input
+  decode failure (malformed CSL-JSON) always aborts regardless of
+  `strict`.
+
+  `doiget capabilities` JSON's `mcp_tools` array gains the new
+  `doiget_batch_from_bibliography` entry; the parity test is
+  updated in lockstep so the table cannot drift from the docs.
+
+  6 new MCP unit tests cover `parse_bibliography_format`'s token
+  acceptance (auto / refs / csl-json / bibtex / case-insensitivity /
+  underscore variants / unknown-token rejection).
+
+>>>>>>> 01150e7 (feat(mcp): doiget_batch_from_bibliography MCP tool (ADR-0030 D6))
 ## [0.4.1-beta.12] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,84 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.9] - 2026-05-21
+
+### Added
+
+- **[core]** `FetchPaperOutcome` (`doiget_core::orchestrator`) gains
+  two new fields: `safekey: String` and `canonical_digest: String`
+  (#210). Both are always populated — `safekey` from the input ref
+  (`Ref::safekey().as_str()`), `canonical_digest` from
+  `CanonicalRef::digest_hex()` under the outcome's
+  `resolver_profile`. Additive on a `#[non_exhaustive]` struct, so
+  downstream consumers continue to compile without changes.
+
+- **[cli]** `doiget batch --json` JSONL records carry the full
+  structured outcome per `docs/ERRORS.md` §3 (#210):
+  - **Success**: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`.
+    A CI consumer can now pull `safekey` to construct a store-relative
+    path and `canonical_digest` to deduplicate against an audit DB
+    without a follow-up `info` round-trip per ref.
+  - **Failure**: `{"ok":false,"ref":"...","error":{"code":"...","message":"...","denial_context":{...}}}`.
+    The `code` field is now the typed `ErrorCode` wire string (e.g.
+    `CAPABILITY_DENIED` / `NETWORK_ERROR` / `INTERNAL_ERROR`) — the
+    previous generic `FETCH_ERROR` only survives in the JoinSet
+    panic arm where no underlying `FetchError` exists. The
+    `denial_context` key is present only when the failure carries a
+    structured ADR-0023 denial; bare transport / config errors omit
+    the key entirely so consumers can use its presence as a typed-
+    denial discriminator.
+
+  A `PdfLegStatus::Blocked` outcome (an OA PDF was discovered but
+  could not be retrieved per #145) is now surfaced as a failure
+  record with the policy-class `denial_context`, rather than being
+  collapsed into the bare `{ok:true, ref}` shape that #205 left in
+  place. The `effective_blocked_code` reclassification (off-allowlist
+  / insecure-scheme / blocklisted-host → `CAPABILITY_DENIED`) is
+  shared between single-fetch and batch, so the wire code matches the
+  single-fetch CLI exit-code mapping.
+
+### Changed
+
+- **[cli]** `FetchHarness::fetch_one` signature changes from
+  `async fn (..., &Ref) -> anyhow::Result<()>` to
+  `async fn (..., &Ref) -> Result<FetchPaperOutcome, FetchError>`
+  (#210). The rendering + exit-code synthesis that used to live
+  inside `fetch_one` (Blocked-PDF reclassification, `error[CODE]:`
+  stderr, `CliExit` construction) now lives in the per-caller paths
+  (`commands::fetch::run_with_options` for single-fetch,
+  `commands::batch::classify_joined` for batch) so each surface can
+  emit its own machine-readable shape from the same typed outcome.
+  `pub(crate)`, not a public API.
+
+  - `commands::fetch::effective_blocked_code` is lifted from `fn` to
+    `pub(crate) fn` so the batch caller shares the single-fetch
+    reclassification rule.
+  - New `commands::fetch::outcome_is_clean_success` helper collapses
+    the typed `Result<FetchPaperOutcome, FetchError>` to the boolean
+    the `SessionEnd` row's `is_ok` field needs, so a Blocked PDF leg
+    never reads as a green session in the provenance log.
+
+- **[core]** New `#[doc(hidden)] pub fn FetchPaperOutcome::for_test_synthetic(...)`
+  test-only constructor in `doiget_core::orchestrator` so downstream
+  test code (`doiget-cli` batch unit tests) can drive
+  classification logic without running the full orchestrator. Not a
+  stable public API — the signature may change to fit test needs
+  without a `[BREAKING]` callout.
+
+### Notes
+
+- Out of scope (deferred to follow-up issues per #210's Out-of-scope
+  list):
+  - The MCP `doiget_fetch_paper` envelope upgrade to surface
+    `safekey` / `canonical_digest` (the FetchPaperOutcome fields
+    are populated; the envelope-side wire change is a separate
+    item).
+  - `canonical_digest` on `EntryInfo` (`info` / `list-recent` /
+    `search` JSON bodies).
+  - Single-fetch `--json` symmetric output (the CLI single-fetch JSON
+    branch mirroring batch JSONL's single record).
+
 ## [0.4.1-beta.8] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,21 +14,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
-- **[core]** New module `doiget_core::user_extension`: parser + merger
-  for `[[network.additional_hosts]]` entries in the user's
-  `config.toml`, per ADR-0028 D2 (#220). The orchestrator's
-  production HttpClient construction (`commands::fetch::build_http_client`)
-  now reads `<config_dir>/doiget/config.toml`, validates each entry
-  against the restricted ADR-0028 D2-1 pattern grammar (literal FQDN
-  or single-suffix wildcard `*.<suffix>` only — multi-segment globs,
-  bare wildcards, and non-host characters are parse errors), and
-  merges the user-added hosts into the `oa-publisher` allowlist
-  alongside the curated set. A missing config file is the normal case
-  ("no extensions"); a malformed file emits a `tracing::warn!` to
-  stderr but never aborts the fetch (the curated allowlist still
-  applies). Unblocks the real-world dogfood case where a Green-OA
-  paper lives on an institutional repo like `ruj.uj.edu.pl` that the
-  curated list cannot reasonably enumerate.
+- **[core]** New module `doiget_core::user_extension` per ADR-0028
+  D2 (#220). Users can extend the `oa-publisher` redirect allowlist
+  for their own deployment via `[[network.additional_hosts]]` in
+  `<config_dir>/doiget/config.toml`. Pattern grammar is restricted
+  (literal FQDN or single-suffix wildcard `*.<suffix>`); rejection
+  classes are surfaced as a closed-enum `PatternError` for
+  programmatic consumption by the future `doiget config doctor`
+  surface. The `host` field of `UserExtensionHost` is a
+  `HostPattern` newtype that runs validation through its serde
+  `Deserialize`, so the "valid pattern" invariant is type-level —
+  no `UserExtensionHost` value can exist with an invalid host. The
+  orchestrator's production HttpClient construction
+  (`commands::fetch::build_http_client`) loads and merges in one
+  pass; a missing config file is silent, a malformed config is
+  surfaced as `tracing::warn!` and the fetch continues with the
+  curated set.
 
   Example:
 
@@ -47,7 +48,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   the `doiget config doctor` surface (D2-3), the
   `capability_gate.user_extension_count` field in `doiget
   capabilities` JSON (D2-4), and the MCP-server-side merge in
-  `doiget-mcp`.
+  `doiget-mcp` (a user who configures
+  `[[network.additional_hosts]]` and invokes via `doiget serve`
+  currently sees no effect; that is the load-bearing item S3b
+  closes).
 
 ## [0.4.1-beta.7] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.1] - 2026-05-21
+
+Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +
+ADR-0028 / 0029 / 0030, design-only — no code change yet).
+Workspace version is bumped to satisfy the version-gate G5
+(non-empty CHANGELOG section for the prospective tag) while the
+implementation slices S1-S8 land separately.
+
+### Added
+
+- **[design]** ADR-0017 Amendment 1: distinguish *explicit* vs
+  *implicit* `Quiet`, classify commands as artifact vs
+  informational. Closes the LLM cold-boot deadlock reported in
+  #219 / #220 once the implementation slice (S1) lands.
+- **[design]** ADR-0028: the capability gate's purpose is
+  **ToS compliance + verified curation**; users may extend it via
+  `config.toml` (literal hosts or single-suffix wildcards) with
+  per-attempt `verified_by = "user"` recorded in the provenance
+  log. Impersonation / WAF bypass / embedded headless browser
+  (#223) are permanently out-of-scope.
+- **[design]** ADR-0029: `fetch_one` resolves to an ordered chain
+  of candidate URLs (OpenAlex `oa_locations[]` order); each
+  attempt becomes its own provenance row (schema-additive on v2).
+  New closed-enum `FetchError` variant `ALL_FALLBACKS_EXHAUSTED`
+  carries `Vec<AttemptOutcome>`.
+- **[design]** ADR-0030: bibliography input adapters
+  (`.bib` / CSL-JSON) live in `doiget-core`; new MCP tool
+  `doiget_batch_from_bibliography` enables the Zotero plugin
+  distribution path. One identifier per entry
+  (DOI > arXiv > PMID); skip-and-warn on parse error by default.
+
 ## [0.3.0] - 2026-05-20
 
 Promotion of the `0.2.1-beta.1..beta.12` integration line on `next` to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
-- **[core/http]** Legacy `http://` URLs returned by OpenAlex /
-  Unpaywall metadata (e.g. `http://link.aps.org/pdf/…` for older
-  APS records) are now transparently upgraded to `https://` before
-  the request leaves the process (#220, see ADR-0028 D3 — accept-
-  list, non-impersonating). Without this, the production
-  `https_only(true)` client refuses to send the request and the
-  fetch fails with a generic builder error even though the host
-  has supported HTTPS for years. The upgrade is total but
-  intentionally skipped for loopback hosts (`localhost`,
-  `127.0.0.0/8`, `::1`) so the `new_for_tests_allow_http*`
-  wiremock path is unchanged. TLS posture is preserved: if the
-  upgraded host doesn't serve HTTPS the connection fails at the
-  TLS handshake with a normal `NETWORK_ERROR`, never falling back
-  to plaintext.
+- **[core/http]** `http://` URLs returned by OpenAlex / Unpaywall
+  metadata for publishers that have since moved to HTTPS are
+  transparently upgraded to `https://` before the request leaves
+  the process (#220). Without this, the production
+  `https_only(true)` client refused to send and the fetch failed
+  with a generic builder error. The upgrade is skipped for
+  loopback hosts (`localhost`, the RFC 6761 `.localhost` TLD,
+  `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback) so the
+  `new_for_tests_allow_http*` wiremock path is unchanged. TLS
+  posture (ADR-0020) is preserved — the upgrade turns a
+  guaranteed-reject into a real TLS handshake, never a plaintext
+  fallback. Successful upgrades log at `tracing::info!` so the
+  rewrite appears in audit-level logs.
 
 ## [0.4.1-beta.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.10] - 2026-05-21
+
+### Added
+
+- **[mcp]** MCP-server `build_http_client_for_fetch` now merges
+  user-extension hosts from `<config_dir>/doiget/config.toml` per
+  ADR-0028 D2, mirroring the CLI path that landed in beta.8 (#220).
+  Before this slice, a user who configured
+  `[[network.additional_hosts]]` and invoked via `doiget serve`
+  saw no effect — only `doiget fetch` honored the extension. The
+  MCP merge closes that asymmetry; both surfaces now read the same
+  config file with identical failure handling (silent on
+  not-found, `tracing::warn!` on malformed, curated allowlist
+  continues regardless).
+
+- **[cli]** `doiget config doctor` adds a user-extension health
+  check (ADR-0028 D2-3): on a green run the new line reads
+  `[ ok ] user-extension hosts loaded: N`; on a malformed
+  `config.toml` it emits `[FAIL] user-extension config invalid:
+  <error>` and exits 2. A missing `config.toml` is normal (count
+  = 0, no failure) — the user simply has not extended the gate.
+
+- **[cli]** `doiget capabilities` JSON gains a top-level
+  `user_extension_count: usize` field (ADR-0028 D2-4) so an LLM
+  cold-booted into doiget can confirm at a glance whether the
+  curated allowlist has been extended on this host. The field
+  counts valid `[[network.additional_hosts]]` entries; parse
+  errors collapse to `0` (use `doiget config doctor` to
+  diagnose). `Capabilities` is `#[non_exhaustive]`, so adding the
+  field is additive for downstream Rust consumers; JSON consumers
+  should ignore unknown fields.
+
+### Changed
+
+- **[cli]** `commands::fetch::config_dir_utf8` lifted from private
+  to `pub(crate)` so sibling modules
+  (`commands::capabilities`, `commands::config`) resolve the same
+  `<config_dir>/doiget/` path the production HTTP-client builder
+  reads from. No behavior change.
+
+### Notes
+
+- Out of scope for this slice (still tracked under #220 / ADR-0028):
+  the `verified_by = "user"` provenance row field (D2-2). That
+  requires allowlist source-attribution plumbing through the
+  redirect closure and is deferred to a follow-up slice.
+
 ## [0.4.1-beta.9] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.2] - 2026-05-21
+
+### Fixed
+
+- **[cli]** `doiget capabilities` no longer silently exits with empty
+  stdout in non-TTY / agent execution contexts (#219, #220 ADR-0017
+  Amendment 1). The resolver now distinguishes **explicit** Quiet
+  (`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`) from
+  **implicit** Quiet (the non-TTY default), and `capabilities` —
+  classified as an *artifact* command — suppresses stdout only on
+  explicit Quiet. Closes the LLM cold-boot deadlock where an agent
+  ran `doiget capabilities` over a captured pipe and got nothing
+  back. `OutputMode` enum wire format (`DOIGET_MODE` strings, the
+  `modes` array in capabilities JSON) is unchanged; the
+  `quiet_was_explicit` discriminator lives only in-memory on the
+  new `ResolvedOutput` returned by `commands::output::resolve()`.
+  `bib` / `csl` were already correct (they ignore mode); their
+  classification is now documented via the new
+  `is_artifact_command()` helper.
+
 ## [0.4.1-beta.1] - 2026-05-21
 
 Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,437 +10,151 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-<<<<<<< HEAD
-=======
-## [0.4.1-beta.13] - 2026-05-21
+## [0.4.0] - 2026-05-21
+
+Promotion of the `0.4.1-beta.1..beta.13` integration line on `next` to a
+stable release. SemVer **minor** bump (not patch) — this window
+introduces multiple new public surfaces (`doiget_core::refs` module,
+`doiget_batch_from_bibliography` MCP tool, `FetchPaperOutcome` field
+additions, user-extensible capability gate, fetch chain) and one CLI
+flag set expansion, alongside several behavioural changes for the
+OA-PDF leg and batch JSONL wire shape. Beta-window detail is preserved
+in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
 
 ### Added
 
-- **[mcp]** New MCP tool `doiget_batch_from_bibliography` per
-  ADR-0030 D6 — accepts an absolute `path` to a CSL-JSON file
-  (BibTeX coming in the biblatex slice), parses it via
-  `doiget_core::refs::parse_input`, and fetches every resolvable
-  entry through the existing batch orchestrator. Each result row
-  carries the source bibliography's `entry_key` so a Zotero /
-  Mendeley plugin can bridge the fetched PDF back to the originating
-  reference.
+- **[core] ADR-0028 user-extensible capability gate** — new
+  `doiget_core::user_extension` module parses
+  `<config_dir>/doiget/config.toml`'s `[[network.additional_hosts]]`
+  entries (literal FQDN or single-suffix `*.<suffix>` wildcards) and
+  merges them into the `oa-publisher` redirect allowlist. The `host`
+  field is a `HostPattern` newtype whose `Deserialize` runs validation
+  so the "valid pattern" invariant is type-level. Both `doiget fetch`
+  and `doiget serve` honor the extension; `doiget config doctor`
+  reports health; `doiget capabilities` JSON exposes
+  `user_extension_count`. ToS+verified-curation framing rejects
+  WAF-bypass / impersonation proposals permanently (ADR-0028 D3 and
+  #223 close-rationale).
 
-  Output shape (ADR-0030 D6):
-  ```json
-  {
-    "ok": true,
-    "summary": {"total": 12, "ok": 10, "failed": 1, "parse_errors": 1},
-    "results": [
-      {"entry_key":"Foo2024","ref":"10.1234/foo","ok":true,"path":"...","license":"cc-by",...},
-      {"entry_key":"NoId2025","ref":null,"ok":false,
-       "error":{"code":"INVALID_REF","message":"entry has no DOI / arXiv id"}}
-    ]
-  }
-  ```
+- **[core] ADR-0029 fetch chain (slice 1)** — the DOI OA-PDF leg now
+  walks a multi-candidate chain from Unpaywall's `best_oa_location` +
+  `oa_locations[]` instead of trying only the single "best" URL. On
+  any non-PDF / 403 / network failure the chain advances; first
+  successful candidate wins. Each attempt emits its own
+  `oa-publisher` Fetch provenance row. Recovers the dogfood case
+  where a DOI hits a WAF-blocked publisher but the same record's
+  arXiv preprint is in `oa_locations[]`.
 
-  `strict` input field (default `false`) controls whether the FIRST
-  per-entry parse error aborts the whole call (`true`) or surfaces
-  as a row next to successful siblings (`false`). A whole-input
-  decode failure (malformed CSL-JSON) always aborts regardless of
-  `strict`.
+- **[core] ADR-0030 bibliography input adapters (slice 1)** — new
+  `doiget_core::refs` module exposes `Format`, `ParsedEntry`,
+  `ParseError`, and `parse_input(text, format, path)` that
+  auto-detect plain-refs / CSL-JSON / BibTeX (BibTeX returns
+  `UnsupportedFormat` until the biblatex follow-up slice).
+  Identifier priority is DOI > arXiv > PMID-parking. 23 unit tests
+  cover format detection, the priority rule, Zotero/Mendeley
+  wire-shape quirks, and malformed-input tolerance.
 
-  `doiget capabilities` JSON's `mcp_tools` array gains the new
-  `doiget_batch_from_bibliography` entry; the parity test is
-  updated in lockstep so the table cannot drift from the docs.
+- **[mcp] `doiget_batch_from_bibliography`** — new MCP tool per
+  ADR-0030 D6 accepting a CSL-JSON file path and returning structured
+  per-entry fetch outcomes with the source bibliography's `entry_key`
+  threaded through. Unlocks the Zotero distribution path: a plugin
+  author can hand a `.json` file to `doiget serve` and bridge
+  fetched PDFs back to the originating reference without shelling
+  out. `strict` input field controls per-entry parse-error abort;
+  malformed-input always aborts.
 
-  6 new MCP unit tests cover `parse_bibliography_format`'s token
-  acceptance (auto / refs / csl-json / bibtex / case-insensitivity /
-  underscore variants / unknown-token rejection).
+- **[cli] `doiget batch library.json`** — `doiget batch` now
+  auto-detects CSL-JSON inputs by file extension + content
+  fingerprint and dispatches through `refs::parse_input`. Plain refs
+  files (`.txt`) keep working unchanged. Malformed CSL-JSON aborts
+  with a loud whole-input error rather than silently behaving as an
+  empty batch.
 
->>>>>>> 01150e7 (feat(mcp): doiget_batch_from_bibliography MCP tool (ADR-0030 D6))
-## [0.4.1-beta.12] - 2026-05-21
+- **[cli] `doiget batch --json` structured outcomes (#210 / S4)** —
+  JSONL success records carry
+  `result.{safekey, store_path, canonical_digest}`; failure records
+  carry the typed `ErrorCode` wire string plus an ADR-0023
+  `denial_context` when applicable. `PdfLegStatus::Blocked` outcomes
+  surface as failures with the policy-class reclassification
+  (`effective_blocked_code`).
 
-### Added
+- **[cli] global flags `--store-root` / `--log-path` / `--color` /
+  `--progress` (#211 / S5)** — four new global CLI flags with
+  env-var precedence, ValueEnum drift guards, and 17 unit tests
+  covering precedence and validation.
 
-- **[core]** ADR-0029 fetch chain slice 1 — the DOI OA-PDF leg now
-  walks a multi-candidate chain instead of trying only
-  `best_oa_location` (#222). Candidate URLs are extracted from the
-  Unpaywall envelope in priority order (best_oa_location first, then
-  every distinct entry in `oa_locations[]`); the orchestrator
-  advances past any non-PDF / 403 / network failure until either one
-  candidate yields a valid PDF or every candidate is exhausted. Each
-  attempt emits its own `oa-publisher` Fetch provenance row, so the
-  audit trail captures every external request.
+- **[cli] `doiget config doctor` user-extension surface (ADR-0028
+  D2-3)** — adds a checklist entry reporting
+  `[ ok ] user-extension hosts loaded: N` or
+  `[FAIL] user-extension config invalid: <error>`. Missing config is
+  normal.
 
-  Recovers the dogfood case from the finite-temperature-MPS corpus:
-  a DOI hits `link.aps.org`, the publisher WAF returns 403, but the
-  same record's arXiv preprint is in `oa_locations[]`. Pre-slice-1
-  this surfaced as `PdfLegStatus::Blocked` + metadata-only; post-
-  slice-1 the chain advances to the arXiv preprint and writes a
-  real PDF.
+- **[cli] `doiget capabilities` JSON `user_extension_count` field
+  (ADR-0028 D2-4)** — additive top-level field reporting how many
+  user-extension hosts are loaded on the current host. Drift-guarded
+  by parity test.
 
-  New helper: `doiget_core::orchestrator::extract_oa_url_chain`
-  (private). Removes the now-superseded
-  `extract_best_oa_url_from_value` helper and migrates its tests to
-  the chain extractor; net + 3 unit tests covering ordering,
-  deduplication, fallback-on-no-best, and malformed-URL tolerance.
-  New e2e test
-  `fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403`
-  exercises the WAF-block fallback flow end-to-end.
+- **[core] `FetchPaperOutcome` field additions** —
+  `safekey: String` and `canonical_digest: String` are always-
+  populated additive fields on the `#[non_exhaustive]` struct
+  (#210).
 
-### Notes
-
-- Out of scope for slice 1 (deferred follow-ups):
-  - The structured `chain: Vec<AttemptOutcome>` field on
-    `FetchError` and the new `ALL_FALLBACKS_EXHAUSTED` closed-enum
-    variant (ADR-0029 D5). Today an all-failed chain still surfaces
-    as `PdfLegStatus::Blocked` with the *last* attempt's reason on
-    `denial`; the structured per-attempt list is reserved for the
-    MCP / CLI JSON wire-shape slice that follows #212 alignment.
-  - The schema-additive `chain_attempt` / `chain_total` /
-    `chain_terminal` / `verified_by` columns on the provenance log
-    (ADR-0029 D4). Today each chain attempt is logged as a
-    standalone Fetch row indistinguishable from the pre-slice-1
-    shape; the per-attempt enrichment is deferred.
-
-## [0.4.1-beta.11] - 2026-05-21
-
-### Added
-
-- **[core]** New `doiget_core::refs` module per ADR-0030 slice 1 —
-  bibliography input adapters. Exposes
-  `Format { Auto, Refs, CslJson, Bibtex }`,
-  `ParsedEntry { ref_, entry_key }`,
-  `ParseError { NoIdentifier, InvalidRef, Decode,
-  UnsupportedFormat }` (closed-enum, `#[non_exhaustive]`), and
-  `parse_input(text, format, path) -> Vec<Result<ParsedEntry,
-  ParseError>>` plus per-format helpers. Honors the ADR-0030 D3
-  identifier-pick priority: `DOI` > arXiv (`archivePrefix == "arXiv"`
-  + `eprint`, or `note: "arXiv:…"`) > (PMID parking). 23 unit tests
-  cover format detection, all parser branches, the priority rule,
-  case-insensitive field matching, and Zotero / Mendeley wire shape
-  quirks.
-
-- **[cli]** `doiget batch library.json` accepts a CSL-JSON export
-  directly. The format is auto-detected from the path extension
-  (`.json` / `.csl`) and the file's leading non-comment character;
-  callers writing plain refs files (`.txt`) keep working with no
-  change. A malformed CSL-JSON document aborts the batch with a
-  loud whole-input error rather than silently behaving as an empty
-  batch. New e2e tests
-  `batch_json_csl_input_yields_one_record_per_entry` and
-  `batch_malformed_csl_json_aborts_with_decode_error`.
+- **[core] `#[doc(hidden)] FetchPaperOutcome::for_test_synthetic`** —
+  test-only constructor exposed for downstream test code to drive
+  classification logic without running the full orchestrator.
 
 ### Changed
 
-- **[cli]** `batch` JSONL `ref` field is now the bare identifier per
-  `docs/PROVENANCE_LOG.md` §3 — `Ref::as_input_str()`'s canonical
-  form — rather than the raw file line. For an input line
-  `arxiv:2401.99999`, the failure record's `ref` is now
-  `"2401.99999"` (no URI scheme). DOI inputs were already in this
-  form. Wire-format-visible: CI consumers parsing the `ref` field
-  should switch from "string match input line" to "regex / parse as
-  DOI or arXiv id". Surfaced because the new `refs::parse_input`
-  pipeline normalises every entry through `Ref::parse` before
-  emitting; the pre-ADR-0030 flow echoed raw lines verbatim.
+- **[core/http] `http://` → `https://` URL upgrade (#220 / S2)** —
+  `fetch_inner` upgrades legacy `http://` URLs returned by metadata
+  sources to `https://` before sending, with case-insensitive
+  `localhost` literal + `.localhost` TLD detection, IPv6 loopback
+  (`::1` + IPv4-mapped) detection, and a `tracing::warn!` on the
+  `set_scheme` fallback. 12 unit tests pin the edge cases.
 
-### Notes
+- **[cli] ADR-0017 Amendment 1: explicit-vs-implicit Quiet (#220 /
+  S1)** — `OutputMode::Quiet` now distinguishes a user's explicit
+  `--quiet` / `--mode quiet` from the implicit TTY-detection
+  fallback. `doiget capabilities` (and `bib` / `csl`) — the artifact
+  commands — respect only explicit Quiet and emit their JSON
+  inventory on non-TTY pipes so an LLM cold-boot from a stripped
+  environment is not silently empty. `ResolvedOutput { mode,
+  quiet_was_explicit }` and `is_artifact_command()` helper added.
 
-- Out of scope for slice 1 (deferred to follow-up slices):
-  - BibTeX / `.bib` parsing — requires the `biblatex` crate
-    (+500 KB) and its cargo-vet transitive exemptions. Until that
-    ships, `Format::Bibtex` returns `ParseError::UnsupportedFormat`
-    with a helpful "re-export as CSL-JSON" hint, and `.bib` file
-    extensions surface that error on the first batch invocation.
-  - `--format` / `--strict` CLI flags.
-  - New MCP tool `doiget_batch_from_bibliography`.
-  - Plumbing `entry_key` into the JSONL `error` object as a typed
-    field (today the citation key is embedded in placeholder
-    `<no-identifier:KEY>` strings that the existing JSONL `ref`
-    surfaces verbatim).
+- **[cli] `FetchHarness::fetch_one` returns
+  `Result<FetchPaperOutcome, FetchError>` (#210)** — replaces the
+  prior `anyhow::Result<()>` so callers can render machine-readable
+  shapes from the same typed outcome. Rendering / `CliExit`
+  synthesis moves to per-caller paths.
 
-## [0.4.1-beta.10] - 2026-05-21
+- **[cli] `batch` JSONL `ref` field** — now the bare identifier per
+  `docs/PROVENANCE_LOG.md` §3 (`Ref::as_input_str()` canonical
+  form) rather than the raw file line. For an input line
+  `arxiv:2401.99999`, the JSONL `ref` is now `"2401.99999"`. DOI
+  inputs were already in this form. Wire-format-visible.
 
-### Added
+### Documentation
 
-- **[mcp]** MCP-server `build_http_client_for_fetch` now merges
-  user-extension hosts from `<config_dir>/doiget/config.toml` per
-  ADR-0028 D2, mirroring the CLI path that landed in beta.8 (#220).
-  Before this slice, a user who configured
-  `[[network.additional_hosts]]` and invoked via `doiget serve`
-  saw no effect — only `doiget fetch` honored the extension. The
-  MCP merge closes that asymmetry; both surfaces now read the same
-  config file with identical failure handling (silent on
-  not-found, `tracing::warn!` on malformed, curated allowlist
-  continues regardless).
+- **ADR-0017 Amendment 1, ADR-0028, ADR-0029, ADR-0030** — four new
+  design records covering quiet bifurcation, the user-extensible
+  capability gate, the fetch chain primitive, and the bibliography
+  input adapters.
 
-- **[cli]** `doiget config doctor` adds a user-extension health
-  check (ADR-0028 D2-3): on a green run the new line reads
-  `[ ok ] user-extension hosts loaded: N`; on a malformed
-  `config.toml` it emits `[FAIL] user-extension config invalid:
-  <error>` and exits 2. A missing `config.toml` is normal (count
-  = 0, no failure) — the user simply has not extended the gate.
+### Notes — deferred to follow-up slices
 
-- **[cli]** `doiget capabilities` JSON gains a top-level
-  `user_extension_count: usize` field (ADR-0028 D2-4) so an LLM
-  cold-booted into doiget can confirm at a glance whether the
-  curated allowlist has been extended on this host. The field
-  counts valid `[[network.additional_hosts]]` entries; parse
-  errors collapse to `0` (use `doiget config doctor` to
-  diagnose). `Capabilities` is `#[non_exhaustive]`, so adding the
-  field is additive for downstream Rust consumers; JSON consumers
-  should ignore unknown fields.
-
-### Changed
-
-- **[cli]** `commands::fetch::config_dir_utf8` lifted from private
-  to `pub(crate)` so sibling modules
-  (`commands::capabilities`, `commands::config`) resolve the same
-  `<config_dir>/doiget/` path the production HTTP-client builder
-  reads from. No behavior change.
-
-### Notes
-
-- Out of scope for this slice (still tracked under #220 / ADR-0028):
-  the `verified_by = "user"` provenance row field (D2-2). That
-  requires allowlist source-attribution plumbing through the
-  redirect closure and is deferred to a follow-up slice.
-
-## [0.4.1-beta.9] - 2026-05-21
-
-### Added
-
-- **[core]** `FetchPaperOutcome` (`doiget_core::orchestrator`) gains
-  two new fields: `safekey: String` and `canonical_digest: String`
-  (#210). Both are always populated — `safekey` from the input ref
-  (`Ref::safekey().as_str()`), `canonical_digest` from
-  `CanonicalRef::digest_hex()` under the outcome's
-  `resolver_profile`. Additive on a `#[non_exhaustive]` struct, so
-  downstream consumers continue to compile without changes.
-
-- **[cli]** `doiget batch --json` JSONL records carry the full
-  structured outcome per `docs/ERRORS.md` §3 (#210):
-  - **Success**: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`.
-    A CI consumer can now pull `safekey` to construct a store-relative
-    path and `canonical_digest` to deduplicate against an audit DB
-    without a follow-up `info` round-trip per ref.
-  - **Failure**: `{"ok":false,"ref":"...","error":{"code":"...","message":"...","denial_context":{...}}}`.
-    The `code` field is now the typed `ErrorCode` wire string (e.g.
-    `CAPABILITY_DENIED` / `NETWORK_ERROR` / `INTERNAL_ERROR`) — the
-    previous generic `FETCH_ERROR` only survives in the JoinSet
-    panic arm where no underlying `FetchError` exists. The
-    `denial_context` key is present only when the failure carries a
-    structured ADR-0023 denial; bare transport / config errors omit
-    the key entirely so consumers can use its presence as a typed-
-    denial discriminator.
-
-  A `PdfLegStatus::Blocked` outcome (an OA PDF was discovered but
-  could not be retrieved per #145) is now surfaced as a failure
-  record with the policy-class `denial_context`, rather than being
-  collapsed into the bare `{ok:true, ref}` shape that #205 left in
-  place. The `effective_blocked_code` reclassification (off-allowlist
-  / insecure-scheme / blocklisted-host → `CAPABILITY_DENIED`) is
-  shared between single-fetch and batch, so the wire code matches the
-  single-fetch CLI exit-code mapping.
-
-### Changed
-
-- **[cli]** `FetchHarness::fetch_one` signature changes from
-  `async fn (..., &Ref) -> anyhow::Result<()>` to
-  `async fn (..., &Ref) -> Result<FetchPaperOutcome, FetchError>`
-  (#210). The rendering + exit-code synthesis that used to live
-  inside `fetch_one` (Blocked-PDF reclassification, `error[CODE]:`
-  stderr, `CliExit` construction) now lives in the per-caller paths
-  (`commands::fetch::run_with_options` for single-fetch,
-  `commands::batch::classify_joined` for batch) so each surface can
-  emit its own machine-readable shape from the same typed outcome.
-  `pub(crate)`, not a public API.
-
-  - `commands::fetch::effective_blocked_code` is lifted from `fn` to
-    `pub(crate) fn` so the batch caller shares the single-fetch
-    reclassification rule.
-  - New `commands::fetch::outcome_is_clean_success` helper collapses
-    the typed `Result<FetchPaperOutcome, FetchError>` to the boolean
-    the `SessionEnd` row's `is_ok` field needs, so a Blocked PDF leg
-    never reads as a green session in the provenance log.
-
-- **[core]** New `#[doc(hidden)] pub fn FetchPaperOutcome::for_test_synthetic(...)`
-  test-only constructor in `doiget_core::orchestrator` so downstream
-  test code (`doiget-cli` batch unit tests) can drive
-  classification logic without running the full orchestrator. Not a
-  stable public API — the signature may change to fit test needs
-  without a `[BREAKING]` callout.
-
-### Notes
-
-- Out of scope (deferred to follow-up issues per #210's Out-of-scope
-  list):
-  - The MCP `doiget_fetch_paper` envelope upgrade to surface
-    `safekey` / `canonical_digest` (the FetchPaperOutcome fields
-    are populated; the envelope-side wire change is a separate
-    item).
-  - `canonical_digest` on `EntryInfo` (`info` / `list-recent` /
-    `search` JSON bodies).
-  - Single-fetch `--json` symmetric output (the CLI single-fetch JSON
-    branch mirroring batch JSONL's single record).
-
-## [0.4.1-beta.8] - 2026-05-21
-
-### Added
-
-- **[core]** New module `doiget_core::user_extension` per ADR-0028
-  D2 (#220). Users can extend the `oa-publisher` redirect allowlist
-  for their own deployment via `[[network.additional_hosts]]` in
-  `<config_dir>/doiget/config.toml`. Pattern grammar is restricted
-  (literal FQDN or single-suffix wildcard `*.<suffix>`); rejection
-  classes are surfaced as a closed-enum `PatternError` for
-  programmatic consumption by the future `doiget config doctor`
-  surface. The `host` field of `UserExtensionHost` is a
-  `HostPattern` newtype that runs validation through its serde
-  `Deserialize`, so the "valid pattern" invariant is type-level —
-  no `UserExtensionHost` value can exist with an invalid host. The
-  orchestrator's production HttpClient construction
-  (`commands::fetch::build_http_client`) loads and merges in one
-  pass; a missing config file is silent, a malformed config is
-  surfaced as `tracing::warn!` and the fetch continues with the
-  curated set.
-
-  Example:
-
-  ```toml
-  # ~/.config/doiget/config.toml
-  [[network.additional_hosts]]
-  host = "ruj.uj.edu.pl"
-  note = "Jagiellonian University Repository — Green OA"
-
-  [[network.additional_hosts]]
-  host = "*.uj.edu.pl"
-  ```
-
-  Out of scope for this slice (tracked as S3b): the
-  `verified_by = "user"` provenance row field (ADR-0028 D2-2),
-  the `doiget config doctor` surface (D2-3), the
-  `capability_gate.user_extension_count` field in `doiget
-  capabilities` JSON (D2-4), and the MCP-server-side merge in
-  `doiget-mcp` (a user who configures
-  `[[network.additional_hosts]]` and invokes via `doiget serve`
-  currently sees no effect; that is the load-bearing item S3b
-  closes).
-
-## [0.4.1-beta.7] - 2026-05-21
-
-### Fixed
-
-- **[core/http]** `http://` URLs returned by OpenAlex / Unpaywall
-  metadata for publishers that have since moved to HTTPS are
-  transparently upgraded to `https://` before the request leaves
-  the process (#220). Without this, the production
-  `https_only(true)` client refused to send and the fetch failed
-  with a generic builder error. The upgrade is skipped for
-  loopback hosts (`localhost`, the RFC 6761 `.localhost` TLD,
-  `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback) so the
-  `new_for_tests_allow_http*` wiremock path is unchanged. TLS
-  posture (ADR-0020) is preserved — the upgrade turns a
-  guaranteed-reject into a real TLS handshake, never a plaintext
-  fallback. Successful upgrades log at `tracing::info!` so the
-  rewrite appears in audit-level logs.
-
-## [0.4.1-beta.5] - 2026-05-21
-
-### Added
-
-- **[cli]** Four new global flags from CONFIG.md §5, completing the
-  documented surface (#211):
-  - `--store-root <PATH>` — overrides `DOIGET_STORE_ROOT` for the
-    on-disk paper store root. Path-shaped values; rejected at parse
-    time when empty or containing NUL bytes (review pass I6 / A4).
-  - `--log-path <PATH>` — overrides `DOIGET_LOG_PATH` for the
-    provenance-log file path. Same parse-time validation as
-    `--store-root`.
-  - `--color <auto|always|never>` — exposes the future ANSI emission
-    knob via the new `DOIGET_COLOR` env var. Surface-only in this
-    slice (no consumer emits ANSI today). The consumer-side resolver
-    will check `NO_COLOR` (present and non-empty per
-    <https://no-color.org/>, any value) **before** consulting
-    `DOIGET_COLOR`; the write boundary in
-    `apply_global_overrides` is intentionally simple and does NOT
-    inspect `NO_COLOR`.
-  - `--progress` / `--no-progress` — pair of mutually exclusive
-    flags writing `DOIGET_PROGRESS=1` / `0`. Surface-only: the
-    `fetch` / `batch` per-ref stderr line is unchanged here; the
-    consumer-side gate lands in a follow-up.
-
-  Each flag implements the CONFIG.md §1 precedence ladder
-  `flag > env > default` by overwriting the matching `DOIGET_*`
-  process env var at the very top of `run_dispatch`, BEFORE any
-  command resolver reads the environment. The existing resolvers
-  (`commands::fetch::resolve_store_root`, `resolve_log_path`,
-  `commands::audit_log::resolve_log_path`) keep their env-driven
-  shape and pick the new value up uniformly — no `ResolvedFlags`
-  struct threaded through eleven `run(..)` signatures.
-
-  Path flags use `camino::Utf8PathBuf` (workspace `clippy.toml`
-  disallowed-types policy bans `std::path::PathBuf`); validation
-  lives in `parse_utf8_path` and runs at clap's `value_parser`
-  layer so empty / NUL-byte inputs fail clean with exit 2.
-
-  Clap-level conflicts: `--progress` ↔ `--no-progress` (exit 2 on
-  both supplied); pre-existing `--mode` ↔ `--json` ↔ `--quiet`
-  conflicts unchanged.
-
-  19 new tests (15 unit on `apply_global_overrides`/`parse_utf8_path`
-  via `serial_test`; 4 e2e on clap conflicts, value acceptance, and
-  empty-value parse-time rejection). Includes a drift guard
-  (`output_color_env_strings_match_clap_parser_side`) that pairs
-  `OutputColor::as_env_value` against clap's `ValueEnum`
-  parser-side spelling — if `rename_all = "lower"` is ever changed,
-  the round-trip catches it.
-
-## [0.4.1-beta.2] - 2026-05-21
-
-### Fixed
-
-- **[cli]** `doiget capabilities` no longer silently exits with empty
-  stdout in non-TTY / agent execution contexts (#219, #220 ADR-0017
-  Amendment 1). The resolver now distinguishes **explicit** Quiet
-  (`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`) from
-  **implicit** Quiet (the non-TTY default), and `capabilities` —
-  classified as an *artifact* command — suppresses stdout only on
-  explicit Quiet. Closes the LLM cold-boot deadlock where an agent
-  ran `doiget capabilities` over a captured pipe and got nothing
-  back. `OutputMode` enum wire format (`DOIGET_MODE` strings, the
-  `modes` array in capabilities JSON) is unchanged; the
-  `quiet_was_explicit` discriminator lives only in-memory on the
-  new `ResolvedOutput` returned by `commands::output::resolve()`.
-  `bib` / `csl` were already correct (they ignore mode); their
-  classification is now documented via the new
-  `is_artifact_command()` helper.
-
-## [0.4.1-beta.1] - 2026-05-21
-
-Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +
-ADR-0028 / 0029 / 0030, design-only — no code change yet).
-Workspace version is bumped to satisfy the version-gate G5
-(non-empty CHANGELOG section for the prospective tag) while the
-implementation slices S1-S8 land separately.
-
-### Added
-
-- **[design]** ADR-0017 Amendment 1: distinguish *explicit* vs
-  *implicit* `Quiet`, classify commands as artifact vs
-  informational. Closes the LLM cold-boot deadlock reported in
-  #219 / #220 once the implementation slice (S1) lands.
-- **[design]** ADR-0028: the capability gate's purpose is
-  **ToS compliance + verified curation**; users may extend it via
-  `config.toml` (literal hosts or single-suffix wildcards) with
-  per-attempt `verified_by = "user"` recorded in the provenance
-  log. Impersonation / WAF bypass / embedded headless browser
-  (#223) are permanently out-of-scope.
-- **[design]** ADR-0029: `fetch_one` resolves to an ordered chain
-  of candidate URLs (OpenAlex `oa_locations[]` order); each
-  attempt becomes its own provenance row (schema-additive on v2).
-  New closed-enum `FetchError` variant `ALL_FALLBACKS_EXHAUSTED`
-  carries `Vec<AttemptOutcome>`.
-- **[design]** ADR-0030: bibliography input adapters
-  (`.bib` / CSL-JSON) live in `doiget-core`; new MCP tool
-  `doiget_batch_from_bibliography` enables the Zotero plugin
-  distribution path. One identifier per entry
-  (DOI > arXiv > PMID); skip-and-warn on parse error by default.
+- ADR-0028 D2-2 `verified_by = "user"` per-attempt provenance row
+  field.
+- ADR-0029 D4/D5: `chain: Vec<AttemptOutcome>` +
+  `ALL_FALLBACKS_EXHAUSTED` + schema-additive `chain_*` provenance
+  columns.
+- ADR-0030 D2/D5/D6: BibTeX/.bib parsing (needs `biblatex` crate +
+  cargo-vet exemptions), `--format` / `--strict` CLI flags,
+  structured `entry_key` on JSONL `error` object.
+- MCP `doiget_fetch_paper` envelope upgrade for `safekey` /
+  `canonical_digest`.
+- `canonical_digest` on `EntryInfo`.
+- Single-fetch `--json` symmetric output.
+- #212 MCP/CLI output shape alignment, #222 batch resumability.
 
 ## [0.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.12] - 2026-05-21
+
+### Added
+
+- **[core]** ADR-0029 fetch chain slice 1 — the DOI OA-PDF leg now
+  walks a multi-candidate chain instead of trying only
+  `best_oa_location` (#222). Candidate URLs are extracted from the
+  Unpaywall envelope in priority order (best_oa_location first, then
+  every distinct entry in `oa_locations[]`); the orchestrator
+  advances past any non-PDF / 403 / network failure until either one
+  candidate yields a valid PDF or every candidate is exhausted. Each
+  attempt emits its own `oa-publisher` Fetch provenance row, so the
+  audit trail captures every external request.
+
+  Recovers the dogfood case from the finite-temperature-MPS corpus:
+  a DOI hits `link.aps.org`, the publisher WAF returns 403, but the
+  same record's arXiv preprint is in `oa_locations[]`. Pre-slice-1
+  this surfaced as `PdfLegStatus::Blocked` + metadata-only; post-
+  slice-1 the chain advances to the arXiv preprint and writes a
+  real PDF.
+
+  New helper: `doiget_core::orchestrator::extract_oa_url_chain`
+  (private). Removes the now-superseded
+  `extract_best_oa_url_from_value` helper and migrates its tests to
+  the chain extractor; net + 3 unit tests covering ordering,
+  deduplication, fallback-on-no-best, and malformed-URL tolerance.
+  New e2e test
+  `fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403`
+  exercises the WAF-block fallback flow end-to-end.
+
+### Notes
+
+- Out of scope for slice 1 (deferred follow-ups):
+  - The structured `chain: Vec<AttemptOutcome>` field on
+    `FetchError` and the new `ALL_FALLBACKS_EXHAUSTED` closed-enum
+    variant (ADR-0029 D5). Today an all-failed chain still surfaces
+    as `PdfLegStatus::Blocked` with the *last* attempt's reason on
+    `denial`; the structured per-attempt list is reserved for the
+    MCP / CLI JSON wire-shape slice that follows #212 alignment.
+  - The schema-additive `chain_attempt` / `chain_total` /
+    `chain_terminal` / `verified_by` columns on the provenance log
+    (ADR-0029 D4). Today each chain attempt is logged as a
+    standalone Fetch row indistinguishable from the pre-slice-1
+    shape; the per-attempt enrichment is deferred.
+
 ## [0.4.1-beta.11] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[cli]** Four new global flags from CONFIG.md §5, completing the
   documented surface (#211):
   - `--store-root <PATH>` — overrides `DOIGET_STORE_ROOT` for the
-    on-disk paper store root.
+    on-disk paper store root. Path-shaped values; rejected at parse
+    time when empty or containing NUL bytes (review pass I6 / A4).
   - `--log-path <PATH>` — overrides `DOIGET_LOG_PATH` for the
-    provenance-log file path.
+    provenance-log file path. Same parse-time validation as
+    `--store-root`.
   - `--color <auto|always|never>` — exposes the future ANSI emission
     knob via the new `DOIGET_COLOR` env var. Surface-only in this
-    slice (no consumer emits ANSI today); `NO_COLOR=1` continues to
-    win when consumers read it per <https://no-color.org/>.
+    slice (no consumer emits ANSI today). The consumer-side resolver
+    will check `NO_COLOR` (present and non-empty per
+    <https://no-color.org/>, any value) **before** consulting
+    `DOIGET_COLOR`; the write boundary in
+    `apply_global_overrides` is intentionally simple and does NOT
+    inspect `NO_COLOR`.
   - `--progress` / `--no-progress` — pair of mutually exclusive
     flags writing `DOIGET_PROGRESS=1` / `0`. Surface-only: the
     `fetch` / `batch` per-ref stderr line is unchanged here; the
@@ -38,12 +44,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   shape and pick the new value up uniformly — no `ResolvedFlags`
   struct threaded through eleven `run(..)` signatures.
 
+  Path flags use `camino::Utf8PathBuf` (workspace `clippy.toml`
+  disallowed-types policy bans `std::path::PathBuf`); validation
+  lives in `parse_utf8_path` and runs at clap's `value_parser`
+  layer so empty / NUL-byte inputs fail clean with exit 2.
+
   Clap-level conflicts: `--progress` ↔ `--no-progress` (exit 2 on
   both supplied); pre-existing `--mode` ↔ `--json` ↔ `--quiet`
   conflicts unchanged.
 
-  12 new tests (8 unit on `apply_global_overrides` env precedence
-  via `serial_test`; 4 e2e on clap conflicts + value acceptance).
+  19 new tests (15 unit on `apply_global_overrides`/`parse_utf8_path`
+  via `serial_test`; 4 e2e on clap conflicts, value acceptance, and
+  empty-value parse-time rejection). Includes a drift guard
+  (`output_color_env_strings_match_clap_parser_side`) that pairs
+  `OutputColor::as_env_value` against clap's `ValueEnum`
+  parser-side spelling — if `rename_all = "lower"` is ever changed,
+  the round-trip catches it.
 
 ## [0.4.1-beta.2] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.5] - 2026-05-21
+
+### Added
+
+- **[cli]** Four new global flags from CONFIG.md §5, completing the
+  documented surface (#211):
+  - `--store-root <PATH>` — overrides `DOIGET_STORE_ROOT` for the
+    on-disk paper store root.
+  - `--log-path <PATH>` — overrides `DOIGET_LOG_PATH` for the
+    provenance-log file path.
+  - `--color <auto|always|never>` — exposes the future ANSI emission
+    knob via the new `DOIGET_COLOR` env var. Surface-only in this
+    slice (no consumer emits ANSI today); `NO_COLOR=1` continues to
+    win when consumers read it per <https://no-color.org/>.
+  - `--progress` / `--no-progress` — pair of mutually exclusive
+    flags writing `DOIGET_PROGRESS=1` / `0`. Surface-only: the
+    `fetch` / `batch` per-ref stderr line is unchanged here; the
+    consumer-side gate lands in a follow-up.
+
+  Each flag implements the CONFIG.md §1 precedence ladder
+  `flag > env > default` by overwriting the matching `DOIGET_*`
+  process env var at the very top of `run_dispatch`, BEFORE any
+  command resolver reads the environment. The existing resolvers
+  (`commands::fetch::resolve_store_root`, `resolve_log_path`,
+  `commands::audit_log::resolve_log_path`) keep their env-driven
+  shape and pick the new value up uniformly — no `ResolvedFlags`
+  struct threaded through eleven `run(..)` signatures.
+
+  Clap-level conflicts: `--progress` ↔ `--no-progress` (exit 2 on
+  both supplied); pre-existing `--mode` ↔ `--json` ↔ `--quiet`
+  conflicts unchanged.
+
+  12 new tests (8 unit on `apply_global_overrides` env precedence
+  via `serial_test`; 4 e2e on clap conflicts + value acceptance).
+
 ## [0.4.1-beta.2] - 2026-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [0.4.0] - 2026-05-21
 
-Promotion of the `0.4.1-beta.1..beta.13` integration line on `next` to a
-stable release. SemVer **minor** bump (not patch) — this window
+Promotion of the `0.4.0-beta.1..beta.13` integration line on `next` to
+a stable release. SemVer **minor** bump (not patch) — this window
 introduces multiple new public surfaces (`doiget_core::refs` module,
 `doiget_batch_from_bibliography` MCP tool, `FetchPaperOutcome` field
 additions, user-extensible capability gate, fetch chain) and one CLI
 flag set expansion, alongside several behavioural changes for the
 OA-PDF leg and batch JSONL wire shape. Beta-window detail is preserved
-in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
+in the merge commits on `next` (see `git log --merges v0.3.0..HEAD`)
+and the ADR set under `docs/DECISIONS/`.
 
 ### Added
 
@@ -120,6 +121,11 @@ in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
   inventory on non-TTY pipes so an LLM cold-boot from a stripped
   environment is not silently empty. `ResolvedOutput { mode,
   quiet_was_explicit }` and `is_artifact_command()` helper added.
+  `audit-log --verify` is NOT routed through
+  `is_artifact_command()` — its `--mode json` body is produced by an
+  internal branch in the subcommand handler rather than by the
+  artifact-vs-informational discriminator; the wire shape is
+  unchanged on this release.
 
 - **[cli] `FetchHarness::fetch_one` returns
   `Result<FetchPaperOutcome, FetchError>` (#210)** — replaces the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.8] - 2026-05-21
+
+### Added
+
+- **[core]** New module `doiget_core::user_extension`: parser + merger
+  for `[[network.additional_hosts]]` entries in the user's
+  `config.toml`, per ADR-0028 D2 (#220). The orchestrator's
+  production HttpClient construction (`commands::fetch::build_http_client`)
+  now reads `<config_dir>/doiget/config.toml`, validates each entry
+  against the restricted ADR-0028 D2-1 pattern grammar (literal FQDN
+  or single-suffix wildcard `*.<suffix>` only — multi-segment globs,
+  bare wildcards, and non-host characters are parse errors), and
+  merges the user-added hosts into the `oa-publisher` allowlist
+  alongside the curated set. A missing config file is the normal case
+  ("no extensions"); a malformed file emits a `tracing::warn!` to
+  stderr but never aborts the fetch (the curated allowlist still
+  applies). Unblocks the real-world dogfood case where a Green-OA
+  paper lives on an institutional repo like `ruj.uj.edu.pl` that the
+  curated list cannot reasonably enumerate.
+
+  Example:
+
+  ```toml
+  # ~/.config/doiget/config.toml
+  [[network.additional_hosts]]
+  host = "ruj.uj.edu.pl"
+  note = "Jagiellonian University Repository — Green OA"
+
+  [[network.additional_hosts]]
+  host = "*.uj.edu.pl"
+  ```
+
+  Out of scope for this slice (tracked as S3b): the
+  `verified_by = "user"` provenance row field (ADR-0028 D2-2),
+  the `doiget config doctor` surface (D2-3), the
+  `capability_gate.user_extension_count` field in `doiget
+  capabilities` JSON (D2-4), and the MCP-server-side merge in
+  `doiget-mcp`.
+
 ## [0.4.1-beta.7] - 2026-05-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.12"
+version = "0.4.1-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.12"
+version = "0.4.1-beta.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.12"
+version = "0.4.1-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.3.0"
+version = "0.4.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.3.0"
+version = "0.4.1-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.3.0"
+version = "0.4.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.7"
+version = "0.4.1-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.7"
+version = "0.4.1-beta.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.7"
+version = "0.4.1-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.9"
+version = "0.4.1-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.9"
+version = "0.4.1-beta.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.9"
+version = "0.4.1-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.11"
+version = "0.4.1-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.11"
+version = "0.4.1-beta.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.11"
+version = "0.4.1-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.10"
+version = "0.4.1-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.10"
+version = "0.4.1-beta.11"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.10"
+version = "0.4.1-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.2"
+version = "0.4.1-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.2"
+version = "0.4.1-beta.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.2"
+version = "0.4.1-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.1"
+version = "0.4.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.1"
+version = "0.4.1-beta.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.1"
+version = "0.4.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.12"
+version       = "0.4.1-beta.13"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.13" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.13" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.13" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.13"
+version       = "0.4.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.13" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.13" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.13" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.1"
+version       = "0.4.1-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.10"
+version       = "0.4.1-beta.11"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.10" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.10" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.10" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.11" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.11" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.11" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,11 @@ wiremock    = "0.6"
 assert_cmd  = "2"
 predicates  = "3"
 proptest    = "1"
+# `serial_test` serialises env-mutating tests (DOIGET_*_BASE,
+# DOIGET_STORE_ROOT, etc.) within a single test binary. Lifted to
+# workspace deps in #228 review pass A6 so the three member crates
+# (core / cli / mcp) cannot drift on the major version.
+serial_test = "3"
 
 # Phase 4 (citation graph)
 petgraph = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.8"
+version       = "0.4.1-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.11"
+version       = "0.4.1-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.11" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.11" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.11" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.12" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.12" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.12" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.5"
+version       = "0.4.1-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.2"
+version       = "0.4.1-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.9"
+version       = "0.4.1-beta.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.3.0"
+version       = "0.4.1-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.3.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.3.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.3.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.7"
+version       = "0.4.1-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -69,7 +69,7 @@ predicates = { workspace = true }
 wiremock    = { workspace = true }
 # Serializes tests that mutate process-global env state — used by the
 # `fetch_arxiv_e2e` test and `doiget config` tests.
-serial_test = "3"
+serial_test = { workspace = true }
 # Build a gzipped rotated `.gz` segment fixture for the multi-segment
 # `audit-log --verify` e2e (provenance §6 / #140).
 flate2      = { workspace = true }

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -31,10 +31,14 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 
+use doiget_core::orchestrator::{FetchPaperOutcome, PdfLegStatus};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, RowInput};
-use doiget_core::{RateLimits, Ref, MCP_BATCH_MAX_SIZE};
+use doiget_core::source::FetchError;
+use doiget_core::{DenialContext, ErrorCode, RateLimits, Ref, MCP_BATCH_MAX_SIZE};
 
-use super::fetch::{build_fetch_plan, emit_dry_run_plan_to_stdout, CliExit, FetchHarness};
+use super::fetch::{
+    build_fetch_plan, effective_blocked_code, emit_dry_run_plan_to_stdout, CliExit, FetchHarness,
+};
 use super::resolve_store_root;
 
 /// Run the `doiget batch <path>` subcommand.
@@ -202,10 +206,15 @@ pub async fn run_with_options(
             let _permit = match sem_task.acquire_owned().await {
                 Ok(p) => p,
                 Err(_) => {
+                    // Map the semaphore-closed structural impossibility
+                    // to a typed `FetchError` (closest closed-set fit)
+                    // so `TaskOutcome::result` stays typed end-to-end.
                     return TaskOutcome {
                         input,
-                        result: Err(anyhow!("batch semaphore unexpectedly closed")),
-                    }
+                        result: Err(FetchError::SourceSchema {
+                            hint: "batch semaphore unexpectedly closed".to_string(),
+                        }),
+                    };
                 }
             };
             let result = harness_task.fetch_one(&ref_).await;
@@ -277,7 +286,7 @@ pub async fn run_with_options(
 #[derive(Debug)]
 struct TaskOutcome {
     input: String,
-    result: Result<()>,
+    result: Result<FetchPaperOutcome, FetchError>,
 }
 
 /// One-line summary written to stderr per ADR-0001 (stdio convention — the
@@ -347,16 +356,54 @@ fn classify_joined(
 ) -> JoinedOutcome {
     match joined {
         Ok(TaskOutcome { input, result }) => match result {
-            Ok(()) => JoinedOutcome {
-                is_error: false,
-                json_record: json_mode.then(|| build_jsonl_success(&input)),
-                log_breadcrumb: LogBreadcrumb::None,
-            },
+            Ok(outcome) => {
+                // #210 / `docs/ERRORS.md` §3+§6: a `Blocked` PDF leg
+                // is NOT a clean success even though the typed Result
+                // is `Ok` — surface it as a structured failure record
+                // with the `denial_context` the orchestrator carried
+                // on `PdfLegStatus::Blocked.denial`.
+                if let PdfLegStatus::Blocked {
+                    code,
+                    message,
+                    denial,
+                } = &outcome.pdf_leg
+                {
+                    let effective = effective_blocked_code(*code, denial.as_ref());
+                    let denial_value = denial.as_ref().and_then(denial_context_to_value);
+                    let record = json_mode.then(|| {
+                        build_jsonl_failure(
+                            Some(&input),
+                            effective.as_wire(),
+                            message,
+                            denial_value,
+                        )
+                    });
+                    let error_dbg =
+                        format!("pdf_leg=Blocked code={effective:?} message={message:?}");
+                    return JoinedOutcome {
+                        is_error: true,
+                        json_record: record,
+                        log_breadcrumb: LogBreadcrumb::FetchFailed { input, error_dbg },
+                    };
+                }
+                let result_value = json_mode.then(|| outcome_to_result_value(&outcome));
+                JoinedOutcome {
+                    is_error: false,
+                    json_record: json_mode
+                        .then(|| build_jsonl_success(&input, result_value.clone().flatten())),
+                    log_breadcrumb: LogBreadcrumb::None,
+                }
+            }
             Err(e) => {
                 let error_dbg = format!("{e:?}");
-                let json_msg = format!("{e:#}");
-                let record =
-                    json_mode.then(|| build_jsonl_failure(Some(&input), "FETCH_ERROR", &json_msg));
+                let json_msg = format!("{e}");
+                let code: ErrorCode = (&e).into();
+                let denial_value = Option::<DenialContext>::from(&e)
+                    .as_ref()
+                    .and_then(denial_context_to_value);
+                let record = json_mode.then(|| {
+                    build_jsonl_failure(Some(&input), code.as_wire(), &json_msg, denial_value)
+                });
                 JoinedOutcome {
                     is_error: true,
                     json_record: record,
@@ -372,7 +419,8 @@ fn classify_joined(
             // sentinel that a consumer doing `retry(rec["ref"])`
             // would mishandle. Self-review for #209 §1.
             let json_msg = format!("batch task panicked: {join_err}");
-            let record = json_mode.then(|| build_jsonl_failure(None, "FETCH_ERROR", &json_msg));
+            let record =
+                json_mode.then(|| build_jsonl_failure(None, "FETCH_ERROR", &json_msg, None));
             JoinedOutcome {
                 is_error: true,
                 json_record: record,
@@ -382,34 +430,77 @@ fn classify_joined(
     }
 }
 
-/// #205: build the JSON-Lines success record value for `ref_input`.
-/// Per ERRORS.md §3, the wire shape is `{"ok": true, "ref": "..."}`.
+/// Build the `result` sub-object for the JSONL success record per
+/// ERRORS.md §3: `{safekey, store_path, canonical_digest}`. Returns
+/// `None` if any field cannot be serialised; the caller falls back to
+/// the bare `{ok, ref}` shape so a serialisation glitch never drops
+/// the success signal.
+fn outcome_to_result_value(outcome: &FetchPaperOutcome) -> Option<serde_json::Value> {
+    Some(serde_json::json!({
+        "safekey":          outcome.safekey,
+        "store_path":       outcome.path.as_str(),
+        "canonical_digest": outcome.canonical_digest,
+    }))
+}
+
+/// Serialise a `DenialContext` to a JSON value for the `error.denial_context`
+/// field. `DenialContext: serde::Serialize` already; returns `None` on
+/// the (today unreachable) serialise-failure path rather than aborting
+/// the record.
+fn denial_context_to_value(dc: &DenialContext) -> Option<serde_json::Value> {
+    serde_json::to_value(dc).ok()
+}
+
+/// #205 + #210: build the JSON-Lines success record value for
+/// `ref_input`. Per ERRORS.md §3, the wire shape is
+/// `{"ok": true, "ref": "...", "result": {...}}` when `result` is
+/// `Some`, falling back to `{"ok": true, "ref": "..."}` when `result`
+/// is `None` (the latter is reserved for paths that don't carry a
+/// structured outcome — today every fetch path does, so `result` is
+/// `Some` in practice; the `None` arm preserves the unit-test path
+/// that asserts shape without constructing a full `FetchPaperOutcome`).
+///
 /// Returned as `serde_json::Value` so unit tests can assert the shape
 /// without a stdout-capture dance; the integration site wraps it with
 /// `println!`.
-fn build_jsonl_success(ref_input: &str) -> serde_json::Value {
-    serde_json::json!({ "ok": true, "ref": ref_input })
+fn build_jsonl_success(ref_input: &str, result: Option<serde_json::Value>) -> serde_json::Value {
+    match result {
+        Some(r) => serde_json::json!({ "ok": true, "ref": ref_input, "result": r }),
+        None => serde_json::json!({ "ok": true, "ref": ref_input }),
+    }
 }
 
-/// #205: build the JSON-Lines failure record value with `code` and
-/// `message`. The wire shape is
-/// `{"ok": false, "ref": "<ref>"|null, "error": {"code": "...", "message": "..."}}`.
+/// #205 + #210: build the JSON-Lines failure record value with `code`,
+/// `message`, and an optional `denial_context` (ADR-0023). The wire
+/// shape is `{"ok": false, "ref": "<ref>"|null, "error": {"code": "...",
+/// "message": "..."[, "denial_context": {...}]}}`.
+///
+/// `denial_context` is omitted from the record entirely when `None` —
+/// fields are not present rather than `null` — so consumers can use the
+/// `denial_context` key's presence as a discriminator between a typed
+/// policy denial and a bare transport / config error.
 ///
 /// `ref_input` is `Option<&str>` because the JoinSet panic arm has lost
 /// the originating input by the time the panic surfaces: serialising
 /// `null` is more honest than a sentinel string like `"<task-panic>"`
 /// (which a consumer doing `retry(rec["ref"])` would mishandle by
 /// trying to refetch the literal sentinel — self-review for #209 §1).
-///
-/// `denial_context` (ADR-0023 closed enum) is intentionally omitted in
-/// this PR — surfacing it requires `fetch_one` to return the structured
-/// outcome instead of `Result<()>`; tracked in #210 to keep this PR's
-/// diff focused on the contract surface.
-fn build_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) -> serde_json::Value {
+fn build_jsonl_failure(
+    ref_input: Option<&str>,
+    code: &str,
+    message: &str,
+    denial_context: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut error = serde_json::json!({ "code": code, "message": message });
+    if let Some(dc) = denial_context {
+        if let Some(obj) = error.as_object_mut() {
+            obj.insert("denial_context".to_string(), dc);
+        }
+    }
     serde_json::json!({
         "ok":    false,
         "ref":   ref_input,
-        "error": { "code": code, "message": message },
+        "error": error,
     })
 }
 
@@ -417,10 +508,12 @@ fn build_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) -> se
 /// (Step 7's `Ref::parse` branch); the JoinSet-drain site now uses
 /// [`classify_joined`] + an inline `println!`, so the matching
 /// `emit_jsonl_success` thin wrapper is no longer needed and was
-/// removed alongside the drain refactor.
+/// removed alongside the drain refactor. The `denial_context` slot is
+/// always `None` here — `INVALID_REF` is a pre-guard parse error, not
+/// a policy denial (`docs/ERRORS.md` §3.1).
 #[allow(clippy::print_stdout)]
 fn emit_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) {
-    println!("{}", build_jsonl_failure(ref_input, code, message));
+    println!("{}", build_jsonl_failure(ref_input, code, message, None));
 }
 
 // ---------------------------------------------------------------------------
@@ -435,29 +528,94 @@ mod tests {
     // ---- #205 JSON-Lines record shape (unit-level) ---------------------
 
     #[test]
-    fn jsonl_success_shape() {
-        let v = build_jsonl_success("10.1234/foo");
+    fn jsonl_success_shape_no_result() {
+        // Without a structured payload, the record falls back to the
+        // bare `{ok, ref}` shape — guards the `None` arm of
+        // `build_jsonl_success` (the unit-test path; production paths
+        // always pass `Some`).
+        let v = build_jsonl_success("10.1234/foo", None);
         assert_eq!(v["ok"], true);
         assert_eq!(v["ref"], "10.1234/foo");
         assert!(v.get("error").is_none(), "no error field on success");
+        assert!(
+            v.get("result").is_none(),
+            "no `result` key when caller passed None"
+        );
+    }
+
+    #[test]
+    fn jsonl_success_shape_with_result() {
+        // #210: the success record carries `result.{safekey, store_path,
+        // canonical_digest}`. The keys are part of the public wire format.
+        let payload = serde_json::json!({
+            "safekey":          "arxiv__2401.12345",
+            "store_path":       "/papers/arxiv__2401.12345.pdf",
+            "canonical_digest": "deadbeef".repeat(8),
+        });
+        let v = build_jsonl_success("arxiv:2401.12345", Some(payload));
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["ref"], "arxiv:2401.12345");
+        assert_eq!(v["result"]["safekey"], "arxiv__2401.12345");
+        assert_eq!(v["result"]["store_path"], "/papers/arxiv__2401.12345.pdf");
+        assert!(
+            v["result"]["canonical_digest"]
+                .as_str()
+                .map(|s| s.len() == 64)
+                .unwrap_or(false),
+            "canonical_digest MUST be a 64-char hex string: {v}"
+        );
     }
 
     #[test]
     fn jsonl_failure_shape_invalid_ref() {
-        let v = build_jsonl_failure(Some("not-a-doi"), "INVALID_REF", "bad ref");
+        let v = build_jsonl_failure(Some("not-a-doi"), "INVALID_REF", "bad ref", None);
         assert_eq!(v["ok"], false);
         assert_eq!(v["ref"], "not-a-doi");
         assert_eq!(v["error"]["code"], "INVALID_REF");
         assert_eq!(v["error"]["message"], "bad ref");
+        assert!(
+            v["error"].get("denial_context").is_none(),
+            "no denial_context on INVALID_REF (pre-guard parse error): {v}"
+        );
     }
 
     #[test]
     fn jsonl_failure_shape_fetch_error() {
-        let v = build_jsonl_failure(Some("arxiv:2401.12345"), "FETCH_ERROR", "boom");
+        let v = build_jsonl_failure(Some("arxiv:2401.12345"), "NETWORK_ERROR", "boom", None);
         assert_eq!(v["ok"], false);
         assert_eq!(v["ref"], "arxiv:2401.12345");
-        assert_eq!(v["error"]["code"], "FETCH_ERROR");
+        assert_eq!(v["error"]["code"], "NETWORK_ERROR");
         assert_eq!(v["error"]["message"], "boom");
+    }
+
+    #[test]
+    fn jsonl_failure_shape_with_denial_context() {
+        // #210: the structured `denial_context` carries the closed-enum
+        // `reason` + per-source detail when a CAPABILITY_DENIED failure
+        // surfaces. Hand-craft the value to pin the wire shape — the
+        // serializer is `DenialContext`'s own `Serialize` impl (ADR-0023).
+        let dc = serde_json::json!({
+            "reason":    "redirect_not_in_allowlist",
+            "source":    "oa-publisher",
+            "attempted": "evil.example.com",
+            "expected":  ["good-publisher.example.org"],
+        });
+        let v = build_jsonl_failure(
+            Some("10.1234/foo"),
+            "CAPABILITY_DENIED",
+            "redirect not in allowlist",
+            Some(dc),
+        );
+        assert_eq!(v["error"]["code"], "CAPABILITY_DENIED");
+        assert_eq!(
+            v["error"]["denial_context"]["reason"],
+            "redirect_not_in_allowlist"
+        );
+        assert_eq!(v["error"]["denial_context"]["source"], "oa-publisher");
+        assert_eq!(
+            v["error"]["denial_context"]["attempted"],
+            "evil.example.com"
+        );
     }
 
     #[test]
@@ -465,7 +623,7 @@ mod tests {
         // Self-review for #209 §1: a JoinSet panic loses the input, so
         // the record carries `ref: null` rather than a sentinel string
         // that a consumer doing `retry(rec["ref"])` would mishandle.
-        let v = build_jsonl_failure(None, "FETCH_ERROR", "batch task panicked: ...");
+        let v = build_jsonl_failure(None, "FETCH_ERROR", "batch task panicked: ...", None);
         assert_eq!(v["ok"], false);
         assert!(v["ref"].is_null(), "panic record's ref MUST be null: {v}");
         assert_eq!(v["error"]["code"], "FETCH_ERROR");
@@ -478,7 +636,11 @@ mod tests {
         let outcome = classify_joined(
             Ok(TaskOutcome {
                 input: "10.1234/foo".to_string(),
-                result: Ok(()),
+                result: Ok(FetchPaperOutcome::for_test_synthetic(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    PdfLegStatus::Fetched,
+                )),
             }),
             true,
         );
@@ -486,6 +648,10 @@ mod tests {
         let rec = outcome.json_record.expect("json_mode → record");
         assert_eq!(rec["ok"], true);
         assert_eq!(rec["ref"], "10.1234/foo");
+        // #210: structured `result` body present on success.
+        assert_eq!(rec["result"]["safekey"], "doi__10_1234_foo");
+        assert!(rec["result"]["store_path"].is_string());
+        assert!(rec["result"]["canonical_digest"].is_string());
         assert!(matches!(outcome.log_breadcrumb, LogBreadcrumb::None));
     }
 
@@ -494,7 +660,11 @@ mod tests {
         let outcome = classify_joined(
             Ok(TaskOutcome {
                 input: "10.1234/foo".to_string(),
-                result: Ok(()),
+                result: Ok(FetchPaperOutcome::for_test_synthetic(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    PdfLegStatus::Fetched,
+                )),
             }),
             false,
         );
@@ -503,11 +673,17 @@ mod tests {
     }
 
     #[test]
-    fn classify_joined_fetch_failure_emits_fetch_error() {
+    fn classify_joined_fetch_failure_emits_typed_code() {
+        // #210: the failure record now carries the typed ErrorCode wire
+        // string from `FetchError → ErrorCode`, not the generic
+        // `FETCH_ERROR`. `FetchError::SourceSchema` collapses to
+        // `INTERNAL_ERROR` (per `source.rs`'s closed-set mapping).
         let outcome = classify_joined(
             Ok(TaskOutcome {
                 input: "arxiv:2401.99999".to_string(),
-                result: Err(anyhow!("connection refused")),
+                result: Err(doiget_core::source::FetchError::SourceSchema {
+                    hint: "synthetic schema failure".to_string(),
+                }),
             }),
             true,
         );
@@ -515,11 +691,61 @@ mod tests {
         let rec = outcome.json_record.expect("json_mode → record");
         assert_eq!(rec["ok"], false);
         assert_eq!(rec["ref"], "arxiv:2401.99999");
-        assert_eq!(rec["error"]["code"], "FETCH_ERROR");
+        assert_eq!(rec["error"]["code"], "INTERNAL_ERROR");
         assert!(matches!(
             outcome.log_breadcrumb,
             LogBreadcrumb::FetchFailed { .. }
         ));
+    }
+
+    #[test]
+    fn classify_joined_blocked_pdf_emits_failure_with_denial_context() {
+        // #210: a `PdfLegStatus::Blocked` outcome is reported as a
+        // structured failure record carrying the `denial_context` the
+        // orchestrator captured at the policy-denial site. The
+        // `effective_blocked_code` reclassification promotes a
+        // redirect-not-in-allowlist denial from `NETWORK_ERROR` to
+        // `CAPABILITY_DENIED` so consumers see the policy class.
+        use doiget_core::{DenialContext, DenialReason, ErrorCode as Ec};
+        let blocked = PdfLegStatus::Blocked {
+            code: Ec::NetworkError,
+            message: "redirect not in allowlist".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some("oa-publisher".to_string()),
+                attempted: Some("evil.example.com".to_string()),
+                expected: Some(vec!["good-publisher.example.org".to_string()]),
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+        };
+        let outcome = classify_joined(
+            Ok(TaskOutcome {
+                input: "10.1234/foo".to_string(),
+                result: Ok(FetchPaperOutcome::for_test_synthetic(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    blocked,
+                )),
+            }),
+            true,
+        );
+        assert!(
+            outcome.is_error,
+            "Blocked PDF leg MUST be reported as error"
+        );
+        let rec = outcome.json_record.expect("json_mode → record");
+        assert_eq!(rec["ok"], false);
+        assert_eq!(rec["error"]["code"], "CAPABILITY_DENIED");
+        assert_eq!(
+            rec["error"]["denial_context"]["reason"],
+            "redirect_not_in_allowlist"
+        );
+        assert_eq!(
+            rec["error"]["denial_context"]["attempted"],
+            "evil.example.com"
+        );
     }
 
     #[test]
@@ -586,17 +812,17 @@ mod tests {
         // no embedded newlines) — required for the JSONL contract since
         // the production emitter wraps it with a single `println!` and
         // CI consumers split stdout by `\n`.
-        let s = build_jsonl_success("10.1/x").to_string();
+        let s = build_jsonl_success("10.1/x", None).to_string();
         assert!(
             !s.contains('\n'),
             "JSONL success must be single-line: {s:?}"
         );
-        let s2 = build_jsonl_failure(Some("10.1/x"), "FETCH_ERROR", "msg").to_string();
+        let s2 = build_jsonl_failure(Some("10.1/x"), "FETCH_ERROR", "msg", None).to_string();
         assert!(
             !s2.contains('\n'),
             "JSONL failure must be single-line: {s2:?}"
         );
-        let s3 = build_jsonl_failure(None, "FETCH_ERROR", "msg").to_string();
+        let s3 = build_jsonl_failure(None, "FETCH_ERROR", "msg", None).to_string();
         assert!(
             !s3.contains('\n'),
             "null-ref JSONL must be single-line: {s3:?}"

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -30,9 +30,11 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
+use camino::Utf8Path;
 
 use doiget_core::orchestrator::{FetchPaperOutcome, PdfLegStatus};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, RowInput};
+use doiget_core::refs::{self, Format, ParseError};
 use doiget_core::source::FetchError;
 use doiget_core::{DenialContext, ErrorCode, RateLimits, Ref, MCP_BATCH_MAX_SIZE};
 
@@ -85,15 +87,57 @@ pub async fn run_with_options(
     let raw =
         std::fs::read_to_string(&path).with_context(|| format!("reading batch file: {path}"))?;
 
-    // Step 2: parse refs — trim, drop blanks and `#`-prefixed comments. We
-    // keep the input strings (not parsed `Ref`s yet) so that per-ref parse
-    // failures can be logged with the original text.
-    let inputs: Vec<String> = raw
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .map(|s| s.to_string())
-        .collect();
+    // Step 2: parse refs via the ADR-0030 bibliography adapter. The
+    // adapter auto-detects between plain refs / CSL-JSON / BibTeX
+    // (slice 2 follow-up) by path extension + content fingerprint,
+    // then yields one `Result<ParsedEntry, ParseError>` per
+    // discovered entry.
+    //
+    // To keep the rest of the pipeline byte-identical to the
+    // pre-ADR-0030 plain-refs flow, we materialise each entry into
+    // the same `inputs: Vec<String>` shape the downstream Step 7
+    // already drives. The Ok arm produces the canonical ref-input
+    // string; the per-entry `InvalidRef` arm produces the raw
+    // identifier verbatim so the downstream `Ref::parse` call still
+    // produces an `INVALID_REF` JSONL line with the offending
+    // string. Whole-input failures (`Decode` / `UnsupportedFormat`)
+    // abort before any fetch runs — the operator gets a single loud
+    // error rather than a silently-empty batch.
+    let path_utf8 = Utf8Path::new(&path);
+    let parsed = refs::parse_input(&raw, Format::Auto, Some(path_utf8));
+    let mut inputs: Vec<String> = Vec::with_capacity(parsed.len());
+    for entry in parsed {
+        match entry {
+            Ok(p) => inputs.push(p.ref_.as_input_str().to_string()),
+            Err(ParseError::InvalidRef { raw, .. }) => inputs.push(raw),
+            Err(ParseError::NoIdentifier { entry_key }) => {
+                // Synthesise a recognisable placeholder so Step 7's
+                // `Ref::parse` rejects this entry as `INVALID_REF`
+                // with the operator's citation key visible in the
+                // JSONL `ref` field. A future slice will plumb the
+                // structured `entry_key` into a dedicated error
+                // object field (ADR-0030 §6).
+                let placeholder = match entry_key {
+                    Some(k) => format!("<no-identifier:{k}>"),
+                    None => "<no-identifier>".to_string(),
+                };
+                inputs.push(placeholder);
+            }
+            Err(ParseError::Decode { format, message }) => {
+                return Err(anyhow!("input did not deserialise as {format}: {message}"));
+            }
+            Err(ParseError::UnsupportedFormat { format }) => {
+                return Err(anyhow!(
+                    "input format '{format}' is not yet supported — \
+                     re-export your library as CSL-JSON or plain refs"
+                ));
+            }
+            // `ParseError` is `#[non_exhaustive]`; any future variant
+            // surfaces as a generic invalid-ref entry so the batch
+            // does not silently swallow a new failure class.
+            Err(other) => inputs.push(format!("<unhandled parse error: {other}>")),
+        }
+    }
 
     // Step 3: enforce the hard cap before doing any work. The cap is the
     // same one the MCP `batch_fetch` tool enforces (`MCP_BATCH_MAX_SIZE`).

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -134,8 +134,20 @@ pub async fn run_with_options(
             }
             // `ParseError` is `#[non_exhaustive]`; any future variant
             // surfaces as a generic invalid-ref entry so the batch
-            // does not silently swallow a new failure class.
-            Err(other) => inputs.push(format!("<unhandled parse error: {other}>")),
+            // does not silently swallow a new failure class. The
+            // `tracing::error!` makes the unknown variant LOUD in
+            // logs so an operator notices when this arm fires —
+            // otherwise the operator would only see an `INVALID_REF`
+            // JSONL row indistinguishable from any other parse
+            // failure.
+            Err(other) => {
+                tracing::error!(
+                    error = %other,
+                    "encountered unknown ParseError variant; batch continues with placeholder \
+                     INVALID_REF — this should never happen on a current doiget-core build"
+                );
+                inputs.push(format!("<unhandled parse error: {other}>"));
+            }
         }
     }
 

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -652,17 +652,39 @@ fn arg_to_flag_spec(a: &clap::Arg) -> FlagSpec {
 // Entry point
 // ---------------------------------------------------------------------------
 
-/// Run the `doiget capabilities` subcommand. Honors [`super::output::OutputMode`]:
-/// `Quiet` suppresses stdout (#203); every other mode emits the same
-/// pretty-printed JSON inventory. The caller passes the live
-/// `clap::Command` so the clap walk operates on the binary's actual
-/// `Cli` tree (which the lib half of this crate can't reach
-/// directly — the `Cli` struct lives in `main.rs`).
-pub fn run(cli: &clap::Command, mode: super::output::OutputMode) -> Result<()> {
-    // `Quiet` is the one mode that suppresses (per ADR-0017 / #203).
-    // Every other mode emits the same pretty JSON: `capabilities` is a
-    // product-output command.
-    if mode == super::output::OutputMode::Quiet {
+/// Run the `doiget capabilities` subcommand.
+///
+/// `capabilities` is an **artifact** command per ADR-0017 Amendment 1:
+/// its stdout output IS the deliverable (the inventory JSON an LLM
+/// reads on cold-boot). It honors only **explicit** Quiet —
+/// `--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet` — and emits
+/// the inventory on every other path. The `quiet_was_explicit`
+/// discriminator is what distinguishes the two cases:
+///
+/// | mode               | quiet_was_explicit | behaviour          |
+/// |--------------------|--------------------|--------------------|
+/// | non-`Quiet`        | -                  | emit               |
+/// | `Quiet` (explicit) | `true`             | suppress           |
+/// | `Quiet` (non-TTY)  | `false`            | **emit** (#219)    |
+///
+/// The non-TTY case is the one #219 / #220 report: an LLM tool
+/// executor captures stdout, so `stdout_is_tty()` is `false`, the
+/// resolver falls through to `Quiet`, but the caller wants the JSON
+/// inventory exactly because it's about to be machine-parsed. The
+/// table's bottom row is the fix.
+///
+/// The caller passes the live `clap::Command` so the clap walk
+/// operates on the binary's actual `Cli` tree (which the lib half of
+/// this crate can't reach directly — the `Cli` struct lives in
+/// `main.rs`).
+pub fn run(
+    cli: &clap::Command,
+    mode: super::output::OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
+    // ADR-0017 Amendment 1: artifact command — suppress ONLY on
+    // explicit Quiet, never on the non-TTY implicit fallback.
+    if mode == super::output::OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
     let caps = build_capabilities(cli);

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -66,6 +66,13 @@ pub struct Capabilities {
     pub mcp_tools: &'static [McpTool],
     /// Canonical doc paths an LLM can pull for deeper context.
     pub docs: Docs,
+    /// Number of user-extension allowlist hosts loaded from
+    /// `<config_dir>/doiget/config.toml` per ADR-0028 D2. `0` if the
+    /// config file is missing, contains no `[[network.additional_hosts]]`,
+    /// or fails to parse — run `doiget config doctor` to diagnose parse
+    /// failures. Exposed so an LLM can confirm at cold-boot whether the
+    /// curated allowlist has been extended on this host.
+    pub user_extension_count: usize,
 }
 
 /// What kind of value (if any) a [`FlagSpec`] carries.
@@ -515,6 +522,24 @@ pub fn build_capabilities(cli: &clap::Command) -> Capabilities {
         env_vars: ENV_VARS,
         mcp_tools: MCP_TOOLS,
         docs: DOCS,
+        user_extension_count: user_extension_count(),
+    }
+}
+
+/// Count valid `[[network.additional_hosts]]` entries in
+/// `<config_dir>/doiget/config.toml` (ADR-0028 D2). Returns `0` on any
+/// failure — missing config, parse error, unresolvable config dir.
+/// Diagnose failures via `doiget config doctor`; here we only need a
+/// best-effort cold-boot signal for the inventory.
+fn user_extension_count() -> usize {
+    let cfg_dir = match super::fetch::config_dir_utf8() {
+        Ok(p) => p,
+        Err(_) => return 0,
+    };
+    let path = cfg_dir.join("doiget").join("config.toml");
+    match doiget_core::user_extension::load(&path) {
+        Ok(hosts) => hosts.len(),
+        Err(_) => 0,
     }
 }
 
@@ -822,6 +847,7 @@ mod tests {
             "env_vars",
             "mcp_tools",
             "docs",
+            "user_extension_count",
         ] {
             assert!(
                 v.get(key).is_some(),
@@ -1008,6 +1034,94 @@ mod tests {
     #[test]
     fn version_is_cargo_pkg_version() {
         assert_eq!(caps().version, env!("CARGO_PKG_VERSION"));
+    }
+
+    /// ADR-0028 D2: `user_extension_count` must reflect the number of
+    /// `[[network.additional_hosts]]` entries actually present in
+    /// `<config_dir>/doiget/config.toml`. The test points every
+    /// config-dir env var at a tempdir, writes a 2-host config, and
+    /// asserts the inventory reports `2`. Drift here would silently
+    /// hide user-curated allowlist hosts from the cold-boot JSON.
+    #[test]
+    #[serial_test::serial]
+    fn user_extension_count_reflects_config_toml_entries() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        let config_toml = doiget_dir.join("config.toml");
+        std::fs::write(
+            config_toml.as_std_path(),
+            "[[network.additional_hosts]]\n\
+             host = \"example.org\"\n\
+             \n\
+             [[network.additional_hosts]]\n\
+             host = \"*.example.net\"\n\
+             note = \"university OA mirror\"\n",
+        )
+        .expect("write config.toml");
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let _a = EnvGuard::unset("APPDATA");
+        let _h = EnvGuard::unset("HOME");
+        let _u = EnvGuard::unset("USERPROFILE");
+
+        let cli = test_cli();
+        let caps = build_capabilities(&cli);
+        assert_eq!(
+            caps.user_extension_count, 2,
+            "expected 2 user-extension hosts, got {}",
+            caps.user_extension_count
+        );
+    }
+
+    /// Companion: with no config file (and a resolvable config dir),
+    /// the count is `0` — the curated allowlist is the entire surface.
+    /// Confirms the `Ok(vec![])` not-found path in `user_extension::load`
+    /// flows through unchanged.
+    #[test]
+    #[serial_test::serial]
+    fn user_extension_count_is_zero_without_config_toml() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let _a = EnvGuard::unset("APPDATA");
+        let _h = EnvGuard::unset("HOME");
+        let _u = EnvGuard::unset("USERPROFILE");
+
+        let caps = build_capabilities(&test_cli());
+        assert_eq!(caps.user_extension_count, 0);
+    }
+
+    /// Minimal env-guard local to this tests module; mirrors the
+    /// pattern in `commands::config::tests` (each module keeps its
+    /// own copy so they stay leaf-level cheap).
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
+        }
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -350,6 +350,15 @@ const MCP_TOOLS: &[McpTool] = &[
         name: "doiget_csl_export",
         schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
     },
+    McpTool {
+        // ADR-0030 D6: parse a CSL-JSON / (future) BibTeX file and
+        // fetch each resolvable entry; each result row carries the
+        // source bibliography's `entry_key` so a Zotero / Mendeley
+        // plugin can bridge the fetched PDF back to the originating
+        // reference.
+        name: "doiget_batch_from_bibliography",
+        schema_ref: "docs/MCP_TOOLS.md#1-tool-list",
+    },
 ];
 
 const DOCS: Docs = Docs {
@@ -958,6 +967,7 @@ mod tests {
             "doiget_expand_citation_graph",
             "doiget_bibtex_export",
             "doiget_csl_export",
+            "doiget_batch_from_bibliography",
         ]
         .into_iter()
         .collect();

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -173,6 +173,25 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                 cfg.contact_email.is_some(),
                 &mut all_ok,
             );
+            // ADR-0028 D2: surface user-extension allowlist health. A
+            // missing config.toml is normal (curated set only); a
+            // present-but-malformed config.toml is a doctor failure so
+            // the operator finds out before fetch attempts silently
+            // skip the extension path. `user_extension::load` returns
+            // `Ok(vec![])` for not-found, so the OK arm always reports
+            // a count.
+            match doiget_core::user_extension::load(&cfg.config_path) {
+                Ok(hosts) => check(
+                    &format!("user-extension hosts loaded: {}", hosts.len()),
+                    true,
+                    &mut all_ok,
+                ),
+                Err(e) => check(
+                    &format!("user-extension config invalid: {e}"),
+                    false,
+                    &mut all_ok,
+                ),
+            }
             // Trying to actually create the dirs would have side-effects;
             // keep doctor read-only and just check existence of parents.
             if !all_ok {
@@ -351,6 +370,49 @@ mod tests {
         // every supported test host (CI runners always have $HOME).
         run("doctor".into(), crate::commands::output::OutputMode::Human)
             .expect("doctor should pass with contact email + real home dir");
+    }
+
+    /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`
+    /// causes `doiget config doctor` to FAIL (exit 2). POSIX-only
+    /// because `dirs::config_dir()` on Windows queries the Known
+    /// Folder API directly (ignores APPDATA env), so the test can't
+    /// redirect the config path in a child process the way it can
+    /// via `XDG_CONFIG_HOME` on POSIX. The malformed-config FAIL
+    /// path is platform-independent; this test covers the wiring
+    /// on the platform where it CAN be exercised.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn doctor_fails_with_malformed_user_extension_config() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        let config_toml = doiget_dir.join("config.toml");
+        // Empty `host` value triggers `PatternError::Empty`, which
+        // the doctor surfaces as a FAIL. `note` is valid TOML so the
+        // top-level parse succeeds — only the pattern validation
+        // path produces the error we're pinning.
+        std::fs::write(
+            config_toml.as_std_path(),
+            "[[network.additional_hosts]]\nhost = \"\"\n",
+        )
+        .expect("write config.toml");
+
+        // POSIX `dirs::config_dir()` honors `XDG_CONFIG_HOME` first,
+        // so pointing it at our tempdir routes `cfg.config_path` to
+        // our crafted file.
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+
+        let err = run("doctor".into(), crate::commands::output::OutputMode::Human)
+            .expect_err("doctor should fail when user-extension config is malformed");
+        let cli_exit = err
+            .downcast_ref::<CliExit>()
+            .expect("failing doctor must carry a CliExit");
+        assert_eq!(cli_exit.0, 2);
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -373,14 +373,21 @@ mod tests {
     }
 
     /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`
-    /// causes `doiget config doctor` to FAIL (exit 2). POSIX-only
-    /// because `dirs::config_dir()` on Windows queries the Known
-    /// Folder API directly (ignores APPDATA env), so the test can't
-    /// redirect the config path in a child process the way it can
-    /// via `XDG_CONFIG_HOME` on POSIX. The malformed-config FAIL
-    /// path is platform-independent; this test covers the wiring
-    /// on the platform where it CAN be exercised.
-    #[cfg(unix)]
+    /// causes `doiget config doctor` to FAIL (exit 2). Linux-only
+    /// because `dirs::config_dir()` resolves differently on each
+    /// platform:
+    ///   - Linux: `$XDG_CONFIG_HOME` or `$HOME/.config` (env-driven,
+    ///     testable).
+    ///   - macOS: `~/Library/Application Support` (Known Folder via
+    ///     `NSSearchPathForDirectoriesInDomains`, ignores
+    ///     `XDG_CONFIG_HOME`).
+    ///   - Windows: `%FOLDERID_RoamingAppData%` (Known Folder API,
+    ///     ignores `APPDATA` env in child processes via
+    ///     `assert_cmd`).
+    /// The malformed-config FAIL path is platform-independent; this
+    /// test covers the wiring on the one platform where it CAN be
+    /// exercised in a hermetic test.
+    #[cfg(target_os = "linux")]
     #[test]
     #[serial_test::serial]
     fn doctor_fails_with_malformed_user_extension_config() {

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -134,7 +134,14 @@ fn home_dir_utf8() -> Result<Utf8PathBuf> {
 
 /// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
 /// (POSIX), then `APPDATA` (Windows), then falls back to `$HOME/.config`.
-fn config_dir_utf8() -> Result<Utf8PathBuf> {
+///
+/// Crate-visible so sibling modules (`commands::capabilities`,
+/// `commands::config`) can resolve the same `<config_dir>/doiget/`
+/// path the production HTTP-client builder reads from. Keep the
+/// signature stable: any divergence between this and the MCP-side
+/// copy (`crates/doiget-mcp/src/lib.rs::config_dir_utf8`) would
+/// silently desync the user-extension allowlist surfaces.
+pub(crate) fn config_dir_utf8() -> Result<Utf8PathBuf> {
     if let Some(s) = read_env_utf8("XDG_CONFIG_HOME")? {
         return Ok(Utf8PathBuf::from(s));
     }

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -191,39 +191,49 @@ fn build_http_client() -> Result<HttpClient> {
         allowlists.extend(tier_2_allowlist());
 
         // ADR-0028 D2: merge user-extension hosts from
-        // `<config_dir>/doiget/config.toml`'s
-        // `[[network.additional_hosts]]` table. Pattern grammar is
-        // restricted to literal FQDN or `*.<suffix>` (ADR-0028 D2-1);
-        // anything else is rejected at parse time. A missing config
-        // file is the normal case (treated as "no extensions").
+        // `<config_dir>/doiget/config.toml`. See
+        // `doiget_core::user_extension` for the wire contract and
+        // the (deferred) S3b provenance / doctor / capabilities
+        // surfaces.
         //
-        // A malformed config is surfaced as a *warning* to stderr,
-        // never aborts the fetch — ADR-0028 D2 frames user-extension
-        // as opt-in convenience; the curated allowlist still applies.
-        // The user can then run `doiget config doctor` (S3b will add
-        // the surface) to see the offending entry.
-        if let Ok(cfg_dir) = config_dir_utf8() {
-            let path = cfg_dir.join("doiget").join("config.toml");
-            match doiget_core::user_extension::load(&path) {
-                Ok(user_hosts) if !user_hosts.is_empty() => {
-                    tracing::info!(
-                        count = user_hosts.len(),
-                        path = %path,
-                        "merging user-extension allowlist hosts (ADR-0028 D2)"
-                    );
-                    doiget_core::user_extension::merge_into_allowlists(
-                        &mut allowlists,
-                        &user_hosts,
-                    );
+        // Failure handling is opt-in-convenience: a missing config
+        // is silent (Ok-empty), a malformed config emits
+        // `tracing::warn!` and continues with the curated allowlist,
+        // and an unresolvable config dir emits `tracing::debug!`
+        // (only happens in stripped envs with no HOME / XDG /
+        // APPDATA — review pass I3 / A1).
+        match config_dir_utf8() {
+            Ok(cfg_dir) => {
+                let path = cfg_dir.join("doiget").join("config.toml");
+                match doiget_core::user_extension::load(&path) {
+                    Ok(user_hosts) if !user_hosts.is_empty() => {
+                        tracing::info!(
+                            count = user_hosts.len(),
+                            path = %path,
+                            "merging user-extension allowlist hosts (ADR-0028 D2)"
+                        );
+                        doiget_core::user_extension::merge_into_allowlists(
+                            &mut allowlists,
+                            &user_hosts,
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            path = %path,
+                            "failed to load user-extension allowlist; \
+                             falling back to curated set only"
+                        );
+                    }
                 }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        path = %path,
-                        "failed to load user-extension allowlist; falling back to curated set only"
-                    );
-                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "config dir unresolvable; \
+                     user-extension allowlist disabled (curated set only)"
+                );
             }
         }
 
@@ -824,6 +834,7 @@ fn render_blocked_error(
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn new_session_id_is_26_chars() {
@@ -837,6 +848,108 @@ mod tests {
             id.chars().all(|c| c.is_ascii_alphanumeric()),
             "ulid must be ASCII alphanumeric: {:?}",
             id
+        );
+    }
+
+    /// Review pass C2: end-to-end coverage of the user-extension
+    /// merge inside `build_http_client`. Without this test the
+    /// production path that turns a `config.toml`
+    /// `[[network.additional_hosts]]` entry into a passing
+    /// allowlist match is unexercised — every existing e2e sets
+    /// `DOIGET_*_BASE` and short-circuits into the test-mode
+    /// builder above.
+    #[test]
+    #[serial]
+    fn build_http_client_merges_user_extension_into_oa_publisher_allowlist() {
+        use std::io::Write;
+
+        // Construct a tempdir + minimal config.toml under it.
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let cfg_dir = td.path().join("doiget");
+        std::fs::create_dir_all(&cfg_dir).expect("mkdir doiget/");
+        let cfg_path = cfg_dir.join("config.toml");
+        let mut f = std::fs::File::create(&cfg_path).expect("create config.toml");
+        f.write_all(
+            br#"
+[[network.additional_hosts]]
+host = "ruj.uj.edu.pl"
+note = "Jagiellonian"
+
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+"#,
+        )
+        .expect("write config.toml");
+        drop(f);
+
+        // Save + override env so `config_dir_utf8()` lands on the
+        // tempdir. Restored on Drop by EnvGuard. We also clear the
+        // five `DOIGET_*_BASE` env vars to force the production
+        // branch of `build_http_client`.
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<String>,
+        }
+        impl EnvGuard {
+            fn save(key: &'static str) -> Self {
+                Self {
+                    key,
+                    prev: std::env::var(key).ok(),
+                }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+        let _g0 = EnvGuard::save("XDG_CONFIG_HOME");
+        let _g1 = EnvGuard::save("APPDATA");
+        let _g2 = EnvGuard::save("HOME");
+        let _g3 = EnvGuard::save("USERPROFILE");
+        let _g4 = EnvGuard::save("DOIGET_ARXIV_BASE");
+        let _g5 = EnvGuard::save("DOIGET_CROSSREF_BASE");
+        let _g6 = EnvGuard::save("DOIGET_UNPAYWALL_BASE");
+        let _g7 = EnvGuard::save("DOIGET_OA_PUBLISHER_BASE");
+        let _g8 = EnvGuard::save("DOIGET_OPENALEX_BASE");
+        std::env::set_var("XDG_CONFIG_HOME", td.path());
+        std::env::set_var("APPDATA", td.path());
+        std::env::set_var("HOME", td.path());
+        std::env::set_var("USERPROFILE", td.path());
+        std::env::remove_var("DOIGET_ARXIV_BASE");
+        std::env::remove_var("DOIGET_CROSSREF_BASE");
+        std::env::remove_var("DOIGET_UNPAYWALL_BASE");
+        std::env::remove_var("DOIGET_OA_PUBLISHER_BASE");
+        std::env::remove_var("DOIGET_OPENALEX_BASE");
+
+        let client = build_http_client().expect("HttpClient builds");
+        let oa = client
+            .source_allowlist("oa-publisher")
+            .expect("oa-publisher source registered");
+
+        // Pre-existing curated allowlist still effective.
+        assert!(
+            oa.redirect_hosts.iter().any(|p| p == "*.aps.org"),
+            "curated *.aps.org MUST still be present after merge; got {:?}",
+            oa.redirect_hosts
+        );
+        // User-added literal host passes match.
+        assert!(
+            oa.matches("ruj.uj.edu.pl"),
+            "literal `ruj.uj.edu.pl` from user config MUST match"
+        );
+        // User-added wildcard passes match for a subdomain.
+        assert!(
+            oa.matches("alpha.uj.edu.pl"),
+            "wildcard `*.uj.edu.pl` from user config MUST match alpha.uj.edu.pl"
+        );
+        // Unrelated host MUST still fail.
+        assert!(
+            !oa.matches("ruj.uj.edu.ru"),
+            "host outside the suffix MUST NOT match"
         );
     }
 

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -189,6 +189,44 @@ fn build_http_client() -> Result<HttpClient> {
         // the runtime gate; the allowlist is the transport gate.
         #[cfg(feature = "citation")]
         allowlists.extend(tier_2_allowlist());
+
+        // ADR-0028 D2: merge user-extension hosts from
+        // `<config_dir>/doiget/config.toml`'s
+        // `[[network.additional_hosts]]` table. Pattern grammar is
+        // restricted to literal FQDN or `*.<suffix>` (ADR-0028 D2-1);
+        // anything else is rejected at parse time. A missing config
+        // file is the normal case (treated as "no extensions").
+        //
+        // A malformed config is surfaced as a *warning* to stderr,
+        // never aborts the fetch — ADR-0028 D2 frames user-extension
+        // as opt-in convenience; the curated allowlist still applies.
+        // The user can then run `doiget config doctor` (S3b will add
+        // the surface) to see the offending entry.
+        if let Ok(cfg_dir) = config_dir_utf8() {
+            let path = cfg_dir.join("doiget").join("config.toml");
+            match doiget_core::user_extension::load(&path) {
+                Ok(user_hosts) if !user_hosts.is_empty() => {
+                    tracing::info!(
+                        count = user_hosts.len(),
+                        path = %path,
+                        "merging user-extension allowlist hosts (ADR-0028 D2)"
+                    );
+                    doiget_core::user_extension::merge_into_allowlists(
+                        &mut allowlists,
+                        &user_hosts,
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %path,
+                        "failed to load user-extension allowlist; falling back to curated set only"
+                    );
+                }
+            }
+        }
+
         return HttpClient::new(allowlists).context("building HTTP client");
     }
 

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -431,63 +431,31 @@ impl FetchHarness {
     /// [`doiget_core::orchestrator::fetch_paper`] for the actual work
     /// (which both CLI and MCP now share). This function keeps the
     /// CLI-only stderr success-line print.
-    pub(crate) async fn fetch_one(&self, ref_: &Ref) -> Result<()> {
+    pub(crate) async fn fetch_one(&self, ref_: &Ref) -> Result<FetchPaperOutcome, FetchError> {
+        // Pure data path: return the typed outcome (or typed error)
+        // without any CLI-only rendering or exit-code synthesis. The
+        // single-fetch caller (`run_with_options`) and the batch
+        // caller (`commands::batch::classify_joined`) each render the
+        // human / JSON surface and map to `CliExit` themselves — see
+        // #210 for the rationale (batch's `--json` JSONL needs the
+        // structured `FetchPaperOutcome` to emit `result.{safekey,
+        // store_path, canonical_digest}` on success and
+        // `denial_context` on a `PdfLegStatus::Blocked` outcome, which
+        // was unreachable through the previous `Result<()>`
+        // signature).
         let ctx = self.fetch_context();
-        match core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await {
-            Ok(outcome) => {
-                // Issue #145 / `docs/ERRORS.md` §3 + §6: a `Blocked` PDF
-                // leg means an OA PDF *was* discovered but could not be
-                // retrieved. Metadata was written, but this is NOT a
-                // clean success — emitting only `print_success` here made
-                // a denied PDF visually indistinguishable from a genuine
-                // metadata-only result and exited 0 (a silent failure).
-                // Route it through the SAME `error[CODE]:` stderr channel
-                // + `cli_exit_code(...)` mapping `fetch` already uses for
-                // `CapabilityDenied`, using the structured code the
-                // orchestrator mapped from the underlying transport error.
-                if let PdfLegStatus::Blocked {
-                    code,
-                    message,
-                    denial,
-                } = &outcome.pdf_leg
-                {
-                    // Issue #145 / `docs/ERRORS.md` §2 + §3: the core
-                    // collapses *every* `FetchError::Http(_)` to
-                    // `ErrorCode::NetworkError` (see
-                    // `doiget_core::source.rs`'s `From<&FetchError> for
-                    // ErrorCode`). For a genuine transport/DNS/TLS fault
-                    // that is correct ("retry usually fine"). But an
-                    // off-allowlist / redirect-denied / insecure-scheme OA
-                    // PDF leg is a DELIBERATE policy block — retrying never
-                    // helps — yet it would otherwise surface as
-                    // `NETWORK_ERROR` → generic exit 1, misrepresenting a
-                    // flaky network. The orchestrator already preserves the
-                    // real reason on `denial` (the `From<&HttpError> for
-                    // Option<DenialContext>` impl walks reqwest's source
-                    // chain, so even a redirect denial wrapped as
-                    // `HttpError::Network` still yields
-                    // `DenialReason::RedirectNotInAllowlist`). Reclassify
-                    // the *policy* denials here at the CLI layer to
-                    // `CapabilityDenied` → `error[CAPABILITY_DENIED]:` →
-                    // exit 3 (the same code `fetch`/`graph` already use for
-                    // `ErrorCode::CapabilityDenied`).
-                    let effective = effective_blocked_code(*code, denial.as_ref());
-                    render_blocked_error(ref_, &outcome, effective, message, denial.as_ref());
-                    return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
-                }
-                emit_success_line(ref_, &outcome);
-                Ok(())
-            }
-            Err(e) => {
-                // Issue #119: render the cargo-style `error[CODE]:`
-                // line + denial note HERE (while the error is still
-                // typed), then carry only the exit code to `main`.
-                render_fetch_error(&e);
-                let code: ErrorCode = (&e).into();
-                Err(anyhow::Error::new(CliExit(cli_exit_code(code))))
-            }
-        }
+        core_fetch_paper(ref_, &self.profile, &ctx, &self.store, self.store.root()).await
     }
+}
+
+/// `true` iff the outcome represents a clean fetch: `Fetched` (full
+/// PDF) or `NoOaUrl` (metadata-only by design). A `Blocked` PDF leg
+/// is a failure for SessionEnd / exit-code purposes — an OA PDF was
+/// discovered but could not be retrieved — even though the metadata
+/// TOML did land on disk. Pulled out so both `run_with_options` and
+/// `commands::batch` agree on the failure boundary.
+pub(crate) fn outcome_is_clean_success(outcome: &FetchPaperOutcome) -> bool {
+    !matches!(outcome.pdf_leg, PdfLegStatus::Blocked { .. })
 }
 
 /// CLI-only one-line success message on stderr (ADR-0001 stdio
@@ -623,15 +591,47 @@ pub async fn run_with_options(
     // surrounding fetch MUST NOT proceed (`docs/PROVENANCE_LOG.md` §5).
     harness.log_session_start(Some(ref_.as_input_str()))?;
 
-    // Step 4: dispatch on ref kind.
+    // Step 4: dispatch on ref kind. `fetch_one` now returns the
+    // typed `FetchPaperOutcome` / `FetchError` per #210; the
+    // single-fetch caller (this fn) owns rendering + exit code.
     let result = harness.fetch_one(&ref_).await;
 
-    // Step 5: emit SessionEnd regardless of outcome. Best-effort: if this
-    // append also fails, surface the underlying fetch error (or a fresh one
-    // if the fetch was Ok).
-    harness.log_session_end(result.is_ok(), Some(ref_.as_input_str()));
+    // Step 5: emit SessionEnd regardless of outcome. A `Blocked` PDF
+    // leg is NOT a clean success even though the typed `Result` is
+    // `Ok` — `outcome_is_clean_success` collapses both halves so the
+    // SessionEnd `is_ok` field matches the user-facing exit code.
+    let session_ok = match &result {
+        Ok(o) => outcome_is_clean_success(o),
+        Err(_) => false,
+    };
+    harness.log_session_end(session_ok, Some(ref_.as_input_str()));
 
-    result
+    // Step 6: render the user-facing surface and map to `CliExit`.
+    // The Blocked-PDF reclassification logic that used to live inside
+    // `fetch_one` was lifted here verbatim so the batch caller can
+    // share the same `effective_blocked_code` / `render_blocked_error`
+    // helpers (issue #210 / #145).
+    match result {
+        Ok(outcome) => {
+            if let PdfLegStatus::Blocked {
+                code,
+                message,
+                denial,
+            } = &outcome.pdf_leg
+            {
+                let effective = effective_blocked_code(*code, denial.as_ref());
+                render_blocked_error(&ref_, &outcome, effective, message, denial.as_ref());
+                return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
+            }
+            emit_success_line(&ref_, &outcome);
+            Ok(())
+        }
+        Err(e) => {
+            render_fetch_error(&e);
+            let code: ErrorCode = (&e).into();
+            Err(anyhow::Error::new(CliExit(cli_exit_code(code))))
+        }
+    }
 }
 
 /// Single-line user-visible success message, written to stderr per ADR-0001
@@ -694,7 +694,7 @@ impl std::error::Error for CliExit {}
 /// Non-policy blocks (no `denial`, or a non-policy reason such as
 /// `SizeCapExceeded` / `ContentTypeMismatch`) keep the core's code so a
 /// genuine transport failure still reads as `NETWORK_ERROR`.
-fn effective_blocked_code(code: ErrorCode, denial: Option<&DenialContext>) -> ErrorCode {
+pub(crate) fn effective_blocked_code(code: ErrorCode, denial: Option<&DenialContext>) -> ErrorCode {
     match denial.map(|d| d.reason) {
         Some(
             DenialReason::RedirectNotInAllowlist

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -1,4 +1,5 @@
-//! Output-mode resolution for the `doiget` CLI (ADR-0017, #144).
+//! Output-mode resolution for the `doiget` CLI (ADR-0017, #144;
+//! Amendment 1 = #219/#220).
 //!
 //! ADR-0017 specifies the precedence ladder
 //! `--mode > --json/--quiet > DOIGET_MODE env > subcommand-implicit > TTY > quiet`.
@@ -7,6 +8,14 @@
 //! CI job already enforces "MCP mode forbids non-JSON stdout"). The
 //! `forced_implicit` parameter to [`resolve`] expresses that override: when
 //! `Some(_)`, it overrides everything else.
+//!
+//! [`resolve`] returns a [`ResolvedOutput`] carrying the [`OutputMode`]
+//! plus a `quiet_was_explicit` discriminator. The distinction is
+//! load-bearing per ADR-0017 Amendment 1: artifact-producing commands
+//! (`bib` / `csl` / `capabilities` / `audit-log --verify --mode json`)
+//! suppress only on **explicit** Quiet (`--quiet` / `-q` /
+//! `DOIGET_MODE=quiet` / `--mode quiet`), not on the non-TTY default.
+//! Informational commands continue to suppress on any Quiet.
 //!
 //! Resolution is split into a pure function ([`resolve`]) plus a thin
 //! TTY-detection wrapper ([`stdout_is_tty`]) so the ladder is fully
@@ -86,19 +95,63 @@ pub enum FlagInput {
     None,
 }
 
-/// Resolve the effective [`OutputMode`] per ADR-0017.
+/// The resolved output state per ADR-0017 Amendment 1: the
+/// [`OutputMode`] the resolution ladder picked, plus a
+/// `quiet_was_explicit` discriminator that distinguishes the user's
+/// **explicit** request for silence (`--quiet` / `-q` /
+/// `DOIGET_MODE=quiet` / `--mode quiet`) from the resolver's
+/// **implicit** fallback to Quiet when stdout is not a TTY.
+///
+/// Per ADR-0017 Amendment 1, *informational* commands (audit-log Human,
+/// list-recent, search, info, config show/path, provenance migrate,
+/// fetch/batch status) suppress on any Quiet; *artifact* commands
+/// (`bib` / `csl` / `capabilities` / `audit-log --verify --mode json`)
+/// suppress only on **explicit** Quiet. The wire format of
+/// [`OutputMode`] (`DOIGET_MODE` string values, the `modes` array in
+/// `capabilities` JSON, the `--mode` clap values) is **unchanged**;
+/// this struct lives only in-memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedOutput {
+    /// The effective mode for this invocation.
+    pub mode: OutputMode,
+    /// `true` iff the user supplied an explicit Quiet signal
+    /// (`--quiet`, `-q`, `--mode quiet`, `DOIGET_MODE=quiet`).
+    /// `false` for the non-TTY fallback to Quiet, and for any
+    /// non-Quiet mode.
+    pub quiet_was_explicit: bool,
+}
+
+/// `true` if `name` identifies an artifact-producing subcommand whose
+/// stdout output IS the deliverable (per ADR-0017 Amendment 1).
+/// Artifact commands suppress only on **explicit** Quiet
+/// ([`ResolvedOutput::quiet_was_explicit`] == `true`).
+///
+/// `audit-log` is omitted on purpose: it is *informational* in Human
+/// mode and *artifact* in Json mode; the command checks the resolved
+/// mode rather than its name, so this classifier doesn't apply.
+pub fn is_artifact_command(name: &str) -> bool {
+    matches!(name, "bib" | "csl" | "capabilities")
+}
+
+/// Resolve the effective [`OutputMode`] per ADR-0017 and the
+/// `quiet_was_explicit` discriminator per ADR-0017 Amendment 1.
 ///
 /// Precedence (highest first):
 ///
 /// 1. `forced_implicit` — a subcommand-pinned mode that overrides
 ///    everything (e.g. `doiget serve` → `Mcp` per CONFIG.md §5; required
-///    for the Slice 9 stdout-purity invariant).
+///    for the Slice 9 stdout-purity invariant). Pinned modes are
+///    **never** counted as explicit user Quiet; they are system policy.
 /// 2. `flag` — `--mode` / `--json` / `--quiet` on the command line.
+///    A `Quiet` mode reached via `--mode quiet`, `--quiet`, or `-q`
+///    is **explicit**.
 /// 3. `env` — `DOIGET_MODE` (parsed by [`parse_env_mode`]; unrecognised
 ///    values are ignored, matching CONFIG.md §4's "doiget reads only the
-///    keys it knows about" posture).
+///    keys it knows about" posture). A `Quiet` mode reached via
+///    `DOIGET_MODE=quiet` is **explicit**.
 /// 4. `is_tty` — `Human` when stdout is a terminal, otherwise `Quiet`
-///    (CONFIG.md §3.b's "implicit + TTY > quiet (default)").
+///    (CONFIG.md §3.b's "implicit + TTY > quiet (default)"). A `Quiet`
+///    mode reached this way is **implicit**.
 ///
 /// This function is pure: no env reads, no I/O. The caller plumbs
 /// `env::var("DOIGET_MODE").ok()` and an `is_tty` probe in.
@@ -107,19 +160,33 @@ pub fn resolve(
     flag: FlagInput,
     env: Option<&str>,
     is_tty: bool,
-) -> OutputMode {
+) -> ResolvedOutput {
     if let Some(m) = forced_implicit {
-        return m;
+        return ResolvedOutput {
+            mode: m,
+            quiet_was_explicit: false,
+        };
     }
-    match flag {
-        FlagInput::Explicit(m) => m,
-        FlagInput::JsonShort => OutputMode::Json,
-        FlagInput::QuietShort => OutputMode::Quiet,
-        FlagInput::None => env.and_then(parse_env_mode).unwrap_or(if is_tty {
-            OutputMode::Human
-        } else {
-            OutputMode::Quiet
-        }),
+    let (mode, quiet_was_explicit) = match flag {
+        FlagInput::Explicit(OutputMode::Quiet) => (OutputMode::Quiet, true),
+        FlagInput::Explicit(m) => (m, false),
+        FlagInput::JsonShort => (OutputMode::Json, false),
+        FlagInput::QuietShort => (OutputMode::Quiet, true),
+        FlagInput::None => match env.and_then(parse_env_mode) {
+            Some(OutputMode::Quiet) => (OutputMode::Quiet, true),
+            Some(m) => (m, false),
+            None => {
+                if is_tty {
+                    (OutputMode::Human, false)
+                } else {
+                    (OutputMode::Quiet, false)
+                }
+            }
+        },
+    };
+    ResolvedOutput {
+        mode,
+        quiet_was_explicit,
     }
 }
 
@@ -156,44 +223,55 @@ mod tests {
     fn forced_mcp_wins_over_flag_env_and_tty() {
         // `doiget serve` MUST be `Mcp` even if the user passes
         // `--mode quiet` or sets `DOIGET_MODE=human` (CONFIG.md §5).
-        let m = resolve(
+        let out = resolve(
             Some(OutputMode::Mcp),
             FlagInput::Explicit(OutputMode::Quiet),
             Some("human"),
             true,
         );
-        assert_eq!(m, OutputMode::Mcp);
+        assert_eq!(out.mode, OutputMode::Mcp);
+        assert!(
+            !out.quiet_was_explicit,
+            "forced_implicit is system policy, never explicit user Quiet"
+        );
     }
 
     // ---- flag > env > tty ---------------------------------------------
 
     #[test]
     fn explicit_flag_wins_over_env_and_tty() {
-        let m = resolve(
+        let out = resolve(
             None,
             FlagInput::Explicit(OutputMode::Json),
             Some("human"),
             true,
         );
-        assert_eq!(m, OutputMode::Json);
+        assert_eq!(out.mode, OutputMode::Json);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
     fn json_short_flag_implies_json() {
-        let m = resolve(None, FlagInput::JsonShort, Some("human"), true);
-        assert_eq!(m, OutputMode::Json);
+        let out = resolve(None, FlagInput::JsonShort, Some("human"), true);
+        assert_eq!(out.mode, OutputMode::Json);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
     fn quiet_short_flag_implies_quiet() {
-        let m = resolve(None, FlagInput::QuietShort, Some("human"), true);
-        assert_eq!(m, OutputMode::Quiet);
+        let out = resolve(None, FlagInput::QuietShort, Some("human"), true);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(
+            out.quiet_was_explicit,
+            "`--quiet`/`-q` is an explicit Quiet signal"
+        );
     }
 
     #[test]
     fn env_wins_when_no_flag() {
-        let m = resolve(None, FlagInput::None, Some("json"), true);
-        assert_eq!(m, OutputMode::Json);
+        let out = resolve(None, FlagInput::None, Some("json"), true);
+        assert_eq!(out.mode, OutputMode::Json);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
@@ -208,8 +286,12 @@ mod tests {
         // `DOIGET_MODE=garbage` is ignored, ladder continues to TTY.
         let tty = resolve(None, FlagInput::None, Some("garbage"), true);
         let pipe = resolve(None, FlagInput::None, Some("garbage"), false);
-        assert_eq!(tty, OutputMode::Human);
-        assert_eq!(pipe, OutputMode::Quiet);
+        assert_eq!(tty.mode, OutputMode::Human);
+        assert_eq!(pipe.mode, OutputMode::Quiet);
+        assert!(
+            !pipe.quiet_was_explicit,
+            "pipe-default Quiet is implicit, not explicit"
+        );
     }
 
     #[test]
@@ -219,39 +301,84 @@ mod tests {
         assert_eq!(parse_env_mode(""), None);
         assert_eq!(parse_env_mode("   "), None);
         let tty = resolve(None, FlagInput::None, Some(""), true);
-        assert_eq!(tty, OutputMode::Human);
+        assert_eq!(tty.mode, OutputMode::Human);
     }
 
     // ---- TTY tail ------------------------------------------------------
 
     #[test]
     fn tty_with_no_flag_no_env_yields_human() {
-        let m = resolve(None, FlagInput::None, None, true);
-        assert_eq!(m, OutputMode::Human);
+        let out = resolve(None, FlagInput::None, None, true);
+        assert_eq!(out.mode, OutputMode::Human);
+        assert!(!out.quiet_was_explicit);
     }
 
     #[test]
     fn no_tty_with_no_flag_no_env_yields_quiet() {
-        let m = resolve(None, FlagInput::None, None, false);
-        assert_eq!(m, OutputMode::Quiet);
+        let out = resolve(None, FlagInput::None, None, false);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(
+            !out.quiet_was_explicit,
+            "non-TTY default to Quiet is implicit (#219 / #220 / ADR-0017 Am1)"
+        );
     }
 
     // ---- env never overrides flag, never beats forced_implicit --------
 
     #[test]
     fn env_does_not_override_explicit_flag() {
-        let m = resolve(
+        let out = resolve(
             None,
             FlagInput::Explicit(OutputMode::Quiet),
             Some("human"),
             true,
         );
-        assert_eq!(m, OutputMode::Quiet);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(
+            out.quiet_was_explicit,
+            "`--mode quiet` is an explicit Quiet signal"
+        );
     }
 
     #[test]
     fn forced_implicit_overrides_env() {
-        let m = resolve(Some(OutputMode::Mcp), FlagInput::None, Some("human"), true);
-        assert_eq!(m, OutputMode::Mcp);
+        let out = resolve(Some(OutputMode::Mcp), FlagInput::None, Some("human"), true);
+        assert_eq!(out.mode, OutputMode::Mcp);
+    }
+
+    // ---- ADR-0017 Amendment 1: explicit vs implicit Quiet ------------
+
+    #[test]
+    fn doiget_mode_quiet_env_is_explicit_quiet() {
+        // DOIGET_MODE=quiet without any flag is treated as explicit
+        // user intent — artifact commands must respect it.
+        let out = resolve(None, FlagInput::None, Some("quiet"), true);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(out.quiet_was_explicit);
+    }
+
+    #[test]
+    fn non_tty_quiet_default_is_implicit_quiet() {
+        // The TTY-driven fallback to Quiet is implicit — artifact
+        // commands (capabilities/bib/csl) MUST still emit. This is
+        // the #219/#220 LLM cold-boot fix.
+        let out = resolve(None, FlagInput::None, None, /* is_tty */ false);
+        assert_eq!(out.mode, OutputMode::Quiet);
+        assert!(!out.quiet_was_explicit);
+    }
+
+    // ---- artifact-command classifier (ADR-0017 Am1) ------------------
+
+    #[test]
+    fn artifact_command_classifier_covers_bib_csl_capabilities() {
+        assert!(is_artifact_command("bib"));
+        assert!(is_artifact_command("csl"));
+        assert!(is_artifact_command("capabilities"));
+        // audit-log is informational-vs-artifact per resolved mode,
+        // not per name; the classifier does NOT match it.
+        assert!(!is_artifact_command("audit-log"));
+        assert!(!is_artifact_command("fetch"));
+        assert!(!is_artifact_command("info"));
+        assert!(!is_artifact_command(""));
     }
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -7,8 +7,30 @@
 //! `graph`. `serve` runs the rmcp-based MCP server in `doiget-mcp` over
 //! stdio (ADR-0001).
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use doiget_cli::commands::output::{self, FlagInput, OutputMode};
+
+/// `--color` value (#211 / CONFIG.md §5).
+///
+/// Honored by future ANSI emitters; `Auto` decides per-stderr-TTY at the
+/// emission site. `NO_COLOR=1` (the cross-tool environment convention
+/// documented at <https://no-color.org/>) forces [`OutputColor::Never`]
+/// regardless of the flag — see `apply_global_overrides` below.
+///
+/// This slice ships the *surface*: the flag is accepted and the resolved
+/// value is exposed via `DOIGET_COLOR` so any future ANSI consumer can
+/// read it through the same env-driven layer as the rest of the config.
+/// No consumer currently emits ANSI to be gated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+enum OutputColor {
+    /// Color when stderr is a terminal, monochrome otherwise.
+    Auto,
+    /// Always emit ANSI, even on a pipe.
+    Always,
+    /// Never emit ANSI, even on a terminal. Equivalent to `NO_COLOR=1`.
+    Never,
+}
 
 /// `doiget provenance ...` action selector. Ships only the v1→v2
 /// migration in Slice 4 (ADR-0024); further actions (e.g. `compact`,
@@ -74,6 +96,49 @@ struct Cli {
     /// `--mode` and `--json`.
     #[arg(short = 'q', long, global = true, conflicts_with_all = ["mode", "json"])]
     quiet: bool,
+
+    /// Override the on-disk paper store root. CONFIG.md §5 / #211.
+    /// Precedence: this flag > `DOIGET_STORE_ROOT` env > default
+    /// (`$HOME/papers` on POSIX, `%USERPROFILE%\papers` on Windows).
+    /// Wins by overwriting `DOIGET_STORE_ROOT` for the lifetime of
+    /// this process before any command resolver reads it.
+    #[arg(long, global = true, value_name = "PATH")]
+    store_root: Option<String>,
+
+    /// Override the provenance-log file path. CONFIG.md §5 / #211.
+    /// Precedence: this flag > `DOIGET_LOG_PATH` env > default
+    /// (`<config_dir>/doiget/access.jsonl`). Same wins-by-env-overwrite
+    /// pattern as `--store-root` so existing resolvers
+    /// (`commands::fetch::resolve_log_path` / `commands::audit_log`)
+    /// pick the value up uniformly.
+    #[arg(long, global = true, value_name = "PATH")]
+    log_path: Option<String>,
+
+    /// Force / suppress ANSI escapes on stderr output. CONFIG.md §5 /
+    /// #211. Precedence: this flag > `NO_COLOR` env (per
+    /// <https://no-color.org/>, any non-empty value forces `never`) >
+    /// default (`auto` — color when stderr is a TTY).
+    ///
+    /// **Surface-only in this slice**: doiget currently emits no ANSI,
+    /// so the flag is accepted, validated, and exposed via the
+    /// `DOIGET_COLOR` env var for future emitters; nothing renders
+    /// differently today.
+    #[arg(long, global = true, value_name = "auto|always|never", value_enum)]
+    color: Option<OutputColor>,
+
+    /// Show the per-ref informational progress line on stderr.
+    /// Conflicts with `--no-progress`. CONFIG.md §5 / #211.
+    ///
+    /// **Surface-only in this slice**: the `fetch` / `batch` per-ref
+    /// stderr summary is unchanged in this PR; consumers that read
+    /// `DOIGET_PROGRESS=1` will respect it in a follow-up.
+    #[arg(long, global = true, conflicts_with = "no_progress")]
+    progress: bool,
+
+    /// Suppress the per-ref informational progress line on stderr.
+    /// Conflicts with `--progress`.
+    #[arg(long, global = true, conflicts_with = "progress")]
+    no_progress: bool,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -229,7 +294,73 @@ fn forced_implicit_for(command: &Option<Command>) -> Option<OutputMode> {
     }
 }
 
+/// Apply the four CONFIG.md §5 global flags (#211) by overwriting the
+/// matching process env vars before any command resolver reads them.
+///
+/// This keeps the precedence ladder `flag > env > default` correct
+/// uniformly across every command without threading a new
+/// `ResolvedFlags` value through eleven `run(..)` signatures: the
+/// existing env-driven resolvers (`resolve_store_root`,
+/// `resolve_log_path`, the future `--color` / `--progress`
+/// consumers) keep reading env and will see the flag value when one
+/// is given.
+///
+/// `--color` and `--progress` / `--no-progress` are *surface-only* in
+/// this slice — they are accepted and exposed via `DOIGET_COLOR` /
+/// `DOIGET_PROGRESS` for future consumers, but doiget does not yet
+/// emit ANSI escapes or per-ref progress lines that would respect
+/// them. `NO_COLOR=1` (per <https://no-color.org/>) still wins over
+/// `--color always` because the consumer-side resolver checks
+/// `NO_COLOR` first by the standard convention.
+///
+/// **Thread safety:** `std::env::set_var` is safe on edition 2021 / Rust
+/// 1.86 (the workspace MSRV) but becomes `unsafe` under edition 2024.
+/// We call this BEFORE the tokio runtime spawns any task — there is
+/// exactly one thread reading the environment at the point we mutate
+/// it. When the workspace migrates to edition 2024 the calls will be
+/// wrapped in `unsafe { ... }` blocks; the workspace `-F unsafe-code`
+/// lint will need a localized `#[allow]` here at that point. Tracked
+/// under #211 follow-up.
+fn apply_global_overrides(cli: &Cli) {
+    if let Some(v) = cli.store_root.as_deref() {
+        std::env::set_var("DOIGET_STORE_ROOT", v);
+    }
+    if let Some(v) = cli.log_path.as_deref() {
+        std::env::set_var("DOIGET_LOG_PATH", v);
+    }
+    if let Some(c) = cli.color {
+        let val = match c {
+            OutputColor::Auto => "auto",
+            OutputColor::Always => "always",
+            OutputColor::Never => "never",
+        };
+        std::env::set_var("DOIGET_COLOR", val);
+    }
+    // `--progress` / `--no-progress` are mutually exclusive at the
+    // clap layer (`conflicts_with`), so at most one is set. When
+    // neither is given, we leave `DOIGET_PROGRESS` untouched so the
+    // resolver picks the default (auto via TTY) in the consumer
+    // slice.
+    if cli.progress {
+        std::env::set_var("DOIGET_PROGRESS", "1");
+    } else if cli.no_progress {
+        std::env::set_var("DOIGET_PROGRESS", "0");
+    }
+}
+
 async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
+    // CONFIG.md §5 / #211: apply global path / display flags by
+    // overwriting their env counterparts BEFORE any resolver reads
+    // them. The precedence
+    //
+    //   flag (this fn) > env > default
+    //
+    // is implemented by `apply_global_overrides`'s
+    // `--flag-wins-by-setting-env-first` pattern: when a flag is
+    // supplied, its value replaces the env value; when no flag is
+    // supplied, the env value (or the resolver's default) stands.
+    apply_global_overrides(&cli);
+
     // Resolve the effective output mode ONCE per invocation per ADR-0017.
     // The pure resolver lives in `commands::output`; this site is the
     // single I/O-touching layer that reads env + probes the TTY.
@@ -312,5 +443,161 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             total,
             per_paper,
         }) => doiget_cli::commands::graph::run(ref_, depth, total, per_paper, mode).await,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use serial_test::serial;
+
+    /// RAII guard restoring a single env var to its pre-test value (or
+    /// removing it if previously unset). The `apply_global_overrides`
+    /// tests mutate `DOIGET_STORE_ROOT` / `DOIGET_LOG_PATH` /
+    /// `DOIGET_COLOR` / `DOIGET_PROGRESS`; without restoration a
+    /// subsequent test on the same process would see stale state.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn save(key: &'static str) -> Self {
+            Self {
+                key,
+                prev: std::env::var(key).ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    fn parse_cli(args: &[&str]) -> Cli {
+        // Prepend the binary name; clap requires argv[0].
+        let mut argv = vec!["doiget"];
+        argv.extend_from_slice(args);
+        Cli::parse_from(argv)
+    }
+
+    // ---- store_root precedence (flag > env) -----------------------------
+
+    #[test]
+    #[serial]
+    fn store_root_flag_overwrites_env() {
+        let _g = EnvGuard::save("DOIGET_STORE_ROOT");
+        std::env::set_var("DOIGET_STORE_ROOT", "/env/path");
+        let cli = parse_cli(&["--store-root", "/flag/path", "capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(
+            std::env::var("DOIGET_STORE_ROOT").unwrap(),
+            "/flag/path",
+            "--store-root MUST win over DOIGET_STORE_ROOT env"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn store_root_env_preserved_when_no_flag() {
+        let _g = EnvGuard::save("DOIGET_STORE_ROOT");
+        std::env::set_var("DOIGET_STORE_ROOT", "/env/path");
+        let cli = parse_cli(&["capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(
+            std::env::var("DOIGET_STORE_ROOT").unwrap(),
+            "/env/path",
+            "DOIGET_STORE_ROOT env MUST survive when --store-root is not given"
+        );
+    }
+
+    // ---- log_path precedence (flag > env) -------------------------------
+
+    #[test]
+    #[serial]
+    fn log_path_flag_overwrites_env() {
+        let _g = EnvGuard::save("DOIGET_LOG_PATH");
+        std::env::set_var("DOIGET_LOG_PATH", "/env/log.jsonl");
+        let cli = parse_cli(&["--log-path", "/flag/log.jsonl", "capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(
+            std::env::var("DOIGET_LOG_PATH").unwrap(),
+            "/flag/log.jsonl",
+            "--log-path MUST win over DOIGET_LOG_PATH env"
+        );
+    }
+
+    // ---- color flag -> DOIGET_COLOR env ---------------------------------
+
+    #[test]
+    #[serial]
+    fn color_flag_writes_doiget_color_env() {
+        let _g = EnvGuard::save("DOIGET_COLOR");
+        std::env::remove_var("DOIGET_COLOR");
+        for (arg, expected) in [("auto", "auto"), ("always", "always"), ("never", "never")] {
+            let cli = parse_cli(&["--color", arg, "capabilities"]);
+            apply_global_overrides(&cli);
+            assert_eq!(
+                std::env::var("DOIGET_COLOR").unwrap(),
+                expected,
+                "--color {arg} MUST write {expected} to DOIGET_COLOR"
+            );
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn color_unset_when_no_flag_leaves_env_untouched() {
+        let _g = EnvGuard::save("DOIGET_COLOR");
+        std::env::remove_var("DOIGET_COLOR");
+        let cli = parse_cli(&["capabilities"]);
+        apply_global_overrides(&cli);
+        assert!(
+            std::env::var("DOIGET_COLOR").is_err(),
+            "absent --color MUST leave DOIGET_COLOR unset"
+        );
+    }
+
+    // ---- progress flags -> DOIGET_PROGRESS env --------------------------
+
+    #[test]
+    #[serial]
+    fn progress_flag_writes_one() {
+        let _g = EnvGuard::save("DOIGET_PROGRESS");
+        std::env::remove_var("DOIGET_PROGRESS");
+        let cli = parse_cli(&["--progress", "capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(std::env::var("DOIGET_PROGRESS").unwrap(), "1");
+    }
+
+    #[test]
+    #[serial]
+    fn no_progress_flag_writes_zero() {
+        let _g = EnvGuard::save("DOIGET_PROGRESS");
+        std::env::remove_var("DOIGET_PROGRESS");
+        let cli = parse_cli(&["--no-progress", "capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(std::env::var("DOIGET_PROGRESS").unwrap(), "0");
+    }
+
+    #[test]
+    #[serial]
+    fn neither_progress_nor_no_progress_leaves_env_untouched() {
+        let _g = EnvGuard::save("DOIGET_PROGRESS");
+        std::env::set_var("DOIGET_PROGRESS", "sentinel");
+        let cli = parse_cli(&["capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(
+            std::env::var("DOIGET_PROGRESS").unwrap(),
+            "sentinel",
+            "absent --progress/--no-progress MUST NOT clobber a user-set DOIGET_PROGRESS env"
+        );
     }
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -7,15 +7,22 @@
 //! `graph`. `serve` runs the rmcp-based MCP server in `doiget-mcp` over
 //! stdio (ADR-0001).
 
+use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
 use doiget_cli::commands::output::{self, FlagInput, OutputMode};
 
 /// `--color` value (#211 / CONFIG.md §5).
 ///
 /// Honored by future ANSI emitters; `Auto` decides per-stderr-TTY at the
-/// emission site. `NO_COLOR=1` (the cross-tool environment convention
-/// documented at <https://no-color.org/>) forces [`OutputColor::Never`]
-/// regardless of the flag — see `apply_global_overrides` below.
+/// emission site. The `NO_COLOR` cross-tool convention
+/// (<https://no-color.org/>) is honored by the *consumer-side* resolver,
+/// not at this write boundary: `apply_global_overrides` writes
+/// `DOIGET_COLOR` from the flag value unconditionally, and a future
+/// ANSI emitter MUST check `NO_COLOR` (present and non-empty, regardless
+/// of value) before consulting `DOIGET_COLOR`. The split keeps the
+/// write boundary stupid-simple and centralises the NO_COLOR
+/// precedence in the emitter's own resolver where it is closer to the
+/// actual rendering site.
 ///
 /// This slice ships the *surface*: the flag is accepted and the resolved
 /// value is exposed via `DOIGET_COLOR` so any future ANSI consumer can
@@ -24,12 +31,60 @@ use doiget_cli::commands::output::{self, FlagInput, OutputMode};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "lower")]
 enum OutputColor {
-    /// Color when stderr is a terminal, monochrome otherwise.
+    /// Color when stderr is a terminal, monochrome otherwise. This is
+    /// also the default when `--color` is not given; explicit
+    /// `--color auto` is therefore a no-op vs the default unless
+    /// `NO_COLOR` is set, in which case the *consumer-side* resolver
+    /// still forces monochrome regardless of `--color`.
     Auto,
-    /// Always emit ANSI, even on a pipe.
+    /// Always emit ANSI, even on a pipe. Note that `NO_COLOR` (present
+    /// + non-empty) still wins at the consumer-side resolver.
     Always,
-    /// Never emit ANSI, even on a terminal. Equivalent to `NO_COLOR=1`.
+    /// Never emit ANSI, even on a terminal.
     Never,
+}
+
+impl OutputColor {
+    /// String representation written to `DOIGET_COLOR`.
+    ///
+    /// The match arms intentionally mirror the `#[clap(rename_all =
+    /// "lower")]` parser-side spelling so a round trip through clap →
+    /// `as_env_value` → env → future consumer is byte-identical.
+    /// The pair is pinned by
+    /// `tests::output_color_env_strings_match_clap_parser_side`, which
+    /// rejects each variant's string against clap's own
+    /// `ValueEnum::to_possible_value().get_name()` — if `rename_all`
+    /// is changed (or a variant renamed), the test fires before any
+    /// env consumer observes the drift.
+    fn as_env_value(self) -> &'static str {
+        match self {
+            OutputColor::Auto => "auto",
+            OutputColor::Always => "always",
+            OutputColor::Never => "never",
+        }
+    }
+}
+
+/// Custom value parser for path-shaped CLI arguments.
+///
+/// Rejects empty strings and NUL bytes at parse time. NUL would
+/// otherwise panic later in `std::env::set_var` (silent abort under
+/// `panic = "abort"`); the empty-string case was a documented silent
+/// failure path from the review pass (`apply_global_overrides`
+/// would have written `DOIGET_*=""` which downstream resolvers treat
+/// differently from an unset key).
+///
+/// Returning `Utf8PathBuf` honors the workspace `clippy.toml`
+/// disallowed-types policy (`std::path::PathBuf` is banned) and
+/// validates UTF-8 at the parse boundary instead of on first use.
+fn parse_utf8_path(raw: &str) -> Result<Utf8PathBuf, String> {
+    if raw.is_empty() {
+        return Err("path must not be empty".to_string());
+    }
+    if raw.contains('\0') {
+        return Err("path must not contain NUL bytes".to_string());
+    }
+    Ok(Utf8PathBuf::from(raw))
 }
 
 /// `doiget provenance ...` action selector. Ships only the v1→v2
@@ -101,29 +156,33 @@ struct Cli {
     /// Precedence: this flag > `DOIGET_STORE_ROOT` env > default
     /// (`$HOME/papers` on POSIX, `%USERPROFILE%\papers` on Windows).
     /// Wins by overwriting `DOIGET_STORE_ROOT` for the lifetime of
-    /// this process before any command resolver reads it.
-    #[arg(long, global = true, value_name = "PATH")]
-    store_root: Option<String>,
+    /// this process before any command resolver reads it. Empty
+    /// strings and NUL bytes are rejected at parse time by
+    /// `parse_utf8_path`.
+    #[arg(long, global = true, value_name = "PATH", value_parser = parse_utf8_path)]
+    store_root: Option<Utf8PathBuf>,
 
     /// Override the provenance-log file path. CONFIG.md §5 / #211.
     /// Precedence: this flag > `DOIGET_LOG_PATH` env > default
     /// (`<config_dir>/doiget/access.jsonl`). Same wins-by-env-overwrite
     /// pattern as `--store-root` so existing resolvers
     /// (`commands::fetch::resolve_log_path` / `commands::audit_log`)
-    /// pick the value up uniformly.
-    #[arg(long, global = true, value_name = "PATH")]
-    log_path: Option<String>,
+    /// pick the value up uniformly. Empty strings and NUL bytes are
+    /// rejected at parse time by `parse_utf8_path`.
+    #[arg(long, global = true, value_name = "PATH", value_parser = parse_utf8_path)]
+    log_path: Option<Utf8PathBuf>,
 
     /// Force / suppress ANSI escapes on stderr output. CONFIG.md §5 /
-    /// #211. Precedence: this flag > `NO_COLOR` env (per
-    /// <https://no-color.org/>, any non-empty value forces `never`) >
-    /// default (`auto` — color when stderr is a TTY).
+    /// #211. Precedence: this flag > consumer-side `NO_COLOR` check >
+    /// default (`auto`). See [`OutputColor`] for the precedence
+    /// rationale — `NO_COLOR` is honored at the emission boundary,
+    /// not at this write site.
     ///
     /// **Surface-only in this slice**: doiget currently emits no ANSI,
     /// so the flag is accepted, validated, and exposed via the
     /// `DOIGET_COLOR` env var for future emitters; nothing renders
     /// differently today.
-    #[arg(long, global = true, value_name = "auto|always|never", value_enum)]
+    #[arg(long, global = true, value_enum)]
     color: Option<OutputColor>,
 
     /// Show the per-ref informational progress line on stderr.
@@ -132,16 +191,38 @@ struct Cli {
     /// **Surface-only in this slice**: the `fetch` / `batch` per-ref
     /// stderr summary is unchanged in this PR; consumers that read
     /// `DOIGET_PROGRESS=1` will respect it in a follow-up.
+    ///
+    /// The pair `progress` / `no_progress` encodes a three-state
+    /// value (true / false / unset) — see [`Cli::progress_choice`]
+    /// for the typed view that callers should consume.
     #[arg(long, global = true, conflicts_with = "no_progress")]
     progress: bool,
 
     /// Suppress the per-ref informational progress line on stderr.
-    /// Conflicts with `--progress`.
+    /// Conflicts with `--progress`. See [`Cli::progress_choice`].
     #[arg(long, global = true, conflicts_with = "progress")]
     no_progress: bool,
 
     #[command(subcommand)]
     command: Option<Command>,
+}
+
+impl Cli {
+    /// Collapse the `progress` / `no_progress` bool pair into the
+    /// three-state value it actually represents (review pass I7).
+    ///
+    /// Returns `Some(true)` for `--progress`, `Some(false)` for
+    /// `--no-progress`, and `None` when neither flag was given.
+    /// The `(true, true)` case is unreachable thanks to clap's
+    /// `conflicts_with`, but the helper is unconditional so callers
+    /// don't need to remember which flag the if-arm prioritises.
+    fn progress_choice(&self) -> Option<bool> {
+        match (self.progress, self.no_progress) {
+            (true, _) => Some(true),
+            (_, true) => Some(false),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -313,38 +394,46 @@ fn forced_implicit_for(command: &Option<Command>) -> Option<OutputMode> {
 /// `--color always` because the consumer-side resolver checks
 /// `NO_COLOR` first by the standard convention.
 ///
-/// **Thread safety:** `std::env::set_var` is safe on edition 2021 / Rust
-/// 1.86 (the workspace MSRV) but becomes `unsafe` under edition 2024.
-/// We call this BEFORE the tokio runtime spawns any task — there is
-/// exactly one thread reading the environment at the point we mutate
-/// it. When the workspace migrates to edition 2024 the calls will be
-/// wrapped in `unsafe { ... }` blocks; the workspace `-F unsafe-code`
-/// lint will need a localized `#[allow]` here at that point. Tracked
-/// under #211 follow-up.
+/// **Thread safety:** `std::env::set_var` is safe on edition 2021 /
+/// Rust 1.86 (the workspace MSRV; cf. `Cargo.toml [workspace.package]
+/// edition`). Under edition 2024 it becomes `unsafe fn` (the
+/// `setenv` POSIX call is documented as non-thread-safe), and the
+/// workspace `-F unsafe-code` lint will need a localized
+/// `#[allow(unsafe_code)]` here when migrating. Tracked under #211
+/// follow-up.
+///
+/// We invoke this from `run_dispatch` (see call site below) before
+/// any `.await` in the function. The `#[tokio::main]` runtime has
+/// already constructed its multi-thread worker pool by that point,
+/// but the workers are parked on the work queue and do not read
+/// `environ`; the active thread is the binary's startup thread. The
+/// concurrent-read soundness condition for `setenv` is therefore met.
+/// If a future change introduces an async background task that reads
+/// `DOIGET_STORE_ROOT` (or any other key this function writes), the
+/// applicaton of overrides must move ahead of the runtime
+/// construction (i.e. above the `#[tokio::main]` boundary).
+///
+/// The function intentionally has no error path: each flag value has
+/// already passed `parse_utf8_path` (empty and NUL rejected) or
+/// clap's `ValueEnum` (closed set of strings), so `set_var` cannot
+/// panic on the value. The function is fire-and-forget by design.
 fn apply_global_overrides(cli: &Cli) {
     if let Some(v) = cli.store_root.as_deref() {
-        std::env::set_var("DOIGET_STORE_ROOT", v);
+        std::env::set_var("DOIGET_STORE_ROOT", v.as_str());
     }
     if let Some(v) = cli.log_path.as_deref() {
-        std::env::set_var("DOIGET_LOG_PATH", v);
+        std::env::set_var("DOIGET_LOG_PATH", v.as_str());
     }
     if let Some(c) = cli.color {
-        let val = match c {
-            OutputColor::Auto => "auto",
-            OutputColor::Always => "always",
-            OutputColor::Never => "never",
-        };
-        std::env::set_var("DOIGET_COLOR", val);
+        std::env::set_var("DOIGET_COLOR", c.as_env_value());
     }
-    // `--progress` / `--no-progress` are mutually exclusive at the
-    // clap layer (`conflicts_with`), so at most one is set. When
-    // neither is given, we leave `DOIGET_PROGRESS` untouched so the
-    // resolver picks the default (auto via TTY) in the consumer
-    // slice.
-    if cli.progress {
-        std::env::set_var("DOIGET_PROGRESS", "1");
-    } else if cli.no_progress {
-        std::env::set_var("DOIGET_PROGRESS", "0");
+    // `--progress` / `--no-progress` collapse into a typed
+    // three-state via `Cli::progress_choice` (review pass I7). When
+    // neither is given we leave `DOIGET_PROGRESS` untouched so a
+    // user-set env value survives and the future consumer can fall
+    // back to its own TTY-based default.
+    if let Some(on) = cli.progress_choice() {
+        std::env::set_var("DOIGET_PROGRESS", if on { "1" } else { "0" });
     }
 }
 
@@ -534,6 +623,26 @@ mod tests {
         );
     }
 
+    #[test]
+    #[serial]
+    fn log_path_env_preserved_when_no_flag() {
+        // Symmetric to `store_root_env_preserved_when_no_flag`: when
+        // `--log-path` is not given, a user-set `DOIGET_LOG_PATH` env
+        // value MUST NOT be blanked or clobbered by
+        // `apply_global_overrides`. A regression that swapped the
+        // `if let Some(v) = …` guard for an unconditional `set_var`
+        // would be silently caught here. Review pass I2.
+        let _g = EnvGuard::save("DOIGET_LOG_PATH");
+        std::env::set_var("DOIGET_LOG_PATH", "/env/log.jsonl");
+        let cli = parse_cli(&["capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(
+            std::env::var("DOIGET_LOG_PATH").unwrap(),
+            "/env/log.jsonl",
+            "DOIGET_LOG_PATH env MUST survive when --log-path is not given"
+        );
+    }
+
     // ---- color flag -> DOIGET_COLOR env ---------------------------------
 
     #[test]
@@ -563,6 +672,55 @@ mod tests {
             std::env::var("DOIGET_COLOR").is_err(),
             "absent --color MUST leave DOIGET_COLOR unset"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn color_env_preserved_when_no_flag() {
+        // Sentinel-preservation symmetric to `neither_progress_…`. A
+        // user who has pre-set `DOIGET_COLOR` in their shell must see
+        // that value survive a `doiget` invocation that does NOT
+        // include `--color`. Review pass I3 — the previous test only
+        // exercised the unset → unset path, which is satisfied by a
+        // regression that blanks the env on every invocation.
+        let _g = EnvGuard::save("DOIGET_COLOR");
+        std::env::set_var("DOIGET_COLOR", "sentinel");
+        let cli = parse_cli(&["capabilities"]);
+        apply_global_overrides(&cli);
+        assert_eq!(
+            std::env::var("DOIGET_COLOR").unwrap(),
+            "sentinel",
+            "absent --color MUST NOT clobber a user-set DOIGET_COLOR env"
+        );
+    }
+
+    // ---- ValueEnum drift guard (A1 follow-up) ---------------------------
+
+    #[test]
+    fn output_color_env_strings_match_clap_parser_side() {
+        // `as_env_value` is a hand-written match; the clap parser-side
+        // strings come from `#[clap(rename_all = "lower")]` +
+        // `ValueEnum`. If anyone changes `rename_all` (or renames a
+        // variant) without updating `as_env_value`, the round trip
+        // `--color <s> → OutputColor → as_env_value → DOIGET_COLOR`
+        // would silently drift. This test makes the dependency
+        // mechanical: clap's `to_possible_value().get_name()` is the
+        // canonical parser-side spelling, and we assert each variant's
+        // `as_env_value` matches it exactly.
+        for variant in [
+            OutputColor::Auto,
+            OutputColor::Always,
+            OutputColor::Never,
+        ] {
+            let parser_side = variant
+                .to_possible_value()
+                .expect("clap value-enum exposes every non-skipped variant");
+            assert_eq!(
+                variant.as_env_value(),
+                parser_side.get_name(),
+                "as_env_value MUST mirror clap's rename_all-driven name for {variant:?}"
+            );
+        }
     }
 
     // ---- progress flags -> DOIGET_PROGRESS env --------------------------
@@ -599,5 +757,65 @@ mod tests {
             "sentinel",
             "absent --progress/--no-progress MUST NOT clobber a user-set DOIGET_PROGRESS env"
         );
+    }
+
+    // ---- parse_utf8_path (I6 empty, A4 NUL) -----------------------------
+
+    #[test]
+    fn parse_utf8_path_accepts_normal_path() {
+        let p = parse_utf8_path("/tmp/papers").expect("normal path");
+        assert_eq!(p.as_str(), "/tmp/papers");
+    }
+
+    #[test]
+    fn parse_utf8_path_accepts_windows_style_path() {
+        // The parser is intentionally non-validating beyond UTF-8,
+        // empty, and NUL — any other path-shaped string passes through
+        // (the platform's own path resolution decides validity).
+        let p = parse_utf8_path("C:\\Users\\me\\papers").expect("windows path");
+        assert_eq!(p.as_str(), "C:\\Users\\me\\papers");
+    }
+
+    #[test]
+    fn parse_utf8_path_rejects_empty_string() {
+        // Review pass I6: prevents silently writing `DOIGET_*=""`.
+        let err = parse_utf8_path("").expect_err("empty rejected");
+        assert!(
+            err.contains("empty"),
+            "error message MUST identify the empty-string condition, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_utf8_path_rejects_nul_byte() {
+        // Review pass A4: `std::env::set_var` panics on NUL bytes
+        // (and the workspace is `panic = abort` in release, so the
+        // process would die silently). Reject at the parse boundary.
+        let err = parse_utf8_path("a/b\0/c").expect_err("NUL rejected");
+        assert!(
+            err.to_ascii_lowercase().contains("nul"),
+            "error message MUST identify the NUL condition, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cli_rejects_empty_path_flag_value_at_parse_time() {
+        // Clap returns Err from `try_parse_from` when a value_parser
+        // rejects the input. The parse failure exit code (2) is
+        // exercised at the e2e layer; here we only assert the parse
+        // attempt itself fails.
+        let res = Cli::try_parse_from(["doiget", "--store-root", "", "capabilities"]);
+        assert!(res.is_err(), "--store-root with empty value MUST parse-fail");
+    }
+
+    #[test]
+    fn cli_rejects_nul_in_path_flag_value_at_parse_time() {
+        let res = Cli::try_parse_from([
+            "doiget",
+            "--log-path",
+            "a/b\0/c",
+            "capabilities",
+        ]);
+        assert!(res.is_err(), "--log-path with NUL byte MUST parse-fail");
     }
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -410,7 +410,7 @@ fn forced_implicit_for(command: &Option<Command>) -> Option<OutputMode> {
 /// concurrent-read soundness condition for `setenv` is therefore met.
 /// If a future change introduces an async background task that reads
 /// `DOIGET_STORE_ROOT` (or any other key this function writes), the
-/// applicaton of overrides must move ahead of the runtime
+/// application of overrides must move ahead of the runtime
 /// construction (i.e. above the `#[tokio::main]` boundary).
 ///
 /// The function intentionally has no error path: each flag value has
@@ -707,11 +707,7 @@ mod tests {
         // mechanical: clap's `to_possible_value().get_name()` is the
         // canonical parser-side spelling, and we assert each variant's
         // `as_env_value` matches it exactly.
-        for variant in [
-            OutputColor::Auto,
-            OutputColor::Always,
-            OutputColor::Never,
-        ] {
+        for variant in [OutputColor::Auto, OutputColor::Always, OutputColor::Never] {
             let parser_side = variant
                 .to_possible_value()
                 .expect("clap value-enum exposes every non-skipped variant");
@@ -805,17 +801,15 @@ mod tests {
         // exercised at the e2e layer; here we only assert the parse
         // attempt itself fails.
         let res = Cli::try_parse_from(["doiget", "--store-root", "", "capabilities"]);
-        assert!(res.is_err(), "--store-root with empty value MUST parse-fail");
+        assert!(
+            res.is_err(),
+            "--store-root with empty value MUST parse-fail"
+        );
     }
 
     #[test]
     fn cli_rejects_nul_in_path_flag_value_at_parse_time() {
-        let res = Cli::try_parse_from([
-            "doiget",
-            "--log-path",
-            "a/b\0/c",
-            "capabilities",
-        ]);
+        let res = Cli::try_parse_from(["doiget", "--log-path", "a/b\0/c", "capabilities"]);
         assert!(res.is_err(), "--log-path with NUL byte MUST parse-fail");
     }
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -233,12 +233,18 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
     // Resolve the effective output mode ONCE per invocation per ADR-0017.
     // The pure resolver lives in `commands::output`; this site is the
     // single I/O-touching layer that reads env + probes the TTY.
-    let mode = output::resolve(
+    // ADR-0017 Amendment 1: the resolver returns ResolvedOutput
+    // carrying mode + quiet_was_explicit; informational commands receive
+    // `out.mode` (their existing OutputMode signature), artifact
+    // commands additionally consume `out.quiet_was_explicit` so the
+    // non-TTY fallback to Quiet does NOT silence them (#219 / #220).
+    let out = output::resolve(
         forced_implicit_for(&cli.command),
         flag_input_from(&cli),
         std::env::var("DOIGET_MODE").ok().as_deref(),
         output::stdout_is_tty(),
     );
+    let mode = out.mode;
 
     match cli.command {
         None => {
@@ -284,14 +290,18 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             let profile = doiget_core::CapabilityProfile::from_env()?;
             doiget_mcp::Server::new(profile).run().await
         }
-        // #214: single-shot inventory for LLM cold-boot. We pass the
-        // live `clap::Command` AST so the subcommand list cannot
-        // drift from the parser. `capabilities::run` honors
-        // `--mode quiet` (suppresses) and emits pretty JSON in every
-        // other mode (product-output convention).
+        // #214 / #219 (ADR-0017 Amendment 1): single-shot inventory
+        // for LLM cold-boot. We pass the live `clap::Command` AST so
+        // the subcommand list cannot drift from the parser.
+        // `capabilities` is an *artifact* command — it suppresses
+        // stdout ONLY on **explicit** Quiet (`--quiet`/`-q`/
+        // `DOIGET_MODE=quiet`/`--mode quiet`), never on the non-TTY
+        // implicit fallback. The `quiet_was_explicit` discriminator
+        // is what closes the LLM cold-boot deadlock reported in
+        // #219 / #220.
         Some(Command::Capabilities) => {
             let cli_cmd = <Cli as clap::CommandFactory>::command();
-            doiget_cli::commands::capabilities::run(&cli_cmd, mode)
+            doiget_cli::commands::capabilities::run(&cli_cmd, mode, out.quiet_was_explicit)
         }
         // Phase 4 / Slice 16. Feature-gated to keep default release
         // binaries free of the OpenAlex-only citation walker.

--- a/crates/doiget-cli/tests/batch_jsonl_e2e.rs
+++ b/crates/doiget-cli/tests/batch_jsonl_e2e.rs
@@ -100,10 +100,16 @@ fn batch_json_fetch_failure_emits_fetch_error_jsonl() {
     assert_eq!(lines.len(), 1, "exactly one JSONL record, got: {stdout}");
     let v: Value = serde_json::from_str(lines[0]).expect("line parses as JSON");
     assert_eq!(v["ok"], Value::Bool(false));
-    assert_eq!(v["ref"], "arxiv:2401.99999");
-    // #210: the typed `FetchError → ErrorCode` mapping now surfaces the
-    // closed-set wire code (`NETWORK_ERROR` for a transport-layer
-    // connect-refused) instead of the previous generic `FETCH_ERROR`.
+    // ADR-0030 + #210: the batch input now goes through
+    // `refs::parse_input` → `Ref::as_input_str()`, which returns the
+    // bare identifier per docs/PROVENANCE_LOG.md §3 (no `arxiv:` URI
+    // scheme — that prefix is stripped at parse time). The
+    // pre-ADR-0030 pipeline echoed the raw file line verbatim.
+    assert_eq!(v["ref"], "2401.99999");
+    // #210: the typed `FetchError → ErrorCode` mapping now surfaces
+    // the closed-set wire code (`NETWORK_ERROR` for a transport-
+    // layer connect-refused) instead of the previous generic
+    // `FETCH_ERROR`.
     assert_eq!(
         v["error"]["code"], "NETWORK_ERROR",
         "connect-refused at the transport layer MUST surface as NETWORK_ERROR"
@@ -157,7 +163,9 @@ async fn batch_json_success_emits_structured_result_record() {
 
     let v: Value = serde_json::from_str(lines[0]).expect("line parses as JSON");
     assert_eq!(v["ok"], Value::Bool(true));
-    assert_eq!(v["ref"], "arxiv:2401.12345");
+    // ADR-0030: ref is the canonical bare identifier
+    // (`Ref::as_input_str`), not the raw input line.
+    assert_eq!(v["ref"], "2401.12345");
     let result = v.get("result").expect("success record carries `result`");
     assert!(
         result["safekey"]
@@ -186,6 +194,90 @@ async fn batch_json_success_emits_structured_result_record() {
             .chars()
             .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
         "canonical_digest MUST be lowercase hex only: got {digest:?}"
+    );
+}
+
+/// ADR-0030 slice 1: `doiget batch library.json` reads a CSL-JSON
+/// export from a reference manager (Zotero / Mendeley) and walks the
+/// resulting Refs through the same per-entry pipeline as plain refs.
+///
+/// This test seeds a 2-entry CSL-JSON file with one valid DOI and one
+/// `archivePrefix=arXiv` entry, points the arxiv resolver at a closed
+/// loopback (no actual fetch — the goal here is purely to verify the
+/// adapter integration produces two JSONL lines, not to exercise the
+/// orchestrator twice). Both entries surface as JSONL records with
+/// the correct `ref` field, confirming the CSL-JSON parser landed
+/// upstream of the fetch pipeline.
+#[test]
+fn batch_json_csl_input_yields_one_record_per_entry() {
+    let dir = TempDir::new().expect("tempdir");
+    let lib = dir.path().join("library.json");
+    let body = r#"[
+        {"id":"FooDOI","DOI":"10.1234/foo"},
+        {"id":"BarArxiv","archivePrefix":"arXiv","eprint":"2401.12345"}
+    ]"#;
+    std::fs::File::create(&lib)
+        .expect("create library.json")
+        .write_all(body.as_bytes())
+        .expect("write library");
+
+    let output = doiget(&dir)
+        // Closed port → every fetch fails fast; the test cares about
+        // record count + per-record `ref` strings, not about success.
+        .env("DOIGET_ARXIV_BASE", "http://127.0.0.1:1/")
+        .env("DOIGET_CROSSREF_BASE", "http://127.0.0.1:1/")
+        .env("DOIGET_UNPAYWALL_BASE", "http://127.0.0.1:1/")
+        .args(["--json", "batch", lib.to_str().unwrap()])
+        .assert()
+        .failure() // every fetch fails → exit > 0
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("stdout utf-8");
+    let lines: Vec<&str> = stdout.lines().filter(|s| !s.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected one JSONL record per CSL-JSON entry, got: {stdout}"
+    );
+    let refs: Vec<String> = lines
+        .iter()
+        .map(|l| {
+            let v: Value = serde_json::from_str(l).expect("line parses as JSON");
+            v["ref"].as_str().expect("ref is string").to_string()
+        })
+        .collect();
+    assert!(
+        refs.iter().any(|r| r.contains("10.1234/foo")),
+        "DOI entry must appear: {refs:?}"
+    );
+    assert!(
+        refs.iter().any(|r| r.contains("2401.12345")),
+        "arXiv entry must appear: {refs:?}"
+    );
+}
+
+/// ADR-0030 slice 1: a malformed CSL-JSON document is surfaced as a
+/// loud whole-input parse error before any fetch runs, not silently
+/// treated as an empty batch.
+#[test]
+fn batch_malformed_csl_json_aborts_with_decode_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let lib = dir.path().join("library.json");
+    std::fs::File::create(&lib)
+        .expect("create library.json")
+        .write_all(b"{this is not JSON}")
+        .expect("write library");
+
+    let assert_result = doiget(&dir)
+        .args(["batch", lib.to_str().unwrap()])
+        .assert()
+        .failure();
+    let stderr =
+        String::from_utf8(assert_result.get_output().stderr.clone()).expect("stderr utf-8");
+    assert!(
+        stderr.contains("csl-json") && stderr.to_lowercase().contains("deserialise"),
+        "stderr must name the failed format + 'deserialise' verb: {stderr:?}"
     );
 }
 

--- a/crates/doiget-cli/tests/batch_jsonl_e2e.rs
+++ b/crates/doiget-cli/tests/batch_jsonl_e2e.rs
@@ -1,14 +1,15 @@
-//! End-to-end tests for `batch --mode json` (#205, ERRORS.md §3 CI persona).
+//! End-to-end tests for `batch --mode json` (#205 + #210, ERRORS.md §3
+//! CI persona).
 //!
-//! Validates the per-ref JSON-Lines wire shape: one record per input
-//! line, success `{"ok":true,"ref":"..."}` or failure
-//! `{"ok":false,"ref":"...","error":{"code":"...","message":"..."}}`.
+//! Validates the per-ref JSON-Lines wire shape:
+//!
+//! - Success: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`
+//!   (#210 structured outcome plumbing).
+//! - Failure: `{"ok":false,"ref":"...","error":{"code":"...","message":"..."[,"denial_context":{...}]}}`
+//!   with `denial_context` per ADR-0023 when the underlying
+//!   [`doiget_core::source::FetchError`] carries one.
+//!
 //! The exit code is the failure count (capped at 255, ERRORS.md §4).
-//!
-//! Only the parse-failure path is exercised here — it requires no
-//! network mocking and exercises both the JSONL emit and the exit
-//! code. A network-mocked success path lands together with the
-//! `fetch_one` outcome-plumbing follow-up.
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
@@ -100,13 +101,91 @@ fn batch_json_fetch_failure_emits_fetch_error_jsonl() {
     let v: Value = serde_json::from_str(lines[0]).expect("line parses as JSON");
     assert_eq!(v["ok"], Value::Bool(false));
     assert_eq!(v["ref"], "arxiv:2401.99999");
-    // Code is FETCH_ERROR (generic) per the #205 contract — the
-    // structured `denial_context` / source-specific code lands with the
-    // FetchPaperOutcome plumbing follow-up.
-    assert_eq!(v["error"]["code"], "FETCH_ERROR");
+    // #210: the typed `FetchError → ErrorCode` mapping now surfaces the
+    // closed-set wire code (`NETWORK_ERROR` for a transport-layer
+    // connect-refused) instead of the previous generic `FETCH_ERROR`.
+    assert_eq!(
+        v["error"]["code"], "NETWORK_ERROR",
+        "connect-refused at the transport layer MUST surface as NETWORK_ERROR"
+    );
     assert!(
         v["error"]["message"].is_string() && !v["error"]["message"].as_str().unwrap().is_empty(),
         "error.message MUST be a non-empty string"
+    );
+}
+
+/// #210: a successful single-arxiv batch produces a structured success
+/// JSONL record carrying `result.{safekey, store_path, canonical_digest}`.
+/// Wiremock-driven so no real network traffic; the subprocess inherits
+/// `DOIGET_ARXIV_BASE` pointing at the in-process mock.
+///
+/// Acceptance for #210: a CI consumer pipelining `batch --json` can
+/// pull `result.safekey` to construct a store-relative path and
+/// `result.canonical_digest` to deduplicate against an audit DB, all
+/// without a follow-up `info` round-trip per ref.
+#[tokio::test]
+async fn batch_json_success_emits_structured_result_record() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let body = b"%PDF-1.7\n%fixture-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let refs = dir.path().join("refs.txt");
+    std::fs::File::create(&refs)
+        .expect("create refs file")
+        .write_all(b"arxiv:2401.12345\n")
+        .expect("write refs");
+
+    let output = doiget(&dir)
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .args(["--json", "batch", refs.to_str().unwrap()])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("stdout utf-8");
+    let lines: Vec<&str> = stdout.lines().filter(|s| !s.trim().is_empty()).collect();
+    assert_eq!(lines.len(), 1, "exactly one JSONL record, got: {stdout}");
+
+    let v: Value = serde_json::from_str(lines[0]).expect("line parses as JSON");
+    assert_eq!(v["ok"], Value::Bool(true));
+    assert_eq!(v["ref"], "arxiv:2401.12345");
+    let result = v.get("result").expect("success record carries `result`");
+    assert!(
+        result["safekey"]
+            .as_str()
+            .map(|s| s.contains("2401.12345"))
+            .unwrap_or(false),
+        "result.safekey must echo the input id: {result}"
+    );
+    assert!(
+        result["store_path"]
+            .as_str()
+            .map(|s| s.ends_with(".pdf"))
+            .unwrap_or(false),
+        "result.store_path must be the on-disk PDF path: {result}"
+    );
+    let digest = result["canonical_digest"]
+        .as_str()
+        .expect("canonical_digest is a string");
+    assert_eq!(
+        digest.len(),
+        64,
+        "canonical_digest MUST be 64-char lowercase hex (ADR-0021 §1): got {digest:?}"
+    );
+    assert!(
+        digest
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+        "canonical_digest MUST be lowercase hex only: got {digest:?}"
     );
 }
 

--- a/crates/doiget-cli/tests/capabilities_e2e.rs
+++ b/crates/doiget-cli/tests/capabilities_e2e.rs
@@ -155,9 +155,11 @@ fn capabilities_fetch_subcommand_carries_artifact_status() {
 
 #[test]
 fn capabilities_quiet_mode_produces_no_stdout() {
-    // ADR-0017 / #203: Quiet suppresses stdout even for product-output
-    // commands. The exit is still 0 (capabilities never errors on a
-    // missing env / store; pure introspection).
+    // ADR-0017 Am1: `capabilities` is an *artifact* command, so it
+    // suppresses stdout ONLY on **explicit** Quiet. Passing `--quiet`
+    // is the canonical explicit signal — output must be empty, exit 0
+    // (capabilities never errors on a missing env / store; pure
+    // introspection).
     let dir = TempDir::new().expect("tempdir");
     Command::cargo_bin("doiget")
         .expect("locate doiget binary")
@@ -169,6 +171,62 @@ fn capabilities_quiet_mode_produces_no_stdout() {
         .assert()
         .success()
         .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn capabilities_quiet_mode_via_doiget_mode_env_produces_no_stdout() {
+    // ADR-0017 Am1: `DOIGET_MODE=quiet` is an **explicit** Quiet
+    // signal (CONFIG.md §4 documents env vars as user-controlled),
+    // so `capabilities` must suppress on it just like `--quiet`.
+    let dir = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("locate doiget binary")
+        .env("HOME", dir.path())
+        .env("USERPROFILE", dir.path())
+        .env("APPDATA", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("DOIGET_MODE", "quiet")
+        .arg("capabilities")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn capabilities_non_tty_default_still_emits_inventory() {
+    // #219 / #220 + ADR-0017 Amendment 1 regression pin: under
+    // `assert_cmd`, stdout is captured (non-TTY), so the resolver
+    // falls through to `Quiet`. Before the Amendment that silenced
+    // `capabilities` — the LLM cold-boot deadlock the issues report.
+    // After the Amendment, the non-TTY fallback to Quiet is *implicit*
+    // and `capabilities` (artifact) must STILL emit the inventory.
+    //
+    // Constructs the command WITHOUT the `doiget()` helper's
+    // `DOIGET_MODE=human` override on purpose: that override was the
+    // workaround the helper applied to compensate for the bug.
+    let dir = TempDir::new().expect("tempdir");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    let out = Command::cargo_bin("doiget")
+        .expect("locate doiget binary")
+        .env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        // Intentionally NOT setting DOIGET_MODE so the resolver lands
+        // on the non-TTY implicit Quiet path.
+        .env_remove("DOIGET_MODE")
+        .arg("capabilities")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v = parse_capabilities(out);
+    assert!(
+        v.get("subcommands").is_some(),
+        "capabilities MUST emit its JSON inventory on the non-TTY \
+         implicit-Quiet path (#219 / #220 regression)"
+    );
 }
 
 #[test]

--- a/crates/doiget-cli/tests/cli_global_flags_e2e.rs
+++ b/crates/doiget-cli/tests/cli_global_flags_e2e.rs
@@ -1,0 +1,110 @@
+//! E2E coverage for the four CONFIG.md §5 global flags landed in S5
+//! (#211): `--store-root`, `--log-path`, `--color`, `--progress` /
+//! `--no-progress`.
+//!
+//! Pinned behaviors:
+//!
+//! 1. Each flag is *accepted* by clap and visible in `--help`.
+//! 2. `--progress` and `--no-progress` are mutually exclusive at the
+//!    clap layer (parse-time failure, exit 2).
+//! 3. `--store-root <path>` wins over `DOIGET_STORE_ROOT` env. We
+//!    cannot observe the resolved value directly from outside the
+//!    process, so we use `doiget config show --mode json` (the env
+//!    snapshot) as a *proxy* — after S5 wires the flag to env, that
+//!    snapshot includes the flag value.
+//! 4. `--color` and `--progress` are *surface-only* in this slice
+//!    (no ANSI / progress emitter consumes them yet). We assert the
+//!    flag is accepted and exposed via `DOIGET_COLOR` /
+//!    `DOIGET_PROGRESS` for future consumers; no behaviour
+//!    assertion beyond "doiget does not crash on the flag".
+//!
+//! All tests use `assert_cmd`'s `cargo_bin` so the production `Cli`
+//! tree is exercised.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("APPDATA", p)
+        .env("XDG_CONFIG_HOME", p)
+        // S1 / ADR-0017 Am1: capabilities is artifact, but `config
+        // show` (informational) suppresses on non-TTY. Force human so
+        // these tests can see the resolved-config JSON.
+        .env("DOIGET_MODE", "human");
+    cmd
+}
+
+#[test]
+fn progress_and_no_progress_are_mutually_exclusive() {
+    // Clap-level conflict — parse fails, exit code 2 (clap default).
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--progress", "--no-progress", "capabilities"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn mode_quiet_conflicts_remain_intact() {
+    // Pre-existing conflict (S1 / #144): --json + --quiet rejected.
+    // S5 adds new global flags; this test makes sure we didn't break
+    // the existing conflicts_with_all wiring on --mode / --json /
+    // --quiet.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--json", "--quiet", "capabilities"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+// The flag-wins-over-env *precedence* for `--store-root` and
+// `--log-path` is verified at the unit-test layer in `main.rs`
+// (`tests::apply_overrides_*`), because asserting it end-to-end via
+// `config show --mode json` would require `dirs::config_dir()` to
+// succeed on every test host — which is platform-dependent in
+// `assert_cmd`'s spawned-child env on Windows. The unit-level tests
+// drive `apply_global_overrides` directly and verify the env mutation
+// independently of `dirs`.
+
+#[test]
+fn color_flag_is_accepted_for_each_value() {
+    // Surface-only in S5: doiget does not yet emit ANSI to gate. We
+    // assert clap accepts each value (`auto` / `always` / `never`),
+    // exit 0, and that an invalid value is rejected at parse time.
+    let dir = TempDir::new().expect("tempdir");
+    for value in ["auto", "always", "never"] {
+        doiget(&dir)
+            .args(["--color", value, "capabilities"])
+            .assert()
+            .success();
+    }
+    // Invalid value -> parse error (exit 2).
+    doiget(&dir)
+        .args(["--color", "rainbow", "capabilities"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn progress_and_no_progress_each_accept_with_capabilities() {
+    // capabilities is artifact-output; --progress / --no-progress
+    // should not affect its JSON inventory. Both must be accepted.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--progress", "capabilities"])
+        .assert()
+        .success();
+    doiget(&dir)
+        .args(["--no-progress", "capabilities"])
+        .assert()
+        .success();
+}

--- a/crates/doiget-cli/tests/cli_global_flags_e2e.rs
+++ b/crates/doiget-cli/tests/cli_global_flags_e2e.rs
@@ -95,16 +95,47 @@ fn color_flag_is_accepted_for_each_value() {
 }
 
 #[test]
-fn progress_and_no_progress_each_accept_with_capabilities() {
-    // capabilities is artifact-output; --progress / --no-progress
-    // should not affect its JSON inventory. Both must be accepted.
+fn progress_flag_accepted_with_capabilities() {
+    // capabilities is artifact-output; --progress should not affect
+    // its JSON inventory. (A7: split from a 2-behavior test.)
     let dir = TempDir::new().expect("tempdir");
     doiget(&dir)
         .args(["--progress", "capabilities"])
         .assert()
         .success();
+}
+
+#[test]
+fn no_progress_flag_accepted_with_capabilities() {
+    // capabilities is artifact-output; --no-progress should not
+    // affect its JSON inventory. (A7: split from a 2-behavior test.)
+    let dir = TempDir::new().expect("tempdir");
     doiget(&dir)
         .args(["--no-progress", "capabilities"])
         .assert()
         .success();
+}
+
+#[test]
+fn store_root_empty_value_is_rejected_at_parse_time() {
+    // I6: an empty `--store-root` value previously slid through clap
+    // and `apply_global_overrides` would set DOIGET_STORE_ROOT="",
+    // silently differing from "unset" for downstream resolvers.
+    // `parse_utf8_path` now rejects empty at the parser layer.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--store-root", "", "capabilities"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn log_path_empty_value_is_rejected_at_parse_time() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["--log-path", "", "capabilities"])
+        .assert()
+        .failure()
+        .code(2);
 }

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -475,3 +475,137 @@ async fn fetch_doi_crossref_down_unpaywall_oa_still_yields_pdf() {
     drop(env);
     drop(td);
 }
+
+/// ADR-0029 fetch chain: when `best_oa_location` returns a non-PDF
+/// failure (here: HTTP 403 simulating a publisher WAF block) and
+/// `oa_locations[]` contains an alternate URL that DOES yield a
+/// PDF, the orchestrator must advance through the chain and write
+/// the fallback PDF.
+///
+/// The dogfood case this exists for: a DOI hits `link.aps.org` and
+/// is WAF-blocked (403), but the same OpenAlex / Unpaywall record
+/// already names an arXiv preprint that resolves under
+/// `oa-publisher` rate-limit posture. Pre-ADR-0029, the user had to
+/// discover that URL manually; post-ADR-0029, the chain walker
+/// recovers automatically.
+#[tokio::test]
+#[serial]
+async fn fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403() {
+    let server = MockServer::start().await;
+    let base_uri = server.uri();
+    let blocked_url = format!("{}/oa/blocked.pdf", base_uri);
+    let fallback_url = format!("{}/oa/fallback.pdf", base_uri);
+
+    // Crossref happy path.
+    Mock::given(method("GET"))
+        .and(path(format!("/works/{}", TEST_DOI)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(crossref_body()))
+        .mount(&server)
+        .await;
+
+    // Unpaywall envelope: best_oa_location names the (about-to-fail)
+    // publisher URL; oa_locations[] carries an alternate that the
+    // chain walker advances to after the first attempt fails.
+    let upw_body = serde_json::json!({
+        "doi": TEST_DOI,
+        "is_oa": true,
+        "title": "E2E chain test paper",
+        "best_oa_location": {
+            "url":         blocked_url,
+            "url_for_pdf": blocked_url,
+            "license":     "cc-by"
+        },
+        "oa_locations": [
+            { "url_for_pdf": blocked_url },
+            { "url_for_pdf": fallback_url }
+        ]
+    });
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{}", TEST_DOI_ENCODED)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(upw_body))
+        .mount(&server)
+        .await;
+
+    // First candidate: 403 (publisher WAF stand-in). Empty body.
+    Mock::given(method("GET"))
+        .and(path("/oa/blocked.pdf"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    // Second candidate: valid PDF. The chain walker MUST land here.
+    let pdf_body = b"%PDF-fallback-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/oa/fallback.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(pdf_body.clone()))
+        .mount(&server)
+        .await;
+
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CROSSREF_BASE", &base_uri);
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", base_uri));
+    env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
+
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
+        .await
+        .expect("chain walker must succeed on the fallback candidate");
+
+    // The PDF on disk MUST be the fallback body, not the blocked URL's
+    // empty 403 body — confirms the chain advanced past the first hit.
+    let pdf_path = store_root.join("doi_10.1234_test.pdf");
+    let pdf_bytes = std::fs::read(pdf_path.as_std_path()).expect("read pdf");
+    assert_eq!(
+        pdf_bytes, pdf_body,
+        "stored PDF MUST be the fallback candidate's body"
+    );
+    assert!(pdf_bytes.starts_with(b"%PDF-"));
+
+    // Provenance log MUST show two oa-publisher Fetch rows — the first
+    // an Err (403), the second an Ok (fallback success). Pre-ADR-0029
+    // there was only one oa-publisher row (the err) and a blocked
+    // metadata-only fallback.
+    let rows = read_log_rows(&log_path);
+    let oa_rows: Vec<&LogRow> = rows
+        .iter()
+        .filter(|r| r.event == LogEvent::Fetch && r.source.as_deref() == Some("oa-publisher"))
+        .collect();
+    assert_eq!(
+        oa_rows.len(),
+        2,
+        "expected 2 oa-publisher Fetch rows (one per chain candidate), got {}: {:?}",
+        oa_rows.len(),
+        oa_rows.iter().map(|r| &r.result).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        oa_rows[0].result,
+        LogResult::Err,
+        "first chain attempt is the 403"
+    );
+    assert_eq!(
+        oa_rows[1].result,
+        LogResult::Ok,
+        "second chain attempt is the fallback PDF success"
+    );
+
+    // Hash chain stays intact across the multi-attempt OA leg.
+    assert_eq!(rows[0].prev_hash, "GENESIS");
+    for i in 1..rows.len() {
+        assert_eq!(
+            rows[i].prev_hash,
+            rows[i - 1].this_hash,
+            "hash chain break at row {i}"
+        );
+    }
+
+    drop(env);
+    drop(td);
+}

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -67,7 +67,7 @@ proptest     = { workspace = true }
 # `CapabilityProfile::from_env` resolution tests, which call
 # `std::env::set_var` / `remove_var`). See docs/CAPABILITY.md §2 and the
 # `EnvGuard` RAII guard in `crates/doiget-core/src/lib.rs::tests`.
-serial_test  = "3"
+serial_test  = { workspace = true }
 # `test-util` enables `tokio::test(start_paused = true)` and the
 # `tokio::time::pause()` / `advance()` API used by rate_limiter tests.
 tokio        = { workspace = true, features = ["test-util"] }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -722,6 +722,27 @@ impl HttpClient {
         headers: &[(&str, &str)],
         check_pdf_magic: bool,
     ) -> Result<(Bytes, Url), HttpError> {
+        // #220: legacy OpenAlex / Unpaywall metadata sometimes contains
+        // `http://` URLs for publishers that have since moved to HTTPS
+        // (`http://link.aps.org/pdf/...` is the common case). The
+        // production client is built with `https_only(true)` and would
+        // refuse to send such a request, so today the fetch fails at
+        // the reqwest layer with a generic builder error. Upgrading the
+        // scheme to `https` before send turns the failure into a
+        // legitimate fetch in 99 %+ of academic-publisher cases (APS,
+        // IOP, SciPost, Springer, Crossref, OpenAlex all serve HTTPS
+        // for years now). The upgrade is intentionally skipped for
+        // loopback hosts so the `new_for_tests_allow_http*` wiremock
+        // path still works.
+        //
+        // TLS posture unchanged: a redirected URL is still verified by
+        // the redirect-allowlist closure on the upgraded scheme; an
+        // upgraded URL whose host doesn't serve HTTPS will fail at the
+        // TLS handshake with a normal `NETWORK_ERROR`, not an insecure
+        // fallback. See ADR-0028 D3 ("non-impersonating tweaks are
+        // accept-list").
+        let url = upgrade_http_to_https(url);
+
         let client = self
             .clients
             .get(source)
@@ -1047,6 +1068,54 @@ fn ensure_crypto_provider() {
     });
 }
 
+/// Upgrade an `http://` URL to `https://` for legacy publisher metadata
+/// (#220). Loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) are
+/// returned unchanged so the `new_for_tests_allow_http*` wiremock path
+/// continues to talk plain HTTP to the local fixture server.
+///
+/// Non-`http` schemes (including `https`, `file`, anything else) are
+/// returned unchanged. The function is total: it never panics and
+/// never returns an error — if `set_scheme` somehow refuses the change
+/// the original URL is returned, and the production client's
+/// `https_only(true)` will then reject the send with a clear network
+/// error, preserving the original posture.
+fn upgrade_http_to_https(url: Url) -> Url {
+    if url.scheme() != "http" {
+        return url;
+    }
+    // Loopback skip: `Url::host()` returns a typed `Host` enum so
+    // IPv4 (127.0.0.0/8) and IPv6 (::1) loopback can be detected
+    // structurally — `host_str()`'s bracket-stripping for IPv6 is
+    // not portable to match against. The `localhost` literal is
+    // also covered (it can resolve to either family).
+    match url.host() {
+        None => {
+            // Cannot-be-base URL (e.g. `http:foo`) — `set_scheme`
+            // would reject the conversion. Leave it untouched; the
+            // downstream client will reject it.
+            return url;
+        }
+        Some(url::Host::Domain(d)) if d.eq_ignore_ascii_case("localhost") => return url,
+        Some(url::Host::Ipv4(ip)) if ip.is_loopback() => return url,
+        Some(url::Host::Ipv6(ip)) if ip.is_loopback() => return url,
+        _ => {}
+    }
+    let mut upgraded = url.clone();
+    if upgraded.set_scheme("https").is_err() {
+        // The `url` crate documents the failure modes for `set_scheme`;
+        // `http -> https` is supported because both are "special"
+        // schemes with the same syntax. The fallback exists for
+        // defence in depth.
+        return url;
+    }
+    tracing::debug!(
+        original = %url,
+        upgraded = %upgraded,
+        "upgraded http -> https for legacy publisher metadata (#220)"
+    );
+    upgraded
+}
+
 fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
     ensure_crypto_provider();
 
@@ -1133,6 +1202,69 @@ mod tests {
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ---------------------------------------------------------------
+    // http -> https scheme upgrade (#220) — pure unit tests, no network.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn upgrade_http_to_https_rewrites_public_http_url() {
+        let input = Url::parse("http://link.aps.org/pdf/10.1103/PhysRev.123.456").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out.scheme(), "https");
+        assert_eq!(out.host_str(), Some("link.aps.org"));
+        assert_eq!(out.path(), "/pdf/10.1103/PhysRev.123.456");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_preserves_port_path_query_fragment() {
+        let input = Url::parse("http://example.org:8080/a/b?q=1#frag").unwrap();
+        let out = upgrade_http_to_https(input);
+        assert_eq!(out.as_str(), "https://example.org:8080/a/b?q=1#frag");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_is_idempotent_on_https() {
+        let input = Url::parse("https://api.crossref.org/works/10.1234/foo").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_localhost() {
+        // wiremock binds to `127.0.0.1:PORT`; the loopback exception
+        // is the load-bearing rule that keeps `new_for_tests_allow_http*`
+        // working alongside the production fetch path.
+        let input = Url::parse("http://localhost:7878/pdf").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out, input, "localhost MUST NOT be upgraded");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_127_loopback_block() {
+        for host in ["127.0.0.1", "127.0.0.42", "127.255.255.254"] {
+            let raw = format!("http://{host}:1234/x");
+            let input = Url::parse(&raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "host `{host}` MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_ipv6_loopback() {
+        let input = Url::parse("http://[::1]:9000/path").unwrap();
+        let out = upgrade_http_to_https(input.clone());
+        assert_eq!(out, input, "IPv6 loopback MUST NOT be upgraded");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_preserves_case_in_path() {
+        // Some publishers (e.g. APS legacy redirects) use mixed-case
+        // path segments; upgrade must NOT lowercase or canonicalise.
+        let input = Url::parse("http://link.aps.org/PDF/10.1103/PhysRevB.109.045136").unwrap();
+        let out = upgrade_http_to_https(input);
+        assert_eq!(out.path(), "/PDF/10.1103/PhysRevB.109.045136");
+    }
 
     // ---------------------------------------------------------------
     // Allowlist matching — pure unit tests, no network.

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -722,25 +722,10 @@ impl HttpClient {
         headers: &[(&str, &str)],
         check_pdf_magic: bool,
     ) -> Result<(Bytes, Url), HttpError> {
-        // #220: legacy OpenAlex / Unpaywall metadata sometimes contains
-        // `http://` URLs for publishers that have since moved to HTTPS
-        // (`http://link.aps.org/pdf/...` is the common case). The
-        // production client is built with `https_only(true)` and would
-        // refuse to send such a request, so today the fetch fails at
-        // the reqwest layer with a generic builder error. Upgrading the
-        // scheme to `https` before send turns the failure into a
-        // legitimate fetch in 99 %+ of academic-publisher cases (APS,
-        // IOP, SciPost, Springer, Crossref, OpenAlex all serve HTTPS
-        // for years now). The upgrade is intentionally skipped for
-        // loopback hosts so the `new_for_tests_allow_http*` wiremock
-        // path still works.
-        //
-        // TLS posture unchanged: a redirected URL is still verified by
-        // the redirect-allowlist closure on the upgraded scheme; an
-        // upgraded URL whose host doesn't serve HTTPS will fail at the
-        // TLS handshake with a normal `NETWORK_ERROR`, not an insecure
-        // fallback. See ADR-0028 D3 ("non-impersonating tweaks are
-        // accept-list").
+        // Normalise legacy `http://` URLs returned by OpenAlex /
+        // Unpaywall metadata before send. See `upgrade_http_to_https`
+        // for the rationale (TLS posture preserved per ADR-0020) and
+        // the loopback carve-out.
         let url = upgrade_http_to_https(url);
 
         let client = self
@@ -1068,52 +1053,96 @@ fn ensure_crypto_provider() {
     });
 }
 
-/// Upgrade an `http://` URL to `https://` for legacy publisher metadata
-/// (#220). Loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) are
-/// returned unchanged so the `new_for_tests_allow_http*` wiremock path
-/// continues to talk plain HTTP to the local fixture server.
+/// Upgrade an `http://` URL to `https://` for legacy publisher
+/// metadata. Loopback hosts (`localhost`, any RFC 6761 `.localhost`
+/// TLD subdomain, `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback)
+/// are returned unchanged so the `new_for_tests_allow_http*` wiremock
+/// path continues to talk plain HTTP to the local fixture server.
 ///
-/// Non-`http` schemes (including `https`, `file`, anything else) are
-/// returned unchanged. The function is total: it never panics and
-/// never returns an error — if `set_scheme` somehow refuses the change
-/// the original URL is returned, and the production client's
-/// `https_only(true)` will then reject the send with a clear network
-/// error, preserving the original posture.
+/// Non-`http` schemes (`https`, `file`, anything else) and cannot-be-
+/// base URLs are returned unchanged. The function is total: it never
+/// panics and never returns an error.
+///
+/// # Audit / posture
+///
+/// On a successful upgrade the function emits a `tracing::info!` event
+/// so the rewrite appears in the operator's default-level structured
+/// log. On the (in-practice unreachable) `set_scheme` failure path a
+/// `tracing::warn!` event is emitted before returning the original
+/// URL; the production client's `https_only(true)` then rejects the
+/// send with a clear network error, preserving the TLS posture
+/// established by ADR-0020.
+///
+/// # `Domain("localhost")` arm subtlety
+///
+/// The url crate resolves the bare host `localhost` to `127.0.0.1`
+/// (Ipv4 variant) when parsing an `http://` URL, so the `Domain` arm
+/// does NOT fire for that case (the `Ipv4` arm catches it). The arm
+/// IS load-bearing for the RFC 6761 `.localhost` TLD (e.g.
+/// `myservice.localhost`, `api.localhost`), which the url crate does
+/// NOT auto-resolve to an IP and keeps as `Host::Domain`.
 fn upgrade_http_to_https(url: Url) -> Url {
     if url.scheme() != "http" {
         return url;
     }
-    // Loopback skip: `Url::host()` returns a typed `Host` enum so
-    // IPv4 (127.0.0.0/8) and IPv6 (::1) loopback can be detected
-    // structurally — `host_str()`'s bracket-stripping for IPv6 is
-    // not portable to match against. The `localhost` literal is
-    // also covered (it can resolve to either family).
     match url.host() {
         None => {
             // Cannot-be-base URL (e.g. `http:foo`) — `set_scheme`
-            // would reject the conversion. Leave it untouched; the
-            // downstream client will reject it.
+            // would reject the conversion.
             return url;
         }
-        Some(url::Host::Domain(d)) if d.eq_ignore_ascii_case("localhost") => return url,
+        Some(url::Host::Domain(d)) if is_localhost_domain(d) => return url,
         Some(url::Host::Ipv4(ip)) if ip.is_loopback() => return url,
-        Some(url::Host::Ipv6(ip)) if ip.is_loopback() => return url,
-        _ => {}
+        Some(url::Host::Ipv6(ip)) if is_ipv6_loopback(ip) => return url,
+        Some(_) => {}
     }
     let mut upgraded = url.clone();
     if upgraded.set_scheme("https").is_err() {
-        // The `url` crate documents the failure modes for `set_scheme`;
+        // url-crate `set_scheme` is documented to fail only for
+        // cannot-be-base URLs and a few cross-family transitions;
         // `http -> https` is supported because both are "special"
-        // schemes with the same syntax. The fallback exists for
-        // defence in depth.
+        // schemes. The fallback below is defence-in-depth.
+        tracing::warn!(
+            url = %url,
+            "set_scheme(http -> https) failed unexpectedly; \
+             sending original URL — https_only(true) will reject",
+        );
         return url;
     }
-    tracing::debug!(
+    tracing::info!(
         original = %url,
         upgraded = %upgraded,
-        "upgraded http -> https for legacy publisher metadata (#220)"
+        "upgraded http -> https for legacy publisher metadata"
     );
     upgraded
+}
+
+/// `true` for the `localhost` literal and any RFC 6761 `.localhost`
+/// TLD subdomain (`myservice.localhost`, `api.localhost`, etc.).
+/// ASCII-case-insensitive per host-name conventions.
+fn is_localhost_domain(d: &str) -> bool {
+    if d.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    let suffix = ".localhost";
+    let d_bytes = d.as_bytes();
+    let s_bytes = suffix.as_bytes();
+    if d_bytes.len() <= s_bytes.len() {
+        return false;
+    }
+    let tail = &d_bytes[d_bytes.len() - s_bytes.len()..];
+    tail.eq_ignore_ascii_case(s_bytes)
+}
+
+/// `true` for `::1` and any IPv4-mapped loopback
+/// (`::ffff:127.0.0.0/8`). `Ipv6Addr::is_loopback()` covers only `::1`,
+/// so dual-stack callers that hit `[::ffff:127.0.0.1]` would otherwise
+/// be silently upgraded.
+fn is_ipv6_loopback(ip: std::net::Ipv6Addr) -> bool {
+    if ip.is_loopback() {
+        return true;
+    }
+    matches!(ip.to_ipv4_mapped(), Some(v4) if v4.is_loopback())
 }
 
 fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
@@ -1264,6 +1293,118 @@ mod tests {
         let input = Url::parse("http://link.aps.org/PDF/10.1103/PhysRevB.109.045136").unwrap();
         let out = upgrade_http_to_https(input);
         assert_eq!(out.path(), "/PDF/10.1103/PhysRevB.109.045136");
+    }
+
+    // ---- Review-pass extensions ------------------------------------
+
+    #[test]
+    fn upgrade_http_to_https_skips_dot_localhost_tld() {
+        // RFC 6761 reserves the entire `.localhost` TLD for loopback.
+        // A developer running `http://myservice.localhost:8080/` MUST
+        // NOT see their URL silently upgraded to https.
+        for raw in [
+            "http://myservice.localhost/",
+            "http://api.localhost:8080/x",
+            "http://a.b.LOCALHOST/y",
+        ] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "{raw} MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_ipv4_mapped_ipv6_loopback() {
+        // `::ffff:127.0.0.1` is the IPv4-mapped IPv6 form of 127.0.0.1.
+        // `Ipv6Addr::is_loopback()` alone returns false for this form,
+        // so dual-stack callers binding wiremock to it would be
+        // silently upgraded without the `to_ipv4_mapped()` check.
+        for raw in [
+            "http://[::ffff:127.0.0.1]:9000/x",
+            "http://[::ffff:127.0.0.42]/y",
+        ] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "{raw} MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_is_noop_on_non_http_schemes() {
+        // The first guard (`url.scheme() != "http"`) covers everything
+        // that isn't http: https (idempotent), file, data, ftp...
+        for raw in [
+            "https://api.crossref.org/works/10.1234/foo",
+            "file:///etc/passwd",
+            "data:text/plain,hello",
+            "ftp://ftp.example.org/papers/",
+        ] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(
+                out, input,
+                "{raw} non-http scheme MUST be returned unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn upgrade_http_to_https_http_url_always_has_host() {
+        // The url crate's parser enforces authority for "special"
+        // schemes (`http`, `https`, `ws`, `wss`, `ftp`, `file`).
+        // `Url::parse("http:foo")` synthesises a Domain("foo")
+        // authority, so an http URL with `host() == None` is
+        // unreachable from `Url::parse`. The `None` arm in
+        // `upgrade_http_to_https` is defence-in-depth only — pinned
+        // here so a future url-crate behavior change is caught.
+        let url = Url::parse("http:foo").expect("parse");
+        assert!(
+            url.host().is_some(),
+            "http URLs always carry a host per WHATWG URL spec"
+        );
+        // The fn still produces a sensible result (upgrade applies).
+        let out = upgrade_http_to_https(url.clone());
+        assert_eq!(out.scheme(), "https");
+    }
+
+    #[test]
+    fn upgrade_http_to_https_skips_localhost_case_insensitive() {
+        // The literal `localhost` is resolved by the url crate to
+        // `127.0.0.1` (Ipv4) at parse time for `http://` URLs, so the
+        // Ipv4 arm catches lowercase. The Domain-arm coverage is
+        // load-bearing only for the `.localhost` TLD case, but we
+        // still pin the casefold semantics in case the url crate
+        // changes its parsing rules.
+        for raw in ["http://LOCALHOST/", "http://Localhost:8080/x"] {
+            let input = Url::parse(raw).unwrap();
+            let out = upgrade_http_to_https(input.clone());
+            assert_eq!(out, input, "{raw} MUST NOT be upgraded");
+        }
+    }
+
+    #[test]
+    fn is_localhost_domain_matches_literal_and_tld_suffix() {
+        assert!(is_localhost_domain("localhost"));
+        assert!(is_localhost_domain("LOCALHOST"));
+        assert!(is_localhost_domain("api.localhost"));
+        assert!(is_localhost_domain("nested.api.localhost"));
+        assert!(is_localhost_domain("X.LocalHost"));
+        assert!(!is_localhost_domain("localhost.example.org"));
+        assert!(!is_localhost_domain("notlocalhost"));
+        assert!(!is_localhost_domain(""));
+        assert!(!is_localhost_domain(".localhost")); // empty label not valid
+    }
+
+    #[test]
+    fn is_ipv6_loopback_covers_both_pure_and_mapped() {
+        use std::net::Ipv6Addr;
+        assert!(is_ipv6_loopback(Ipv6Addr::LOCALHOST)); // ::1
+        assert!(is_ipv6_loopback("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_ipv6_loopback("::ffff:127.0.0.42".parse().unwrap()));
+        assert!(!is_ipv6_loopback("::".parse().unwrap()));
+        assert!(!is_ipv6_loopback("2001:db8::1".parse().unwrap()));
+        // IPv4-mapped non-loopback must NOT be considered loopback.
+        assert!(!is_ipv6_loopback("::ffff:1.2.3.4".parse().unwrap()));
     }
 
     // ---------------------------------------------------------------

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod http;
 pub mod orchestrator;
 pub mod provenance;
 pub mod rate_limiter;
+pub mod refs;
 pub mod source;
 pub mod sources;
 pub mod store;

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod rate_limiter;
 pub mod source;
 pub mod sources;
 pub mod store;
+pub mod user_extension;
 
 // Phase 4 citation graph (ADR-0010). Compile-gated by the `citation`
 // Cargo feature, which itself enables the `metadata` feature so the

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -604,6 +604,54 @@ pub struct FetchPaperOutcome {
     /// reason an OA PDF existed but could not be retrieved, so the
     /// CLI / MCP surface it instead of a silent metadata-only success.
     pub pdf_leg: PdfLegStatus,
+    /// Per-ref [`crate::Safekey`] stringified (`Ref::safekey().as_str()`).
+    /// Exposed on the outcome so JSON-mode CLI / MCP callers can
+    /// emit a structured success body without re-parsing the input
+    /// ref (#210 / `docs/ERRORS.md` §3). Always populated.
+    pub safekey: String,
+    /// ADR-0021 §1 canonical-digest as 64-char lowercase hex for the
+    /// resolver_profile that produced this outcome's audit identity.
+    /// For an arXiv fetch this is the digest under `"arxiv"`; for a
+    /// DOI OA PDF leg this is under `"oa-publisher"`; for the DOI
+    /// metadata-only fallback this is under the metadata source key
+    /// (`"crossref"` / `"unpaywall"`). Always populated.
+    pub canonical_digest: String,
+}
+
+impl FetchPaperOutcome {
+    /// Test-only constructor for downstream crates (`doiget-cli`,
+    /// `doiget-mcp`) that need to drive classification / rendering
+    /// logic without running the full orchestrator. Produces a
+    /// minimal but structurally-valid outcome — all required fields
+    /// populated with defensible stubs — so unit tests can assert
+    /// the surrounding behavior (JSONL shape, exit-code mapping,
+    /// PDF-leg branching) in isolation.
+    ///
+    /// `#[doc(hidden)]` because this is not a stable public API; the
+    /// signature may change to fit test needs without a CHANGELOG
+    /// `[BREAKING]` callout.
+    #[doc(hidden)]
+    pub fn for_test_synthetic(
+        safekey: impl Into<String>,
+        source: impl Into<String>,
+        pdf_leg: PdfLegStatus,
+    ) -> Self {
+        let safekey: String = safekey.into();
+        let source: String = source.into();
+        Self {
+            source: source.clone(),
+            resolver_profile: source.clone(),
+            license: "unknown".to_string(),
+            path: Utf8PathBuf::from(format!("/tmp/{safekey}.pdf")),
+            size_bytes: 0,
+            schema_version: SCHEMA_VERSION.to_string(),
+            pdf_leg,
+            safekey: safekey.clone(),
+            // 32 bytes of `0x00` → a stable, non-secret digest stub
+            // that's still 64 chars of lowercase hex.
+            canonical_digest: "00".repeat(32),
+        }
+    }
 }
 
 /// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it
@@ -751,6 +799,8 @@ async fn fetch_paper_arxiv(
     drop(tmp);
 
     let path = store_root.join(format!("{}.pdf", safekey.as_str()));
+    let canonical_digest =
+        crate::CanonicalRef::new(crate::SourceType::Arxiv, id.as_str(), "arxiv", None).digest_hex();
     Ok(FetchPaperOutcome {
         source: "arxiv".to_string(),
         resolver_profile: "arxiv".to_string(),
@@ -761,6 +811,8 @@ async fn fetch_paper_arxiv(
         // arXiv always delivers the PDF (or the whole fn already
         // returned Err above) — there is no metadata-only fallback.
         pdf_leg: PdfLegStatus::Fetched,
+        safekey: safekey.as_str().to_string(),
+        canonical_digest,
     })
 }
 
@@ -918,6 +970,13 @@ async fn fetch_paper_doi(
             .join(".metadata")
             .join(format!("{}.toml", safekey.as_str()))
     };
+    let canonical_digest = crate::CanonicalRef::new(
+        crate::SourceType::Doi,
+        doi.as_str(),
+        &final_source_label,
+        None,
+    )
+    .digest_hex();
     Ok(FetchPaperOutcome {
         source: final_source_label.clone(),
         resolver_profile: final_source_label,
@@ -926,6 +985,8 @@ async fn fetch_paper_doi(
         size_bytes,
         schema_version: SCHEMA_VERSION.to_string(),
         pdf_leg,
+        safekey: safekey.as_str().to_string(),
+        canonical_digest,
     })
 }
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -868,9 +868,24 @@ async fn fetch_paper_doi(
             (r.license, label, chain)
         }
         Err(e) => {
+            // Unpaywall unreachable / errored. We continue with the
+            // Crossref-only metadata, but the resulting empty OA
+            // chain will be reported downstream as
+            // `PdfLegStatus::NoOaUrl` — semantically distinct from
+            // "Unpaywall confirmed no OA URL". The provenance log
+            // already carries an Unpaywall Fetch err row (the
+            // Unpaywall source impl logged its own attempt before
+            // returning), so the audit trail captures the cause; the
+            // tracing line below makes the orchestrator-level signal
+            // loud as well. Surfacing the distinction at the
+            // `PdfLegStatus` level (a new variant like
+            // `MetadataSourceUnavailable`) is a deliberate
+            // follow-up — see CHANGELOG `[0.4.0]` Notes.
             tracing::warn!(
                 error = %e,
-                "unpaywall fetch failed; continuing with crossref-only metadata"
+                doi = %doi.as_str(),
+                "unpaywall fetch failed; OA chain will be empty (downstream PdfLegStatus::NoOaUrl \
+                 is conservative — Unpaywall was unreachable, not authoritatively oa-free)"
             );
             ("unknown".to_string(), "crossref".to_string(), Vec::new())
         }
@@ -944,11 +959,33 @@ async fn fetch_paper_doi(
                     None,
                 )
             }
-            // Unreachable: `oa_chain` is non-empty in this branch, so
-            // at least one iteration set either `succeeded` or
-            // `last_err`. Conservative fallback if a future refactor
-            // breaks the invariant.
-            (None, None) => (PdfLegStatus::NoOaUrl, None),
+            // Defensive fallback. `oa_chain` is non-empty in this
+            // branch, so structurally at least one iteration must set
+            // either `succeeded` or `last_err`. If a future refactor
+            // breaks the invariant we fail CLOSED — surface a
+            // `Blocked` outcome with a self-describing message
+            // rather than `NoOaUrl` (which would falsely tell the
+            // caller no candidate URL was ever discovered). Routes
+            // to `INTERNAL_ERROR` so the CLI's exit-code mapping
+            // signals a doiget bug, not a remote failure.
+            (None, None) => {
+                tracing::error!(
+                    total = oa_chain.len(),
+                    "OA PDF chain walker exhausted without recording success or error \
+                     (defensive fallback — should be unreachable)"
+                );
+                (
+                    PdfLegStatus::Blocked {
+                        code: crate::ErrorCode::InternalError,
+                        message:
+                            "OA PDF chain walker exhausted without recording success or error \
+                             (orchestrator bug — please report)"
+                                .to_string(),
+                        denial: None,
+                    },
+                    None,
+                )
+            }
         }
     };
 
@@ -1104,11 +1141,17 @@ fn write_metadata_and_pdf(
         }
         Err(e) => {
             // Best-effort: record the StoreWrite failure before
-            // propagating. Surface as `SourceSchema` so the
+            // propagating the store.write error. We do NOT
+            // propagate the log-append error itself here — we're
+            // already in an error state from the store, and the
+            // primary failure is what the caller needs to act on.
+            // But the log-append failure is observable via tracing
+            // so an operator can spot a broken hash chain when
+            // both fail. Surface as `SourceSchema` so the
             // FetchError -> ErrorCode collapse routes it to
             // `INTERNAL_ERROR` (closest closed-set fit; `StoreError`
             // does not have a direct closed-set arm).
-            let _ = ctx.log.append(RowInput {
+            if let Err(log_err) = ctx.log.append(RowInput {
                 event: LogEvent::StoreWrite,
                 result: LogResult::Err,
                 capability: Capability::Oa,
@@ -1123,7 +1166,14 @@ fn write_metadata_and_pdf(
                 license: None,
                 store_path: Some(&store_path_relative),
                 canonical_digest: canonical_digest.as_deref(),
-            });
+            }) {
+                tracing::error!(
+                    store_err = %e,
+                    log_err = %log_err,
+                    "BOTH store.write AND provenance log append failed; \
+                     audit trail is broken for this attempt"
+                );
+            }
             Err(FetchError::SourceSchema {
                 hint: format!("store write failed: {e}"),
             })

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1764,7 +1764,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_oa_url_chain_skips_unparseable_urls() {
+    fn extract_oa_url_chain_skips_unparsable_urls() {
         // A malformed URL in oa_locations[] is dropped silently
         // rather than aborting the chain — the metadata source can
         // emit a stray entry without poisoning the whole fetch.

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -852,43 +852,85 @@ async fn fetch_paper_doi(
         .unwrap_or(Value::Null);
     let extracted = extract_crossref_fields(&crossref_meta);
 
-    // Unpaywall second — license enrichment + OA URL discovery. A
-    // failure here is non-fatal: we still write the Crossref-derived
-    // metadata.
+    // Unpaywall second — license enrichment + OA URL chain discovery.
+    // A failure here is non-fatal: we still write the Crossref-
+    // derived metadata.
     let unpaywall = unpaywall_source_from_env(&unpaywall_contact);
     let upw_result = unpaywall.fetch(ref_, profile, ctx).await;
-    let (license, source_label, oa_url) = match upw_result {
+    let (license, source_label, oa_chain) = match upw_result {
         Ok(r) => {
-            let oa = extract_best_oa_url_from_value(r.metadata_json.as_ref());
+            let chain = extract_oa_url_chain(r.metadata_json.as_ref());
             let label = if r.license != "unknown" {
                 "unpaywall".to_string()
             } else {
                 "crossref".to_string()
             };
-            (r.license, label, oa)
+            (r.license, label, chain)
         }
         Err(e) => {
             tracing::warn!(
                 error = %e,
                 "unpaywall fetch failed; continuing with crossref-only metadata"
             );
-            ("unknown".to_string(), "crossref".to_string(), None)
+            ("unknown".to_string(), "crossref".to_string(), Vec::new())
         }
     };
 
-    // OA PDF leg. Try the URL Unpaywall returned via the `oa-publisher`
-    // source allowlist. Magic-byte check is enforced inside
-    // `HttpClient::fetch_pdf`. Issue #118: a failure here is NEVER
-    // silently turned into a clean metadata-only success — the
-    // structured reason is carried out on `PdfLegStatus::Blocked` so
-    // the CLI / MCP can explain WHY the PDF could not be fetched.
-    let (pdf_leg, pdf_bytes) = match oa_url {
-        None => (PdfLegStatus::NoOaUrl, None),
-        Some(url) => match try_fetch_oa_pdf(doi, &url, ctx).await {
-            Ok((bytes, _final_url)) => (PdfLegStatus::Fetched, Some(bytes)),
-            Err(e) => {
-                // Borrow for the denial side-channel + human message,
-                // then consume into the closed ErrorCode last.
+    // OA PDF leg — ADR-0029 fetch chain. Walk the candidate URL list
+    // in order; first successful PDF wins, all-failed surfaces as
+    // `PdfLegStatus::Blocked` with the LAST attempt's error (the most
+    // informative for the operator — typically the network /
+    // allowlist reason the chain could not be exhausted). Each
+    // `try_fetch_oa_pdf` call already emits its own per-attempt
+    // provenance row (`oa-publisher` Fetch ok / err), so the audit
+    // trail captures every external request without orchestrator-
+    // side bookkeeping.
+    //
+    // Issue #118: a failure here is NEVER silently turned into a
+    // clean metadata-only success — the structured reason is carried
+    // out on `PdfLegStatus::Blocked`.
+    let (pdf_leg, pdf_bytes) = if oa_chain.is_empty() {
+        (PdfLegStatus::NoOaUrl, None)
+    } else {
+        let mut succeeded: Option<Vec<u8>> = None;
+        let mut last_err: Option<HttpError> = None;
+        let total = oa_chain.len();
+        for (idx, candidate) in oa_chain.iter().enumerate() {
+            let attempt = idx + 1;
+            tracing::debug!(
+                attempt,
+                total,
+                url = %candidate,
+                "trying OA PDF candidate (ADR-0029 chain)"
+            );
+            match try_fetch_oa_pdf(doi, candidate, ctx).await {
+                Ok((bytes, _final_url)) => {
+                    if attempt > 1 {
+                        tracing::info!(
+                            attempt,
+                            total,
+                            url = %candidate,
+                            "OA PDF chain succeeded on fallback candidate (ADR-0029)"
+                        );
+                    }
+                    succeeded = Some(bytes);
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        attempt,
+                        total,
+                        url = %candidate,
+                        error = %e,
+                        "OA PDF candidate failed; advancing to next (ADR-0029 chain)"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        match (succeeded, last_err) {
+            (Some(bytes), _) => (PdfLegStatus::Fetched, Some(bytes)),
+            (None, Some(e)) => {
                 let fe = FetchError::Http(e);
                 let denial: Option<crate::DenialContext> = (&fe).into();
                 let message = fe.to_string();
@@ -902,7 +944,12 @@ async fn fetch_paper_doi(
                     None,
                 )
             }
-        },
+            // Unreachable: `oa_chain` is non-empty in this branch, so
+            // at least one iteration set either `succeeded` or
+            // `last_err`. Conservative fallback if a future refactor
+            // breaks the invariant.
+            (None, None) => (PdfLegStatus::NoOaUrl, None),
+        }
     };
 
     // Issue #120: Crossref is non-fatal, but if it failed AND the OA
@@ -1303,12 +1350,60 @@ fn extract_crossref_fields(msg: &Value) -> CrossrefFields {
     }
 }
 
-/// Pull the preferred OA URL out of an Unpaywall `metadata_json`
-/// envelope. Tries `best_oa_location.url_for_pdf` first (direct PDF
-/// link), falling back to `best_oa_location.url`.
-fn extract_best_oa_url_from_value(meta: Option<&Value>) -> Option<url::Url> {
-    let meta = meta?;
-    let loc = meta.get("best_oa_location")?;
+/// Pull the ordered chain of candidate OA URLs out of an Unpaywall
+/// `metadata_json` envelope per ADR-0029 D2.
+///
+/// Order is `best_oa_location` first (when present), then every
+/// distinct entry in `oa_locations[]`. Duplicate URLs are deduped by
+/// exact string match so a candidate that appears as both the "best"
+/// entry and an array element is fetched at most once.
+///
+/// Each location's URL is resolved via the same `url_for_pdf` →
+/// `url` fallback the single-URL extractor uses.
+///
+/// Returns `Vec::new()` when no OA location was reported (the chain
+/// is empty and the caller surfaces [`PdfLegStatus::NoOaUrl`]).
+fn extract_oa_url_chain(meta: Option<&Value>) -> Vec<url::Url> {
+    let meta = match meta {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+    let mut out: Vec<url::Url> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut push_unique = |u: url::Url| {
+        let key = u.as_str().to_string();
+        if seen.insert(key) {
+            out.push(u);
+        }
+    };
+
+    // Priority 1: best_oa_location (Unpaywall's own quality-ordered
+    // pick — ADR-0029 D2 NORMATIVE: defer to the metadata source's
+    // ordering).
+    if let Some(best) = meta.get("best_oa_location") {
+        if let Some(u) = pull_oa_url_from_location(best) {
+            push_unique(u);
+        }
+    }
+    // Priority 2: every entry in oa_locations[] after the best one.
+    // The fallback target this ADR exists to enable is precisely the
+    // arXiv preprint that lives here when `best_oa_location` is a
+    // WAF-blocked publisher URL.
+    if let Some(arr) = meta.get("oa_locations").and_then(|v| v.as_array()) {
+        for loc in arr {
+            if let Some(u) = pull_oa_url_from_location(loc) {
+                push_unique(u);
+            }
+        }
+    }
+    out
+}
+
+/// Resolve a single OA location object to a `url::Url`. Tries
+/// `url_for_pdf` first (the direct PDF link Unpaywall annotates when
+/// it knows one), falling back to `url` (the landing page). Returns
+/// `None` if neither field is present or parses.
+fn pull_oa_url_from_location(loc: &Value) -> Option<url::Url> {
     let candidate = loc
         .get("url_for_pdf")
         .and_then(|v| v.as_str())
@@ -1531,33 +1626,111 @@ mod tests {
     }
 
     #[test]
-    fn extract_best_oa_url_from_value_prefers_url_for_pdf() {
+    fn extract_oa_url_chain_prefers_best_url_for_pdf() {
+        // `best_oa_location.url_for_pdf` is the highest-priority
+        // candidate (ADR-0029 D2 — defer to the metadata source's
+        // ordering). Falls back to `best_oa_location.url` only when
+        // no PDF link is annotated.
         let meta = serde_json::json!({
             "best_oa_location": {
                 "url_for_pdf": "https://example.org/pdf",
                 "url": "https://example.org/landing"
             }
         });
-        let url = extract_best_oa_url_from_value(Some(&meta)).expect("Some(Url)");
-        assert_eq!(url.as_str(), "https://example.org/pdf");
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].as_str(), "https://example.org/pdf");
     }
 
     #[test]
-    fn extract_best_oa_url_from_value_falls_back_to_url() {
+    fn extract_oa_url_chain_falls_back_to_url_when_url_for_pdf_absent() {
         let meta = serde_json::json!({
             "best_oa_location": {
                 "url": "https://example.org/landing"
             }
         });
-        let url = extract_best_oa_url_from_value(Some(&meta)).expect("Some(Url)");
-        assert_eq!(url.as_str(), "https://example.org/landing");
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].as_str(), "https://example.org/landing");
     }
 
     #[test]
-    fn extract_best_oa_url_from_value_none_on_missing() {
+    fn extract_oa_url_chain_is_empty_when_no_locations() {
         let meta = serde_json::json!({});
-        assert!(extract_best_oa_url_from_value(Some(&meta)).is_none());
-        assert!(extract_best_oa_url_from_value(None).is_none());
+        assert!(extract_oa_url_chain(Some(&meta)).is_empty());
+        assert!(extract_oa_url_chain(None).is_empty());
+    }
+
+    #[test]
+    fn extract_oa_url_chain_appends_oa_locations_after_best() {
+        // ADR-0029 D2: best_oa_location first, then the rest of
+        // oa_locations in metadata-source order. This is the load-
+        // bearing test: it pins the fact that an arXiv preprint
+        // listed *after* a WAF-blocked publisher in oa_locations[]
+        // becomes a fallback candidate the chain walker can reach.
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://publisher.example.org/pdf"
+            },
+            "oa_locations": [
+                {"url_for_pdf": "https://publisher.example.org/pdf"},
+                {"url_for_pdf": "https://arxiv.org/pdf/2401.12345"},
+                {"url": "https://repo.example.edu/handle/123"}
+            ]
+        });
+        let chain = extract_oa_url_chain(Some(&meta));
+        let strs: Vec<&str> = chain.iter().map(|u| u.as_str()).collect();
+        assert_eq!(
+            strs,
+            vec![
+                "https://publisher.example.org/pdf",
+                "https://arxiv.org/pdf/2401.12345",
+                "https://repo.example.edu/handle/123",
+            ],
+            "chain ordering MUST be best_oa_location first, oa_locations[] verbatim after"
+        );
+    }
+
+    #[test]
+    fn extract_oa_url_chain_dedupes_repeated_urls() {
+        // A URL that appears as both `best_oa_location` and an entry
+        // in `oa_locations[]` is fetched at most once. Without this,
+        // a publisher whose record has the same URL in both slots
+        // would consume two HTTP requests + two rate-limit ticks.
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/pdf"
+            },
+            "oa_locations": [
+                {"url_for_pdf": "https://example.org/pdf"},
+                {"url_for_pdf": "https://example.org/pdf"},
+                {"url_for_pdf": "https://arxiv.org/pdf/2401.12345"}
+            ]
+        });
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].as_str(), "https://example.org/pdf");
+        assert_eq!(chain[1].as_str(), "https://arxiv.org/pdf/2401.12345");
+    }
+
+    #[test]
+    fn extract_oa_url_chain_skips_unparseable_urls() {
+        // A malformed URL in oa_locations[] is dropped silently
+        // rather than aborting the chain — the metadata source can
+        // emit a stray entry without poisoning the whole fetch.
+        let meta = serde_json::json!({
+            "best_oa_location": {
+                "url_for_pdf": "https://good.example.org/pdf"
+            },
+            "oa_locations": [
+                {"url_for_pdf": "not a url"},
+                {"url_for_pdf": "https://arxiv.org/pdf/2401.12345"}
+            ]
+        });
+        let chain = extract_oa_url_chain(Some(&meta));
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].as_str(), "https://good.example.org/pdf");
+        assert_eq!(chain[1].as_str(), "https://arxiv.org/pdf/2401.12345");
     }
 
     #[test]

--- a/crates/doiget-core/src/refs.rs
+++ b/crates/doiget-core/src/refs.rs
@@ -1,0 +1,607 @@
+//! Bibliography input adapters per ADR-0030.
+//!
+//! Parses three input shapes into an iterator of `Ref`s with optional
+//! `entry_key` provenance back to the source bibliography:
+//!
+//! - **Plain refs**: one `doi:…` / `arxiv:…` / bare-DOI / bare-arXiv id
+//!   per line, with `#`-prefixed comments and blank lines tolerated.
+//!   The existing `doiget batch <refs.txt>` shape.
+//! - **CSL-JSON**: a JSON array of entries with `id` (citation key),
+//!   `DOI`, and optionally `archivePrefix = "arXiv"` + `eprint`
+//!   fields. Parsed via the workspace's existing `serde_json` — no
+//!   new dependency.
+//! - **BibTeX / BibLaTeX (.bib)**: deferred to a follow-up slice (the
+//!   `biblatex` crate adds cargo-vet exemption churn that is
+//!   independent of the slice 1 wire shape; users with a `.bib`
+//!   library can re-export it as CSL-JSON from Zotero today).
+//!
+//! Identifier-pick priority per ADR-0030 D3: `doi` > `arxiv` > `pmid`
+//! (PMID adapter parking until the `Ref::Pmid` variant lands in a
+//! later slice; current code carries the rule through without
+//! producing a `Pmid` ref).
+//!
+//! Parse-error policy per ADR-0030 D5: a single entry's failure is
+//! captured per-entry and does NOT abort the whole batch. The caller
+//! decides whether to skip-and-warn (default) or fail-closed
+//! (`--strict`).
+
+use camino::Utf8Path;
+use thiserror::Error;
+
+use crate::{Ref, RefParseError};
+
+/// One successfully-parsed bibliography entry.
+///
+/// `entry_key` echoes the source bibliography's citation key
+/// (BibTeX `@article{KEY,…}` / CSL-JSON `"id"`) so downstream
+/// automation can bridge the fetch outcome back to the originating
+/// reference — the load-bearing field for the Zotero / Mendeley
+/// "attach fetched PDF to this reference" workflow per ADR-0030 §6.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ParsedEntry {
+    /// The identifier the adapter chose for this entry (`Ref::Doi` /
+    /// `Ref::Arxiv`).
+    pub ref_: Ref,
+    /// The source bibliography's citation key, when one is available.
+    /// `None` for plain-refs input (no key concept) and for any
+    /// future input shape that lacks per-entry keys.
+    pub entry_key: Option<String>,
+}
+
+/// Why a single bibliography entry failed to produce a `Ref`.
+///
+/// Closed-enum so the failure-class can be exposed at the
+/// `docs/ERRORS.md` §3 INVALID_REF surface without leaking parser
+/// internals.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseError {
+    /// The line did not contain a `doi:` / `arxiv:` / bare-DOI /
+    /// bare-arXiv id — empty (after trimming) or just a comment.
+    /// Plain-refs path filters these out silently; CSL-JSON path
+    /// emits this when an entry has no resolvable identifier.
+    #[error("entry has no DOI / arXiv id (entry_key={entry_key:?})")]
+    NoIdentifier {
+        /// The source bibliography's citation key, when known.
+        entry_key: Option<String>,
+    },
+    /// The identifier was present but `Ref::parse` rejected it
+    /// (malformed DOI suffix, invalid arXiv id shape, etc.).
+    #[error(
+        "entry identifier {raw:?} did not parse as a Ref \
+         (entry_key={entry_key:?}): {source}"
+    )]
+    InvalidRef {
+        /// The raw identifier string the parser saw.
+        raw: String,
+        /// The source bibliography's citation key, when known.
+        entry_key: Option<String>,
+        /// The structured `Ref::parse` failure.
+        #[source]
+        source: RefParseError,
+    },
+    /// The whole input did not deserialise — CSL-JSON that is not a
+    /// JSON array, top-level malformed JSON, etc. This is a
+    /// whole-input failure, not a per-entry failure; callers receive
+    /// it as the sole `Err` element of the result iterator.
+    #[error("input did not deserialise as {format}: {message}")]
+    Decode {
+        /// Which parser branch produced the failure (`"csl-json"`).
+        format: &'static str,
+        /// `serde_json::Error::to_string()`.
+        message: String,
+    },
+    /// Format requested or detected, but the parser for that format is
+    /// not yet shipped. Today this is the `.bib` / BibLaTeX path —
+    /// users should re-export their library as CSL-JSON from Zotero
+    /// until slice 2 ships.
+    #[error(
+        "{format} parsing is not yet implemented — \
+         re-export as CSL-JSON from your reference manager, \
+         or wait for the BibLaTeX slice (ADR-0030 D2 follow-up)"
+    )]
+    UnsupportedFormat {
+        /// The format token (`"bibtex"`).
+        format: &'static str,
+    },
+}
+
+/// Input-shape discriminator per ADR-0030 D4.
+///
+/// `Auto` means "detect from path extension and/or content
+/// fingerprint"; the explicit variants name a parser directly and
+/// skip detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Format {
+    /// Detect from file extension if a path was supplied, else from
+    /// content fingerprint; fall through to [`Format::Refs`].
+    Auto,
+    /// Plain refs — one identifier per line, `#` comments, blanks.
+    Refs,
+    /// CSL-JSON array per <https://citationstyles.org/>.
+    CslJson,
+    /// BibTeX / BibLaTeX. Currently unsupported — parser ships in a
+    /// follow-up slice.
+    Bibtex,
+}
+
+impl Format {
+    /// Wire token used by the CLI `--format` flag and the MCP tool
+    /// input schema's `format` field per ADR-0030 §6.
+    pub fn as_wire(&self) -> &'static str {
+        match self {
+            Format::Auto => "auto",
+            Format::Refs => "refs",
+            Format::CslJson => "csl-json",
+            Format::Bibtex => "bibtex",
+        }
+    }
+}
+
+/// Detect the input format per ADR-0030 D4.
+///
+/// Precedence: file extension first (when `path` is `Some`), then
+/// content fingerprint, then fallback to [`Format::Refs`]. The
+/// caller's explicit `--format` flag should short-circuit this
+/// function — it is the slowest of the three precedence rules in the
+/// ADR.
+pub fn detect_format(path: Option<&Utf8Path>, content: &str) -> Format {
+    if let Some(p) = path {
+        let ext = p.extension().unwrap_or_default().to_ascii_lowercase();
+        match ext.as_str() {
+            "bib" | "biblatex" => return Format::Bibtex,
+            "json" | "csl" => return Format::CslJson,
+            _ => {}
+        }
+    }
+    // Content fingerprint: peek the first non-blank, non-comment line.
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed.starts_with('@') {
+            return Format::Bibtex;
+        }
+        if trimmed.starts_with('[') || trimmed.starts_with('{') {
+            return Format::CslJson;
+        }
+        break;
+    }
+    Format::Refs
+}
+
+/// Parse `text` per `format`, dispatching to the matching shape
+/// parser. `path` is consulted only when `format == Format::Auto` to
+/// drive [`detect_format`].
+///
+/// Returns one element per discovered entry — `Ok` for entries that
+/// produced a `Ref`, `Err` for per-entry failures the caller should
+/// surface as a JSONL `INVALID_REF` line. A whole-input decode
+/// failure ([`ParseError::Decode`]) is returned as a single-element
+/// `Err` so the caller's exit-code path treats it as one parse error
+/// rather than zero.
+pub fn parse_input(
+    text: &str,
+    format: Format,
+    path: Option<&Utf8Path>,
+) -> Vec<Result<ParsedEntry, ParseError>> {
+    let resolved = match format {
+        Format::Auto => detect_format(path, text),
+        other => other,
+    };
+    match resolved {
+        Format::Refs | Format::Auto => parse_plain_refs(text),
+        Format::CslJson => parse_csl_json(text),
+        Format::Bibtex => vec![Err(ParseError::UnsupportedFormat { format: "bibtex" })],
+    }
+}
+
+/// Parse plain refs — the existing batch input format. One ref per
+/// non-blank, non-comment line. `entry_key` is always `None` for this
+/// shape; plain refs have no citation-key concept.
+pub fn parse_plain_refs(text: &str) -> Vec<Result<ParsedEntry, ParseError>> {
+    let mut out = Vec::new();
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        out.push(match Ref::parse(line) {
+            Ok(ref_) => Ok(ParsedEntry {
+                ref_,
+                entry_key: None,
+            }),
+            Err(e) => Err(ParseError::InvalidRef {
+                raw: line.to_string(),
+                entry_key: None,
+                source: e,
+            }),
+        });
+    }
+    out
+}
+
+/// Parse a CSL-JSON document — a JSON array of objects, each with at
+/// least an `id` (citation key) and one of `DOI`, or `archivePrefix`
+/// + `eprint` (arXiv).
+///
+/// Identifier-pick priority per ADR-0030 D3:
+///
+/// 1. `DOI` field (case-sensitive per the CSL-JSON spec but Zotero
+///    sometimes emits `doi` lowercase — we accept both).
+/// 2. `archivePrefix == "arXiv"` (case-insensitive) + `eprint`
+///    (or `note: "arXiv:..."` shape Zotero emits).
+/// 3. (PMID parking — `Ref::Pmid` not yet defined; PMIDs in CSL-JSON
+///    are recorded as parse failures with `NoIdentifier` until the
+///    variant lands.)
+///
+/// `entry_key` is the `id` field verbatim.
+pub fn parse_csl_json(text: &str) -> Vec<Result<ParsedEntry, ParseError>> {
+    let parsed: serde_json::Result<Vec<serde_json::Value>> = serde_json::from_str(text);
+    let entries = match parsed {
+        Ok(arr) => arr,
+        Err(e) => {
+            return vec![Err(ParseError::Decode {
+                format: "csl-json",
+                message: e.to_string(),
+            })]
+        }
+    };
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        // `id` is usually a string in real-world Zotero exports but
+        // the spec allows numeric ids too — stringify either form so
+        // the operator can find the entry in their library.
+        let entry_key = entry.get("id").and_then(|v| {
+            if let Some(s) = v.as_str() {
+                Some(s.to_string())
+            } else if v.is_number() {
+                Some(v.to_string())
+            } else {
+                None
+            }
+        });
+        out.push(parse_csl_entry(&entry, entry_key));
+    }
+    out
+}
+
+/// Pick the highest-priority identifier on a single CSL-JSON entry
+/// and parse it. Honors ADR-0030 D3 priority.
+fn parse_csl_entry(
+    entry: &serde_json::Value,
+    entry_key: Option<String>,
+) -> Result<ParsedEntry, ParseError> {
+    // Priority 1: DOI (both `DOI` per spec and `doi` lowercase per
+    // real-world exports). Zotero emits uppercase; Mendeley sometimes
+    // lowercase.
+    if let Some(doi) = entry
+        .get("DOI")
+        .or_else(|| entry.get("doi"))
+        .and_then(|v| v.as_str())
+    {
+        let raw = doi.trim();
+        if !raw.is_empty() {
+            return match Ref::parse(raw) {
+                Ok(ref_) => Ok(ParsedEntry { ref_, entry_key }),
+                Err(e) => Err(ParseError::InvalidRef {
+                    raw: raw.to_string(),
+                    entry_key,
+                    source: e,
+                }),
+            };
+        }
+    }
+    // Priority 2: arXiv — `archivePrefix == "arXiv"` (CSL extension)
+    // OR the Zotero-specific `note: "arXiv:..."` shape.
+    let is_arxiv = entry
+        .get("archivePrefix")
+        .or_else(|| entry.get("archive_prefix"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.eq_ignore_ascii_case("arxiv"))
+        .unwrap_or(false);
+    if is_arxiv {
+        if let Some(eprint) = entry.get("eprint").and_then(|v| v.as_str()) {
+            let raw = eprint.trim();
+            if !raw.is_empty() {
+                let with_scheme = if raw.to_ascii_lowercase().starts_with("arxiv:") {
+                    raw.to_string()
+                } else {
+                    format!("arxiv:{raw}")
+                };
+                return match Ref::parse(&with_scheme) {
+                    Ok(ref_) => Ok(ParsedEntry { ref_, entry_key }),
+                    Err(e) => Err(ParseError::InvalidRef {
+                        raw: with_scheme,
+                        entry_key,
+                        source: e,
+                    }),
+                };
+            }
+        }
+    }
+    // Fallback: scan `note` for an embedded `arXiv:NNNN.NNNNN` —
+    // Zotero often stores the arXiv id there instead of a typed
+    // field. The pattern is intentionally narrow (must follow the
+    // canonical "arXiv:" prefix); free-text DOIs in notes are NOT
+    // mined here.
+    if let Some(note) = entry.get("note").and_then(|v| v.as_str()) {
+        if let Some(idx) = note.to_ascii_lowercase().find("arxiv:") {
+            let tail = &note[idx + "arxiv:".len()..];
+            // Take chars matching the arXiv id alphabet (digits / dot /
+            // slash / letters / hyphen) — stop at the first separator
+            // so the rest of the note is ignored.
+            let id: String = tail
+                .chars()
+                .take_while(|c| matches!(c, '0'..='9' | '.' | '/' | 'a'..='z' | 'A'..='Z' | '-'))
+                .collect();
+            if !id.is_empty() {
+                let with_scheme = format!("arxiv:{id}");
+                return match Ref::parse(&with_scheme) {
+                    Ok(ref_) => Ok(ParsedEntry { ref_, entry_key }),
+                    Err(e) => Err(ParseError::InvalidRef {
+                        raw: with_scheme,
+                        entry_key,
+                        source: e,
+                    }),
+                };
+            }
+        }
+    }
+    Err(ParseError::NoIdentifier { entry_key })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    // ---- detect_format ---------------------------------------------
+
+    #[test]
+    fn detect_by_bib_extension() {
+        let p = Utf8Path::new("/tmp/library.bib");
+        assert_eq!(detect_format(Some(p), ""), Format::Bibtex);
+    }
+
+    #[test]
+    fn detect_by_json_extension() {
+        let p = Utf8Path::new("/tmp/library.json");
+        assert_eq!(detect_format(Some(p), ""), Format::CslJson);
+    }
+
+    #[test]
+    fn detect_by_csl_extension() {
+        let p = Utf8Path::new("/tmp/library.csl");
+        assert_eq!(detect_format(Some(p), ""), Format::CslJson);
+    }
+
+    #[test]
+    fn detect_by_fingerprint_bibtex_at_sign() {
+        let body = "# comment\n\n@article{foo,\n  doi = {10.1/x}\n}\n";
+        assert_eq!(detect_format(None, body), Format::Bibtex);
+    }
+
+    #[test]
+    fn detect_by_fingerprint_csl_json_array() {
+        let body = "[{\"id\":\"foo\",\"DOI\":\"10.1/x\"}]";
+        assert_eq!(detect_format(None, body), Format::CslJson);
+    }
+
+    #[test]
+    fn detect_by_fingerprint_falls_through_to_refs() {
+        let body = "doi:10.1234/foo\narxiv:2401.12345\n";
+        assert_eq!(detect_format(None, body), Format::Refs);
+    }
+
+    // ---- plain refs ------------------------------------------------
+
+    #[test]
+    fn plain_refs_parses_mix_with_comments_and_blanks() {
+        let body = "\
+# header comment
+doi:10.1234/foo
+
+   arxiv:2401.12345
+# trailing comment
+";
+        let parsed = parse_plain_refs(body);
+        assert_eq!(parsed.len(), 2);
+        let okays: Vec<_> = parsed.into_iter().filter_map(Result::ok).collect();
+        assert!(matches!(okays[0].ref_, Ref::Doi(_)));
+        assert!(matches!(okays[1].ref_, Ref::Arxiv(_)));
+        assert!(okays.iter().all(|e| e.entry_key.is_none()));
+    }
+
+    #[test]
+    fn plain_refs_surface_per_line_invalid_refs() {
+        let body = "doi:10.1234/foo\nnot-a-ref\narxiv:2401.12345\n";
+        let parsed = parse_plain_refs(body);
+        assert_eq!(parsed.len(), 3);
+        assert!(parsed[0].is_ok());
+        assert!(matches!(parsed[1], Err(ParseError::InvalidRef { .. })));
+        assert!(parsed[2].is_ok());
+    }
+
+    // ---- CSL-JSON --------------------------------------------------
+
+    #[test]
+    fn csl_json_picks_doi_when_present() {
+        let body = r#"[{"id":"foo2024","DOI":"10.1234/foo"}]"#;
+        let parsed = parse_csl_json(body);
+        assert_eq!(parsed.len(), 1);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
+        assert_eq!(entry.entry_key.as_deref(), Some("foo2024"));
+    }
+
+    #[test]
+    fn csl_json_accepts_lowercase_doi_field() {
+        // Mendeley exports sometimes lowercase the field name.
+        let body = r#"[{"id":"x","doi":"10.5555/bar"}]"#;
+        let parsed = parse_csl_json(body);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
+    }
+
+    #[test]
+    fn csl_json_picks_arxiv_via_archive_prefix_and_eprint() {
+        let body = r#"[{"id":"arx","archivePrefix":"arXiv","eprint":"2401.12345"}]"#;
+        let parsed = parse_csl_json(body);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Arxiv(_)));
+    }
+
+    #[test]
+    fn csl_json_arxiv_archive_prefix_is_case_insensitive() {
+        let body = r#"[{"id":"arx","archivePrefix":"ARXIV","eprint":"2401.12345"}]"#;
+        let parsed = parse_csl_json(body);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Arxiv(_)));
+    }
+
+    #[test]
+    fn csl_json_doi_beats_arxiv_when_both_present() {
+        // ADR-0030 D3: priority is DOI > arXiv > PMID.
+        let body = r#"[{
+            "id":"both",
+            "DOI":"10.1234/foo",
+            "archivePrefix":"arXiv",
+            "eprint":"2401.12345"
+        }]"#;
+        let parsed = parse_csl_json(body);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
+    }
+
+    #[test]
+    fn csl_json_arxiv_from_note_field() {
+        // Zotero often dumps "arXiv:NNNN.NNNNN" into the note field
+        // instead of a typed field.
+        let body = r#"[{"id":"znote","note":"Comment: 12 pages. arXiv:2401.12345"}]"#;
+        let parsed = parse_csl_json(body);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Arxiv(_)));
+    }
+
+    #[test]
+    fn csl_json_entry_without_any_identifier_yields_no_identifier_error() {
+        let body = r#"[{"id":"empty","title":"no ids here"}]"#;
+        let parsed = parse_csl_json(body);
+        assert!(matches!(
+            parsed.into_iter().next().unwrap(),
+            Err(ParseError::NoIdentifier { .. })
+        ));
+    }
+
+    #[test]
+    fn csl_json_invalid_doi_surface_as_invalid_ref_per_entry() {
+        let body = r#"[{"id":"bad","DOI":"not-a-doi"}]"#;
+        let parsed = parse_csl_json(body);
+        match &parsed[0] {
+            Err(ParseError::InvalidRef { raw, entry_key, .. }) => {
+                assert_eq!(raw, "not-a-doi");
+                assert_eq!(entry_key.as_deref(), Some("bad"));
+            }
+            other => panic!("expected InvalidRef, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn csl_json_top_level_malformed_yields_single_decode_error() {
+        let body = "{this is not JSON}";
+        let parsed = parse_csl_json(body);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(
+            parsed[0],
+            Err(ParseError::Decode {
+                format: "csl-json",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn csl_json_non_array_top_level_yields_decode_error() {
+        // A single-entry object (not an array) is not a valid CSL-JSON
+        // document by the spec — the top level MUST be an array even
+        // for a single entry.
+        let body = r#"{"id":"x","DOI":"10.1/x"}"#;
+        let parsed = parse_csl_json(body);
+        assert!(matches!(
+            parsed[0],
+            Err(ParseError::Decode {
+                format: "csl-json",
+                ..
+            })
+        ));
+    }
+
+    // ---- parse_input dispatch -------------------------------------
+
+    #[test]
+    fn parse_input_auto_dispatches_csl_json_by_content() {
+        let body = r#"[{"id":"foo","DOI":"10.1234/foo"}]"#;
+        let parsed = parse_input(body, Format::Auto, None);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(
+            parsed[0],
+            Ok(ParsedEntry {
+                ref_: Ref::Doi(_),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_input_auto_dispatches_refs_by_content() {
+        let body = "doi:10.1234/foo\n";
+        let parsed = parse_input(body, Format::Auto, None);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(
+            parsed[0],
+            Ok(ParsedEntry {
+                ref_: Ref::Doi(_),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_input_bibtex_returns_unsupported_format_error() {
+        let body = "@article{foo, doi={10.1234/x}}";
+        let parsed = parse_input(body, Format::Bibtex, None);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(
+            parsed[0],
+            Err(ParseError::UnsupportedFormat { format: "bibtex" })
+        ));
+    }
+
+    #[test]
+    fn parse_input_auto_with_path_uses_extension() {
+        let body = "[]";
+        let parsed = parse_input(body, Format::Auto, Some(Utf8Path::new("foo.csl")));
+        assert_eq!(
+            parsed.len(),
+            0,
+            "empty array yields zero entries: {parsed:?}"
+        );
+    }
+
+    // ---- Format::as_wire ------------------------------------------
+
+    #[test]
+    fn format_wire_strings_are_stable() {
+        // Pinned because the strings appear in the CLI --format flag,
+        // the MCP tool input schema, and the JSON-Lines parse-error
+        // records (ADR-0030 §6). A drift would be a wire-format break.
+        assert_eq!(Format::Auto.as_wire(), "auto");
+        assert_eq!(Format::Refs.as_wire(), "refs");
+        assert_eq!(Format::CslJson.as_wire(), "csl-json");
+        assert_eq!(Format::Bibtex.as_wire(), "bibtex");
+    }
+}

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -128,6 +128,7 @@ pub struct UserExtensionHost {
 impl UserExtensionHost {
     /// Test-only constructor. Production callers go through [`load`].
     #[cfg(test)]
+    #[allow(clippy::expect_used)]
     pub(crate) fn for_test(host: &str) -> Self {
         Self {
             host: HostPattern::new(host).expect("test host must be valid"),
@@ -473,8 +474,14 @@ mod tests {
 
     #[test]
     fn validate_pattern_rejects_whitespace() {
-        assert_eq!(validate_pattern("  example.org"), Err(PatternError::Whitespace));
-        assert_eq!(validate_pattern("example.org  "), Err(PatternError::Whitespace));
+        assert_eq!(
+            validate_pattern("  example.org"),
+            Err(PatternError::Whitespace)
+        );
+        assert_eq!(
+            validate_pattern("example.org  "),
+            Err(PatternError::Whitespace)
+        );
     }
 
     #[test]
@@ -613,12 +620,15 @@ mod tests {
     #[test]
     fn parse_rejects_unknown_field_inside_additional_hosts_entry() {
         // The [[network.additional_hosts]] table itself uses
-        // deny_unknown_fields, so typos like `hsot = "..."` surface
-        // as a parse error (review pass I5).
+        // deny_unknown_fields, so typos and stray keys surface as a
+        // parse error (review pass I5). The unknown-key string is
+        // chosen so the typos lint doesn't fight us — `notez`
+        // doesn't trip any English-word dictionary while still
+        // exercising the deny_unknown_fields code path.
         let toml = r#"
             [[network.additional_hosts]]
             host = "ruj.uj.edu.pl"
-            commet = "typo"
+            notez = "typo"
         "#;
         let err = parse_str(toml, p("config.toml")).expect_err("typo must fail");
         assert!(matches!(err, UserExtensionError::Parse { .. }));
@@ -691,11 +701,8 @@ mod tests {
 
     #[test]
     fn parse_rejects_malformed_toml() {
-        let err = parse_str(
-            "[[network.additional_hosts\nhost=\"foo\"",
-            p("config.toml"),
-        )
-        .expect_err("malformed toml must error");
+        let err = parse_str("[[network.additional_hosts\nhost=\"foo\"", p("config.toml"))
+            .expect_err("malformed toml must error");
         assert!(matches!(err, UserExtensionError::Parse { .. }));
     }
 
@@ -704,9 +711,7 @@ mod tests {
     #[test]
     fn load_returns_empty_when_file_missing() {
         let td = tempfile::TempDir::new().unwrap();
-        let path = Utf8Path::from_path(td.path())
-            .unwrap()
-            .join("missing.toml");
+        let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
         let got = load(&path).expect("missing file MUST be Ok(empty)");
         assert_eq!(got, vec![]);
     }

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -2,14 +2,14 @@
 //!
 //! Parses the `[[network.additional_hosts]]` array-of-tables from the
 //! user's `config.toml`, validates each entry against the restricted
-//! pattern grammar (literal FQDN or single-suffix wildcard `*.foo.bar`),
-//! and exposes a helper that merges the user-added hosts into the
-//! orchestrator's `oa-publisher` [`crate::http::SourceAllowlist`].
+//! ADR-0028 D2-1 pattern grammar, and merges the user-added hosts into
+//! the orchestrator's `oa-publisher` [`crate::http::SourceAllowlist`].
 //!
-//! This module is intentionally minimal: it does NOT layer config.toml
-//! with env vars or implement the full `docs/CONFIG.md` resolution
-//! ladder. The full reader is a separate slice (S3b); this slice ships
-//! only the surface needed for ADR-0028 D2 (user-extensible allowlist).
+//! This module is intentionally minimal — it does NOT layer
+//! `config.toml` with env vars or implement the full
+//! `docs/CONFIG.md` resolution ladder. The full reader is a separate
+//! slice (S3b); this slice ships only the surface needed for
+//! ADR-0028 D2 (user-extensible allowlist) to actually work end-to-end.
 //!
 //! # Wire contract (ADR-0028 D2-1)
 //!
@@ -20,73 +20,174 @@
 //!
 //! [[network.additional_hosts]]
 //! host = "*.uj.edu.pl"          # single-suffix wildcard, allowed
-//!
-//! # Rejected at parse time:
-//! # [[network.additional_hosts]]
-//! # host = "*.edu.*"            # multi-segment glob — rejected
-//! # host = "*"                  # bare wildcard — rejected
-//! # host = "user@host.com"      # `@` not in host charset
 //! ```
+//!
+//! Every rejection class enforced by [`validate_pattern`]:
+//!
+//! - empty string
+//! - leading or trailing whitespace
+//! - bare wildcard (`*`)
+//! - multi-segment glob (`*.edu.*`, `*.*`, `*.foo.*`)
+//! - mid-string wildcard (`foo.*.org`, `f*o.bar`, `*foo.bar`)
+//! - no `.` (single-label hostnames)
+//! - non-host characters (`@`, `/`, `:`, port suffixes, scheme prefix)
+//! - empty leading / inner / trailing label
+//! - label starting or ending with `-`
+//!
+//! Each rejection maps to a [`PatternError`] variant for downstream
+//! consumers (S3b `doiget config doctor`) to branch on programmatically.
 //!
 //! # Provenance & doctor (deferred to S3b)
 //!
 //! ADR-0028 D2-2 / D2-3 / D2-4 (the `verified_by = "user"` provenance
-//! field, `config doctor` surface, `capabilities` count) ship in the
-//! S3b follow-up; this slice is purely the **data path** so a user's
-//! `ruj.uj.edu.pl` actually passes the redirect-allowlist gate.
+//! field, `doiget config doctor` surface, `doiget capabilities`
+//! `user_extension_count`) ship in the S3b follow-up. The
+//! MCP-server-side merge in `doiget-mcp` is also deferred — this
+//! slice wires user extensions only through the CLI production path
+//! (`commands::fetch::build_http_client`). A user who configures
+//! `[[network.additional_hosts]]` and invokes via `doiget serve`
+//! (MCP) currently sees no effect; that is the load-bearing item
+//! S3b closes.
 
 use camino::Utf8Path;
 use serde::Deserialize;
 
 use crate::http::SourceAllowlist;
 
+/// A validated host pattern from `[[network.additional_hosts]]`.
+///
+/// Construction goes through [`HostPattern::new`] (or the
+/// `TryFrom<&str>` / `TryFrom<String>` impls), which run
+/// [`validate_pattern`] internally. The serde `Deserialize` impl
+/// also goes through `TryFrom<String>`, so any path that produces a
+/// `HostPattern` value — including TOML deserialisation — has
+/// passed validation. The invariant "this is a syntactically valid
+/// ADR-0028 D2-1 pattern" is therefore type-level.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HostPattern(String);
+
+impl HostPattern {
+    /// Construct after validation. Most callers prefer the
+    /// `TryFrom` impls.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PatternError`] for any input that fails
+    /// [`validate_pattern`].
+    pub fn new(raw: impl Into<String>) -> Result<Self, PatternError> {
+        let s: String = raw.into();
+        validate_pattern(&s)?;
+        Ok(Self(s))
+    }
+
+    /// Borrow the validated pattern as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for HostPattern {
+    type Error = PatternError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for HostPattern {
+    type Error = PatternError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HostPattern {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
 /// One user-added host entry from `[[network.additional_hosts]]`.
 ///
-/// The `note` field is free-text user documentation (e.g. "Jagiellonian
-/// University Repository — Green OA"); it is recorded in the
-/// provenance log alongside the host but never used for matching.
+/// The `note` field is free-text user documentation (e.g.
+/// "Jagiellonian University Repository — Green OA"); it is recorded
+/// in the provenance log alongside the host (S3b) but never consulted
+/// for matching.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[non_exhaustive]
 pub struct UserExtensionHost {
-    /// The host pattern. Either a literal FQDN (`example.org`) or a
-    /// single-suffix wildcard (`*.example.org`). Validated by
-    /// [`validate_pattern`] before this struct reaches a caller.
-    pub host: String,
-    /// Optional free-text note. Surfaced by `doiget config doctor`
-    /// (S3b) but never consulted for matching.
+    /// Validated host pattern (literal FQDN or single-suffix
+    /// wildcard `*.foo.bar`). Construction is type-enforced via
+    /// [`HostPattern`].
+    pub host: HostPattern,
+    /// Optional free-text note.
     #[serde(default)]
     pub note: Option<String>,
 }
 
 impl UserExtensionHost {
-    /// Construct a new entry with no note. Used by tests; production
-    /// callers go through [`load`].
-    #[doc(hidden)]
-    pub fn new(host: impl Into<String>) -> Self {
+    /// Test-only constructor. Production callers go through [`load`].
+    #[cfg(test)]
+    pub(crate) fn for_test(host: &str) -> Self {
         Self {
-            host: host.into(),
+            host: HostPattern::new(host).expect("test host must be valid"),
             note: None,
         }
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct ConfigFile {
-    #[serde(default)]
-    network: Option<NetworkSection>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct NetworkSection {
-    #[serde(default)]
-    additional_hosts: Vec<UserExtensionHost>,
+/// Closed-enum classification of a single pattern's rejection
+/// reason. Used by [`validate_pattern`] and carried as the `kind`
+/// field on [`InvalidPatternIssue`]. S3b's `doiget config doctor`
+/// surface branches on this for actionable per-error rendering.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PatternError {
+    /// Empty string.
+    #[error("empty pattern")]
+    Empty,
+    /// Leading or trailing whitespace.
+    #[error("pattern has leading or trailing whitespace")]
+    Whitespace,
+    /// Bare `*` with no leading-segment suffix.
+    #[error("bare wildcard `*` is not allowed")]
+    BareWildcard,
+    /// `*` appearing anywhere other than the very first character
+    /// followed by `.`.
+    #[error("wildcard `*` is only allowed as the first character followed by `.`")]
+    MisplacedWildcard,
+    /// Multi-segment glob (a second `*` after stripping `*.` prefix).
+    #[error("multi-segment globs are not allowed; use a single `*.<suffix>`")]
+    MultiSegmentGlob,
+    /// Nothing after the `*.` prefix (`*.` alone).
+    #[error("nothing after wildcard prefix `*.`")]
+    EmptySuffix,
+    /// No `.` in the host portion (single-label hostnames rejected).
+    #[error("host must contain at least one `.`")]
+    NoDot,
+    /// A label is empty (consecutive `.`s or leading/trailing `.`).
+    #[error("empty label (consecutive `.` or leading/trailing `.`)")]
+    EmptyLabel,
+    /// A label starts or ends with `-`.
+    #[error("label `{label}` starts or ends with `-`")]
+    LabelHyphenBorder {
+        /// The offending label.
+        label: String,
+    },
+    /// A label contains a character outside the allowed host charset.
+    #[error("label `{label}` contains a non-host character (allowed: A-Z a-z 0-9 - .)")]
+    BadChar {
+        /// The offending label.
+        label: String,
+    },
 }
 
 /// Errors from loading `config.toml`'s user-extension section.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum UserExtensionError {
-    /// Filesystem read failed (other than "not found", which is treated
-    /// as "no user extensions" — see [`load`]).
+    /// Filesystem read failed (other than "not found", which is
+    /// treated as "no user extensions" — see [`load`]).
     #[error("io reading {path}: {source}")]
     Io {
         /// The path we tried to read.
@@ -104,34 +205,52 @@ pub enum UserExtensionError {
         #[source]
         source: toml::de::Error,
     },
-    /// One of the `host` patterns failed grammar validation per
-    /// ADR-0028 D2-1.
-    #[error("invalid host pattern `{pattern}` in {path}: {reason}")]
-    InvalidPattern {
-        /// The path containing the offending entry.
+    /// One or more `host` patterns failed grammar validation per
+    /// ADR-0028 D2-1. The vec collects every offending entry so the
+    /// user sees all errors in a single pass rather than fixing them
+    /// one at a time (review pass I6).
+    #[error("invalid host pattern(s) in {path}: {issues:?}")]
+    InvalidPatterns {
+        /// The path containing the offending entries.
         path: String,
-        /// The pattern that did not validate.
-        pattern: String,
-        /// Human-readable reason.
-        reason: String,
+        /// All rejected patterns in this file.
+        issues: Vec<InvalidPatternIssue>,
     },
+}
+
+/// One per-entry rejection inside [`UserExtensionError::InvalidPatterns`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InvalidPatternIssue {
+    /// The raw pattern string from the TOML.
+    pub pattern: String,
+    /// Closed-enum rejection reason.
+    pub kind: PatternError,
+}
+
+impl std::fmt::Display for InvalidPatternIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "`{}`: {}", self.pattern, self.kind)
+    }
 }
 
 /// Load user-extension hosts from a `config.toml` path.
 ///
 /// Returns an empty `Vec` if the path does not exist (the user simply
-/// has not extended the gate). Returns `Err` only when the file exists
-/// but cannot be read, parsed, or contains an invalid pattern. The
-/// orchestrator is expected to log an `Err` as a warning and continue
-/// with the curated allowlist; failing the whole fetch on a malformed
-/// optional config would be hostile.
+/// has not extended the gate). Returns `Err` only when the file
+/// exists but cannot be read, parsed, or contains invalid pattern(s).
+///
+/// Every entry in the returned vec has its `host` already validated
+/// at the type level via [`HostPattern`].
 ///
 /// # Errors
 ///
-/// [`UserExtensionError::Io`] on filesystem error (other than not-found),
-/// [`UserExtensionError::Parse`] on malformed TOML, and
-/// [`UserExtensionError::InvalidPattern`] on the first entry that
-/// violates ADR-0028 D2-1.
+/// - [`UserExtensionError::Io`] for filesystem errors other than
+///   not-found.
+/// - [`UserExtensionError::Parse`] for malformed TOML.
+/// - [`UserExtensionError::InvalidPatterns`] for invalid patterns;
+///   the variant carries *every* offending entry, not just the first
+///   (review pass I6).
 pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
     let text = match std::fs::read_to_string(config_path.as_std_path()) {
         Ok(s) => s,
@@ -146,99 +265,139 @@ pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtens
     parse_str(&text, config_path)
 }
 
+/// Raw TOML shape used internally so we can collect every bad
+/// pattern in a single pass (vs failing on the first via
+/// `HostPattern`'s deserialize). The outer config / network tables
+/// tolerate unknown keys via `IgnoredAny`-flatten — the S3b full
+/// reader will own `deny_unknown_fields` on a complete schema.
+#[derive(Debug, Default, Deserialize)]
+struct RawConfig {
+    #[serde(default)]
+    network: Option<RawNetwork>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawNetwork {
+    #[serde(default)]
+    additional_hosts: Vec<RawHost>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+/// The `[[network.additional_hosts]]` table itself is the load-
+/// bearing schema and DOES forbid unknown keys — that's the level
+/// where typos like `hsot = "..."` should fail loudly.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHost {
+    host: String,
+    #[serde(default)]
+    note: Option<String>,
+}
+
 /// Parse a `config.toml` body string. Pure function; the path is used
-/// only for error messages. Useful in unit tests where we don't want
-/// to touch the filesystem.
+/// only for error messages.
 fn parse_str(
     text: &str,
     config_path: &Utf8Path,
 ) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
-    let cf: ConfigFile = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
+    let raw: RawConfig = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
         path: config_path.to_string(),
         source: e,
     })?;
-    let hosts = cf.network.unwrap_or_default().additional_hosts;
-    for h in &hosts {
-        validate_pattern(&h.host).map_err(|reason| UserExtensionError::InvalidPattern {
-            path: config_path.to_string(),
-            pattern: h.host.clone(),
-            reason,
-        })?;
+    let raw_hosts = raw.network.unwrap_or_default().additional_hosts;
+
+    // Two-phase: collect ALL invalid patterns rather than failing on
+    // the first. Saves the user an iterative edit-run-error cycle
+    // when migrating a large additional_hosts block (review pass I6).
+    let mut issues = Vec::new();
+    let mut validated = Vec::with_capacity(raw_hosts.len());
+    for raw_host in raw_hosts {
+        match HostPattern::new(raw_host.host.clone()) {
+            Ok(host) => validated.push(UserExtensionHost {
+                host,
+                note: raw_host.note,
+            }),
+            Err(kind) => issues.push(InvalidPatternIssue {
+                pattern: raw_host.host,
+                kind,
+            }),
+        }
     }
-    Ok(hosts)
+    if !issues.is_empty() {
+        return Err(UserExtensionError::InvalidPatterns {
+            path: config_path.to_string(),
+            issues,
+        });
+    }
+    Ok(validated)
 }
 
 /// Validate a host pattern per ADR-0028 D2-1.
 ///
 /// Accepted shapes:
 ///
-/// - Literal FQDN: `example.org`, `ruj.uj.edu.pl`. Must contain only
-///   `[A-Za-z0-9.-]`, with at least one `.` and no leading/trailing
-///   `.` or `-`.
+/// - Literal FQDN: `example.org`, `ruj.uj.edu.pl`. Only
+///   `[A-Za-z0-9.-]`, at least one `.`, no empty / hyphen-bordering
+///   labels.
 /// - Single-suffix wildcard: `*.example.org`. The `*` MUST be the
-///   *only* `*` in the pattern, MUST be at the very start, and MUST
-///   be followed by `.` and a valid FQDN.
-///
-/// Rejected shapes:
-///
-/// - Bare wildcard `*`.
-/// - Multi-segment globs `*.edu.*`, `*.*`.
-/// - Mid-string wildcards `foo.*.org`, `f*o.bar`.
-/// - Empty / whitespace-only.
-/// - Non-host characters (`@`, `/`, `:`, port suffixes, scheme prefix).
+///   first character, MUST be followed by `.`, and MUST be the only
+///   `*` in the pattern.
 ///
 /// # Errors
 ///
-/// Returns a human-readable reason on rejection. The caller wraps it in
-/// [`UserExtensionError::InvalidPattern`].
-pub fn validate_pattern(pattern: &str) -> Result<(), String> {
+/// Returns the closed-enum [`PatternError`] for any rejected input.
+pub fn validate_pattern(pattern: &str) -> Result<(), PatternError> {
     if pattern.is_empty() {
-        return Err("empty pattern".into());
+        return Err(PatternError::Empty);
     }
     if pattern.trim() != pattern {
-        return Err("leading or trailing whitespace".into());
+        return Err(PatternError::Whitespace);
     }
     if pattern == "*" {
-        return Err("bare wildcard `*` is not allowed".into());
+        return Err(PatternError::BareWildcard);
     }
-    // Split off a single leading `*.`, then require the remainder to be
-    // a valid FQDN with no further `*`.
     let body = match pattern.strip_prefix("*.") {
-        Some(rest) => rest,
+        Some(rest) => {
+            // A `*` in the body after stripping `*.` means a second
+            // wildcard (e.g. `*.edu.*` → body = `edu.*`).
+            if rest.contains('*') {
+                return Err(PatternError::MultiSegmentGlob);
+            }
+            rest
+        }
         None if pattern.contains('*') => {
-            return Err(
-                "wildcard `*` is only allowed as the first character followed by `.`".into(),
-            );
+            // A `*` not in leading `*.` position (e.g. `foo.*.org`,
+            // `f*o.bar`, `*foo.bar`).
+            return Err(PatternError::MisplacedWildcard);
         }
         None => pattern,
     };
     if body.is_empty() {
-        return Err("nothing after wildcard prefix `*.`".into());
-    }
-    if body.contains('*') {
-        return Err("multi-segment globs are not allowed; use a single `*.<suffix>`".into());
+        return Err(PatternError::EmptySuffix);
     }
     validate_fqdn(body)
 }
 
-/// `body` must look like a plausible FQDN: ASCII letters / digits /
-/// hyphens / dots, at least one dot, no empty labels, labels do not
-/// start or end with `-`.
-fn validate_fqdn(body: &str) -> Result<(), String> {
+fn validate_fqdn(body: &str) -> Result<(), PatternError> {
     if !body.contains('.') {
-        return Err("host must contain at least one `.`".into());
+        return Err(PatternError::NoDot);
     }
     for label in body.split('.') {
         if label.is_empty() {
-            return Err("empty label (consecutive `.` or leading/trailing `.`)".into());
+            return Err(PatternError::EmptyLabel);
         }
         if label.starts_with('-') || label.ends_with('-') {
-            return Err(format!("label `{label}` starts or ends with `-`"));
+            return Err(PatternError::LabelHyphenBorder {
+                label: label.to_string(),
+            });
         }
         if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-            return Err(format!(
-                "label `{label}` contains a non-host character (allowed: A-Z a-z 0-9 - .)"
-            ));
+            return Err(PatternError::BadChar {
+                label: label.to_string(),
+            });
         }
     }
     Ok(())
@@ -247,15 +406,16 @@ fn validate_fqdn(body: &str) -> Result<(), String> {
 /// Merge a slice of [`UserExtensionHost`] into the `oa-publisher`
 /// entry of an existing allowlist vector.
 ///
-/// If the vector already contains a `SourceAllowlist` with
-/// `source == "oa-publisher"`, the user hosts are appended to its
-/// `redirect_hosts`. Otherwise a new `oa-publisher` allowlist entry is
-/// pushed onto the vector. A no-op when `user_hosts` is empty.
+/// Duplicates are de-duplicated against the existing `redirect_hosts`
+/// to keep the host list minimal and the future `verified_by`
+/// provenance count honest (review pass I9). If the vector contains
+/// no `oa-publisher` entry, one is created.
+///
+/// A no-op when `user_hosts` is empty.
 ///
 /// The `note` field is intentionally dropped at the merge boundary —
-/// it is preserved on the [`UserExtensionHost`] passed to S3b's
-/// provenance plumbing, but the allowlist itself only needs the
-/// pattern string for matching.
+/// it remains on [`UserExtensionHost`] for S3b's provenance plumbing
+/// to consume from the same parsed vector.
 pub fn merge_into_allowlists(
     allowlists: &mut Vec<SourceAllowlist>,
     user_hosts: &[UserExtensionHost],
@@ -263,10 +423,21 @@ pub fn merge_into_allowlists(
     if user_hosts.is_empty() {
         return;
     }
-    let new_patterns: Vec<String> = user_hosts.iter().map(|h| h.host.clone()).collect();
     if let Some(oa) = allowlists.iter_mut().find(|a| a.source == "oa-publisher") {
-        oa.redirect_hosts.extend(new_patterns);
+        for h in user_hosts {
+            let s = h.host.as_str();
+            if !oa.redirect_hosts.iter().any(|p| p == s) {
+                oa.redirect_hosts.push(s.to_string());
+            }
+        }
         return;
+    }
+    let mut new_patterns: Vec<String> = Vec::with_capacity(user_hosts.len());
+    for h in user_hosts {
+        let s = h.host.as_str().to_string();
+        if !new_patterns.contains(&s) {
+            new_patterns.push(s);
+        }
     }
     allowlists.push(SourceAllowlist::new("oa-publisher", new_patterns));
 }
@@ -280,7 +451,7 @@ mod tests {
         Utf8Path::new(s)
     }
 
-    // ---- validate_pattern (ADR-0028 D2-1) ---------------------------
+    // ---- validate_pattern (typed PatternError) ----------------------
 
     #[test]
     fn validate_pattern_accepts_literal_fqdn() {
@@ -296,58 +467,117 @@ mod tests {
     }
 
     #[test]
-    fn validate_pattern_rejects_bare_wildcard() {
-        assert!(validate_pattern("*").is_err());
+    fn validate_pattern_rejects_empty() {
+        assert_eq!(validate_pattern(""), Err(PatternError::Empty));
     }
 
     #[test]
-    fn validate_pattern_rejects_multi_segment_glob() {
+    fn validate_pattern_rejects_whitespace() {
+        assert_eq!(validate_pattern("  example.org"), Err(PatternError::Whitespace));
+        assert_eq!(validate_pattern("example.org  "), Err(PatternError::Whitespace));
+    }
+
+    #[test]
+    fn validate_pattern_rejects_bare_wildcard() {
+        assert_eq!(validate_pattern("*"), Err(PatternError::BareWildcard));
+    }
+
+    #[test]
+    fn validate_pattern_rejects_multi_segment_globs() {
         for bad in ["*.edu.*", "*.ac.*", "*.*", "*.example.*"] {
-            let err = validate_pattern(bad).unwrap_err();
-            assert!(
-                err.contains("multi-segment") || err.contains("wildcard"),
-                "expected wildcard-related error for `{bad}`, got: {err}"
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::MultiSegmentGlob),
+                "{bad} should be MultiSegmentGlob"
             );
         }
     }
 
     #[test]
-    fn validate_pattern_rejects_mid_wildcard() {
+    fn validate_pattern_rejects_misplaced_wildcards() {
         for bad in ["foo.*.org", "f*o.bar", "*foo.bar"] {
-            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::MisplacedWildcard),
+                "{bad} should be MisplacedWildcard"
+            );
         }
     }
 
     #[test]
     fn validate_pattern_rejects_non_host_chars() {
         for bad in ["user@host.com", "host.com/", "host.com:80", "https://x.y"] {
-            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+            assert!(
+                matches!(
+                    validate_pattern(bad),
+                    Err(PatternError::BadChar { .. }) | Err(PatternError::EmptyLabel)
+                ),
+                "{bad} should be BadChar or EmptyLabel; got {:?}",
+                validate_pattern(bad)
+            );
         }
     }
 
     #[test]
     fn validate_pattern_rejects_no_dot() {
-        assert!(validate_pattern("singlelabel").is_err());
+        assert_eq!(validate_pattern("singlelabel"), Err(PatternError::NoDot));
     }
 
     #[test]
-    fn validate_pattern_rejects_empty_label() {
-        for bad in [".example.org", "example..org", "example.org.", ""] {
-            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+    fn validate_pattern_rejects_empty_label_classes() {
+        for bad in [".example.org", "example..org", "example.org."] {
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::EmptyLabel),
+                "{bad} should be EmptyLabel"
+            );
         }
     }
 
     #[test]
-    fn validate_pattern_rejects_label_starting_with_hyphen() {
-        assert!(validate_pattern("-foo.example.org").is_err());
-        assert!(validate_pattern("foo.-example.org").is_err());
-        assert!(validate_pattern("foo.example-.org").is_err());
+    fn validate_pattern_rejects_hyphen_bordering_labels() {
+        for (bad, label) in [
+            ("-foo.example.org", "-foo"),
+            ("foo.-example.org", "-example"),
+            ("foo.example-.org", "example-"),
+        ] {
+            assert_eq!(
+                validate_pattern(bad),
+                Err(PatternError::LabelHyphenBorder {
+                    label: label.to_string()
+                }),
+                "{bad} should be LabelHyphenBorder({label})"
+            );
+        }
     }
 
     #[test]
-    fn validate_pattern_rejects_whitespace() {
-        assert!(validate_pattern("  example.org").is_err());
-        assert!(validate_pattern("example.org  ").is_err());
+    fn validate_pattern_rejects_empty_suffix_after_wildcard() {
+        assert_eq!(validate_pattern("*."), Err(PatternError::EmptySuffix));
+    }
+
+    // ---- HostPattern type ------------------------------------------
+
+    #[test]
+    fn host_pattern_new_validates() {
+        assert!(HostPattern::new("ruj.uj.edu.pl").is_ok());
+        assert_eq!(HostPattern::new(""), Err(PatternError::Empty));
+    }
+
+    #[test]
+    fn host_pattern_try_from_str_and_string() {
+        let from_str: HostPattern = "*.aps.org".try_into().expect("ok");
+        let from_string: HostPattern = String::from("*.aps.org").try_into().expect("ok");
+        assert_eq!(from_str, from_string);
+    }
+
+    #[test]
+    fn host_pattern_deserialize_validates() {
+        // The serde impl runs validate_pattern; an invalid value
+        // fails deserialisation (review pass C1 — the invariant is
+        // type-level, not only enforced post-deserialise).
+        let bad = toml::from_str::<HostPattern>("\"*.edu.*\"");
+        assert!(bad.is_err(), "TOML deserialize MUST validate the pattern");
     }
 
     // ---- parse_str -------------------------------------------------
@@ -367,12 +597,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_config_without_additional_hosts_returns_no_hosts() {
+    fn parse_config_with_unknown_network_fields_is_accepted() {
+        // S3b's full reader will own deny_unknown_fields on a
+        // complete schema; until then we tolerate the rest of the
+        // [network] table (`contact_email`, future `cooldown_ms`,
+        // etc.) so an existing user config still loads.
         let toml = r#"
             [network]
             contact_email = "x@y.org"
+            cooldown_ms = 250
         "#;
         assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_field_inside_additional_hosts_entry() {
+        // The [[network.additional_hosts]] table itself uses
+        // deny_unknown_fields, so typos like `hsot = "..."` surface
+        // as a parse error (review pass I5).
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "ruj.uj.edu.pl"
+            commet = "typo"
+        "#;
+        let err = parse_str(toml, p("config.toml")).expect_err("typo must fail");
+        assert!(matches!(err, UserExtensionError::Parse { .. }));
     }
 
     #[test]
@@ -384,7 +633,7 @@ mod tests {
         "#;
         let got = parse_str(toml, p("config.toml")).unwrap();
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
         assert_eq!(
             got[0].note.as_deref(),
             Some("Jagiellonian University Repository")
@@ -403,36 +652,50 @@ mod tests {
         "#;
         let got = parse_str(toml, p("config.toml")).unwrap();
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
         assert!(got[0].note.is_none());
-        assert_eq!(got[1].host, "*.aps.org");
+        assert_eq!(got[1].host.as_str(), "*.aps.org");
         assert_eq!(got[1].note.as_deref(), Some("user override"));
     }
 
     #[test]
-    fn parse_rejects_invalid_pattern_with_path_in_error() {
+    fn parse_collects_all_invalid_patterns_not_just_first() {
+        // Review pass I6: every offender appears in the error.
         let toml = r#"
             [[network.additional_hosts]]
             host = "*.edu.*"
+
+            [[network.additional_hosts]]
+            host = "ok.example.org"
+
+            [[network.additional_hosts]]
+            host = "user@host.com"
         "#;
         let err = parse_str(toml, p("/home/u/.config/doiget/config.toml"))
-            .expect_err("invalid pattern must error");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("*.edu.*"),
-            "error should mention the pattern, got: {msg}"
-        );
-        assert!(
-            msg.contains("/home/u/.config/doiget/config.toml"),
-            "error should mention the path, got: {msg}"
-        );
+            .expect_err("invalid patterns must error");
+        match err {
+            UserExtensionError::InvalidPatterns { path, issues } => {
+                assert_eq!(path, "/home/u/.config/doiget/config.toml");
+                assert_eq!(issues.len(), 2, "both bad patterns collected");
+                assert_eq!(issues[0].pattern, "*.edu.*");
+                assert_eq!(issues[0].kind, PatternError::MultiSegmentGlob);
+                assert_eq!(issues[1].pattern, "user@host.com");
+                assert!(matches!(
+                    issues[1].kind,
+                    PatternError::BadChar { .. } | PatternError::EmptyLabel
+                ));
+            }
+            other => panic!("expected InvalidPatterns, got {other:?}"),
+        }
     }
 
     #[test]
     fn parse_rejects_malformed_toml() {
-        // Missing closing `]`.
-        let err = parse_str("[[network.additional_hosts\nhost=\"foo\"", p("config.toml"))
-            .expect_err("malformed toml must error");
+        let err = parse_str(
+            "[[network.additional_hosts\nhost=\"foo\"",
+            p("config.toml"),
+        )
+        .expect_err("malformed toml must error");
         assert!(matches!(err, UserExtensionError::Parse { .. }));
     }
 
@@ -441,7 +704,9 @@ mod tests {
     #[test]
     fn load_returns_empty_when_file_missing() {
         let td = tempfile::TempDir::new().unwrap();
-        let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
+        let path = Utf8Path::from_path(td.path())
+            .unwrap()
+            .join("missing.toml");
         let got = load(&path).expect("missing file MUST be Ok(empty)");
         assert_eq!(got, vec![]);
     }
@@ -462,7 +727,7 @@ note = "Jagiellonian"
         .unwrap();
         let got = load(&path).expect("ok");
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
     }
 
     // ---- merge_into_allowlists -------------------------------------
@@ -473,7 +738,7 @@ note = "Jagiellonian"
             SourceAllowlist::new("crossref", vec!["api.crossref.org".into()]),
             SourceAllowlist::new("oa-publisher", vec!["pmc.ncbi.nlm.nih.gov".into()]),
         ];
-        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        let user_hosts = vec![UserExtensionHost::for_test("ruj.uj.edu.pl")];
         merge_into_allowlists(&mut allowlists, &user_hosts);
 
         let oa = allowlists
@@ -487,7 +752,6 @@ note = "Jagiellonian"
                 "ruj.uj.edu.pl".to_string()
             ]
         );
-        // crossref entry must remain untouched.
         assert_eq!(allowlists.len(), 2);
     }
 
@@ -497,7 +761,7 @@ note = "Jagiellonian"
             "crossref",
             vec!["api.crossref.org".into()],
         )];
-        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        let user_hosts = vec![UserExtensionHost::for_test("ruj.uj.edu.pl")];
         merge_into_allowlists(&mut allowlists, &user_hosts);
         assert_eq!(allowlists.len(), 2);
         let oa = allowlists
@@ -526,11 +790,42 @@ note = "Jagiellonian"
     }
 
     #[test]
+    fn merge_dedupes_against_existing_entries() {
+        // Review pass I9.
+        let mut allowlists = vec![SourceAllowlist::new(
+            "oa-publisher",
+            vec!["ruj.uj.edu.pl".into()],
+        )];
+        let user_hosts = vec![
+            UserExtensionHost::for_test("ruj.uj.edu.pl"),
+            UserExtensionHost::for_test("*.uj.edu.pl"),
+            UserExtensionHost::for_test("*.uj.edu.pl"),
+        ];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert_eq!(
+            oa.redirect_hosts,
+            vec!["ruj.uj.edu.pl".to_string(), "*.uj.edu.pl".to_string()]
+        );
+    }
+
+    #[test]
+    fn merge_dedupes_when_creating_new_entry() {
+        let mut allowlists = Vec::new();
+        let user_hosts = vec![
+            UserExtensionHost::for_test("ruj.uj.edu.pl"),
+            UserExtensionHost::for_test("ruj.uj.edu.pl"),
+        ];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+        assert_eq!(allowlists.len(), 1);
+        assert_eq!(allowlists[0].redirect_hosts, vec!["ruj.uj.edu.pl"]);
+    }
+
+    #[test]
     fn merged_pattern_is_matched_by_source_allowlist() {
-        // End-to-end: parse a wildcard, merge into allowlist, ask
-        // SourceAllowlist::matches() about a concrete host. This is the
-        // load-bearing assertion that user_extension + SourceAllowlist
-        // compose correctly.
         let parsed = parse_str(
             r#"
 [[network.additional_hosts]]
@@ -545,17 +840,8 @@ host = "*.uj.edu.pl"
             .iter()
             .find(|a| a.source == "oa-publisher")
             .unwrap();
-        assert!(
-            oa.matches("ruj.uj.edu.pl"),
-            "wildcard `*.uj.edu.pl` MUST match `ruj.uj.edu.pl`"
-        );
-        assert!(
-            oa.matches("alpha.uj.edu.pl"),
-            "wildcard must also match other subdomains"
-        );
-        assert!(
-            !oa.matches("ruj.uj.edu.ru"),
-            "wildcard MUST NOT match other suffixes"
-        );
+        assert!(oa.matches("ruj.uj.edu.pl"));
+        assert!(oa.matches("alpha.uj.edu.pl"));
+        assert!(!oa.matches("ruj.uj.edu.ru"));
     }
 }

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -1,0 +1,561 @@
+//! User-extensible capability gate (ADR-0028, #220).
+//!
+//! Parses the `[[network.additional_hosts]]` array-of-tables from the
+//! user's `config.toml`, validates each entry against the restricted
+//! pattern grammar (literal FQDN or single-suffix wildcard `*.foo.bar`),
+//! and exposes a helper that merges the user-added hosts into the
+//! orchestrator's `oa-publisher` [`crate::http::SourceAllowlist`].
+//!
+//! This module is intentionally minimal: it does NOT layer config.toml
+//! with env vars or implement the full `docs/CONFIG.md` resolution
+//! ladder. The full reader is a separate slice (S3b); this slice ships
+//! only the surface needed for ADR-0028 D2 (user-extensible allowlist).
+//!
+//! # Wire contract (ADR-0028 D2-1)
+//!
+//! ```toml
+//! [[network.additional_hosts]]
+//! host = "ruj.uj.edu.pl"
+//! note = "Jagiellonian University Repository — Green OA"
+//!
+//! [[network.additional_hosts]]
+//! host = "*.uj.edu.pl"          # single-suffix wildcard, allowed
+//!
+//! # Rejected at parse time:
+//! # [[network.additional_hosts]]
+//! # host = "*.edu.*"            # multi-segment glob — rejected
+//! # host = "*"                  # bare wildcard — rejected
+//! # host = "user@host.com"      # `@` not in host charset
+//! ```
+//!
+//! # Provenance & doctor (deferred to S3b)
+//!
+//! ADR-0028 D2-2 / D2-3 / D2-4 (the `verified_by = "user"` provenance
+//! field, `config doctor` surface, `capabilities` count) ship in the
+//! S3b follow-up; this slice is purely the **data path** so a user's
+//! `ruj.uj.edu.pl` actually passes the redirect-allowlist gate.
+
+use camino::Utf8Path;
+use serde::Deserialize;
+
+use crate::http::SourceAllowlist;
+
+/// One user-added host entry from `[[network.additional_hosts]]`.
+///
+/// The `note` field is free-text user documentation (e.g. "Jagiellonian
+/// University Repository — Green OA"); it is recorded in the
+/// provenance log alongside the host but never used for matching.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[non_exhaustive]
+pub struct UserExtensionHost {
+    /// The host pattern. Either a literal FQDN (`example.org`) or a
+    /// single-suffix wildcard (`*.example.org`). Validated by
+    /// [`validate_pattern`] before this struct reaches a caller.
+    pub host: String,
+    /// Optional free-text note. Surfaced by `doiget config doctor`
+    /// (S3b) but never consulted for matching.
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+impl UserExtensionHost {
+    /// Construct a new entry with no note. Used by tests; production
+    /// callers go through [`load`].
+    #[doc(hidden)]
+    pub fn new(host: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            note: None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ConfigFile {
+    #[serde(default)]
+    network: Option<NetworkSection>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NetworkSection {
+    #[serde(default)]
+    additional_hosts: Vec<UserExtensionHost>,
+}
+
+/// Errors from loading `config.toml`'s user-extension section.
+#[derive(Debug, thiserror::Error)]
+pub enum UserExtensionError {
+    /// Filesystem read failed (other than "not found", which is treated
+    /// as "no user extensions" — see [`load`]).
+    #[error("io reading {path}: {source}")]
+    Io {
+        /// The path we tried to read.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// TOML deserialisation failed (malformed file).
+    #[error("toml parse of {path}: {source}")]
+    Parse {
+        /// The path that failed to parse.
+        path: String,
+        /// The underlying TOML deserialiser error.
+        #[source]
+        source: toml::de::Error,
+    },
+    /// One of the `host` patterns failed grammar validation per
+    /// ADR-0028 D2-1.
+    #[error("invalid host pattern `{pattern}` in {path}: {reason}")]
+    InvalidPattern {
+        /// The path containing the offending entry.
+        path: String,
+        /// The pattern that did not validate.
+        pattern: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+}
+
+/// Load user-extension hosts from a `config.toml` path.
+///
+/// Returns an empty `Vec` if the path does not exist (the user simply
+/// has not extended the gate). Returns `Err` only when the file exists
+/// but cannot be read, parsed, or contains an invalid pattern. The
+/// orchestrator is expected to log an `Err` as a warning and continue
+/// with the curated allowlist; failing the whole fetch on a malformed
+/// optional config would be hostile.
+///
+/// # Errors
+///
+/// [`UserExtensionError::Io`] on filesystem error (other than not-found),
+/// [`UserExtensionError::Parse`] on malformed TOML, and
+/// [`UserExtensionError::InvalidPattern`] on the first entry that
+/// violates ADR-0028 D2-1.
+pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
+    let text = match std::fs::read_to_string(config_path.as_std_path()) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(UserExtensionError::Io {
+                path: config_path.to_string(),
+                source: e,
+            })
+        }
+    };
+    parse_str(&text, config_path)
+}
+
+/// Parse a `config.toml` body string. Pure function; the path is used
+/// only for error messages. Useful in unit tests where we don't want
+/// to touch the filesystem.
+fn parse_str(
+    text: &str,
+    config_path: &Utf8Path,
+) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
+    let cf: ConfigFile = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
+        path: config_path.to_string(),
+        source: e,
+    })?;
+    let hosts = cf.network.unwrap_or_default().additional_hosts;
+    for h in &hosts {
+        validate_pattern(&h.host).map_err(|reason| UserExtensionError::InvalidPattern {
+            path: config_path.to_string(),
+            pattern: h.host.clone(),
+            reason,
+        })?;
+    }
+    Ok(hosts)
+}
+
+/// Validate a host pattern per ADR-0028 D2-1.
+///
+/// Accepted shapes:
+///
+/// - Literal FQDN: `example.org`, `ruj.uj.edu.pl`. Must contain only
+///   `[A-Za-z0-9.-]`, with at least one `.` and no leading/trailing
+///   `.` or `-`.
+/// - Single-suffix wildcard: `*.example.org`. The `*` MUST be the
+///   *only* `*` in the pattern, MUST be at the very start, and MUST
+///   be followed by `.` and a valid FQDN.
+///
+/// Rejected shapes:
+///
+/// - Bare wildcard `*`.
+/// - Multi-segment globs `*.edu.*`, `*.*`.
+/// - Mid-string wildcards `foo.*.org`, `f*o.bar`.
+/// - Empty / whitespace-only.
+/// - Non-host characters (`@`, `/`, `:`, port suffixes, scheme prefix).
+///
+/// # Errors
+///
+/// Returns a human-readable reason on rejection. The caller wraps it in
+/// [`UserExtensionError::InvalidPattern`].
+pub fn validate_pattern(pattern: &str) -> Result<(), String> {
+    if pattern.is_empty() {
+        return Err("empty pattern".into());
+    }
+    if pattern.trim() != pattern {
+        return Err("leading or trailing whitespace".into());
+    }
+    if pattern == "*" {
+        return Err("bare wildcard `*` is not allowed".into());
+    }
+    // Split off a single leading `*.`, then require the remainder to be
+    // a valid FQDN with no further `*`.
+    let body = match pattern.strip_prefix("*.") {
+        Some(rest) => rest,
+        None if pattern.contains('*') => {
+            return Err(
+                "wildcard `*` is only allowed as the first character followed by `.`".into(),
+            );
+        }
+        None => pattern,
+    };
+    if body.is_empty() {
+        return Err("nothing after wildcard prefix `*.`".into());
+    }
+    if body.contains('*') {
+        return Err("multi-segment globs are not allowed; use a single `*.<suffix>`".into());
+    }
+    validate_fqdn(body)
+}
+
+/// `body` must look like a plausible FQDN: ASCII letters / digits /
+/// hyphens / dots, at least one dot, no empty labels, labels do not
+/// start or end with `-`.
+fn validate_fqdn(body: &str) -> Result<(), String> {
+    if !body.contains('.') {
+        return Err("host must contain at least one `.`".into());
+    }
+    for label in body.split('.') {
+        if label.is_empty() {
+            return Err("empty label (consecutive `.` or leading/trailing `.`)".into());
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(format!("label `{label}` starts or ends with `-`"));
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(format!(
+                "label `{label}` contains a non-host character (allowed: A-Z a-z 0-9 - .)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Merge a slice of [`UserExtensionHost`] into the `oa-publisher`
+/// entry of an existing allowlist vector.
+///
+/// If the vector already contains a `SourceAllowlist` with
+/// `source == "oa-publisher"`, the user hosts are appended to its
+/// `redirect_hosts`. Otherwise a new `oa-publisher` allowlist entry is
+/// pushed onto the vector. A no-op when `user_hosts` is empty.
+///
+/// The `note` field is intentionally dropped at the merge boundary —
+/// it is preserved on the [`UserExtensionHost`] passed to S3b's
+/// provenance plumbing, but the allowlist itself only needs the
+/// pattern string for matching.
+pub fn merge_into_allowlists(
+    allowlists: &mut Vec<SourceAllowlist>,
+    user_hosts: &[UserExtensionHost],
+) {
+    if user_hosts.is_empty() {
+        return;
+    }
+    let new_patterns: Vec<String> = user_hosts.iter().map(|h| h.host.clone()).collect();
+    if let Some(oa) = allowlists.iter_mut().find(|a| a.source == "oa-publisher") {
+        oa.redirect_hosts.extend(new_patterns);
+        return;
+    }
+    allowlists.push(SourceAllowlist::new("oa-publisher", new_patterns));
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> &Utf8Path {
+        Utf8Path::new(s)
+    }
+
+    // ---- validate_pattern (ADR-0028 D2-1) ---------------------------
+
+    #[test]
+    fn validate_pattern_accepts_literal_fqdn() {
+        assert!(validate_pattern("ruj.uj.edu.pl").is_ok());
+        assert!(validate_pattern("example.org").is_ok());
+        assert!(validate_pattern("a.b.c.d.e").is_ok());
+    }
+
+    #[test]
+    fn validate_pattern_accepts_single_suffix_wildcard() {
+        assert!(validate_pattern("*.uj.edu.pl").is_ok());
+        assert!(validate_pattern("*.aps.org").is_ok());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_bare_wildcard() {
+        assert!(validate_pattern("*").is_err());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_multi_segment_glob() {
+        for bad in ["*.edu.*", "*.ac.*", "*.*", "*.example.*"] {
+            let err = validate_pattern(bad).unwrap_err();
+            assert!(
+                err.contains("multi-segment") || err.contains("wildcard"),
+                "expected wildcard-related error for `{bad}`, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_mid_wildcard() {
+        for bad in ["foo.*.org", "f*o.bar", "*foo.bar"] {
+            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_non_host_chars() {
+        for bad in ["user@host.com", "host.com/", "host.com:80", "https://x.y"] {
+            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_no_dot() {
+        assert!(validate_pattern("singlelabel").is_err());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_empty_label() {
+        for bad in [".example.org", "example..org", "example.org.", ""] {
+            assert!(validate_pattern(bad).is_err(), "should reject `{bad}`");
+        }
+    }
+
+    #[test]
+    fn validate_pattern_rejects_label_starting_with_hyphen() {
+        assert!(validate_pattern("-foo.example.org").is_err());
+        assert!(validate_pattern("foo.-example.org").is_err());
+        assert!(validate_pattern("foo.example-.org").is_err());
+    }
+
+    #[test]
+    fn validate_pattern_rejects_whitespace() {
+        assert!(validate_pattern("  example.org").is_err());
+        assert!(validate_pattern("example.org  ").is_err());
+    }
+
+    // ---- parse_str -------------------------------------------------
+
+    #[test]
+    fn parse_empty_config_returns_no_hosts() {
+        assert_eq!(parse_str("", p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_config_without_network_section_returns_no_hosts() {
+        let toml = r#"
+            [store]
+            root = "/tmp"
+        "#;
+        assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_config_without_additional_hosts_returns_no_hosts() {
+        let toml = r#"
+            [network]
+            contact_email = "x@y.org"
+        "#;
+        assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_one_literal_host_with_note() {
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "ruj.uj.edu.pl"
+            note = "Jagiellonian University Repository"
+        "#;
+        let got = parse_str(toml, p("config.toml")).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert_eq!(
+            got[0].note.as_deref(),
+            Some("Jagiellonian University Repository")
+        );
+    }
+
+    #[test]
+    fn parse_multiple_hosts_mixed_literal_and_wildcard() {
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "ruj.uj.edu.pl"
+
+            [[network.additional_hosts]]
+            host = "*.aps.org"
+            note = "user override"
+        "#;
+        let got = parse_str(toml, p("config.toml")).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+        assert!(got[0].note.is_none());
+        assert_eq!(got[1].host, "*.aps.org");
+        assert_eq!(got[1].note.as_deref(), Some("user override"));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_pattern_with_path_in_error() {
+        let toml = r#"
+            [[network.additional_hosts]]
+            host = "*.edu.*"
+        "#;
+        let err = parse_str(toml, p("/home/u/.config/doiget/config.toml"))
+            .expect_err("invalid pattern must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("*.edu.*"),
+            "error should mention the pattern, got: {msg}"
+        );
+        assert!(
+            msg.contains("/home/u/.config/doiget/config.toml"),
+            "error should mention the path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_toml() {
+        // Missing closing `]`.
+        let err = parse_str("[[network.additional_hosts\nhost=\"foo\"", p("config.toml"))
+            .expect_err("malformed toml must error");
+        assert!(matches!(err, UserExtensionError::Parse { .. }));
+    }
+
+    // ---- load -------------------------------------------------------
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let td = tempfile::TempDir::new().unwrap();
+        let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
+        let got = load(&path).expect("missing file MUST be Ok(empty)");
+        assert_eq!(got, vec![]);
+    }
+
+    #[test]
+    fn load_reads_real_file() {
+        use std::io::Write;
+        let td = tempfile::TempDir::new().unwrap();
+        let path = Utf8Path::from_path(td.path()).unwrap().join("config.toml");
+        let mut f = std::fs::File::create(path.as_std_path()).unwrap();
+        f.write_all(
+            br#"
+[[network.additional_hosts]]
+host = "ruj.uj.edu.pl"
+note = "Jagiellonian"
+"#,
+        )
+        .unwrap();
+        let got = load(&path).expect("ok");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].host, "ruj.uj.edu.pl");
+    }
+
+    // ---- merge_into_allowlists -------------------------------------
+
+    #[test]
+    fn merge_appends_to_existing_oa_publisher_entry() {
+        let mut allowlists = vec![
+            SourceAllowlist::new("crossref", vec!["api.crossref.org".into()]),
+            SourceAllowlist::new("oa-publisher", vec!["pmc.ncbi.nlm.nih.gov".into()]),
+        ];
+        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert_eq!(
+            oa.redirect_hosts,
+            vec![
+                "pmc.ncbi.nlm.nih.gov".to_string(),
+                "ruj.uj.edu.pl".to_string()
+            ]
+        );
+        // crossref entry must remain untouched.
+        assert_eq!(allowlists.len(), 2);
+    }
+
+    #[test]
+    fn merge_creates_oa_publisher_entry_if_missing() {
+        let mut allowlists = vec![SourceAllowlist::new(
+            "crossref",
+            vec!["api.crossref.org".into()],
+        )];
+        let user_hosts = vec![UserExtensionHost::new("ruj.uj.edu.pl")];
+        merge_into_allowlists(&mut allowlists, &user_hosts);
+        assert_eq!(allowlists.len(), 2);
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert_eq!(oa.redirect_hosts, vec!["ruj.uj.edu.pl".to_string()]);
+    }
+
+    #[test]
+    fn merge_is_noop_on_empty_user_hosts() {
+        let mut allowlists = vec![SourceAllowlist::new(
+            "crossref",
+            vec!["api.crossref.org".into()],
+        )];
+        let snapshot: Vec<(String, Vec<String>)> = allowlists
+            .iter()
+            .map(|a| (a.source.clone(), a.redirect_hosts.clone()))
+            .collect();
+        merge_into_allowlists(&mut allowlists, &[]);
+        let after: Vec<(String, Vec<String>)> = allowlists
+            .iter()
+            .map(|a| (a.source.clone(), a.redirect_hosts.clone()))
+            .collect();
+        assert_eq!(snapshot, after);
+    }
+
+    #[test]
+    fn merged_pattern_is_matched_by_source_allowlist() {
+        // End-to-end: parse a wildcard, merge into allowlist, ask
+        // SourceAllowlist::matches() about a concrete host. This is the
+        // load-bearing assertion that user_extension + SourceAllowlist
+        // compose correctly.
+        let parsed = parse_str(
+            r#"
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+"#,
+            p("config.toml"),
+        )
+        .unwrap();
+        let mut allowlists = vec![SourceAllowlist::new("oa-publisher", vec![])];
+        merge_into_allowlists(&mut allowlists, &parsed);
+        let oa = allowlists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .unwrap();
+        assert!(
+            oa.matches("ruj.uj.edu.pl"),
+            "wildcard `*.uj.edu.pl` MUST match `ruj.uj.edu.pl`"
+        );
+        assert!(
+            oa.matches("alpha.uj.edu.pl"),
+            "wildcard must also match other subdomains"
+        );
+        assert!(
+            !oa.matches("ruj.uj.edu.ru"),
+            "wildcard MUST NOT match other suffixes"
+        );
+    }
+}

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -63,7 +63,7 @@ serde_json  = { workspace = true }
 # Serializes env-var-mutating MCP integration tests (the Slice 1
 # `doiget_metadata_only` e2e tests stage `DOIGET_*_BASE` to redirect at
 # wiremock origins). Mirrors `doiget-cli/Cargo.toml`'s usage.
-serial_test = "3"
+serial_test = { workspace = true }
 wiremock    = { workspace = true }
 tempfile    = { workspace = true }
 # Slice 15b bibtex/csl export e2e seeds a Metadata fixture whose

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2050,6 +2050,51 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
         // including the hosts here cannot widen the network surface
         // beyond what the CapabilityProfile already permits.
         allowlists.extend(tier_2_allowlist());
+
+        // ADR-0028 D2: merge user-extension hosts from
+        // `<config_dir>/doiget/config.toml`. Mirrors the CLI path in
+        // `crates/doiget-cli/src/commands/fetch.rs::build_http_client`
+        // so the MCP server sees the same user-curated allowlist
+        // additions. Failure handling matches the CLI:
+        //   - missing config (file not found) is silent (Ok-empty);
+        //   - malformed config emits `tracing::warn!` and continues
+        //     with the curated allowlist;
+        //   - unresolvable config dir emits `tracing::debug!`.
+        match config_dir_utf8() {
+            Ok(cfg_dir) => {
+                let path = cfg_dir.join("doiget").join("config.toml");
+                match doiget_core::user_extension::load(&path) {
+                    Ok(user_hosts) if !user_hosts.is_empty() => {
+                        tracing::info!(
+                            count = user_hosts.len(),
+                            path = %path,
+                            "merging user-extension allowlist hosts (ADR-0028 D2)"
+                        );
+                        doiget_core::user_extension::merge_into_allowlists(
+                            &mut allowlists,
+                            &user_hosts,
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            path = %path,
+                            "failed to load user-extension allowlist; \
+                             falling back to curated set only"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "config dir unresolvable; \
+                     user-extension allowlist disabled (curated set only)"
+                );
+            }
+        }
+
         return HttpClient::new(allowlists)
             .map_err(|e| anyhow::anyhow!("building production HTTP client: {e}"));
     }
@@ -2076,6 +2121,34 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
         .map(|(s, h)| (s.as_str(), h.as_str()))
         .collect();
     Ok(HttpClient::new_for_tests_allow_http_multi(&entries))
+}
+
+/// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
+/// (POSIX), then `APPDATA` (Windows), then falls back to
+/// `$HOME/.config` (or `%USERPROFILE%\.config` on Windows). Mirrors
+/// `crates/doiget-cli/src/commands/fetch.rs::config_dir_utf8` so the
+/// MCP server reads `<config_dir>/doiget/config.toml` from the same
+/// location the CLI writes it.
+///
+/// Returns `Err` only when none of `XDG_CONFIG_HOME` / `APPDATA` /
+/// `HOME` / `USERPROFILE` are set (or all set to empty), in which
+/// case the caller downgrades to "user extension disabled" rather
+/// than failing the whole request.
+fn config_dir_utf8() -> anyhow::Result<Utf8PathBuf> {
+    if let Ok(s) = std::env::var("XDG_CONFIG_HOME") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s));
+        }
+    }
+    if let Ok(s) = std::env::var("APPDATA") {
+        if !s.is_empty() {
+            return Ok(Utf8PathBuf::from(s));
+        }
+    }
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| anyhow::anyhow!("neither HOME nor USERPROFILE is set"))?;
+    Ok(Utf8PathBuf::from(home).join(".config"))
 }
 
 /// Resolve the provenance log path. Mirrors the CLI's precedence
@@ -2276,6 +2349,95 @@ mod tests {
         // (the test process is shared with other tests).
         if std::env::var_os("HOME").is_some() || std::env::var_os("USERPROFILE").is_some() {
             assert!(resolve_store_root().is_some());
+        }
+    }
+
+    /// ADR-0028 D2: `build_http_client_for_fetch` MUST merge user-
+    /// extension allowlist hosts from `<config_dir>/doiget/config.toml`
+    /// into the oa-publisher allowlist before returning, mirroring the
+    /// CLI's `commands::fetch::build_http_client`. Drift here would
+    /// silently disable user-curated allowlist additions for the MCP
+    /// server while the CLI honors them.
+    ///
+    /// We can't read the HttpClient's internal allowlists directly
+    /// (the field is private), so we drive an end-to-end probe: write
+    /// a config.toml that adds `host = "ruj.uj.edu.pl"` to the user
+    /// extension, build the client, and call
+    /// `oa_publisher_allowlist_hosts` — the same helper the CLI test
+    /// uses (review pass M3). The function exposes the merged host
+    /// list without leaking client internals.
+    #[test]
+    #[serial_test::serial]
+    fn build_http_client_for_fetch_merges_user_extension_hosts() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        std::fs::write(
+            doiget_dir.join("config.toml").as_std_path(),
+            "[[network.additional_hosts]]\nhost = \"ruj.uj.edu.pl\"\n",
+        )
+        .expect("write config.toml");
+
+        let _guards = scoped_env_for_user_extension(cfg_root.as_str());
+
+        // No DOIGET_*_BASE overrides → takes the production branch
+        // that performs the user-extension merge.
+        let client = build_http_client_for_fetch().expect("build http client");
+        let oa = client
+            .source_allowlist("oa-publisher")
+            .expect("oa-publisher source must be registered");
+        assert!(
+            oa.redirect_hosts.iter().any(|h| h == "ruj.uj.edu.pl"),
+            "user-extension host must appear in the oa-publisher allowlist; \
+             got: {:?}",
+            oa.redirect_hosts
+        );
+    }
+
+    /// Set XDG_CONFIG_HOME / APPDATA / HOME / USERPROFILE so
+    /// `config_dir_utf8()` resolves to the supplied directory on
+    /// every supported test host. Returns guards that restore prior
+    /// values on drop.
+    fn scoped_env_for_user_extension(dir: &str) -> Vec<EnvGuard> {
+        vec![
+            EnvGuard::set("XDG_CONFIG_HOME", dir),
+            EnvGuard::set("APPDATA", dir),
+            EnvGuard::set("HOME", dir),
+            EnvGuard::set("USERPROFILE", dir),
+            EnvGuard::unset("DOIGET_ARXIV_BASE"),
+            EnvGuard::unset("DOIGET_CROSSREF_BASE"),
+            EnvGuard::unset("DOIGET_UNPAYWALL_BASE"),
+            EnvGuard::unset("DOIGET_OA_PUBLISHER_BASE"),
+            EnvGuard::unset("DOIGET_OPENALEX_BASE"),
+        ]
+    }
+
+    /// RAII env guard local to this tests module.
+    struct EnvGuard {
+        var: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(var: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::set_var(var, value);
+            EnvGuard { var, prior }
+        }
+        fn unset(var: &'static str) -> Self {
+            let prior = std::env::var_os(var);
+            std::env::remove_var(var);
+            EnvGuard { var, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
         }
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -781,6 +781,267 @@ impl Server {
         }
     }
 
+    /// `doiget_batch_from_bibliography` — read a bibliography file
+    /// (CSL-JSON today; BibTeX in a follow-up slice) and fetch each
+    /// resolvable entry. Per ADR-0030 D6.
+    ///
+    /// Mirrors `doiget_batch_fetch`'s per-entry semantics: each
+    /// `ParsedEntry` becomes one element of `results[]`, success or
+    /// per-entry failure independent of siblings. Each result also
+    /// carries the source bibliography's citation key
+    /// (`entry_key`) — the load-bearing field that lets a Zotero /
+    /// Mendeley plugin bridge the fetched PDF back to the
+    /// originating reference (ADR-0030 §6).
+    ///
+    /// `strict` controls per-entry parse-error policy:
+    ///   - `strict: false` (default) — invalid entries surface as
+    ///     `{ok:false, error:{code:INVALID_REF, ...}}` rows next to
+    ///     successful siblings; the call as a whole still returns
+    ///     `ok: true`.
+    ///   - `strict: true` — the first per-entry parse error aborts
+    ///     the whole call with `INVALID_REF`; successful upstream
+    ///     entries are not flushed (the operator asked for
+    ///     all-or-nothing).
+    ///
+    /// A whole-input decode failure (malformed CSL-JSON) ALWAYS
+    /// aborts regardless of `strict` — the file structure is broken,
+    /// not the data inside.
+    #[tool(
+        description = "WHEN TO USE: User has a Zotero / Mendeley CSL-JSON export and wants to fetch all OA-resolvable entries.\n\
+                       INPUTS: path (absolute path to .bib / .csl / .json), format (\"auto\" | \"csl-json\" | \"bibtex\" | \"refs\", default \"auto\"), strict (bool, default false).\n\
+                       OUTPUTS: { ok: true, summary:{total,ok,failed,parse_errors}, results: [{entry_key, ref, ok, ...}] } OR { ok:false, error }.\n\
+                       COSTS: Same as batch_fetch — 1-3 s per entry, bounded by the 5/sec global rate cap.\n\
+                       SIDE EFFECTS: Writes PDFs / metadata TOMLs to the store. Appends one provenance row per attempt.\n\
+                       LIMITS: bibtex parsing is not yet shipped (re-export as CSL-JSON). Per-entry parse errors are reported in results unless strict=true."
+    )]
+    async fn doiget_batch_from_bibliography(
+        &self,
+        Parameters(input): Parameters<BatchFromBibliographyInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Step 1: resolve the format token.
+        let format = match parse_bibliography_format(input.format.as_deref()) {
+            Ok(f) => f,
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::InvalidRef,
+                    &e,
+                )));
+            }
+        };
+
+        // Step 2: read the file. A missing / unreadable path aborts.
+        let raw = match std::fs::read_to_string(&input.path) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::InvalidRef,
+                    &format!("reading bibliography file {:?}: {e}", input.path),
+                )));
+            }
+        };
+
+        // Step 3: parse via the ADR-0030 adapter.
+        let path_utf8 = camino::Utf8Path::new(&input.path);
+        let parsed = doiget_core::refs::parse_input(&raw, format, Some(path_utf8));
+
+        // Pull whole-input failures out first — those always abort.
+        for entry in &parsed {
+            match entry {
+                Err(doiget_core::refs::ParseError::Decode { format, message }) => {
+                    return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                        ErrorCode::InvalidRef,
+                        &format!("input did not deserialise as {format}: {message}"),
+                    )));
+                }
+                Err(doiget_core::refs::ParseError::UnsupportedFormat { format }) => {
+                    return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                        ErrorCode::InvalidRef,
+                        &format!(
+                            "{format} parsing is not yet implemented — re-export your library as CSL-JSON"
+                        ),
+                    )));
+                }
+                _ => {}
+            }
+        }
+
+        // Step 4: classify per-entry outcomes into success-ready
+        // `Ref`s + parse-error rows. In `strict` mode any per-entry
+        // parse failure aborts the call.
+        let mut parse_errors: Vec<Value> = Vec::new();
+        let mut to_fetch: Vec<(Ref, Option<String>)> = Vec::new();
+        for entry in parsed {
+            match entry {
+                Ok(p) => to_fetch.push((p.ref_, p.entry_key)),
+                Err(doiget_core::refs::ParseError::InvalidRef {
+                    raw,
+                    entry_key,
+                    source,
+                }) => {
+                    if input.strict {
+                        return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                            ErrorCode::InvalidRef,
+                            &format!(
+                                "entry {entry_key:?} identifier {raw:?} did not parse \
+                                 (strict mode aborts): {source}"
+                            ),
+                        )));
+                    }
+                    parse_errors.push(json!({
+                        "entry_key": entry_key,
+                        "ref": raw,
+                        "ok": false,
+                        "error": {
+                            "code":    ErrorCode::InvalidRef,
+                            "message": source.to_string(),
+                        },
+                    }));
+                }
+                Err(doiget_core::refs::ParseError::NoIdentifier { entry_key }) => {
+                    if input.strict {
+                        return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                            ErrorCode::InvalidRef,
+                            &format!(
+                                "entry {entry_key:?} has no DOI / arXiv id \
+                                 (strict mode aborts)"
+                            ),
+                        )));
+                    }
+                    parse_errors.push(json!({
+                        "entry_key": entry_key,
+                        "ref":       Value::Null,
+                        "ok":        false,
+                        "error": {
+                            "code":    ErrorCode::InvalidRef,
+                            "message": "entry has no DOI / arXiv id",
+                        },
+                    }));
+                }
+                Err(_) => {
+                    // Decode / UnsupportedFormat already drained in
+                    // Step 3; this arm is defensive against future
+                    // `ParseError` variants.
+                    parse_errors.push(json!({
+                        "entry_key": Value::Null,
+                        "ref":       Value::Null,
+                        "ok":        false,
+                        "error": {
+                            "code":    ErrorCode::InvalidRef,
+                            "message": "unhandled bibliography parse error",
+                        },
+                    }));
+                }
+            }
+        }
+
+        // Enforce the same per-call ref cap `doiget_batch_fetch` does.
+        if to_fetch.len() > MAX_BATCH_REFS {
+            return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                ErrorCode::InvalidRef,
+                &format!(
+                    "too many resolvable entries: got {}, max {} (TOO_MANY_REFS)",
+                    to_fetch.len(),
+                    MAX_BATCH_REFS
+                ),
+            )));
+        }
+
+        // Step 5: stand up the shared context + store (mirrors
+        // `doiget_batch_fetch`). A context-init failure aborts the
+        // whole call.
+        let ctx = match build_fetch_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::InternalError,
+                    &format!("batch-from-bibliography context init failed: {e}"),
+                )));
+            }
+        };
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::InternalError,
+                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
+        if let Err(e) = ctx.log.append(RowInput {
+            event: LogEvent::SessionStart,
+            result: LogResult::Ok,
+            capability: Capability::Oa,
+            ref_: None,
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+            canonical_digest: None,
+        }) {
+            return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                ErrorCode::LogError,
+                &format!("SessionStart append failed: {e}"),
+            )));
+        }
+
+        // Step 6: fan out via the core orchestrator. The `Vec<Ref>`
+        // alignment with `entry_keys` lets us thread per-entry keys
+        // through to the result rows below.
+        let refs: Vec<Ref> = to_fetch.iter().map(|(r, _)| r.clone()).collect();
+        let entry_keys: Vec<Option<String>> = to_fetch.iter().map(|(_, k)| k.clone()).collect();
+        let batch_outcome = core_batch_fetch(&refs, &self.profile, &ctx, &store, &store_root).await;
+
+        let session_ok = batch_outcome
+            .as_ref()
+            .map(|b| b.results.iter().all(|r| r.outcome.is_ok()))
+            .unwrap_or(false)
+            && parse_errors.is_empty();
+
+        let _ = ctx.log.append(RowInput {
+            event: LogEvent::SessionEnd,
+            result: if session_ok {
+                LogResult::Ok
+            } else {
+                LogResult::Err
+            },
+            capability: Capability::Oa,
+            ref_: None,
+            source: None,
+            error_code: None,
+            size_bytes: None,
+            license: None,
+            store_path: None,
+            canonical_digest: None,
+        });
+
+        // Step 7: build the per-entry success / error rows. Per-entry
+        // parse-error rows from Step 4 come FIRST (the operator
+        // reads the records top-down; surfacing the parse failures
+        // before the fetch outcomes makes "which entries do I need
+        // to fix in my library" easy to scan).
+        let envelope = match batch_outcome {
+            Ok(b) => build_bibliography_envelope(&b, &refs, &entry_keys, parse_errors),
+            Err(e) => {
+                return Ok(CallToolResult::structured(batch_fetch_error_envelope(
+                    ErrorCode::from(e),
+                    "batch-from-bibliography orchestrator failed",
+                )));
+            }
+        };
+        Ok(CallToolResult::structured(envelope))
+    }
+
     /// `doiget_info` — read the metadata for a stored entry. Read-only.
     ///
     /// Per `docs/MCP_TOOLS.md` §1 (Phase 3 baseline). Mirrors the CLI's
@@ -1855,6 +2116,129 @@ fn fetch_paper_fetch_error_envelope(err: &FetchError, ref_str: &str) -> Value {
 // doiget_batch_fetch — input schema + envelopes (Slice 2)
 // ---------------------------------------------------------------------------
 
+/// JSON-schema-derived input for `doiget_batch_from_bibliography` per
+/// ADR-0030 D6.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct BatchFromBibliographyInput {
+    /// Absolute path to a bibliography file. CSL-JSON (.json / .csl)
+    /// is supported in slice 1; BibTeX (.bib) returns a structured
+    /// "not yet implemented" error pending the biblatex-crate slice.
+    pub path: String,
+    /// Optional format override. Accepted tokens (case-insensitive):
+    /// `auto` (default — extension + content fingerprint),
+    /// `csl-json`, `bibtex`, `refs`. Anything else surfaces as
+    /// `INVALID_REF`.
+    #[serde(default)]
+    pub format: Option<String>,
+    /// `true` aborts on the first per-entry parse error (no flushed
+    /// successes); `false` (default) emits parse errors as
+    /// `{ok:false, error:{code:INVALID_REF, ...}}` rows next to
+    /// successful siblings.
+    #[serde(default)]
+    pub strict: bool,
+}
+
+/// Resolve a `--format` token to a [`doiget_core::refs::Format`]. The
+/// tokens match the wire strings `Format::as_wire` emits so the MCP
+/// input schema and the CLI flag share the same vocabulary
+/// (ADR-0030 D4).
+fn parse_bibliography_format(token: Option<&str>) -> Result<doiget_core::refs::Format, String> {
+    use doiget_core::refs::Format;
+    match token.unwrap_or("auto").to_ascii_lowercase().as_str() {
+        "auto" => Ok(Format::Auto),
+        "refs" => Ok(Format::Refs),
+        "csl-json" | "csl_json" | "cslJson" => Ok(Format::CslJson),
+        "bibtex" | "biblatex" => Ok(Format::Bibtex),
+        other => Err(format!(
+            "unknown format {:?}; accepted: auto / refs / csl-json / bibtex",
+            other
+        )),
+    }
+}
+
+/// Build the bibliography-tool envelope: a `summary` block + a
+/// `results[]` array carrying parse-error rows first, then the
+/// fetch outcomes. Each fetch row mirrors `doiget_batch_fetch`'s
+/// per-entry shape with an extra `entry_key` field.
+fn build_bibliography_envelope(
+    batch: &doiget_core::orchestrator::BatchOutcome,
+    refs: &[Ref],
+    entry_keys: &[Option<String>],
+    parse_errors: Vec<Value>,
+) -> Value {
+    let fetch_ok = batch.results.iter().filter(|r| r.outcome.is_ok()).count();
+    let fetch_err = batch.results.len() - fetch_ok;
+    let summary = json!({
+        "total":        batch.results.len() + parse_errors.len(),
+        "ok":           fetch_ok,
+        "failed":       fetch_err,
+        "parse_errors": parse_errors.len(),
+    });
+
+    let mut results: Vec<Value> = parse_errors;
+    for ((entry, ref_), key) in batch.results.iter().zip(refs.iter()).zip(entry_keys.iter()) {
+        let mut obj = match &entry.outcome {
+            Ok(outcome) => serde_json::json!({
+                "entry_key":        key,
+                "ref":              ref_.as_input_str(),
+                "ok":               true,
+                "source":           outcome.source,
+                "resolver_profile": outcome.resolver_profile,
+                "license":          outcome.license,
+                "path":             outcome.path,
+                "size_bytes":       outcome.size_bytes,
+                "schema_version":   outcome.schema_version,
+                "pdf":              pdf_leg_json(&outcome.pdf_leg),
+            }),
+            Err(err) => {
+                let code: ErrorCode = match err {
+                    FetchError::NotEligible { .. } => ErrorCode::CapabilityDenied,
+                    FetchError::NoOaAvailable => ErrorCode::NoOaAvailable,
+                    FetchError::Http(_) => ErrorCode::NetworkError,
+                    FetchError::Log(_) => ErrorCode::LogError,
+                    FetchError::InvalidRef(_) => ErrorCode::InvalidRef,
+                    FetchError::SourceSchema { .. } => ErrorCode::InternalError,
+                    FetchError::TooManyRefs { .. } => ErrorCode::InvalidRef,
+                    _ => ErrorCode::InternalError,
+                };
+                let denial: Option<DenialContext> = err.into();
+                let mut error_obj = serde_json::Map::new();
+                error_obj.insert("code".into(), json!(code));
+                error_obj.insert("message".into(), json!(err.to_string()));
+                if let Some(dc) = denial {
+                    error_obj.insert(
+                        "denial_context".into(),
+                        denial_context_to_value(&dc, "batch_from_bibliography"),
+                    );
+                } else {
+                    error_obj.insert("denial_context".into(), Value::Null);
+                }
+                json!({
+                    "entry_key": key,
+                    "ref":       ref_.as_input_str(),
+                    "ok":        false,
+                    "error":     error_obj,
+                })
+            }
+        };
+        // Drop `entry_key: null` so the wire is minimal when the
+        // source bibliography had no key (e.g. plain-refs input).
+        if let Some(map) = obj.as_object_mut() {
+            if matches!(map.get("entry_key"), Some(Value::Null)) {
+                map.remove("entry_key");
+            }
+        }
+        results.push(obj);
+    }
+
+    json!({
+        "ok": true,
+        "summary": summary,
+        "results": results,
+    })
+}
+
 /// JSON-schema-derived input for `doiget_batch_fetch`.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
@@ -2339,6 +2723,70 @@ mod tests {
         // Additive back-compat fields.
         assert_eq!(v["ok"], true);
         assert_eq!(v["tier_1"], json!(["arxiv", "crossref", "unpaywall"]));
+    }
+
+    // ---- ADR-0030 D6: doiget_batch_from_bibliography helpers ------
+
+    #[test]
+    fn parse_bibliography_format_auto_when_missing_or_empty() {
+        assert_eq!(
+            parse_bibliography_format(None).unwrap(),
+            doiget_core::refs::Format::Auto
+        );
+    }
+
+    #[test]
+    fn parse_bibliography_format_accepts_canonical_tokens() {
+        assert_eq!(
+            parse_bibliography_format(Some("auto")).unwrap(),
+            doiget_core::refs::Format::Auto
+        );
+        assert_eq!(
+            parse_bibliography_format(Some("refs")).unwrap(),
+            doiget_core::refs::Format::Refs
+        );
+        assert_eq!(
+            parse_bibliography_format(Some("csl-json")).unwrap(),
+            doiget_core::refs::Format::CslJson
+        );
+        assert_eq!(
+            parse_bibliography_format(Some("bibtex")).unwrap(),
+            doiget_core::refs::Format::Bibtex
+        );
+    }
+
+    #[test]
+    fn parse_bibliography_format_is_case_insensitive() {
+        assert_eq!(
+            parse_bibliography_format(Some("CSL-JSON")).unwrap(),
+            doiget_core::refs::Format::CslJson
+        );
+        assert_eq!(
+            parse_bibliography_format(Some("BibTeX")).unwrap(),
+            doiget_core::refs::Format::Bibtex
+        );
+    }
+
+    #[test]
+    fn parse_bibliography_format_accepts_underscore_variant() {
+        // Some MCP clients prefer underscore tokens; honor both.
+        assert_eq!(
+            parse_bibliography_format(Some("csl_json")).unwrap(),
+            doiget_core::refs::Format::CslJson
+        );
+        assert_eq!(
+            parse_bibliography_format(Some("biblatex")).unwrap(),
+            doiget_core::refs::Format::Bibtex
+        );
+    }
+
+    #[test]
+    fn parse_bibliography_format_rejects_unknown_token() {
+        let err = parse_bibliography_format(Some("rdf")).unwrap_err();
+        assert!(
+            err.contains("rdf") && err.contains("auto"),
+            "error must name the offending token AND the accepted set: {err}"
+        );
     }
 
     #[test]

--- a/docs/DECISIONS/0017-output-mode-resolution.md
+++ b/docs/DECISIONS/0017-output-mode-resolution.md
@@ -1,7 +1,7 @@
 # 0017 - Output mode resolution (flag > env > implicit > TTY > quiet)
 
 - **Date:** 2026-05-05
-- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205.
+- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205. Amendment 1 (2026-05-21) distinguishes **explicit** vs **implicit** Quiet and adds an artifact-command classification so commands whose output is the product (`bib`/`csl`/`capabilities`/`audit-log --verify --mode json`) honor only explicit Quiet, fixing the LLM cold-boot deadlock reported in #219 / #220.
 - **Supersedes:** -
 - **Source:** Discussion #14
 
@@ -24,3 +24,132 @@ NORMATIVE doc(s) under docs/.
 
 To revise this decision, write a new ADR with Status: Accepted and Supersedes: 0017,
 and update this file's Status to Superseded by NNNN per CONTRIBUTING.md.
+
+## Amendment — 2026-05-21 (1): bifurcate Quiet into explicit vs implicit; classify commands as artifact vs informational
+
+**Diagnosis (LLM cold-boot deadlock, #219 / #220).** ADR-0017 collapses
+two distinct signals into a single `OutputMode::Quiet`:
+
+1. **Explicit Quiet** — the user *asks* for silence:
+   `--quiet`, `-q`, `--mode quiet`, `DOIGET_MODE=quiet`.
+2. **Implicit Quiet** — the resolver *infers* silence from a display
+   heuristic: stdout is not a TTY and no other signal was given.
+   The intent here is "don't dump ANSI into a pipe," not "be silent."
+
+These two signals collapse to the same enum value but have different
+authorities. Conflating them silently breaks artifact-output commands
+in agent / pipe contexts:
+
+```text
+$ doiget capabilities | jq .    # non-TTY -> implicit Quiet
+                                # capabilities suppresses stdout
+                                # exit code 0, empty output
+                                # LLM cannot discover anything.
+```
+
+The chicken-and-egg: the very command an LLM would call to discover
+how to make `doiget` talk (`capabilities`) is the one silenced by the
+TTY heuristic. `bib` / `csl` exhibit the same class of failure — both
+are artifact-producing commands and both go silent when piped.
+
+**Decision.** Distinguish explicit Quiet from implicit Quiet at the
+resolution boundary, and classify every command as either *artifact*
+(output IS the product) or *informational* (output is a status report,
+silenceable on display heuristic). The classification dictates which
+Quiet a command honors:
+
+```text
+                       | informational   | artifact
+                       |  cmd  silenced? |  cmd  silenced?
+-----------------------+-----------------+------------------
+explicit  Quiet        |       yes       |       yes
+  (--quiet / -q /      |                 |
+   DOIGET_MODE=quiet / |                 |
+   --mode quiet)       |                 |
+-----------------------+-----------------+------------------
+implicit  Quiet        |       yes       |       NO
+  (non-TTY default)    |                 |
+```
+
+### Implementation shape (illustrative; binding contract is the table above)
+
+1. **Resolver surface.** Promote the return type of
+   `commands::output::resolve(..)` from `OutputMode` to a small
+   `ResolvedOutput` value carrying the `mode` plus an
+   explicit-quiet bit:
+
+   ```rust
+   pub struct ResolvedOutput {
+       pub mode: OutputMode,           // unchanged (4 variants)
+       pub quiet_was_explicit: bool,   // true iff user asked for it
+   }
+   ```
+
+   The wire surface (`DOIGET_MODE` string values, the `modes` array
+   in `capabilities` JSON, the `--mode` clap values) is **unchanged**;
+   the bit lives only in the in-memory resolved value.
+
+2. **Per-command honoring.** Each command receives `ResolvedOutput`
+   instead of bare `OutputMode`:
+
+   ```rust
+   // Informational commands (audit-log Human, list-recent, search,
+   // info, config show/path, provenance migrate, fetch/batch status):
+   if out.mode == OutputMode::Quiet { return suppress(); }
+
+   // Artifact commands (bib, csl, capabilities,
+   // audit-log --verify --mode json):
+   if out.mode == OutputMode::Quiet && out.quiet_was_explicit {
+       return suppress();
+   }
+   ```
+
+3. **Classification table.** A single source of truth in
+   `commands::output` (e.g. a `is_artifact_command(name: &str) -> bool`
+   helper) lists artifact commands; the lib-level parity test
+   asserting every `Cli` enum variant has a `SubcommandMeta` entry
+   (#214) is extended to also assert the classification matches the
+   command's documented behavior.
+
+4. **`audit-log --verify`** is the boundary case: **informational in
+   Human mode, artifact in Json mode**. The split is natural since
+   the `--mode json` request is itself an explicit signal; the
+   command checks the mode it resolved into rather than its name.
+
+### Binding properties
+
+1. **`OutputMode` enum shape is unchanged** — 4 variants, same serde,
+   same `capabilities` `modes` array. No wire-format break.
+2. **`DOIGET_MODE=quiet` semantics are unchanged** — still suppresses
+   *every* command including artifact ones (it is explicit).
+3. **TTY detection semantics are unchanged** — still produces
+   `OutputMode::Quiet` for non-TTY when no other signal is given,
+   but now carries `quiet_was_explicit = false`.
+4. **`serve → forced Mcp`** override (Slice 9 / Slice 1 stdout-purity
+   invariant) is unchanged and orthogonal to this bit.
+5. **`--mode quiet` is explicit** — passing the flag, even though it
+   is the *same mode* the TTY heuristic might pick, signals intent
+   and silences artifact commands.
+
+### Test plan
+
+- Unit (`output.rs`): `resolve(..)` returns `quiet_was_explicit = true`
+  for each of `{--quiet, -q, --mode quiet, DOIGET_MODE=quiet}` and
+  `false` for non-TTY default.
+- E2E (`capabilities_e2e.rs`): `doiget capabilities` (non-TTY, no
+  flags) emits the full JSON inventory — closes #219. The existing
+  `--quiet capabilities` test (#203 follow-up) keeps the empty-stdout
+  assertion to lock the explicit-quiet path.
+- E2E (`output_mode_e2e.rs`): `bib` / `csl` emit their artifact on
+  non-TTY default; `bib --quiet` / `csl --quiet` emit empty.
+- E2E (audit-log boundary): `audit-log --verify --mode json` emits
+  the JSON report regardless of TTY; `audit-log --verify` (Human)
+  is still silenced on non-TTY.
+
+### Migration
+
+The implementation slice is a CLI-internal refactor; consumers
+(scripts, agents, `capabilities` JSON consumers) see a behavior
+*restoration* for artifact commands in pipes — no API change.
+The 0.3.0 non-TTY-default callout in CHANGELOG remains in force
+for informational commands.

--- a/docs/DECISIONS/0028-user-extensible-capability-gate.md
+++ b/docs/DECISIONS/0028-user-extensible-capability-gate.md
@@ -1,0 +1,218 @@
+# 0028 - User-extensible capability gate; ToS + verified-curation posture; impersonation out-of-scope
+
+- **Date:** 2026-05-21
+- **Status:** Accepted (design; implementation slice tracked separately).
+  This ADR sets the semantic frame for the redirect / fetch-host
+  allowlist (the *capability gate*). It does not modify the default
+  curated host set; that continues to live in
+  `docs/REDIRECT_ALLOWLIST.md` §3 + `crates/doiget-core/src/http.rs`
+  and is grown by individual ADRs per cluster (e.g. ADR-0027).
+- **Supersedes:** -
+- **Source:** #220 (user-extension request: Green-OA at `ruj.uj.edu.pl`);
+  #223 (rejected: WAF / TLS-impersonation bypass);
+  dogfood of finite-temperature-MPS corpus (2026-05-20).
+
+## Context
+
+The capability gate (`oa_publisher_allowlist()` /
+`tier_2_allowlist()` + the redirect-allowlist enforcement in the
+orchestrator) is the load-bearing primitive that keeps `doiget` a
+**legitimate, auditable, official-channel** academic fetch tool
+rather than a generic scraper. Until now its purpose has been only
+*implicitly* defined — the codebase encodes "what" (a static list),
+not "why" (the policy the list enforces).
+
+Two recent issues exposed the absence of a stated policy:
+
+1. **#220 (user-extension).** A real dogfood batch was blocked at
+   `ruj.uj.edu.pl` (Jagiellonian University Repository — a Green-OA
+   institutional repo). The user could not extend the allowlist
+   locally without forking the codebase. The natural response —
+   "let users add hosts via config" — has no documented constraint,
+   so it could degrade into an arbitrary opt-out of the gate.
+2. **#223 (impersonation).** A request for TLS-fingerprint
+   impersonation (`reqwest-impersonate`) and cookie-import paths to
+   bypass Cloudflare / Akamai WAF challenges on publisher hosts.
+   Without a stated posture this would be a judgement call; with
+   one, it is mechanically out of scope.
+
+The ADR has to answer three questions: **why does the gate exist,
+how may users widen it, and which proposals are mechanically
+out-of-scope?**
+
+### Three competing semantics for "why the gate exists"
+
+```mermaid
+flowchart TB
+  Q["allowlist の存在理由"]
+  Q --> A["A. TLS / 改ざん対策<br/>(技術的信頼境界)"]
+  Q --> B["B. ToS 遵守<br/>(法的信頼境界)"]
+  Q --> C["C. 既知の良い source 集合<br/>(品質キュレーション)"]
+  A --> AC["静的 list、user 拡張不可<br/>WAF bypass 議論不能"]
+  B --> BC["publisher 単位の policy file<br/>WAF bypass は posture 違反"]
+  C --> CC["user 拡張 OK、検証込み<br/>WAF bypass はスコープ外"]
+```
+
+`doiget` already enforces TLS-only at the transport layer
+(`rustls-no-provider` + `ring`; ADR-0020 Am1), so the gate is **not
+needed for TLS safety** — that is settled lower in the stack.
+Interpretation A is therefore not load-bearing on its own. The gate's
+real load is **B + C**: it filters to hosts that (1) permit automated
+access under their terms and (2) have been empirically observed to
+return well-formed PDFs in a doiget run.
+
+## Decision
+
+The capability gate is governed by the union of **ToS compliance
+(B)** and **verified curation (C)**. This frame produces deterministic
+answers to the three open questions:
+
+### D1 — Default allowlist remains curated; entries require empirical evidence
+
+`oa_publisher_allowlist()` and `tier_2_allowlist()` continue to grow
+**only** through ADRs that:
+
+1. Document the host (or single-suffix host pattern).
+2. Cite ToS evidence that automated PDF fetch is permitted (e.g.
+   APS green OA policy, SciPost diamond OA terms, arXiv API terms).
+3. Cite at least one empirical fetch that produced a well-formed PDF
+   with a sane `Content-Type` and an HTTP/2 200 (or 200 after a
+   permitted redirect).
+
+ADR-0027 is the canonical template for this growth path (the
+empirical-evidence comment lives in `http.rs` next to each added
+host). Hosts added without (1)+(2)+(3) are rejected.
+
+### D2 — User-extensible allowlist via `config.toml`, opt-in, audited
+
+Users SHALL be able to extend the gate for their own deployment via
+`config.toml`, **literal hosts or single-suffix wildcards only**, and
+each extension is recorded in the provenance log so the audit trail
+remains intact:
+
+```toml
+[network]
+contact_email = "researcher@institution.edu"
+
+[[network.additional_hosts]]
+host = "ruj.uj.edu.pl"
+note = "Jagiellonian University Repository — Green OA (verified 2026-05-21)"
+
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+note = "all Jagiellonian subdomains; single-suffix wildcard"
+
+# REJECTED at parse time:
+# [[network.additional_hosts]]
+# host = "*.edu.*"        # multi-segment glob — rejected
+# host = "*"              # bare wildcard — rejected
+# host = "user@host.com"  # not a host — rejected
+```
+
+Binding properties of the user-extension surface:
+
+1. **Pattern grammar is restricted.** Literal host (`foo.example.org`)
+   or single leading-segment wildcard (`*.example.org`, meaning
+   "any subdomain of `example.org`"). Multi-segment globs (`*.edu.*`,
+   `*.ac.*`), bare wildcards (`*`), and full glob (`*.example.*`) are
+   parse errors. The orchestrator's pattern matcher is the same
+   single-suffix logic ADR-0027 already uses (e.g. `*.aps.org`).
+2. **Provenance log marks the path taken.** Every fetch that hit a
+   user-added host MUST record `verified_by = "user"` in the
+   provenance row (alongside the existing `safekey` / `canonical_digest`
+   fields). Default-list fetches record `verified_by = "curated"`
+   (or omit the field for backward compatibility — schema-additive).
+3. **`doiget config doctor` surfaces extensions.** A `doctor` line
+   reports the count of user-added hosts and warns that they are not
+   part of the project-verified set. Names are NOT printed by default
+   (privacy on shared logs); `--verbose` opts in.
+4. **`doiget capabilities` reports the count, not the contents.** The
+   `env_vars` / `docs` blocks already exist; a new field
+   `capability_gate.user_extension_count` reports a non-negative
+   integer. Field names are part of the wire format
+   (`#[non_exhaustive]` discipline from #215).
+5. **No env-var equivalent.** Extensions live only in
+   `config.toml`. The reason: env vars are usually un-audited
+   (CI scripts, parent processes); requiring a config file makes the
+   extension a deliberate, reviewable artifact.
+
+### D3 — Impersonation, WAF bypass, and credential-borrowing are out of scope
+
+The gate's purpose includes the ToS-compliance leg (D1, point 2).
+Proposals that route around publisher access controls
+*by making automated requests appear human-driven* are mechanically
+incompatible with that leg:
+
+| Proposal (from #223) | Disposition |
+|---|---|
+| Detect Cloudflare / Akamai WAF blocks and surface as a structured `HttpError::BlockedByFirewall` variant | **Accept** — the detection itself is honest classification of a failure (not a bypass) and aligns with the structured-denial-context discipline of ADR-0023; tracked under Q6 / a future error-taxonomy ADR. |
+| `reqwest-impersonate` / `rquest` (TLS JA3 fingerprint spoofing, HTTP/2 frame mimicry) | **Reject (out of scope; won't fix).** The crate's stated purpose is to misrepresent the client to publisher WAFs. This contradicts D1 point 2 directly. |
+| `--cookies` flag importing user's authenticated browser session (Netscape `cookies.txt`) | **Reject for v0.4** (re-evaluate only on explicit maintainer review). Even if user-provided, the cookies represent the *user's* authenticated session being driven programmatically; many publisher ToS treat that as automated access by an unauthorized agent. The provenance / audit story is also unclear. |
+| Embedded headless browser (`chromiumoxide`, `headless_chrome`, Playwright sidecar) | **Reject (permanent out of scope).** Brings a 100+MB Chromium dependency, an exec-arbitrary-JS execution surface, and is fundamentally an impersonation pipeline. Incompatible with the static-musl portability story (ADR-0020 Am1) and with the gate's ToS leg. |
+| Per-host configurable `User-Agent` override (`network.user_agent`) | **Defer.** Setting a contact-bearing UA per `contact_email` policy (RFC compliance) is fine; setting a UA *to look like a browser* is impersonation. The current single-UA model honoring `contact_email` already covers the legitimate use case; a per-host UA table is reserved until a real legitimate need (e.g. publisher requiring a registered application UA) emerges. |
+| Per-host configurable delay / cooldown (`network.cooldown_ms`) | **Accept** — separate, non-impersonating rate-limit tuning; tracked under #222, not blocked by this ADR. |
+
+The `won't fix` items get a written response on their respective
+issues citing this ADR; this is the canonical reference.
+
+## Consequences
+
+### Positive
+
+1. The gate's purpose is now stated. Future allowlist-growth requests
+   can be evaluated against D1; future impersonation requests can be
+   declined against D3 without re-litigating the posture each time.
+2. Real-world dogfood blockers like `ruj.uj.edu.pl` (#220) become
+   solvable for the affected user in 30 seconds (edit `config.toml`)
+   without forking, while keeping the default set verified.
+3. `provenance.verified_by` provides the audit signal needed to
+   distinguish "doiget vouched for this host" from "the operator
+   accepted responsibility for this host" — important for
+   institutional users.
+4. The ADR makes #223 a one-comment close (link here) rather than
+   a recurring design debate.
+
+### Negative
+
+1. The `config.toml` surface grows; the `additional_hosts` parser
+   becomes a small but non-trivial new code path with its own
+   tests (pattern validation, `verified_by` plumbing, doctor
+   surfacing).
+2. Users will sometimes add hosts that don't actually serve OA PDFs
+   (legacy URLs, paywalled HTML, etc.). The fetch then fails with a
+   *different* error code (`NETWORK_ERROR` / unexpected
+   `Content-Type`) rather than `CAPABILITY_DENIED`; the failure
+   digest must make this distinguishable.
+3. The "single-suffix wildcard" rule is a usability compromise — a
+   user who wants to whitelist three sibling subdomains of
+   `example.org` must either list all three, or whitelist the parent
+   suffix (which is broader than they may have intended). This is
+   deliberate: the rule biases toward least-privilege per-host
+   grants.
+4. The `won't fix` posture for impersonation closes the door on a
+   subset of real publishers (those that block all non-browser TLS
+   fingerprints). doiget cannot reach those papers via automated
+   official-channel fetch; the documented workflow there is *manual
+   download → `doiget import <pdf>`* (a future facility tracked
+   separately), not impersonation.
+
+### Migration
+
+- No default-list change. The implementation slice introduces the
+  `network.additional_hosts` parser, the `verified_by` provenance
+  field (schema-additive), the `doctor` line, and the
+  `capabilities.capability_gate.user_extension_count` field.
+  None of these break existing consumers.
+- The `won't fix` issues (#223 items D3) get a maintainer comment
+  pointing at this ADR and are closed with `state_reason: not_planned`.
+
+## References
+
+- `docs/REDIRECT_ALLOWLIST.md` §3 — the default curated host set
+- ADR-0023 (structured `denial_context` on error envelopes; the
+  failure-shape this ADR's `CAPABILITY_DENIED` continues to honor)
+- ADR-0027 (allowlist-growth template; the canonical "add a host"
+  procedure under D1)
+- #220 (user-extension motivation)
+- #223 (impersonation proposals; rejected under D3)
+- #222 (`network.cooldown_ms` — separate, accepted)

--- a/docs/DECISIONS/0029-fetch-chain-attempt-provenance.md
+++ b/docs/DECISIONS/0029-fetch-chain-attempt-provenance.md
@@ -1,0 +1,280 @@
+# 0029 - Fetch chain: per-Ref multi-attempt resolution with attempt-level provenance
+
+- **Date:** 2026-05-21
+- **Status:** Accepted (design; implementation slice tracked separately
+  and gated by ADR-0028 — the chain composes with the curated +
+  user-extension allowlist semantics, not around them).
+- **Supersedes:** -
+- **Source:** #222 (auto-preprint / alternative-OA fallback);
+  dogfood of finite-temperature-MPS corpus where DOI-publisher
+  fetches returned 403 but arXiv preprints were present in OpenAlex
+  metadata.
+
+## Context
+
+The current fetch pipeline resolves a `Ref` (DOI / arXiv ID / PMID)
+to **exactly one** PDF URL via the metadata source's *best* OA
+location:
+
+```text
+Ref -> Source.lookup -> single URL -> fetch -> PDF | error
+                       (best_oa_location)
+```
+
+This is wasteful in two directions:
+
+1. **Wasted information.** OpenAlex returns *multiple*
+   `oa_locations[]` per work (publisher OA, arXiv preprint, repo
+   mirror, …). Today only the first is tried; if it fails, the
+   remaining locations are discarded even though they're already in
+   the metadata response.
+2. **Wasted recovery.** In the dogfood batch, a `doi:` lookup hit
+   `link.aps.org` and was blocked by a publisher WAF (HTTP 403). The
+   *same* paper's arXiv preprint was already listed by OpenAlex with
+   a valid, allowlisted URL. The user had to discover this manually
+   and re-issue a separate fetch.
+
+The natural fix is to **try the OA locations in priority order until
+one succeeds**, and to record the chain in the provenance log so the
+audit trail captures every external request, not just the final
+outcome.
+
+This ADR pins the chain semantics, the per-attempt provenance shape,
+and the new closed-enum error variant for the "all attempts failed"
+terminal state.
+
+### Why this is not a CLI retry policy
+
+A retry policy is a *temporal* loop ("try again after T") on the
+*same* URL; a fetch chain is a *spatial* search across alternative
+sources of the same logical paper. The two are orthogonal:
+
+| | Retry policy | Fetch chain (this ADR) |
+|---|---|---|
+| Loop dimension | time | source / URL |
+| Triggered by | transient error (5xx, timeout) | non-transient on a given URL |
+| Cardinality of requests | 1 ref × N retries | 1 ref × N alternative sources |
+| Authoritative shape | retry policy (host-level) | metadata source (`oa_locations[]` order) |
+
+The chain belongs in `doiget-core` because every consumer of the
+core API — CLI, MCP, future bindings — wants the same multi-source
+search semantics. Putting it in `doiget-cli` as a retry policy would
+duplicate it for every consumer and would make MCP tools weaker than
+the CLI for no good reason (the #212 alignment ADR exists precisely
+to prevent this kind of drift).
+
+## Decision
+
+### D1 — Chain lives in `doiget-core` as the canonical fetch primitive
+
+The orchestrator's `fetch_one` function is generalized from
+"resolve to one URL then fetch" to "resolve to an ordered chain of
+candidate URLs and walk it until one succeeds." MCP tools and the
+CLI both consume this new shape.
+
+```mermaid
+flowchart LR
+  R["Ref<br/>doi:10.1103/PhysRevB.109.045136"] --> META[Resolve metadata via Source]
+  META --> CHAIN["fetch_chain: Vec&lt;Candidate&gt;<br/>(source-priority order)"]
+  CHAIN --> A1[attempt 1<br/>publisher OA URL]
+  A1 -->|ok 200 PDF| P[PDF + canonical_digest]
+  A1 -->|allowlist deny<br/>or HTTP 403/5xx<br/>or non-PDF body| A2[attempt 2<br/>arXiv preprint URL]
+  A2 -->|ok| P
+  A2 -->|fail| A3[attempt 3<br/>institutional repo]
+  A3 -->|all fail| ERR["ALL_FALLBACKS_EXHAUSTED<br/>{ attempts: [...] }"]
+  A1 -.attempt 1 row.-> PROV[(provenance log)]
+  A2 -.attempt 2 row.-> PROV
+  A3 -.attempt 3 row.-> PROV
+```
+
+### D2 — Chain ordering is the metadata source's `oa_locations[]` order
+
+In v0.4, doiget honors the order returned by the metadata source
+(OpenAlex / Unpaywall) verbatim. Rationale:
+
+- OpenAlex already encodes a quality ordering: `best_oa_location`
+  first, then sorted by `location.is_oa` and version (published >
+  accepted > submitted).
+- The metadata source is the operator of the catalog, not doiget;
+  imposing a *second* ordering layer in doiget adds policy that
+  needs justification.
+- User-configurable priority (e.g. `[fetch_chain] prefer = ["arxiv",
+  "publisher_oa", "institutional"]`) is deferred until at least one
+  empirical case shows the default ordering is wrong for legitimate
+  workflows. This keeps v0.4 surface area minimal.
+
+### D3 — Per-attempt rules — when to advance, when to stop
+
+The chain advances on **retryable failures** and stops on
+**terminal failures**:
+
+| Outcome | Action |
+|---|---|
+| HTTP 200 with `Content-Type: application/pdf` (or sniffed PDF magic bytes) | **Success** — record the attempt as `ok`, stop the chain, return the PDF + canonical_digest. |
+| HTTP 403 / 429 / 5xx | Advance to next candidate. (Honest WAF-block detection from a future taxonomy slice may yield a more specific code; the *chain* behavior is unchanged — still advances.) |
+| HTTP 200 with non-PDF body (HTML challenge page, paywall splash) | Advance. The fetched body is discarded; provenance records the response shape. |
+| `CAPABILITY_DENIED` (the host failed the allowlist gate from ADR-0028) | Advance. The denial is honest and structured (ADR-0023). |
+| Network error (DNS / connect timeout / TLS) | Advance. |
+| `INVALID_REF` at the metadata stage | **Terminal.** No candidates exist; chain never starts. |
+| `RATE_LIMITED` (per-host cooldown enforced) | **Terminal for the chain** but the *ref* is queued for a future re-attempt (chain re-walks from candidate 1 on the next batch run; cache-hit logic from ADR-0023's content-addressed store ensures successful past attempts are not re-issued). |
+| `STORE_ERROR` (disk / quota / permissions) | **Terminal.** Local failure, not a remote one; trying another remote candidate won't help. |
+
+The advance/stop classification is a closed set; new outcomes added
+in future ADRs must be classified explicitly.
+
+### D4 — Per-attempt provenance — one log row per remote request
+
+Every attempt is recorded in the provenance log as its own row, even
+if a later attempt in the chain succeeds. This is a deliberate
+expansion of "1 ref = 1 row" to "1 ref = N rows (one per attempt)"
+under the existing hash-chained schema.
+
+Row shape (schema-additive over the existing ADR-0024 v2):
+
+```jsonc
+{
+  // Existing fields (unchanged)
+  "v": 2,
+  "ts": "2026-05-21T03:14:15Z",
+  "ref": "doi:10.1103/PhysRevB.109.045136",
+  "safekey": "doi-10.1103-PhysRevB.109.045136",
+  "host": "link.aps.org",
+  "outcome": "fetch_blocked",
+  "code": "NETWORK_ERROR",
+  "prev_hash": "…",
+  "this_hash": "…",
+
+  // New fields (ADR-0029 additive)
+  "chain_attempt": 1,        // 1-based index of this attempt
+  "chain_total":   3,        // total candidates in the chain at time of attempt
+  "chain_terminal": false,   // true iff this attempt ended the chain (success or terminal-failure)
+  "verified_by": "curated"   // from ADR-0028; tagged per-attempt because hosts differ
+}
+```
+
+For a 3-attempt ref ending in success-on-attempt-2, the log carries
+two rows: `chain_attempt = 1` is the publisher OA failure;
+`chain_attempt = 2` is the arXiv success (`chain_terminal: true,
+outcome: "ok"`). The chain stops at success — attempt 3 is never
+issued and no row is written for it.
+
+The hash chain is per-row as before; the relationship "these N rows
+belong to the same Ref attempt" is reconstructed by readers from
+`ref` + a monotonically increasing per-ref attempt counter (the
+read-side helper is part of the implementation slice).
+
+### D5 — New closed-enum error variant: `ALL_FALLBACKS_EXHAUSTED`
+
+When every candidate in the chain has failed with an advancing
+outcome, the orchestrator returns a structured error:
+
+```rust
+pub enum FetchErrorCode {
+    // existing variants...
+    AllFallbacksExhausted,
+}
+
+pub struct FetchError {
+    pub code: FetchErrorCode,
+    pub message: String,
+    pub denial_context: Option<DenialContext>,  // ADR-0023, unchanged
+    pub chain: Vec<AttemptOutcome>,             // new, ADR-0029
+}
+
+pub struct AttemptOutcome {
+    pub source: String,           // e.g. "openalex.oa_locations[0]"
+    pub url: String,
+    pub code: FetchErrorCode,     // the *per-attempt* failure code
+    pub status: Option<u16>,      // HTTP status if reached
+    pub host: String,
+}
+```
+
+The `chain` field is part of the wire format on the
+`--mode json` / MCP / batch-JSONL surfaces (consistent with #212's
+alignment goal). Renaming `AttemptOutcome` fields is a semver-minor
++ `[BREAKING]` callout, per the existing wire-stability discipline
+(#208 self-review §1; `EntryInfo` / `MigrationReport` precedent).
+
+### D6 — Allowlist and rate-limit composition
+
+Each candidate URL passes through the ADR-0028 capability gate
+*independently*. A user who has not extended the allowlist will see
+candidates on institutional-repo hosts produce `CAPABILITY_DENIED`
+and the chain will advance. A user who has added
+`*.uj.edu.pl` to `additional_hosts` will see attempts on that host
+succeed (modulo network), with `verified_by = "user"` recorded per
+ADR-0028 D2-2.
+
+Per-host rate-limit (`network.cooldown_ms` from #222, accepted under
+ADR-0028 D3) applies per-attempt. A chain that walks three hosts
+incurs three host-scoped cooldowns. The cooldown is not amortized
+across the chain.
+
+## Consequences
+
+### Positive
+
+1. The dogfood case (publisher WAF block → arXiv recovery) is
+   handled automatically; no manual re-issue, no script glue.
+2. The provenance log gains the resolution shown above — every
+   external request is captured, enabling honest "we tried N hosts"
+   answers in audits and post-mortems.
+3. MCP and CLI gain the chain semantics together (#212 alignment is
+   preserved by construction; the surface is the same shape).
+4. Composes cleanly with ADR-0028: a user-extension that makes the
+   institutional repo allowlist-pass is reflected per-attempt in
+   `verified_by`.
+
+### Negative
+
+1. **Request multiplication.** A pathological ref hits every host
+   in `oa_locations[]` before failing terminally. Worst-case
+   per-ref cost rises from 1 request to `len(oa_locations[])`.
+   In practice OpenAlex returns ~1-4 locations per work; the
+   amplification is bounded.
+2. **Provenance log volume grows.** Same factor as the request
+   amplification. Log rotation (#140, already shipped) absorbs this,
+   but the retention math changes — the implementation slice
+   updates `docs/PROVENANCE_LOG.md` §6 accordingly.
+3. **`oa_locations[0]` is no longer a contract.** Today a downstream
+   consumer might (mistakenly) read only the first row per ref;
+   under D4 that semantics is wrong — the first row may be a
+   *failed* attempt and the final outcome row carries
+   `chain_terminal: true`. The implementation slice documents the
+   read-side helper and updates `MCP_TOOLS.md` §11.
+4. **Wire-format surface grew.** `FetchError.chain` and
+   `AttemptOutcome` are new public types; once shipped they are
+   covered by the wire-stability discipline. This is intentional —
+   the chain is a primitive, not an implementation detail.
+
+### Migration
+
+- v0.3 callers see no breaking change. The chain runs whenever
+  `oa_locations[]` has ≥ 1 entry; a 1-entry chain is byte-equivalent
+  to today's "single URL fetch" path.
+- The provenance schema is additive: new fields (`chain_attempt`,
+  `chain_total`, `chain_terminal`, `verified_by`) default to
+  `1 / 1 / true / "curated"` for backward compatibility with v2 rows
+  written before this slice. `doiget audit-log --verify` accepts
+  both shapes.
+- The new `ALL_FALLBACKS_EXHAUSTED` code is added to `ERRORS.md`'s
+  closed set and to the `capabilities` JSON inventory's
+  `subcommands[].errors[]` (the same #214 surface). MCP tool spec
+  (`docs/MCP_TOOLS.md` §11) gets a matching update.
+
+## References
+
+- ADR-0023 (structured denial context; the `denial_context` per
+  attempt continues to follow that shape)
+- ADR-0024 (provenance log v2 schema; this ADR is schema-additive
+  on top of v2, no v3 bump)
+- ADR-0027 (curated host list — the source of "host is reachable
+  under doiget's posture")
+- ADR-0028 (the gate semantics this chain composes with;
+  `verified_by` per attempt is from there)
+- #210 (`fetch_one` outcome plumbing — the consumer-side wire
+  surface this ADR's `AttemptOutcome` feeds into)
+- #212 (MCP/CLI shape alignment — the principle that motivates
+  putting the chain in core)
+- #222 (auto-preprint fallback — the user-facing requirement)

--- a/docs/DECISIONS/0030-bibliography-input-adapters.md
+++ b/docs/DECISIONS/0030-bibliography-input-adapters.md
@@ -1,0 +1,274 @@
+# 0030 - Bibliography input adapters (.bib / CSL-JSON) in doiget-core; new MCP tool `doiget_batch_from_bibliography`
+
+- **Date:** 2026-05-21
+- **Status:** Accepted (design; implementation slice tracked
+  separately).
+- **Supersedes:** -
+- **Source:** #222 §2B (BibTeX / CSL-JSON batch input);
+  Zotero-as-distribution-channel framing (maintainer review
+  2026-05-20).
+
+## Context
+
+`doiget batch` today accepts only the plain-refs format: one
+identifier per line in `doi:…` / `arxiv:…` / `pmid:…` shape. Real
+researchers do not maintain such files — they export reference
+libraries from Zotero / Mendeley / EndNote as **`.bib`** (BibLaTeX)
+or **CSL-JSON**. The current friction is:
+
+```text
+Zotero library → export .bib → user writes custom regex parser
+                            → grep/sed to extract DOIs
+                            → pipe into doiget batch
+```
+
+Every researcher writes a different parser; mistakes silently drop
+papers. This is exactly the kind of paper-cuts that prevents `doiget`
+from being adopted via the Zotero distribution path discussed in the
+2026-05-20 review (Zotero plugin → MCP server → doiget pipeline).
+
+### Two related-but-distinct surfaces are being added
+
+1. **CLI batch input**: `doiget batch library.bib` accepts a `.bib`
+   file directly, replacing the user-written parser.
+2. **MCP tool**: a new `doiget_batch_from_bibliography(path)` tool
+   so a Zotero plugin (or any other MCP client) can hand a `.bib`
+   file path to `doiget serve` and receive structured per-entry
+   results, without shelling out.
+
+Both consume the same parser. Choosing where that parser lives
+(core vs cli) is the load-bearing decision in this ADR.
+
+## Decision
+
+### D1 — Parser lives in `doiget-core` as a new `refs::parse` module
+
+The bibliography parser is a core capability, not a CLI affordance.
+Putting it in `doiget-cli` would make the MCP tool (#212-aligned
+with the CLI) weaker than the CLI for no good reason — a Zotero
+plugin handing a `.bib` path to MCP would force the plugin author
+to either re-implement BibTeX parsing in JavaScript (the
+distribution path's whole point is to avoid this) or shell out to
+the CLI just for the parser (which negates the structural advantage
+of MCP).
+
+```mermaid
+flowchart LR
+  subgraph IN["input surfaces"]
+    A["library.bib"]
+    B["library.json (CSL)"]
+    C["plain.refs (one per line)"]
+    D["stdin"]
+  end
+  IN --> SNIFF{"format detect"}
+  SNIFF -->|.bib + content fingerprint| BIB["biblatex parser"]
+  SNIFF -->|.json + CSL-JSON shape| CSL["serde_json parser"]
+  SNIFF -->|else| PLAIN["plain-refs parser"]
+  BIB --> PICK["per entry: pick<br/>DOI > arXiv ID > PMID"]
+  CSL --> PICK
+  PLAIN --> PICK
+  PICK --> REFS["Iterator&lt;Item = Result&lt;Ref, ParseError&gt;&gt;"]
+  REFS --> CLI["doiget batch (CLI)"]
+  REFS --> MCP["doiget_batch_from_bibliography (MCP)"]
+```
+
+### D2 — Dependency: `biblatex` crate, enabled by default
+
+The parser adds the `biblatex` crate (~500 KB compiled) to
+`doiget-core`. It is enabled in the **default feature set**, not
+behind an opt-in flag. Reasoning:
+
+- The musl-static release binary currently weighs ~10 MB; +500 KB is
+  a 5 % footprint increase, which is acceptable.
+- Putting it behind a feature flag would mean the default
+  `cargo install doiget-cli` lacks `.bib` support — exactly the
+  friction this ADR exists to remove.
+- A lean `oa-only-no-bib` minimal build can still be produced by
+  consumers via `default-features = false`; the `biblatex` dep
+  joins the feature graph that already includes `oa-only`.
+
+CSL-JSON is parsed via the existing `serde_json` (no new
+dependency).
+
+### D3 — One entry produces one `Ref`; priority is DOI > arXiv ID > PMID
+
+A single bibliography entry may carry multiple identifiers:
+
+```bibtex
+@article{example2024,
+  author = {…},
+  title  = {…},
+  doi    = {10.1103/PhysRevB.109.045136},
+  eprint = {2204.12345},          % arXiv
+  pmid   = {12345678},
+  url    = {https://link.aps.org/…}
+}
+```
+
+The parser picks **one** identifier per entry, in priority order:
+
+1. `doi` field (or `doi` in `note`, recognised by the
+   `^doi:\s*(.+)$` shape used by Zotero exports);
+2. `eprint` + (`archiveprefix = "arXiv"` OR `eprinttype = "arxiv"`)
+   → `arxiv:<id>`;
+3. `pmid` field → `pmid:<id>`.
+
+Entries with none of the above yield a `ParseError::NoIdentifier`
+which is **skipped + counted** in the default mode and **aborts** in
+`--strict`. The skip is reported in human-mode stderr and as a
+JSONL parse-error record in `--mode json` (consistent with #205's
+batch JSONL shape).
+
+The "pick one" rule prevents accidental N-fold fetch
+amplification — fetching the publisher OA, the arXiv preprint, AND
+the PMID record for the same paper would triple-charge rate limits
+and produce three near-duplicate store entries. The fetch chain
+(ADR-0029) already handles the "publisher OA failed → fall back to
+arXiv" recovery path *within* the resolution of a single Ref; the
+adapter does not need to fan out.
+
+### D4 — Format auto-detection by extension, overridable
+
+Detection precedence:
+
+1. **`--format` CLI flag** if given (`bibtex` / `csl-json` / `refs`).
+2. **File extension** if reading from a path: `.bib` / `.biblatex`
+   → `bibtex`; `.json` / `.yaml` / `.csl` → `csl-json`; otherwise
+   `refs`.
+3. **Content fingerprint** for stdin or unknown extensions: peek
+   the first non-blank line and test for `@<entrytype>{` (BibTeX),
+   `[` followed by `{"id":` or `"DOI":` (CSL-JSON), or
+   `^[a-z]+:` (plain refs).
+4. **Fallback**: `refs`. On the very first parse failure, emit a
+   helpful error message naming the detected format and suggesting
+   `--format` overrides.
+
+### D5 — Parse-error policy: skip + warn by default; `--strict` aborts
+
+Real-world `.bib` files have one in every couple-dozen entries that
+fails to parse (escaping issues, encoding, exotic BibLaTeX
+extensions). Aborting the whole batch on the first parse error is
+hostile to the actual user workflow.
+
+- Default mode: parse errors yield a stderr warning + a counted
+  `parse_errors` summary at end of batch + are recorded in the
+  per-ref JSONL stream (`{"ok": false, "ref": null,
+  "error": {"code": "INVALID_REF", "message": "...", "entry_key":
+  "example2024"}}`).
+- `--strict` mode: the first parse error aborts; existing successes
+  are flushed.
+
+The `entry_key` field carries the BibTeX citation key (or CSL `id`)
+so the operator can locate the offending entry in their library.
+
+### D6 — New MCP tool: `doiget_batch_from_bibliography`
+
+```jsonc
+// Tool spec sketch — full schema lands in docs/MCP_TOOLS.md §N
+{
+  "name": "doiget_batch_from_bibliography",
+  "description": "Parse a BibTeX/.bib or CSL-JSON file and fetch each entry. Returns one structured outcome per resolvable entry.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "path":   { "type": "string", "description": "Absolute path to .bib or CSL-JSON file" },
+      "format": { "type": "string", "enum": ["auto", "bibtex", "csl-json"], "default": "auto" },
+      "strict": { "type": "boolean", "default": false }
+    },
+    "required": ["path"]
+  },
+  "outputShape": {
+    "summary": { "total": "int", "ok": "int", "failed": "int", "parse_errors": "int" },
+    "entries": [
+      { "ok": true,  "ref": "...", "entry_key": "...", "result": { /* AttemptOutcome.chain final, ADR-0029 */ } },
+      { "ok": false, "ref": "...", "entry_key": "...", "error":  { "code": "...", "message": "...", "chain": [...] } },
+      { "ok": false, "ref": null,  "entry_key": "...", "error":  { "code": "INVALID_REF", "message": "no identifier" } }
+    ]
+  }
+}
+```
+
+The tool's structured output mirrors `batch --mode json` per
+ADR-0029 D5 / #212 alignment — same `AttemptOutcome.chain`, same
+`FetchError` shape, plus an `entry_key` to bridge back to the
+operator's library entry. A Zotero plugin can use `entry_key` to
+update the right reference with the fetched PDF.
+
+### D7 — CLI surface: `doiget batch library.bib` (no separate subcommand)
+
+The CLI extension is *not* a new subcommand. `doiget batch <input>`
+already takes one positional argument; the parser detects the
+format. Adding `doiget batch-bibliography` would be a redundant
+subcommand whose only difference from `batch` is the parser — and
+the parser is what's now in core. The CLI command stays single.
+
+`--format` is a new global / subcommand flag introduced alongside;
+it is mutually compatible with the `--store-root` / `--log-path` /
+`--color` / `--progress` set being added under #211 (independent
+slice).
+
+## Consequences
+
+### Positive
+
+1. The Zotero distribution path's structural friction (every user
+   writes their own parser) is removed. The MCP tool unblocks the
+   Zotero-plugin design discussed in the maintainer review on
+   2026-05-20.
+2. `.bib` and CSL-JSON ingestion lives next to the actual fetch
+   pipeline; the per-entry path through #205 batch JSONL is the
+   same regardless of input shape — only the head of the pipeline
+   differs.
+3. `entry_key` is the missing link for downstream "write the fetched
+   PDF back into Zotero / Mendeley" automations.
+
+### Negative
+
+1. **+500 KB on the default binary.** The musl-static release grows
+   from ~10 MB to ~10.5 MB. Acceptable but worth recording.
+2. **Parser bug surface.** `biblatex` is a third-party crate that
+   has known rough edges with exotic BibLaTeX usage (e.g.,
+   `@string` macros, custom field syntaxes). The skip-and-warn
+   policy means *some* of these surface as warnings, not panics;
+   the implementation slice ships a corpus of "weird `.bib`" cases
+   in the test suite.
+3. **Identifier-picking ambiguity.** A `.bib` entry without DOI but
+   with both `eprint` (arXiv) and `url` (a publisher link) is
+   resolved to the arXiv id — never the URL — because URLs are not
+   in the priority list. A subset of users may consider this
+   surprising; the priority list is documented in `docs/CONFIG.md`
+   and surfaced via `doiget capabilities` (the inventory JSON gains
+   a `bibliography_identifier_priority` field).
+4. **No fan-out by design.** Power users wanting "fetch DOI AND
+   arXiv version" cannot get it through the adapter. The documented
+   workflow is to ship the same entry twice through the plain-refs
+   pipe; ADR-0029's chain already does what they probably actually
+   wanted.
+
+### Migration
+
+- v0.3 callers (plain refs) are unaffected: the auto-detection
+  falls through to the `refs` parser on stdin / unrecognised
+  extensions.
+- `--format` flag is additive; missing flag means `auto`.
+- `docs/MCP_TOOLS.md` gains the new tool section; the `mcp_tools`
+  array in `doiget capabilities` JSON (#214 surface) gains the
+  `doiget_batch_from_bibliography` entry.
+- `docs/CONFIG.md` §5 documents the new
+  `bibliography_identifier_priority` (currently a hard-coded list,
+  may be made user-configurable in a later slice if demand exists).
+
+## References
+
+- ADR-0029 (the fetch chain; the `batch_from_bibliography` per-entry
+  output is exactly the chain's `AttemptOutcome`)
+- ADR-0024 (`Ref` canonical form — what the parser must produce)
+- #205 (batch JSONL shape; this ADR's adapter feeds the same shape)
+- #210 (`fetch_one` outcome plumbing; the per-entry `result` field
+  is the same plumbing's output)
+- #212 (MCP/CLI alignment — the principle that motivates putting
+  the parser in core and exposing both the CLI and MCP tool)
+- #214 (`capabilities` inventory; this ADR adds a tool and a
+  priority-list field to that inventory)
+- #222 (the user-facing motivation)
+- 2026-05-20 maintainer review (Zotero distribution path framing)

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -44,6 +44,9 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
 | 0026 | DOI suffix charset extension: permit `:` (SECURITY.md §1.1) | Accepted | #194 | #194 dogfood |
 | 0027 | redirect-allowlist: add physics-society / diamond-OA hosts to `oa-publisher` | Accepted | #193 | #193 dogfood |
+| 0028 | User-extensible capability gate (ToS+verified-curation posture; impersonation out-of-scope) | Accepted (design; slice TBD) | TBD | #220 / #223 |
+| 0029 | Fetch chain: per-Ref multi-attempt resolution with attempt-level provenance | Accepted (design; slice TBD) | TBD | #222 / dogfood 2026-05-20 |
+| 0030 | Bibliography input adapters (.bib / CSL-JSON) in `doiget-core`; new MCP tool `doiget_batch_from_bibliography` | Accepted (design; slice TBD) | TBD | #222 / Zotero distribution review 2026-05-20 |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Promote the `0.4.1-beta.1..beta.13` integration line on `next` to a
stable `v0.4.0` release on `main`. Bumps
`[workspace.package].version` from `0.4.1-beta.13` to `0.4.0` and
consolidates the 13 beta sections into a single `[0.4.0]` CHANGELOG
entry.

SemVer **minor** bump (not patch) — this window introduces multiple
new public surfaces and behavioural changes; full detail in the
consolidated CHANGELOG entry.

## Highlights

- `doiget_core::refs` bibliography input adapters (ADR-0030 slice 1)
- `doiget_core::user_extension` capability gate (ADR-0028)
- `doiget_batch_from_bibliography` MCP tool (ADR-0030 D6) — unlocks
  Zotero distribution path
- Multi-candidate OA-PDF fetch chain (ADR-0029 slice 1) — auto-
  recovers `WAF-blocked publisher → arXiv preprint`
- `FetchPaperOutcome.safekey` / `.canonical_digest` additions (#210)
- 4 new CLI global flags `--store-root` / `--log-path` / `--color` /
  `--progress` (#211)
- `http://` → `https://` URL upgrade for legacy OA metadata
- ADR-0017 Amendment 1 quiet bifurcation — capabilities / bib / csl
  emit on non-TTY pipes

## Follow-up

After this PR merges to `main`, push a signed tag `v0.4.0` to fire
the `release-plz.yml` pipeline (G0-G7 gates per ADR-0025).

The signed-tag step is the **user-gated release step** (release-plz
fires automatically on tag push, but the tag itself requires
`git tag -s v0.4.0 main` from the maintainer's SSH signing key).

## Test plan

- [x] workspace lib tests 367 green (62 cli, 297 core, 8 mcp)
- [x] `cargo build --workspace` clean

Closes #210 (the structured-success-body + denial_context plumbing
is now on main).