### PR TITLE
fix(243-followup): strip arXiv version suffix, add e-print host, MCP e2e test, docs

### DIFF
--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1467,21 +1467,49 @@ fn pull_oa_url_from_location(loc: &Value) -> Option<url::Url> {
     url::Url::parse(candidate).ok()
 }
 
-/// Helper to parse clean arXiv IDs from URLs like arxiv.org/pdf/1901.12345.pdf
+/// Helper to parse clean arXiv IDs from URLs like arxiv.org/pdf/1901.12345.pdf.
+///
+/// Strips the trailing `.pdf` extension and any version suffix (`v1`, `v2`, …)
+/// so the returned ID refers to the latest version rather than pinning a
+/// specific one. Returns `None` for non-arXiv hosts or unrecognised path shapes.
 fn extract_arxiv_id_from_url(url: &url::Url) -> Option<String> {
-    if let Some(host) = url.host_str() {
-        if host == "arxiv.org" || host == "www.arxiv.org" || host == "export.arxiv.org" {
-            let path = url.path();
-            if path.starts_with("/pdf/") {
-                let stripped = path.strip_prefix("/pdf/")?;
-                let stripped = stripped.strip_suffix(".pdf").unwrap_or(stripped);
-                return Some(stripped.to_string());
-            } else if path.starts_with("/abs/") {
-                return Some(path.strip_prefix("/abs/")?.to_string());
-            }
+    let host = url.host_str()?;
+    let is_arxiv = matches!(
+        host,
+        "arxiv.org" | "www.arxiv.org" | "export.arxiv.org" | "e-print.arxiv.org"
+    );
+    if !is_arxiv {
+        return None;
+    }
+    let path = url.path();
+    let raw = if path.starts_with("/pdf/") {
+        let s = path.strip_prefix("/pdf/")?;
+        s.strip_suffix(".pdf").unwrap_or(s)
+    } else if path.starts_with("/abs/") {
+        path.strip_prefix("/abs/")?
+    } else {
+        return None;
+    };
+    Some(strip_arxiv_version(raw).to_string())
+}
+
+/// Strip a trailing arXiv version suffix (`v1`, `v2`, …) from an ID string.
+///
+/// Recognises the suffix only when the `v` is **preceded by a digit** (ruling
+/// out category fragments like `quant-ph`) and followed by one or more ASCII
+/// digits. Leaves IDs without a recognisable version suffix unchanged.
+fn strip_arxiv_version(id: &str) -> &str {
+    if let Some(v_pos) = id.rfind('v') {
+        let before_v = id[..v_pos].chars().next_back();
+        let suffix = &id[v_pos + 1..];
+        if before_v.map_or(false, |c| c.is_ascii_digit())
+            && !suffix.is_empty()
+            && suffix.bytes().all(|b| b.is_ascii_digit())
+        {
+            return &id[..v_pos];
         }
     }
-    None
+    id
 }
 
 fn unpaywall_email_from_env(fallback_contact: &str) -> String {
@@ -1598,8 +1626,13 @@ mod tests {
     #[test]
     fn test_extract_arxiv_id_from_url() {
         let urls = [
+            // Basic new-style ID
             ("https://arxiv.org/pdf/1901.12345.pdf", Some("1901.12345")),
             ("https://arxiv.org/abs/1901.12345", Some("1901.12345")),
+            // Version suffix is stripped
+            ("https://arxiv.org/pdf/1901.12345v2.pdf", Some("1901.12345")),
+            ("https://arxiv.org/abs/1901.12345v3", Some("1901.12345")),
+            // Old-style category/ID
             (
                 "https://www.arxiv.org/pdf/cond-mat/9501001.pdf",
                 Some("cond-mat/9501001"),
@@ -1608,12 +1641,40 @@ mod tests {
                 "https://export.arxiv.org/abs/cond-mat/9501001",
                 Some("cond-mat/9501001"),
             ),
+            // Old-style with version stripped
+            (
+                "https://arxiv.org/pdf/cond-mat/9501001v1.pdf",
+                Some("cond-mat/9501001"),
+            ),
+            // e-print subdomain
+            (
+                "https://e-print.arxiv.org/pdf/2401.12345.pdf",
+                Some("2401.12345"),
+            ),
+            // Non-arXiv host
             ("https://example.org/pdf/1901.12345.pdf", None),
         ];
         for (url_str, expected) in urls {
             let url = url::Url::parse(url_str).unwrap();
-            assert_eq!(extract_arxiv_id_from_url(&url), expected.map(String::from));
+            assert_eq!(
+                extract_arxiv_id_from_url(&url),
+                expected.map(String::from),
+                "url: {url_str}"
+            );
         }
+    }
+
+    #[test]
+    fn test_strip_arxiv_version() {
+        assert_eq!(strip_arxiv_version("2401.12345v2"), "2401.12345");
+        assert_eq!(strip_arxiv_version("2401.12345v10"), "2401.12345");
+        assert_eq!(strip_arxiv_version("2401.12345"), "2401.12345");
+        assert_eq!(
+            strip_arxiv_version("cond-mat/9501001v3"),
+            "cond-mat/9501001"
+        );
+        // "v" not followed by digits — unchanged
+        assert_eq!(strip_arxiv_version("quant-phv5"), "quant-phv5");
     }
 
     #[test]

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1502,7 +1502,7 @@ fn strip_arxiv_version(id: &str) -> &str {
     if let Some(v_pos) = id.rfind('v') {
         let before_v = id[..v_pos].chars().next_back();
         let suffix = &id[v_pos + 1..];
-        if before_v.map_or(false, |c| c.is_ascii_digit())
+        if before_v.is_some_and(|c| c.is_ascii_digit())
             && !suffix.is_empty()
             && suffix.bytes().all(|b| b.is_ascii_digit())
         {

--- a/crates/doiget-mcp/tests/fetch_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/fetch_paper_e2e.rs
@@ -468,3 +468,118 @@ async fn batch_fetch_partial_failure_emits_per_ref_outcomes() -> anyhow::Result<
     drop(td);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// suggested_arxiv_id — issue #243
+// ---------------------------------------------------------------------------
+
+/// When all OA-chain PDF candidates fail and at least one candidate URL is
+/// hosted on arxiv.org, `doiget_fetch_paper` MUST include `suggested_arxiv_id`
+/// in the `pdf` object of the success envelope (the PDF leg is `blocked`).
+/// The version suffix (e.g. `v2`) must be stripped so the suggestion points
+/// to the latest version rather than a pinned one.
+#[tokio::test]
+#[serial_test::serial]
+async fn fetch_paper_doi_blocked_pdf_includes_suggested_arxiv_id() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+
+    // Crossref metadata — minimal envelope.
+    // Crossref uses `Url::join("/works/<doi>")` which does NOT percent-encode
+    // the `/` inside the DOI suffix, so wiremock matches the raw path.
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/suggest-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "message": {
+                "title": ["Suggestion Test Paper"],
+                "author": [{"family": "Doe", "given": "Jane"}],
+                "issued": {"date-parts": [[2024, 1, 1]]}
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    // Unpaywall metadata — `best_oa_location` points to a versioned arXiv URL.
+    // The arXiv host is off the `oa-publisher` allowlist (which only permits
+    // the wiremock host), so the PDF leg will be denied at the pre-fetch
+    // allowlist check, triggering PdfLegStatus::Blocked with a suggestion.
+    // Unpaywall uses `path_segments_mut().push()` which percent-encodes `/`.
+    Mock::given(method("GET"))
+        .and(path("/v2/10.1234%2Fsuggest-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "doi": "10.1234/suggest-test",
+            "is_oa": true,
+            "best_oa_location": {
+                "url_for_pdf": "https://arxiv.org/pdf/2401.99999v2.pdf",
+                "url": "https://arxiv.org/abs/2401.99999v2",
+                "license": "cc-by"
+            },
+            "oa_locations": [
+                {
+                    "url_for_pdf": "https://arxiv.org/pdf/2401.99999v2.pdf",
+                    "url": "https://arxiv.org/abs/2401.99999v2"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let temp_root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", server.uri()));
+    // Register only the wiremock host for oa-publisher. arxiv.org is absent
+    // so the arXiv OA candidate is denied → PdfLegStatus::Blocked.
+    env.set("DOIGET_OA_PUBLISHER_BASE", &server.uri());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/suggest-test"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_fetch_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_fetch_paper uses CallToolResult::structured");
+
+    // Metadata fetch succeeds (ok:true) but PDF leg is blocked.
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope should be ok:true (metadata was written); got: {structured:?}"
+    );
+    assert_eq!(
+        structured["pdf"]["status"],
+        serde_json::json!("blocked"),
+        "pdf leg must be blocked; got: {:?}",
+        structured["pdf"]
+    );
+    // Version suffix `v2` must be stripped — suggestion points to latest version.
+    assert_eq!(
+        structured["pdf"]["suggested_arxiv_id"],
+        serde_json::json!("2401.99999"),
+        "suggested_arxiv_id must be present and version-stripped; got: {:?}",
+        structured["pdf"]["suggested_arxiv_id"]
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -91,6 +91,8 @@ type FetchResult =
       license: string,
       size_bytes: number,
       schema_version: string,
+      // Issue #118 / #243: PDF leg status. Always present on ok:true responses.
+      pdf: PdfLeg,
     }
   | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
       rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
@@ -98,6 +100,22 @@ type FetchResult =
       ref: string,
       error: { code: ErrorCode, message: string, denial_context?: DenialContext }
     };
+
+type PdfLeg =
+  | { status: "fetched" }
+  | { status: "no_oa_url" }
+  | { status: "blocked",
+      code: ErrorCode,
+      message: string,
+      // Present when the failure was an allowlist / scheme denial (ADR-0023).
+      denial_context?: DenialContext,
+      // Present when Unpaywall metadata includes an arXiv alternative URL
+      // for the same paper. The version suffix (e.g. `v2`) is stripped so
+      // the ID refers to the latest version. Use as:
+      //   doiget fetch arxiv:<suggested_arxiv_id>
+      suggested_arxiv_id?: string,
+    }
+  | { status: "unknown" };
 
 type DenialContext = {
   reason: "redirect_not_in_allowlist" | "insecure_scheme"


### PR DESCRIPTION
## Summary

Follow-up to #244 addressing review findings from the post-merge review.

- **Version suffix stripping**: `extract_arxiv_id_from_url` now strips the trailing `vN` suffix (e.g. `2401.12345v2` → `2401.12345`) so `suggested_arxiv_id` always points to the latest version rather than pinning a specific one. The `v` is only stripped when immediately preceded by a digit, ruling out category fragments like `quant-ph`.
- **`e-print.arxiv.org` host**: Added to the recognised arXiv host set alongside `arxiv.org`, `www.arxiv.org`, and `export.arxiv.org`.
- **MCP e2e test**: New `fetch_paper_doi_blocked_pdf_includes_suggested_arxiv_id` test (wiremock-driven) that exercises the full path: DOI fetch → Crossref/Unpaywall mocks → arXiv OA URL off allowlist → `pdf.status=blocked` → `suggested_arxiv_id` present and version-stripped.
- **Docs**: Added `PdfLeg` type to `MCP_TOOLS.md` §5 documenting all three status variants and the optional `suggested_arxiv_id` field with usage example. Added `pdf: PdfLeg` to the `FetchResult` ok:true arm.

## Test plan

- [ ] `cargo test --workspace` passes (all 36 test suites green)
- [ ] New MCP e2e test `fetch_paper_doi_blocked_pdf_includes_suggested_arxiv_id` passes
- [ ] New unit tests `test_strip_arxiv_version` and expanded `test_extract_arxiv_id_from_url` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)