### PR TITLE
feat(236): add doiget version --check (Slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "doiget-mcp",
  "flate2",
  "predicates",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -55,6 +55,8 @@ ulid               = { workspace = true }
 # URL parsing for the source-base env-var overrides
 # (`DOIGET_ARXIV_BASE` / `DOIGET_CROSSREF_BASE` / `DOIGET_UNPAYWALL_BASE`).
 url                = { workspace = true }
+# Used by `doiget version --check` to query the GitHub Releases API.
+reqwest            = { workspace = true }
 # Production dep: the orchestrator stages PDF bytes to a tempfile so the
 # existing `Store::write(_, _, Some(&Utf8Path))` atomic-rename code path
 # applies (Source impls return `Bytes`, Store takes a path).

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -494,6 +494,15 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
             json_mode: JsonMode::Artifact,
             feature_gated: Some("citation"),
         },
+        "version" => SubcommandMeta {
+            examples: &[
+                "doiget version",
+                "doiget version --check",
+                "doiget version --check --mode json",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
         "capabilities" => SubcommandMeta {
             examples: &["doiget capabilities | jq ."],
             // The whole point of capabilities IS JSON output.

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod output;
 pub mod provenance;
 pub mod resolve_citation;
 pub mod search;
+pub mod version;
 
 // Phase 4 / Slice 16. Compile-gated by the `citation` Cargo feature
 // (which itself enables `doiget-core/citation`).

--- a/crates/doiget-cli/src/commands/version.rs
+++ b/crates/doiget-cli/src/commands/version.rs
@@ -22,6 +22,7 @@
 //! so callers never receive a hard error just because GitHub is slow.
 
 use std::io::Write;
+use std::time::Duration;
 
 use anyhow::Result;
 use serde::Serialize;
@@ -32,19 +33,32 @@ const CURRENT: &str = env!("CARGO_PKG_VERSION");
 
 const RELEASES_API: &str = "https://api.github.com/repos/sotashimozono/doiget/releases";
 
+/// Connect + read timeout for the version check HTTP request.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Return the releases endpoint URL, honouring `DOIGET_GITHUB_BASE` for
 /// integration tests (same override pattern as `DOIGET_CROSSREF_BASE` etc.).
-fn releases_url() -> String {
+///
+/// Returns an error when `DOIGET_GITHUB_BASE` is set but not a valid URL.
+fn releases_url() -> anyhow::Result<String> {
     match std::env::var("DOIGET_GITHUB_BASE").ok() {
-        Some(base) => format!(
-            "{}/repos/sotashimozono/doiget/releases",
-            base.trim_end_matches('/')
-        ),
-        None => RELEASES_API.to_string(),
+        Some(base) => {
+            url::Url::parse(&base)
+                .map_err(|e| anyhow::anyhow!("invalid DOIGET_GITHUB_BASE: {e}"))?;
+            Ok(format!(
+                "{}/repos/sotashimozono/doiget/releases",
+                base.trim_end_matches('/')
+            ))
+        }
+        None => Ok(RELEASES_API.to_string()),
     }
 }
 
 /// Output shape for `--check` in JSON mode.
+///
+/// On failure `latest`, `newer_available`, and `html_url` are `null`;
+/// `error` carries a human-readable reason. These `null` fields are stable
+/// wire format — they are present, not absent, in the error path.
 #[derive(Debug, Serialize)]
 pub struct VersionCheckResult {
     /// Current compiled-in version.
@@ -134,9 +148,12 @@ async fn try_fetch_latest() -> anyhow::Result<VersionCheckResult> {
     doiget_core::http::init_tls();
     let client = reqwest::Client::builder()
         .user_agent(format!("doiget/{CURRENT}"))
+        .timeout(CHECK_TIMEOUT)
         .build()?;
 
-    let resp = client.get(releases_url()).send().await.map_err(|e| {
+    let url = releases_url()?;
+
+    let resp = client.get(url).send().await.map_err(|e| {
         if e.is_connect() || e.is_timeout() {
             anyhow::anyhow!("unreachable")
         } else {
@@ -194,13 +211,20 @@ async fn try_fetch_latest() -> anyhow::Result<VersionCheckResult> {
 
 /// Return `true` when `candidate` is strictly newer than `current` by
 /// dot-separated numeric comparison on the version core (before any `-`
-/// pre-release suffix).
+/// pre-release suffix). Both vectors are padded to equal length so that
+/// `"1.0"` and `"1.0.0"` compare equal rather than the shorter one
+/// appearing lesser.
 fn is_newer(candidate: &str, current: &str) -> bool {
     let parse = |s: &str| -> Vec<u64> {
         let core = s.split('-').next().unwrap_or(s);
         core.split('.').map(|p| p.parse().unwrap_or(0)).collect()
     };
-    parse(candidate) > parse(current)
+    let mut a = parse(candidate);
+    let mut b = parse(current);
+    let len = a.len().max(b.len());
+    a.resize(len, 0);
+    b.resize(len, 0);
+    a > b
 }
 
 /// Return `true` when a version string has a known pre-release suffix.
@@ -228,10 +252,33 @@ mod tests {
     }
 
     #[test]
+    fn is_newer_pads_mismatched_component_counts() {
+        // "1.0" and "1.0.0" must compare equal, not report "1.0" as older.
+        assert!(!is_newer("1.0", "1.0.0"));
+        assert!(!is_newer("1.0.0", "1.0"));
+        assert!(is_newer("1.0.1", "1.0"));
+    }
+
+    #[test]
     fn has_prerelease_suffix_cases() {
         assert!(has_prerelease_suffix("0.4.1-beta.0"));
         assert!(has_prerelease_suffix("1.0.0-alpha"));
         assert!(has_prerelease_suffix("1.0.0-rc.1"));
         assert!(!has_prerelease_suffix("0.4.0"));
+    }
+
+    #[test]
+    fn releases_url_rejects_invalid_base() {
+        std::env::set_var("DOIGET_GITHUB_BASE", "not a url !!!");
+        let result = releases_url();
+        std::env::remove_var("DOIGET_GITHUB_BASE");
+        assert!(result.is_err(), "invalid base must return Err");
+    }
+
+    #[test]
+    fn releases_url_falls_back_to_production_when_unset() {
+        std::env::remove_var("DOIGET_GITHUB_BASE");
+        let url = releases_url().expect("fallback must succeed");
+        assert_eq!(url, RELEASES_API);
     }
 }

--- a/crates/doiget-cli/src/commands/version.rs
+++ b/crates/doiget-cli/src/commands/version.rs
@@ -1,0 +1,223 @@
+//! `doiget version [--check]` — print the current version and optionally
+//! query GitHub Releases for the latest stable tag.
+//!
+//! Without `--check` the command prints the compiled-in version string and
+//! exits immediately (no network, no side-effects).
+//!
+//! With `--check` it queries the GitHub Releases API, compares with the
+//! compiled-in version, and emits a machine-readable JSON object:
+//!
+//! ```json
+//! {
+//!   "current":          "0.4.1-beta.0",
+//!   "latest":           "0.4.0",
+//!   "newer_available":  false,
+//!   "html_url":         "https://github.com/…/releases/tag/v0.4.0"
+//! }
+//! ```
+//!
+//! When the check fails (rate-limited, network down) the `latest` and
+//! `html_url` fields are `null` and an `error` key is populated instead,
+//! so callers never receive a hard error just because GitHub is slow.
+
+use std::io::Write;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use super::output::OutputMode;
+
+const CURRENT: &str = env!("CARGO_PKG_VERSION");
+
+const RELEASES_API: &str = "https://api.github.com/repos/sotashimozono/doiget/releases";
+
+/// Output shape for `--check` in JSON mode.
+#[derive(Debug, Serialize)]
+pub struct VersionCheckResult {
+    /// Current compiled-in version.
+    pub current: &'static str,
+    /// Latest stable tag without the `v` prefix (e.g. `"0.4.0"`).
+    /// `null` when the check could not complete.
+    pub latest: Option<String>,
+    /// `true` when `latest` is set and strictly newer than `current`.
+    /// `null` when `latest` is `null`.
+    pub newer_available: Option<bool>,
+    /// GitHub release page URL. `null` when the check could not complete.
+    pub html_url: Option<String>,
+    /// Human-readable error reason when the check failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Entry point for `doiget version [--check]`.
+pub async fn run(check: bool, mode: OutputMode) -> Result<()> {
+    if mode == OutputMode::Quiet || mode == OutputMode::Mcp {
+        return Ok(());
+    }
+
+    if !check {
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        if mode == OutputMode::Json {
+            writeln!(
+                out,
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({ "version": CURRENT }))?
+            )?;
+        } else {
+            writeln!(out, "doiget {CURRENT}")?;
+        }
+        return Ok(());
+    }
+
+    let result = fetch_latest().await;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    if mode == OutputMode::Json {
+        writeln!(out, "{}", serde_json::to_string_pretty(&result)?)?;
+    } else {
+        match (&result.latest, &result.newer_available) {
+            (Some(latest), Some(true)) => {
+                writeln!(out, "doiget {CURRENT} — update available: {latest}")?;
+                if let Some(url) = &result.html_url {
+                    writeln!(out, "  {url}")?;
+                }
+            }
+            (Some(latest), _) => {
+                writeln!(
+                    out,
+                    "doiget {CURRENT} — up to date (latest stable: {latest})"
+                )?;
+            }
+            (None, _) => {
+                let reason = result.error.as_deref().unwrap_or("unknown");
+                writeln!(out, "doiget {CURRENT} — version check failed: {reason}")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Query the GitHub Releases API and return the latest stable (non-prerelease,
+/// non-draft) release. Returns a populated `error` field on any failure so
+/// callers are never hard-blocked by a network hiccup.
+async fn fetch_latest() -> VersionCheckResult {
+    match try_fetch_latest().await {
+        Ok(r) => r,
+        Err(e) => VersionCheckResult {
+            current: CURRENT,
+            latest: None,
+            newer_available: None,
+            html_url: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+async fn try_fetch_latest() -> anyhow::Result<VersionCheckResult> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("doiget/{CURRENT}"))
+        .build()?;
+
+    let resp = client.get(RELEASES_API).send().await.map_err(|e| {
+        if e.is_connect() || e.is_timeout() {
+            anyhow::anyhow!("unreachable")
+        } else {
+            anyhow::anyhow!("{e}")
+        }
+    })?;
+
+    if resp.status().as_u16() == 403 {
+        return Err(anyhow::anyhow!("rate_limited"));
+    }
+
+    let releases: serde_json::Value = resp.error_for_status()?.json().await?;
+
+    let arr = releases
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("unexpected API shape"))?;
+
+    // First non-draft, non-prerelease release without a pre-release suffix.
+    let stable = arr.iter().find(|r| {
+        let draft = r.get("draft").and_then(|v| v.as_bool()).unwrap_or(true);
+        let prerelease = r
+            .get("prerelease")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        if draft || prerelease {
+            return false;
+        }
+        let tag = r.get("tag_name").and_then(|v| v.as_str()).unwrap_or("");
+        let bare = tag.strip_prefix('v').unwrap_or(tag);
+        !has_prerelease_suffix(bare)
+    });
+
+    let Some(release) = stable else {
+        return Err(anyhow::anyhow!("no stable release found"));
+    };
+
+    let tag = release
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing tag_name"))?;
+    let html_url = release
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let latest = tag.strip_prefix('v').unwrap_or(tag).to_string();
+
+    Ok(VersionCheckResult {
+        current: CURRENT,
+        newer_available: Some(is_newer(&latest, CURRENT)),
+        latest: Some(latest),
+        html_url,
+        error: None,
+    })
+}
+
+/// Return `true` when `candidate` is strictly newer than `current` by
+/// dot-separated numeric comparison on the version core (before any `-`
+/// pre-release suffix).
+fn is_newer(candidate: &str, current: &str) -> bool {
+    let parse = |s: &str| -> Vec<u64> {
+        let core = s.split('-').next().unwrap_or(s);
+        core.split('.').map(|p| p.parse().unwrap_or(0)).collect()
+    };
+    parse(candidate) > parse(current)
+}
+
+/// Return `true` when a version string has a known pre-release suffix.
+fn has_prerelease_suffix(version: &str) -> bool {
+    let lower = version.to_ascii_lowercase();
+    lower.contains("-beta") || lower.contains("-alpha") || lower.contains("-rc")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_detects_upgrade() {
+        assert!(is_newer("0.5.0", "0.4.0"));
+        assert!(is_newer("0.4.1", "0.4.0"));
+        assert!(!is_newer("0.4.0", "0.4.0"));
+        assert!(!is_newer("0.3.9", "0.4.0"));
+    }
+
+    #[test]
+    fn is_newer_ignores_prerelease_suffix_in_current() {
+        assert!(!is_newer("0.4.0", "0.4.1-beta.0"));
+        assert!(is_newer("0.5.0", "0.4.1-beta.0"));
+    }
+
+    #[test]
+    fn has_prerelease_suffix_cases() {
+        assert!(has_prerelease_suffix("0.4.1-beta.0"));
+        assert!(has_prerelease_suffix("1.0.0-alpha"));
+        assert!(has_prerelease_suffix("1.0.0-rc.1"));
+        assert!(!has_prerelease_suffix("0.4.0"));
+    }
+}

--- a/crates/doiget-cli/src/commands/version.rs
+++ b/crates/doiget-cli/src/commands/version.rs
@@ -32,6 +32,18 @@ const CURRENT: &str = env!("CARGO_PKG_VERSION");
 
 const RELEASES_API: &str = "https://api.github.com/repos/sotashimozono/doiget/releases";
 
+/// Return the releases endpoint URL, honouring `DOIGET_GITHUB_BASE` for
+/// integration tests (same override pattern as `DOIGET_CROSSREF_BASE` etc.).
+fn releases_url() -> String {
+    match std::env::var("DOIGET_GITHUB_BASE").ok() {
+        Some(base) => format!(
+            "{}/repos/sotashimozono/doiget/releases",
+            base.trim_end_matches('/')
+        ),
+        None => RELEASES_API.to_string(),
+    }
+}
+
 /// Output shape for `--check` in JSON mode.
 #[derive(Debug, Serialize)]
 pub struct VersionCheckResult {
@@ -119,11 +131,12 @@ async fn fetch_latest() -> VersionCheckResult {
 }
 
 async fn try_fetch_latest() -> anyhow::Result<VersionCheckResult> {
+    doiget_core::http::init_tls();
     let client = reqwest::Client::builder()
         .user_agent(format!("doiget/{CURRENT}"))
         .build()?;
 
-    let resp = client.get(RELEASES_API).send().await.map_err(|e| {
+    let resp = client.get(releases_url()).send().await.map_err(|e| {
         if e.is_connect() || e.is_timeout() {
             anyhow::anyhow!("unreachable")
         } else {

--- a/crates/doiget-cli/src/commands/version.rs
+++ b/crates/doiget-cli/src/commands/version.rs
@@ -1,3 +1,4 @@
+// allow: outbound-network
 //! `doiget version [--check]` — print the current version and optionally
 //! query GitHub Releases for the latest stable tag.
 //!

--- a/crates/doiget-cli/src/commands/version.rs
+++ b/crates/doiget-cli/src/commands/version.rs
@@ -234,6 +234,7 @@ fn has_prerelease_suffix(version: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -288,6 +288,13 @@ enum Command {
         #[command(subcommand)]
         action: ProvenanceAction,
     },
+    /// Print the current version. With `--check`, query GitHub Releases for
+    /// the latest stable tag and report whether an update is available.
+    Version {
+        /// Check GitHub Releases for a newer stable release.
+        #[arg(long)]
+        check: bool,
+    },
     /// Resolve a bibliographic citation string to ranked DOI candidates.
     #[command(name = "resolve-citation")]
     ResolveCitation {
@@ -504,6 +511,7 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_, mode),
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit, mode),
         Some(Command::Search { query }) => doiget_cli::commands::search::run(query, mode),
+        Some(Command::Version { check }) => doiget_cli::commands::version::run(check, mode).await,
         Some(Command::ResolveCitation { query, limit }) => {
             doiget_cli::commands::resolve_citation::run(query, limit, mode).await
         }

--- a/crates/doiget-cli/tests/version_e2e.rs
+++ b/crates/doiget-cli/tests/version_e2e.rs
@@ -1,0 +1,380 @@
+// allow: outbound-network
+//! End-to-end tests for `doiget version [--check]`.
+//!
+//! The `--check` tests spin up a wiremock server and pass
+//! `DOIGET_GITHUB_BASE=<mock-uri>` to the subprocess so no real GitHub
+//! network calls are made.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        // Non-TTY implicit-quiet override — without this the ADR-0017
+        // resolver falls back to Quiet in captured-stdout contexts.
+        .env("DOIGET_MODE", "human");
+    cmd
+}
+
+fn releases_body(tag: &str, draft: bool, prerelease: bool) -> serde_json::Value {
+    serde_json::json!([{
+        "tag_name":  tag,
+        "html_url":  format!("https://github.com/sotashimozono/doiget/releases/tag/{tag}"),
+        "draft":     draft,
+        "prerelease": prerelease,
+    }])
+}
+
+// ---------------------------------------------------------------------------
+// doiget version (no --check)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_no_flag_prints_human_line() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .arg("version")
+        .assert()
+        .success()
+        .stdout(contains("doiget "));
+}
+
+#[test]
+fn version_json_mode_emits_version_key() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--mode", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).expect("stdout is valid JSON");
+    assert!(
+        v.get("version").and_then(|v| v.as_str()).is_some(),
+        "json output must have a `version` string field; got: {v}"
+    );
+}
+
+#[test]
+fn version_quiet_mode_produces_no_stdout() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--quiet"])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+// ---------------------------------------------------------------------------
+// doiget version --check  (wiremock-driven)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn version_check_newer_available_human_output() {
+    let server = MockServer::start().await;
+    // v1.0.0 is numerically greater than any 0.x.y build.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v1.0.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).unwrap();
+    assert!(
+        s.contains("update available") || s.contains("1.0.0"),
+        "expected update-available message; got: {s:?}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_up_to_date_human_output() {
+    let server = MockServer::start().await;
+    // v0.1.0 is older than any current build (>= 0.4.x).
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v0.1.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).unwrap();
+    assert!(
+        s.contains("up to date") || s.contains("0.1.0"),
+        "expected up-to-date message; got: {s:?}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_json_mode_emits_structured_object() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v1.0.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value =
+        serde_json::from_slice(&out).expect("--check --mode json stdout is valid JSON");
+    assert!(v.get("current").is_some(), "must have `current`; got: {v}");
+    assert!(v.get("latest").is_some(), "must have `latest`; got: {v}");
+    assert!(
+        v.get("newer_available").is_some(),
+        "must have `newer_available`; got: {v}"
+    );
+    assert!(
+        v.get("html_url").is_some(),
+        "must have `html_url`; got: {v}"
+    );
+    assert_eq!(
+        v["newer_available"],
+        serde_json::json!(true),
+        "v1.0.0 must be newer than current build; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_skips_draft_releases() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v9.0.0", true, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "draft releases must not surface as latest; got: {v}"
+    );
+    assert!(v.get("error").is_some(), "must report an error; got: {v}");
+}
+
+#[tokio::test]
+async fn version_check_skips_prerelease_flag_releases() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v9.0.0", false, true)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "prerelease=true releases must not surface; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_skips_tags_with_beta_suffix() {
+    let server = MockServer::start().await;
+    // draft=false, prerelease=false, but tag has -beta — must be filtered.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                "tag_name":   "v9.0.0-beta.1",
+                "html_url":   "https://github.com/sotashimozono/doiget/releases/tag/v9.0.0-beta.1",
+                "draft":      false,
+                "prerelease": false,
+            }])),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "-beta tag must be filtered even when prerelease=false; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_picks_first_stable_skipping_unstable() {
+    let server = MockServer::start().await;
+    // First entry is a draft; second is the stable release to pick.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "tag_name":   "v10.0.0",
+                "html_url":   "https://github.com/example/releases/tag/v10.0.0",
+                "draft":      true,
+                "prerelease": false,
+            },
+            {
+                "tag_name":   "v0.9.0",
+                "html_url":   "https://github.com/sotashimozono/doiget/releases/tag/v0.9.0",
+                "draft":      false,
+                "prerelease": false,
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(
+        v["latest"].as_str(),
+        Some("0.9.0"),
+        "must pick v0.9.0, skipping draft v10.0.0; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_rate_limited_json_reports_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success() // must never hard-fail on a network error
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "rate-limited must return null latest; got: {v}"
+    );
+    assert_eq!(
+        v["error"].as_str(),
+        Some("rate_limited"),
+        "must report rate_limited; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_rate_limited_human_exits_zero() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .stdout(contains("version check failed"));
+}
+
+#[tokio::test]
+async fn version_check_empty_releases_reports_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v.get("error").is_some(),
+        "empty releases must report error; got: {v}"
+    );
+    assert!(v["latest"].is_null(), "latest must be null; got: {v}");
+}

--- a/crates/doiget-cli/tests/version_e2e.rs
+++ b/crates/doiget-cli/tests/version_e2e.rs
@@ -97,7 +97,7 @@ async fn version_check_newer_available_human_output() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -125,7 +125,7 @@ async fn version_check_up_to_date_human_output() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -152,7 +152,7 @@ async fn version_check_json_mode_emits_structured_object() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -191,7 +191,7 @@ async fn version_check_skips_draft_releases() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -219,7 +219,7 @@ async fn version_check_skips_prerelease_flag_releases() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -252,7 +252,7 @@ async fn version_check_skips_tags_with_beta_suffix() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -291,7 +291,7 @@ async fn version_check_picks_first_stable_skipping_unstable() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -317,7 +317,7 @@ async fn version_check_rate_limited_json_reports_error() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success() // must never hard-fail on a network error
         .get_output()
@@ -347,7 +347,7 @@ async fn version_check_rate_limited_human_exits_zero() {
     let dir = TempDir::new().expect("tempdir");
     doiget(&dir)
         .args(["version", "--check"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .stdout(contains("version check failed"));
@@ -365,7 +365,7 @@ async fn version_check_empty_releases_reports_error() {
     let dir = TempDir::new().expect("tempdir");
     let out = doiget(&dir)
         .args(["version", "--check", "--mode", "json"])
-        .env("DOIGET_GITHUB_BASE", &server.uri())
+        .env("DOIGET_GITHUB_BASE", server.uri())
         .assert()
         .success()
         .get_output()
@@ -377,4 +377,71 @@ async fn version_check_empty_releases_reports_error() {
         "empty releases must report error; got: {v}"
     );
     assert!(v["latest"].is_null(), "latest must be null; got: {v}");
+}
+
+#[tokio::test]
+async fn version_check_quiet_suppresses_network_call() {
+    // With --quiet the command must exit 0 and produce no stdout,
+    // even when --check is also passed. The mock is intentionally not
+    // mounted: if the subprocess made a network call it would fail or
+    // produce output, both of which would cause the assertion to fail.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--check", "--quiet"])
+        // Point at localhost on a port with no listener; any actual
+        // network attempt would surface as an error, not silence.
+        .env("DOIGET_GITHUB_BASE", "http://127.0.0.1:1")
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[tokio::test]
+async fn version_check_newer_available_human_prints_release_url() {
+    let server = MockServer::start().await;
+    let tag = "v1.0.0";
+    let expected_url = format!("https://github.com/sotashimozono/doiget/releases/tag/{tag}");
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(releases_body(tag, false, false)))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .stdout(contains(&expected_url));
+}
+
+#[tokio::test]
+async fn version_check_json_up_to_date_newer_available_false() {
+    let server = MockServer::start().await;
+    // v0.1.0 is older than any current build — newer_available must be false.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v0.1.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(
+        v["newer_available"],
+        serde_json::json!(false),
+        "v0.1.0 must not be reported as newer; got: {v}"
+    );
+    assert!(v.get("error").is_none(), "no error on success; got: {v}");
 }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -1053,6 +1053,15 @@ fn ensure_crypto_provider() {
     });
 }
 
+/// Public entry point for callers that build their own `reqwest::Client`
+/// outside of [`HttpClient`] and need the process-default TLS provider
+/// installed first (ADR-0020 Amendment 1).
+///
+/// Safe to call multiple times; the underlying `Once` makes it idempotent.
+pub fn init_tls() {
+    ensure_crypto_provider();
+}
+
 /// Upgrade an `http://` URL to `https://` for legacy publisher
 /// metadata. Loopback hosts (`localhost`, any RFC 6761 `.localhost`
 /// TLD subdomain, `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback)


### PR DESCRIPTION
Resolves #236 (Slice 1 only — Slice 2 self-update requires a separate ADR).

## Summary

- `doiget version` — prints `doiget <version>` (human) or `{"version":"…"}` (json). No network.
- `doiget version --check` — queries the GitHub Releases API, finds the latest stable tag (non-draft, non-prerelease, no `-beta`/`-alpha`/`-rc` suffix), and emits:

```json
{
  "current":         "0.4.1-beta.0",
  "latest":          "0.4.0",
  "newer_available": false,
  "html_url":        "https://github.com/sotashimozono/doiget/releases/tag/v0.4.0"
}
```

- Rate-limit (HTTP 403) or network failure is captured in an `error` field; the command always exits 0 so it never blocks callers.
- Version comparison uses dot-separated numeric ordering on the core before any `-` suffix, so the current beta correctly reports `0.4.0` as "older".
- Wired into `capabilities` metadata (`JsonMode::Supported`, three examples).

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `doiget version` prints `doiget 0.4.1-beta.0`
- [ ] `doiget version --mode json` prints `{"version":"0.4.1-beta.0"}`
- [ ] `doiget version --check` queries GitHub and prints a one-liner
- [ ] `doiget version --check --mode json` emits the structured object
- [ ] `doiget capabilities | jq '.subcommands[] | select(.name=="version")'` shows the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)