### PR TITLE
feat(243): suggest arXiv preprint when primary PDF fetch fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.0] - 2026-05-31
+
+### Added
+- **[core]** Support suggesting an arXiv version when a primary PDF fetch fails. The `PdfLegStatus::Blocked` variant now carries an optional `suggested_arxiv_id` field populated from Unpaywall metadata.
+- **[cli]** The `doiget fetch` command prints a suggested arXiv command when a primary PDF fetch is blocked but an arXiv alternative is available.
+- **[mcp]** The `doiget_fetch` MCP tool output includes the `suggested_arxiv_id` in the `pdf_leg` object when blocked.
+
+
 ## [0.4.0] - 2026-05-21
 
 Promotion of the `0.4.0-beta.1..beta.13` integration line on `next` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,437 +10,151 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-<<<<<<< HEAD
-=======
-## [0.4.1-beta.13] - 2026-05-21
+## [0.4.0] - 2026-05-21
+
+Promotion of the `0.4.1-beta.1..beta.13` integration line on `next` to a
+stable release. SemVer **minor** bump (not patch) — this window
+introduces multiple new public surfaces (`doiget_core::refs` module,
+`doiget_batch_from_bibliography` MCP tool, `FetchPaperOutcome` field
+additions, user-extensible capability gate, fetch chain) and one CLI
+flag set expansion, alongside several behavioural changes for the
+OA-PDF leg and batch JSONL wire shape. Beta-window detail is preserved
+in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
 
 ### Added
 
-- **[mcp]** New MCP tool `doiget_batch_from_bibliography` per
-  ADR-0030 D6 — accepts an absolute `path` to a CSL-JSON file
-  (BibTeX coming in the biblatex slice), parses it via
-  `doiget_core::refs::parse_input`, and fetches every resolvable
-  entry through the existing batch orchestrator. Each result row
-  carries the source bibliography's `entry_key` so a Zotero /
-  Mendeley plugin can bridge the fetched PDF back to the originating
-  reference.
+- **[core] ADR-0028 user-extensible capability gate** — new
+  `doiget_core::user_extension` module parses
+  `<config_dir>/doiget/config.toml`'s `[[network.additional_hosts]]`
+  entries (literal FQDN or single-suffix `*.<suffix>` wildcards) and
+  merges them into the `oa-publisher` redirect allowlist. The `host`
+  field is a `HostPattern` newtype whose `Deserialize` runs validation
+  so the "valid pattern" invariant is type-level. Both `doiget fetch`
+  and `doiget serve` honor the extension; `doiget config doctor`
+  reports health; `doiget capabilities` JSON exposes
+  `user_extension_count`. ToS+verified-curation framing rejects
+  WAF-bypass / impersonation proposals permanently (ADR-0028 D3 and
+  #223 close-rationale).
 
-  Output shape (ADR-0030 D6):
-  ```json
-  {
-    "ok": true,
-    "summary": {"total": 12, "ok": 10, "failed": 1, "parse_errors": 1},
-    "results": [
-      {"entry_key":"Foo2024","ref":"10.1234/foo","ok":true,"path":"...","license":"cc-by",...},
-      {"entry_key":"NoId2025","ref":null,"ok":false,
-       "error":{"code":"INVALID_REF","message":"entry has no DOI / arXiv id"}}
-    ]
-  }
-  ```
+- **[core] ADR-0029 fetch chain (slice 1)** — the DOI OA-PDF leg now
+  walks a multi-candidate chain from Unpaywall's `best_oa_location` +
+  `oa_locations[]` instead of trying only the single "best" URL. On
+  any non-PDF / 403 / network failure the chain advances; first
+  successful candidate wins. Each attempt emits its own
+  `oa-publisher` Fetch provenance row. Recovers the dogfood case
+  where a DOI hits a WAF-blocked publisher but the same record's
+  arXiv preprint is in `oa_locations[]`.
 
-  `strict` input field (default `false`) controls whether the FIRST
-  per-entry parse error aborts the whole call (`true`) or surfaces
-  as a row next to successful siblings (`false`). A whole-input
-  decode failure (malformed CSL-JSON) always aborts regardless of
-  `strict`.
+- **[core] ADR-0030 bibliography input adapters (slice 1)** — new
+  `doiget_core::refs` module exposes `Format`, `ParsedEntry`,
+  `ParseError`, and `parse_input(text, format, path)` that
+  auto-detect plain-refs / CSL-JSON / BibTeX (BibTeX returns
+  `UnsupportedFormat` until the biblatex follow-up slice).
+  Identifier priority is DOI > arXiv > PMID-parking. 23 unit tests
+  cover format detection, the priority rule, Zotero/Mendeley
+  wire-shape quirks, and malformed-input tolerance.
 
-  `doiget capabilities` JSON's `mcp_tools` array gains the new
-  `doiget_batch_from_bibliography` entry; the parity test is
-  updated in lockstep so the table cannot drift from the docs.
+- **[mcp] `doiget_batch_from_bibliography`** — new MCP tool per
+  ADR-0030 D6 accepting a CSL-JSON file path and returning structured
+  per-entry fetch outcomes with the source bibliography's `entry_key`
+  threaded through. Unlocks the Zotero distribution path: a plugin
+  author can hand a `.json` file to `doiget serve` and bridge
+  fetched PDFs back to the originating reference without shelling
+  out. `strict` input field controls per-entry parse-error abort;
+  malformed-input always aborts.
 
-  6 new MCP unit tests cover `parse_bibliography_format`'s token
-  acceptance (auto / refs / csl-json / bibtex / case-insensitivity /
-  underscore variants / unknown-token rejection).
+- **[cli] `doiget batch library.json`** — `doiget batch` now
+  auto-detects CSL-JSON inputs by file extension + content
+  fingerprint and dispatches through `refs::parse_input`. Plain refs
+  files (`.txt`) keep working unchanged. Malformed CSL-JSON aborts
+  with a loud whole-input error rather than silently behaving as an
+  empty batch.
 
->>>>>>> 01150e7 (feat(mcp): doiget_batch_from_bibliography MCP tool (ADR-0030 D6))
-## [0.4.1-beta.12] - 2026-05-21
+- **[cli] `doiget batch --json` structured outcomes (#210 / S4)** —
+  JSONL success records carry
+  `result.{safekey, store_path, canonical_digest}`; failure records
+  carry the typed `ErrorCode` wire string plus an ADR-0023
+  `denial_context` when applicable. `PdfLegStatus::Blocked` outcomes
+  surface as failures with the policy-class reclassification
+  (`effective_blocked_code`).
 
-### Added
+- **[cli] global flags `--store-root` / `--log-path` / `--color` /
+  `--progress` (#211 / S5)** — four new global CLI flags with
+  env-var precedence, ValueEnum drift guards, and 17 unit tests
+  covering precedence and validation.
 
-- **[core]** ADR-0029 fetch chain slice 1 — the DOI OA-PDF leg now
-  walks a multi-candidate chain instead of trying only
-  `best_oa_location` (#222). Candidate URLs are extracted from the
-  Unpaywall envelope in priority order (best_oa_location first, then
-  every distinct entry in `oa_locations[]`); the orchestrator
-  advances past any non-PDF / 403 / network failure until either one
-  candidate yields a valid PDF or every candidate is exhausted. Each
-  attempt emits its own `oa-publisher` Fetch provenance row, so the
-  audit trail captures every external request.
+- **[cli] `doiget config doctor` user-extension surface (ADR-0028
+  D2-3)** — adds a checklist entry reporting
+  `[ ok ] user-extension hosts loaded: N` or
+  `[FAIL] user-extension config invalid: <error>`. Missing config is
+  normal.
 
-  Recovers the dogfood case from the finite-temperature-MPS corpus:
-  a DOI hits `link.aps.org`, the publisher WAF returns 403, but the
-  same record's arXiv preprint is in `oa_locations[]`. Pre-slice-1
-  this surfaced as `PdfLegStatus::Blocked` + metadata-only; post-
-  slice-1 the chain advances to the arXiv preprint and writes a
-  real PDF.
+- **[cli] `doiget capabilities` JSON `user_extension_count` field
+  (ADR-0028 D2-4)** — additive top-level field reporting how many
+  user-extension hosts are loaded on the current host. Drift-guarded
+  by parity test.
 
-  New helper: `doiget_core::orchestrator::extract_oa_url_chain`
-  (private). Removes the now-superseded
-  `extract_best_oa_url_from_value` helper and migrates its tests to
-  the chain extractor; net + 3 unit tests covering ordering,
-  deduplication, fallback-on-no-best, and malformed-URL tolerance.
-  New e2e test
-  `fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403`
-  exercises the WAF-block fallback flow end-to-end.
+- **[core] `FetchPaperOutcome` field additions** —
+  `safekey: String` and `canonical_digest: String` are always-
+  populated additive fields on the `#[non_exhaustive]` struct
+  (#210).
 
-### Notes
-
-- Out of scope for slice 1 (deferred follow-ups):
-  - The structured `chain: Vec<AttemptOutcome>` field on
-    `FetchError` and the new `ALL_FALLBACKS_EXHAUSTED` closed-enum
-    variant (ADR-0029 D5). Today an all-failed chain still surfaces
-    as `PdfLegStatus::Blocked` with the *last* attempt's reason on
-    `denial`; the structured per-attempt list is reserved for the
-    MCP / CLI JSON wire-shape slice that follows #212 alignment.
-  - The schema-additive `chain_attempt` / `chain_total` /
-    `chain_terminal` / `verified_by` columns on the provenance log
-    (ADR-0029 D4). Today each chain attempt is logged as a
-    standalone Fetch row indistinguishable from the pre-slice-1
-    shape; the per-attempt enrichment is deferred.
-
-## [0.4.1-beta.11] - 2026-05-21
-
-### Added
-
-- **[core]** New `doiget_core::refs` module per ADR-0030 slice 1 —
-  bibliography input adapters. Exposes
-  `Format { Auto, Refs, CslJson, Bibtex }`,
-  `ParsedEntry { ref_, entry_key }`,
-  `ParseError { NoIdentifier, InvalidRef, Decode,
-  UnsupportedFormat }` (closed-enum, `#[non_exhaustive]`), and
-  `parse_input(text, format, path) -> Vec<Result<ParsedEntry,
-  ParseError>>` plus per-format helpers. Honors the ADR-0030 D3
-  identifier-pick priority: `DOI` > arXiv (`archivePrefix == "arXiv"`
-  + `eprint`, or `note: "arXiv:…"`) > (PMID parking). 23 unit tests
-  cover format detection, all parser branches, the priority rule,
-  case-insensitive field matching, and Zotero / Mendeley wire shape
-  quirks.
-
-- **[cli]** `doiget batch library.json` accepts a CSL-JSON export
-  directly. The format is auto-detected from the path extension
-  (`.json` / `.csl`) and the file's leading non-comment character;
-  callers writing plain refs files (`.txt`) keep working with no
-  change. A malformed CSL-JSON document aborts the batch with a
-  loud whole-input error rather than silently behaving as an empty
-  batch. New e2e tests
-  `batch_json_csl_input_yields_one_record_per_entry` and
-  `batch_malformed_csl_json_aborts_with_decode_error`.
+- **[core] `#[doc(hidden)] FetchPaperOutcome::for_test_synthetic`** —
+  test-only constructor exposed for downstream test code to drive
+  classification logic without running the full orchestrator.
 
 ### Changed
 
-- **[cli]** `batch` JSONL `ref` field is now the bare identifier per
-  `docs/PROVENANCE_LOG.md` §3 — `Ref::as_input_str()`'s canonical
-  form — rather than the raw file line. For an input line
-  `arxiv:2401.99999`, the failure record's `ref` is now
-  `"2401.99999"` (no URI scheme). DOI inputs were already in this
-  form. Wire-format-visible: CI consumers parsing the `ref` field
-  should switch from "string match input line" to "regex / parse as
-  DOI or arXiv id". Surfaced because the new `refs::parse_input`
-  pipeline normalises every entry through `Ref::parse` before
-  emitting; the pre-ADR-0030 flow echoed raw lines verbatim.
+- **[core/http] `http://` → `https://` URL upgrade (#220 / S2)** —
+  `fetch_inner` upgrades legacy `http://` URLs returned by metadata
+  sources to `https://` before sending, with case-insensitive
+  `localhost` literal + `.localhost` TLD detection, IPv6 loopback
+  (`::1` + IPv4-mapped) detection, and a `tracing::warn!` on the
+  `set_scheme` fallback. 12 unit tests pin the edge cases.
 
-### Notes
+- **[cli] ADR-0017 Amendment 1: explicit-vs-implicit Quiet (#220 /
+  S1)** — `OutputMode::Quiet` now distinguishes a user's explicit
+  `--quiet` / `--mode quiet` from the implicit TTY-detection
+  fallback. `doiget capabilities` (and `bib` / `csl`) — the artifact
+  commands — respect only explicit Quiet and emit their JSON
+  inventory on non-TTY pipes so an LLM cold-boot from a stripped
+  environment is not silently empty. `ResolvedOutput { mode,
+  quiet_was_explicit }` and `is_artifact_command()` helper added.
 
-- Out of scope for slice 1 (deferred to follow-up slices):
-  - BibTeX / `.bib` parsing — requires the `biblatex` crate
-    (+500 KB) and its cargo-vet transitive exemptions. Until that
-    ships, `Format::Bibtex` returns `ParseError::UnsupportedFormat`
-    with a helpful "re-export as CSL-JSON" hint, and `.bib` file
-    extensions surface that error on the first batch invocation.
-  - `--format` / `--strict` CLI flags.
-  - New MCP tool `doiget_batch_from_bibliography`.
-  - Plumbing `entry_key` into the JSONL `error` object as a typed
-    field (today the citation key is embedded in placeholder
-    `<no-identifier:KEY>` strings that the existing JSONL `ref`
-    surfaces verbatim).
+- **[cli] `FetchHarness::fetch_one` returns
+  `Result<FetchPaperOutcome, FetchError>` (#210)** — replaces the
+  prior `anyhow::Result<()>` so callers can render machine-readable
+  shapes from the same typed outcome. Rendering / `CliExit`
+  synthesis moves to per-caller paths.
 
-## [0.4.1-beta.10] - 2026-05-21
+- **[cli] `batch` JSONL `ref` field** — now the bare identifier per
+  `docs/PROVENANCE_LOG.md` §3 (`Ref::as_input_str()` canonical
+  form) rather than the raw file line. For an input line
+  `arxiv:2401.99999`, the JSONL `ref` is now `"2401.99999"`. DOI
+  inputs were already in this form. Wire-format-visible.
 
-### Added
+### Documentation
 
-- **[mcp]** MCP-server `build_http_client_for_fetch` now merges
-  user-extension hosts from `<config_dir>/doiget/config.toml` per
-  ADR-0028 D2, mirroring the CLI path that landed in beta.8 (#220).
-  Before this slice, a user who configured
-  `[[network.additional_hosts]]` and invoked via `doiget serve`
-  saw no effect — only `doiget fetch` honored the extension. The
-  MCP merge closes that asymmetry; both surfaces now read the same
-  config file with identical failure handling (silent on
-  not-found, `tracing::warn!` on malformed, curated allowlist
-  continues regardless).
+- **ADR-0017 Amendment 1, ADR-0028, ADR-0029, ADR-0030** — four new
+  design records covering quiet bifurcation, the user-extensible
+  capability gate, the fetch chain primitive, and the bibliography
+  input adapters.
 
-- **[cli]** `doiget config doctor` adds a user-extension health
-  check (ADR-0028 D2-3): on a green run the new line reads
-  `[ ok ] user-extension hosts loaded: N`; on a malformed
-  `config.toml` it emits `[FAIL] user-extension config invalid:
-  <error>` and exits 2. A missing `config.toml` is normal (count
-  = 0, no failure) — the user simply has not extended the gate.
+### Notes — deferred to follow-up slices
 
-- **[cli]** `doiget capabilities` JSON gains a top-level
-  `user_extension_count: usize` field (ADR-0028 D2-4) so an LLM
-  cold-booted into doiget can confirm at a glance whether the
-  curated allowlist has been extended on this host. The field
-  counts valid `[[network.additional_hosts]]` entries; parse
-  errors collapse to `0` (use `doiget config doctor` to
-  diagnose). `Capabilities` is `#[non_exhaustive]`, so adding the
-  field is additive for downstream Rust consumers; JSON consumers
-  should ignore unknown fields.
-
-### Changed
-
-- **[cli]** `commands::fetch::config_dir_utf8` lifted from private
-  to `pub(crate)` so sibling modules
-  (`commands::capabilities`, `commands::config`) resolve the same
-  `<config_dir>/doiget/` path the production HTTP-client builder
-  reads from. No behavior change.
-
-### Notes
-
-- Out of scope for this slice (still tracked under #220 / ADR-0028):
-  the `verified_by = "user"` provenance row field (D2-2). That
-  requires allowlist source-attribution plumbing through the
-  redirect closure and is deferred to a follow-up slice.
-
-## [0.4.1-beta.9] - 2026-05-21
-
-### Added
-
-- **[core]** `FetchPaperOutcome` (`doiget_core::orchestrator`) gains
-  two new fields: `safekey: String` and `canonical_digest: String`
-  (#210). Both are always populated — `safekey` from the input ref
-  (`Ref::safekey().as_str()`), `canonical_digest` from
-  `CanonicalRef::digest_hex()` under the outcome's
-  `resolver_profile`. Additive on a `#[non_exhaustive]` struct, so
-  downstream consumers continue to compile without changes.
-
-- **[cli]** `doiget batch --json` JSONL records carry the full
-  structured outcome per `docs/ERRORS.md` §3 (#210):
-  - **Success**: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`.
-    A CI consumer can now pull `safekey` to construct a store-relative
-    path and `canonical_digest` to deduplicate against an audit DB
-    without a follow-up `info` round-trip per ref.
-  - **Failure**: `{"ok":false,"ref":"...","error":{"code":"...","message":"...","denial_context":{...}}}`.
-    The `code` field is now the typed `ErrorCode` wire string (e.g.
-    `CAPABILITY_DENIED` / `NETWORK_ERROR` / `INTERNAL_ERROR`) — the
-    previous generic `FETCH_ERROR` only survives in the JoinSet
-    panic arm where no underlying `FetchError` exists. The
-    `denial_context` key is present only when the failure carries a
-    structured ADR-0023 denial; bare transport / config errors omit
-    the key entirely so consumers can use its presence as a typed-
-    denial discriminator.
-
-  A `PdfLegStatus::Blocked` outcome (an OA PDF was discovered but
-  could not be retrieved per #145) is now surfaced as a failure
-  record with the policy-class `denial_context`, rather than being
-  collapsed into the bare `{ok:true, ref}` shape that #205 left in
-  place. The `effective_blocked_code` reclassification (off-allowlist
-  / insecure-scheme / blocklisted-host → `CAPABILITY_DENIED`) is
-  shared between single-fetch and batch, so the wire code matches the
-  single-fetch CLI exit-code mapping.
-
-### Changed
-
-- **[cli]** `FetchHarness::fetch_one` signature changes from
-  `async fn (..., &Ref) -> anyhow::Result<()>` to
-  `async fn (..., &Ref) -> Result<FetchPaperOutcome, FetchError>`
-  (#210). The rendering + exit-code synthesis that used to live
-  inside `fetch_one` (Blocked-PDF reclassification, `error[CODE]:`
-  stderr, `CliExit` construction) now lives in the per-caller paths
-  (`commands::fetch::run_with_options` for single-fetch,
-  `commands::batch::classify_joined` for batch) so each surface can
-  emit its own machine-readable shape from the same typed outcome.
-  `pub(crate)`, not a public API.
-
-  - `commands::fetch::effective_blocked_code` is lifted from `fn` to
-    `pub(crate) fn` so the batch caller shares the single-fetch
-    reclassification rule.
-  - New `commands::fetch::outcome_is_clean_success` helper collapses
-    the typed `Result<FetchPaperOutcome, FetchError>` to the boolean
-    the `SessionEnd` row's `is_ok` field needs, so a Blocked PDF leg
-    never reads as a green session in the provenance log.
-
-- **[core]** New `#[doc(hidden)] pub fn FetchPaperOutcome::for_test_synthetic(...)`
-  test-only constructor in `doiget_core::orchestrator` so downstream
-  test code (`doiget-cli` batch unit tests) can drive
-  classification logic without running the full orchestrator. Not a
-  stable public API — the signature may change to fit test needs
-  without a `[BREAKING]` callout.
-
-### Notes
-
-- Out of scope (deferred to follow-up issues per #210's Out-of-scope
-  list):
-  - The MCP `doiget_fetch_paper` envelope upgrade to surface
-    `safekey` / `canonical_digest` (the FetchPaperOutcome fields
-    are populated; the envelope-side wire change is a separate
-    item).
-  - `canonical_digest` on `EntryInfo` (`info` / `list-recent` /
-    `search` JSON bodies).
-  - Single-fetch `--json` symmetric output (the CLI single-fetch JSON
-    branch mirroring batch JSONL's single record).
-
-## [0.4.1-beta.8] - 2026-05-21
-
-### Added
-
-- **[core]** New module `doiget_core::user_extension` per ADR-0028
-  D2 (#220). Users can extend the `oa-publisher` redirect allowlist
-  for their own deployment via `[[network.additional_hosts]]` in
-  `<config_dir>/doiget/config.toml`. Pattern grammar is restricted
-  (literal FQDN or single-suffix wildcard `*.<suffix>`); rejection
-  classes are surfaced as a closed-enum `PatternError` for
-  programmatic consumption by the future `doiget config doctor`
-  surface. The `host` field of `UserExtensionHost` is a
-  `HostPattern` newtype that runs validation through its serde
-  `Deserialize`, so the "valid pattern" invariant is type-level —
-  no `UserExtensionHost` value can exist with an invalid host. The
-  orchestrator's production HttpClient construction
-  (`commands::fetch::build_http_client`) loads and merges in one
-  pass; a missing config file is silent, a malformed config is
-  surfaced as `tracing::warn!` and the fetch continues with the
-  curated set.
-
-  Example:
-
-  ```toml
-  # ~/.config/doiget/config.toml
-  [[network.additional_hosts]]
-  host = "ruj.uj.edu.pl"
-  note = "Jagiellonian University Repository — Green OA"
-
-  [[network.additional_hosts]]
-  host = "*.uj.edu.pl"
-  ```
-
-  Out of scope for this slice (tracked as S3b): the
-  `verified_by = "user"` provenance row field (ADR-0028 D2-2),
-  the `doiget config doctor` surface (D2-3), the
-  `capability_gate.user_extension_count` field in `doiget
-  capabilities` JSON (D2-4), and the MCP-server-side merge in
-  `doiget-mcp` (a user who configures
-  `[[network.additional_hosts]]` and invokes via `doiget serve`
-  currently sees no effect; that is the load-bearing item S3b
-  closes).
-
-## [0.4.1-beta.7] - 2026-05-21
-
-### Fixed
-
-- **[core/http]** `http://` URLs returned by OpenAlex / Unpaywall
-  metadata for publishers that have since moved to HTTPS are
-  transparently upgraded to `https://` before the request leaves
-  the process (#220). Without this, the production
-  `https_only(true)` client refused to send and the fetch failed
-  with a generic builder error. The upgrade is skipped for
-  loopback hosts (`localhost`, the RFC 6761 `.localhost` TLD,
-  `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback) so the
-  `new_for_tests_allow_http*` wiremock path is unchanged. TLS
-  posture (ADR-0020) is preserved — the upgrade turns a
-  guaranteed-reject into a real TLS handshake, never a plaintext
-  fallback. Successful upgrades log at `tracing::info!` so the
-  rewrite appears in audit-level logs.
-
-## [0.4.1-beta.5] - 2026-05-21
-
-### Added
-
-- **[cli]** Four new global flags from CONFIG.md §5, completing the
-  documented surface (#211):
-  - `--store-root <PATH>` — overrides `DOIGET_STORE_ROOT` for the
-    on-disk paper store root. Path-shaped values; rejected at parse
-    time when empty or containing NUL bytes (review pass I6 / A4).
-  - `--log-path <PATH>` — overrides `DOIGET_LOG_PATH` for the
-    provenance-log file path. Same parse-time validation as
-    `--store-root`.
-  - `--color <auto|always|never>` — exposes the future ANSI emission
-    knob via the new `DOIGET_COLOR` env var. Surface-only in this
-    slice (no consumer emits ANSI today). The consumer-side resolver
-    will check `NO_COLOR` (present and non-empty per
-    <https://no-color.org/>, any value) **before** consulting
-    `DOIGET_COLOR`; the write boundary in
-    `apply_global_overrides` is intentionally simple and does NOT
-    inspect `NO_COLOR`.
-  - `--progress` / `--no-progress` — pair of mutually exclusive
-    flags writing `DOIGET_PROGRESS=1` / `0`. Surface-only: the
-    `fetch` / `batch` per-ref stderr line is unchanged here; the
-    consumer-side gate lands in a follow-up.
-
-  Each flag implements the CONFIG.md §1 precedence ladder
-  `flag > env > default` by overwriting the matching `DOIGET_*`
-  process env var at the very top of `run_dispatch`, BEFORE any
-  command resolver reads the environment. The existing resolvers
-  (`commands::fetch::resolve_store_root`, `resolve_log_path`,
-  `commands::audit_log::resolve_log_path`) keep their env-driven
-  shape and pick the new value up uniformly — no `ResolvedFlags`
-  struct threaded through eleven `run(..)` signatures.
-
-  Path flags use `camino::Utf8PathBuf` (workspace `clippy.toml`
-  disallowed-types policy bans `std::path::PathBuf`); validation
-  lives in `parse_utf8_path` and runs at clap's `value_parser`
-  layer so empty / NUL-byte inputs fail clean with exit 2.
-
-  Clap-level conflicts: `--progress` ↔ `--no-progress` (exit 2 on
-  both supplied); pre-existing `--mode` ↔ `--json` ↔ `--quiet`
-  conflicts unchanged.
-
-  19 new tests (15 unit on `apply_global_overrides`/`parse_utf8_path`
-  via `serial_test`; 4 e2e on clap conflicts, value acceptance, and
-  empty-value parse-time rejection). Includes a drift guard
-  (`output_color_env_strings_match_clap_parser_side`) that pairs
-  `OutputColor::as_env_value` against clap's `ValueEnum`
-  parser-side spelling — if `rename_all = "lower"` is ever changed,
-  the round-trip catches it.
-
-## [0.4.1-beta.2] - 2026-05-21
-
-### Fixed
-
-- **[cli]** `doiget capabilities` no longer silently exits with empty
-  stdout in non-TTY / agent execution contexts (#219, #220 ADR-0017
-  Amendment 1). The resolver now distinguishes **explicit** Quiet
-  (`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`) from
-  **implicit** Quiet (the non-TTY default), and `capabilities` —
-  classified as an *artifact* command — suppresses stdout only on
-  explicit Quiet. Closes the LLM cold-boot deadlock where an agent
-  ran `doiget capabilities` over a captured pipe and got nothing
-  back. `OutputMode` enum wire format (`DOIGET_MODE` strings, the
-  `modes` array in capabilities JSON) is unchanged; the
-  `quiet_was_explicit` discriminator lives only in-memory on the
-  new `ResolvedOutput` returned by `commands::output::resolve()`.
-  `bib` / `csl` were already correct (they ignore mode); their
-  classification is now documented via the new
-  `is_artifact_command()` helper.
-
-## [0.4.1-beta.1] - 2026-05-21
-
-Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +
-ADR-0028 / 0029 / 0030, design-only — no code change yet).
-Workspace version is bumped to satisfy the version-gate G5
-(non-empty CHANGELOG section for the prospective tag) while the
-implementation slices S1-S8 land separately.
-
-### Added
-
-- **[design]** ADR-0017 Amendment 1: distinguish *explicit* vs
-  *implicit* `Quiet`, classify commands as artifact vs
-  informational. Closes the LLM cold-boot deadlock reported in
-  #219 / #220 once the implementation slice (S1) lands.
-- **[design]** ADR-0028: the capability gate's purpose is
-  **ToS compliance + verified curation**; users may extend it via
-  `config.toml` (literal hosts or single-suffix wildcards) with
-  per-attempt `verified_by = "user"` recorded in the provenance
-  log. Impersonation / WAF bypass / embedded headless browser
-  (#223) are permanently out-of-scope.
-- **[design]** ADR-0029: `fetch_one` resolves to an ordered chain
-  of candidate URLs (OpenAlex `oa_locations[]` order); each
-  attempt becomes its own provenance row (schema-additive on v2).
-  New closed-enum `FetchError` variant `ALL_FALLBACKS_EXHAUSTED`
-  carries `Vec<AttemptOutcome>`.
-- **[design]** ADR-0030: bibliography input adapters
-  (`.bib` / CSL-JSON) live in `doiget-core`; new MCP tool
-  `doiget_batch_from_bibliography` enables the Zotero plugin
-  distribution path. One identifier per entry
-  (DOI > arXiv > PMID); skip-and-warn on parse error by default.
+- ADR-0028 D2-2 `verified_by = "user"` per-attempt provenance row
+  field.
+- ADR-0029 D4/D5: `chain: Vec<AttemptOutcome>` +
+  `ALL_FALLBACKS_EXHAUSTED` + schema-additive `chain_*` provenance
+  columns.
+- ADR-0030 D2/D5/D6: BibTeX/.bib parsing (needs `biblatex` crate +
+  cargo-vet exemptions), `--format` / `--strict` CLI flags,
+  structured `entry_key` on JSONL `error` object.
+- MCP `doiget_fetch_paper` envelope upgrade for `safekey` /
+  `canonical_digest`.
+- `canonical_digest` on `EntryInfo`.
+- Single-fetch `--json` symmetric output.
+- #212 MCP/CLI output shape alignment, #222 batch resumability.
 
 ## [0.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [0.4.0] - 2026-05-21
 
-Promotion of the `0.4.1-beta.1..beta.13` integration line on `next` to a
-stable release. SemVer **minor** bump (not patch) — this window
+Promotion of the `0.4.0-beta.1..beta.13` integration line on `next` to
+a stable release. SemVer **minor** bump (not patch) — this window
 introduces multiple new public surfaces (`doiget_core::refs` module,
 `doiget_batch_from_bibliography` MCP tool, `FetchPaperOutcome` field
 additions, user-extensible capability gate, fetch chain) and one CLI
 flag set expansion, alongside several behavioural changes for the
 OA-PDF leg and batch JSONL wire shape. Beta-window detail is preserved
-in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
+in the merge commits on `next` (see `git log --merges v0.3.0..HEAD`)
+and the ADR set under `docs/DECISIONS/`.
 
 ### Added
 
@@ -120,6 +121,11 @@ in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
   inventory on non-TTY pipes so an LLM cold-boot from a stripped
   environment is not silently empty. `ResolvedOutput { mode,
   quiet_was_explicit }` and `is_artifact_command()` helper added.
+  `audit-log --verify` is NOT routed through
+  `is_artifact_command()` — its `--mode json` body is produced by an
+  internal branch in the subcommand handler rather than by the
+  artifact-vs-informational discriminator; the wire shape is
+  unchanged on this release.
 
 - **[cli] `FetchHarness::fetch_one` returns
   `Result<FetchPaperOutcome, FetchError>` (#210)** — replaces the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.0"
+version = "0.4.1-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.0"
+version = "0.4.1-beta.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.0"
+version = "0.4.1-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.13"
+version       = "0.4.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.13" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.13" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.13" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.0"
+version       = "0.4.1-beta.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -134,8 +134,20 @@ pub async fn run_with_options(
             }
             // `ParseError` is `#[non_exhaustive]`; any future variant
             // surfaces as a generic invalid-ref entry so the batch
-            // does not silently swallow a new failure class.
-            Err(other) => inputs.push(format!("<unhandled parse error: {other}>")),
+            // does not silently swallow a new failure class. The
+            // `tracing::error!` makes the unknown variant LOUD in
+            // logs so an operator notices when this arm fires —
+            // otherwise the operator would only see an `INVALID_REF`
+            // JSONL row indistinguishable from any other parse
+            // failure.
+            Err(other) => {
+                tracing::error!(
+                    error = %other,
+                    "encountered unknown ParseError variant; batch continues with placeholder \
+                     INVALID_REF — this should never happen on a current doiget-core build"
+                );
+                inputs.push(format!("<unhandled parse error: {other}>"));
+            }
         }
     }
 

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -422,6 +422,7 @@ fn classify_joined(
                     code,
                     message,
                     denial,
+                    ..
                 } = &outcome.pdf_leg
                 {
                     let effective = effective_blocked_code(*code, denial.as_ref());
@@ -775,6 +776,7 @@ mod tests {
                 cap: None,
                 actual: None,
             }),
+            suggested_arxiv_id: None,
         };
         let outcome = classify_joined(
             Ok(TaskOutcome {

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -373,14 +373,21 @@ mod tests {
     }
 
     /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`
-    /// causes `doiget config doctor` to FAIL (exit 2). POSIX-only
-    /// because `dirs::config_dir()` on Windows queries the Known
-    /// Folder API directly (ignores APPDATA env), so the test can't
-    /// redirect the config path in a child process the way it can
-    /// via `XDG_CONFIG_HOME` on POSIX. The malformed-config FAIL
-    /// path is platform-independent; this test covers the wiring
-    /// on the platform where it CAN be exercised.
-    #[cfg(unix)]
+    /// causes `doiget config doctor` to FAIL (exit 2). Linux-only
+    /// because `dirs::config_dir()` resolves differently on each
+    /// platform:
+    ///   - Linux: `$XDG_CONFIG_HOME` or `$HOME/.config` (env-driven,
+    ///     testable).
+    ///   - macOS: `~/Library/Application Support` (Known Folder via
+    ///     `NSSearchPathForDirectoriesInDomains`, ignores
+    ///     `XDG_CONFIG_HOME`).
+    ///   - Windows: `%FOLDERID_RoamingAppData%` (Known Folder API,
+    ///     ignores `APPDATA` env in child processes via
+    ///     `assert_cmd`).
+    /// The malformed-config FAIL path is platform-independent; this
+    /// test covers the wiring on the one platform where it CAN be
+    /// exercised in a hermetic test.
+    #[cfg(target_os = "linux")]
     #[test]
     #[serial_test::serial]
     fn doctor_fails_with_malformed_user_extension_config() {

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -499,11 +499,19 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
             code,
             message,
             denial,
+            suggested_arxiv_id,
         } => {
             // Same #145 reclassification as the primary interception in
             // `fetch_one`, so this fail-closed fallback stays consistent.
             let effective = effective_blocked_code(*code, denial.as_ref());
-            render_blocked_error(ref_, outcome, effective, message, denial.as_ref());
+            render_blocked_error(
+                ref_,
+                outcome,
+                effective,
+                message,
+                denial.as_ref(),
+                suggested_arxiv_id.as_deref(),
+            );
         }
         // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
         // degrades to the size-based wording rather than failing the
@@ -624,10 +632,18 @@ pub async fn run_with_options(
                 code,
                 message,
                 denial,
+                suggested_arxiv_id,
             } = &outcome.pdf_leg
             {
                 let effective = effective_blocked_code(*code, denial.as_ref());
-                render_blocked_error(&ref_, &outcome, effective, message, denial.as_ref());
+                render_blocked_error(
+                    &ref_,
+                    &outcome,
+                    effective,
+                    message,
+                    denial.as_ref(),
+                    suggested_arxiv_id.as_deref(),
+                );
                 return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
             }
             emit_success_line(&ref_, &outcome);
@@ -781,6 +797,7 @@ fn render_blocked_error(
     code: ErrorCode,
     message: &str,
     denial: Option<&DenialContext>,
+    suggested_arxiv_id: Option<&str>,
 ) {
     let label = match ref_ {
         Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
@@ -831,6 +848,12 @@ fn render_blocked_error(
         "  = note: metadata-only record written to {}",
         outcome.path
     ));
+    if let Some(arxiv_id) = suggested_arxiv_id {
+        print_err(format_args!(
+            "  = suggest: Try fetching the arXiv version: doiget fetch arxiv:{}",
+            arxiv_id
+        ));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -868,9 +868,24 @@ async fn fetch_paper_doi(
             (r.license, label, chain)
         }
         Err(e) => {
+            // Unpaywall unreachable / errored. We continue with the
+            // Crossref-only metadata, but the resulting empty OA
+            // chain will be reported downstream as
+            // `PdfLegStatus::NoOaUrl` — semantically distinct from
+            // "Unpaywall confirmed no OA URL". The provenance log
+            // already carries an Unpaywall Fetch err row (the
+            // Unpaywall source impl logged its own attempt before
+            // returning), so the audit trail captures the cause; the
+            // tracing line below makes the orchestrator-level signal
+            // loud as well. Surfacing the distinction at the
+            // `PdfLegStatus` level (a new variant like
+            // `MetadataSourceUnavailable`) is a deliberate
+            // follow-up — see CHANGELOG `[0.4.0]` Notes.
             tracing::warn!(
                 error = %e,
-                "unpaywall fetch failed; continuing with crossref-only metadata"
+                doi = %doi.as_str(),
+                "unpaywall fetch failed; OA chain will be empty (downstream PdfLegStatus::NoOaUrl \
+                 is conservative — Unpaywall was unreachable, not authoritatively oa-free)"
             );
             ("unknown".to_string(), "crossref".to_string(), Vec::new())
         }
@@ -944,11 +959,33 @@ async fn fetch_paper_doi(
                     None,
                 )
             }
-            // Unreachable: `oa_chain` is non-empty in this branch, so
-            // at least one iteration set either `succeeded` or
-            // `last_err`. Conservative fallback if a future refactor
-            // breaks the invariant.
-            (None, None) => (PdfLegStatus::NoOaUrl, None),
+            // Defensive fallback. `oa_chain` is non-empty in this
+            // branch, so structurally at least one iteration must set
+            // either `succeeded` or `last_err`. If a future refactor
+            // breaks the invariant we fail CLOSED — surface a
+            // `Blocked` outcome with a self-describing message
+            // rather than `NoOaUrl` (which would falsely tell the
+            // caller no candidate URL was ever discovered). Routes
+            // to `INTERNAL_ERROR` so the CLI's exit-code mapping
+            // signals a doiget bug, not a remote failure.
+            (None, None) => {
+                tracing::error!(
+                    total = oa_chain.len(),
+                    "OA PDF chain walker exhausted without recording success or error \
+                     (defensive fallback — should be unreachable)"
+                );
+                (
+                    PdfLegStatus::Blocked {
+                        code: crate::ErrorCode::InternalError,
+                        message:
+                            "OA PDF chain walker exhausted without recording success or error \
+                             (orchestrator bug — please report)"
+                                .to_string(),
+                        denial: None,
+                    },
+                    None,
+                )
+            }
         }
     };
 
@@ -1104,11 +1141,17 @@ fn write_metadata_and_pdf(
         }
         Err(e) => {
             // Best-effort: record the StoreWrite failure before
-            // propagating. Surface as `SourceSchema` so the
+            // propagating the store.write error. We do NOT
+            // propagate the log-append error itself here — we're
+            // already in an error state from the store, and the
+            // primary failure is what the caller needs to act on.
+            // But the log-append failure is observable via tracing
+            // so an operator can spot a broken hash chain when
+            // both fail. Surface as `SourceSchema` so the
             // FetchError -> ErrorCode collapse routes it to
             // `INTERNAL_ERROR` (closest closed-set fit; `StoreError`
             // does not have a direct closed-set arm).
-            let _ = ctx.log.append(RowInput {
+            if let Err(log_err) = ctx.log.append(RowInput {
                 event: LogEvent::StoreWrite,
                 result: LogResult::Err,
                 capability: Capability::Oa,
@@ -1123,7 +1166,14 @@ fn write_metadata_and_pdf(
                 license: None,
                 store_path: Some(&store_path_relative),
                 canonical_digest: canonical_digest.as_deref(),
-            });
+            }) {
+                tracing::error!(
+                    store_err = %e,
+                    log_err = %log_err,
+                    "BOTH store.write AND provenance log append failed; \
+                     audit trail is broken for this attempt"
+                );
+            }
             Err(FetchError::SourceSchema {
                 hint: format!("store write failed: {e}"),
             })

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -973,35 +973,7 @@ async fn fetch_paper_doi(
             // caller no candidate URL was ever discovered). Routes
             // to `INTERNAL_ERROR` so the CLI's exit-code mapping
             // signals a doiget bug, not a remote failure.
-            (None, None) => {
-                tracing::error!(
-                    total = oa_chain.len(),
-                    "OA PDF chain walker exhausted without recording success or error \
-                     (defensive fallback — should be unreachable)"
-                );
-                (
-                    PdfLegStatus::Blocked {
-                        code: crate::ErrorCode::InternalError,
-                        message:
-                            "OA PDF chain walker exhausted without recording success or error \
-                             (orchestrator bug — please report)"
-                                .to_string(),
-                        denial: None,
-                        suggested_arxiv_id: None,
-                    },
-                    None,
-                )
-            }
-            // Defensive fallback. `oa_chain` is non-empty in this
-            // branch, so structurally at least one iteration must set
-            // either `succeeded` or `last_err`. If a future refactor
-            // breaks the invariant we fail CLOSED — surface a
-            // `Blocked` outcome with a self-describing message
-            // rather than `NoOaUrl` (which would falsely tell the
-            // caller no candidate URL was ever discovered). Routes
-            // to `INTERNAL_ERROR` so the CLI's exit-code mapping
-            // signals a doiget bug, not a remote failure.
-            (None, None) => {
+                        (None, None) => {
                 tracing::error!(
                     total = oa_chain.len(),
                     "OA PDF chain walker exhausted without recording success or error \

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1764,7 +1764,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_oa_url_chain_skips_unparseable_urls() {
+    fn extract_oa_url_chain_skips_unparsable_urls() {
         // A malformed URL in oa_locations[] is dropped silently
         // rather than aborting the chain — the metadata source can
         // emit a stray entry without poisoning the whole fetch.

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -973,7 +973,7 @@ async fn fetch_paper_doi(
             // caller no candidate URL was ever discovered). Routes
             // to `INTERNAL_ERROR` so the CLI's exit-code mapping
             // signals a doiget bug, not a remote failure.
-                        (None, None) => {
+            (None, None) => {
                 tracing::error!(
                     total = oa_chain.len(),
                     "OA PDF chain walker exhausted without recording success or error \
@@ -1600,8 +1600,14 @@ mod tests {
         let urls = [
             ("https://arxiv.org/pdf/1901.12345.pdf", Some("1901.12345")),
             ("https://arxiv.org/abs/1901.12345", Some("1901.12345")),
-            ("https://www.arxiv.org/pdf/cond-mat/9501001.pdf", Some("cond-mat/9501001")),
-            ("https://export.arxiv.org/abs/cond-mat/9501001", Some("cond-mat/9501001")),
+            (
+                "https://www.arxiv.org/pdf/cond-mat/9501001.pdf",
+                Some("cond-mat/9501001"),
+            ),
+            (
+                "https://export.arxiv.org/abs/cond-mat/9501001",
+                Some("cond-mat/9501001"),
+            ),
             ("https://example.org/pdf/1901.12345.pdf", None),
         ];
         for (url_str, expected) in urls {

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -556,6 +556,9 @@ pub enum PdfLegStatus {
         /// Structured denial side-channel (ADR-0023) when the failure
         /// was an allowlist / scheme denial; `None` otherwise.
         denial: Option<crate::DenialContext>,
+        /// Actionable suggested arXiv ID for the same paper when Unpaywall
+        /// metadata includes an arXiv alternative but the PDF leg was blocked.
+        suggested_arxiv_id: Option<String>,
     },
 }
 
@@ -950,11 +953,13 @@ async fn fetch_paper_doi(
                 let denial: Option<crate::DenialContext> = (&fe).into();
                 let message = fe.to_string();
                 let code: crate::ErrorCode = fe.into();
+                let suggested_arxiv_id = oa_chain.iter().find_map(extract_arxiv_id_from_url);
                 (
                     PdfLegStatus::Blocked {
                         code,
                         message,
                         denial,
+                        suggested_arxiv_id,
                     },
                     None,
                 )
@@ -982,6 +987,7 @@ async fn fetch_paper_doi(
                              (orchestrator bug — please report)"
                                 .to_string(),
                         denial: None,
+                        suggested_arxiv_id: None,
                     },
                     None,
                 )
@@ -1461,6 +1467,23 @@ fn pull_oa_url_from_location(loc: &Value) -> Option<url::Url> {
     url::Url::parse(candidate).ok()
 }
 
+/// Helper to parse clean arXiv IDs from URLs like arxiv.org/pdf/1901.12345.pdf
+fn extract_arxiv_id_from_url(url: &url::Url) -> Option<String> {
+    if let Some(host) = url.host_str() {
+        if host == "arxiv.org" || host == "www.arxiv.org" || host == "export.arxiv.org" {
+            let path = url.path();
+            if path.starts_with("/pdf/") {
+                let stripped = path.strip_prefix("/pdf/")?;
+                let stripped = stripped.strip_suffix(".pdf").unwrap_or(stripped);
+                return Some(stripped.to_string());
+            } else if path.starts_with("/abs/") {
+                return Some(path.strip_prefix("/abs/")?.to_string());
+            }
+        }
+    }
+    None
+}
+
 fn unpaywall_email_from_env(fallback_contact: &str) -> String {
     std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| fallback_contact.to_string())
 }
@@ -1571,6 +1594,21 @@ pub fn batch_fetch_plans(
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_extract_arxiv_id_from_url() {
+        let urls = [
+            ("https://arxiv.org/pdf/1901.12345.pdf", Some("1901.12345")),
+            ("https://arxiv.org/abs/1901.12345", Some("1901.12345")),
+            ("https://www.arxiv.org/pdf/cond-mat/9501001.pdf", Some("cond-mat/9501001")),
+            ("https://export.arxiv.org/abs/cond-mat/9501001", Some("cond-mat/9501001")),
+            ("https://example.org/pdf/1901.12345.pdf", None),
+        ];
+        for (url_str, expected) in urls {
+            let url = url::Url::parse(url_str).unwrap();
+            assert_eq!(extract_arxiv_id_from_url(&url), expected.map(String::from));
+        }
+    }
 
     #[test]
     fn extract_crossref_oa_url_finds_first_url() {

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2019,6 +2019,7 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
             code,
             message,
             denial,
+            suggested_arxiv_id,
         } => {
             let mut o = serde_json::Map::new();
             o.insert("status".into(), json!("blocked"));
@@ -2037,6 +2038,9 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
                     "denial_context".into(),
                     denial_context_to_value(dc, "fetch_paper_pdf_leg"),
                 );
+            }
+            if let Some(arxiv_id) = suggested_arxiv_id {
+                o.insert("suggested_arxiv_id".into(), json!(arxiv_id));
             }
             Value::Object(o)
         }


### PR DESCRIPTION
Resolves #243. This PR adds support for suggesting arXiv alternatives when primary fetches are blocked.