### PR TITLE
chore: back-merge main → next (ADR-0025 §D6)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2.0.19
         with:
           command: check
           # Audit only the published surface (oa-only). TDM features are

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-      - uses: taiki-e/install-action@b550161ef8a7bc4f2a671c0b03a18ac9ccedea1e  # v2.79.1
+      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4  # v2.79.7
         with:
           tool: cargo-llvm-cov
       - name: Generate workspace coverage (lcov)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate workspace coverage (lcov)
         run: cargo llvm-cov --workspace --locked --lcov --output-path lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
 
       - name: Download site artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093   # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c   # v8.0.1
         with:
           name: site-public
           path: site/public/

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -20,4 +20,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      - uses: crate-ci/typos@aca895bf05aec0cb7dffa6f94495e923224d9f17     # v1.46.2
+      - uses: crate-ci/typos@7b04f660f4ee4f048d18fd341887cf28dfbedfe2     # v1.46.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.1-beta.0] - 2026-05-31
+
+### Added
+- **[core]** Support suggesting an arXiv version when a primary PDF fetch fails. The `PdfLegStatus::Blocked` variant now carries an optional `suggested_arxiv_id` field populated from Unpaywall metadata.
+- **[core]** Support resolving free-form bibliographic citation strings to ranked DOI candidates via Crossref Works query API. Compute a token-based overlap similarity score to filter (score >= 0.5) and rank candidates.
+- **[cli]** The `doiget fetch` command prints a suggested arXiv command when a primary PDF fetch is blocked but an arXiv alternative is available.
+- **[cli]** Add `doiget resolve-citation "<query>"` command and `doiget batch-resolve-citations` command (which reads queries from stdin line-by-line) to return resolved DOI candidates in JSON.
+- **[cli]** Add `doiget version [--check]` command to print the current version and optionally query GitHub Releases for the latest stable tag.
+- **[mcp]** The `doiget_fetch` MCP tool output includes the `suggested_arxiv_id` in the `pdf_leg` object when blocked.
+- **[mcp]** Add `doiget_resolve_citation` and `doiget_batch_resolve_citations` MCP tools to resolve bibliographic citation strings to ranked DOI candidates.
+
+
 ## [0.4.0] - 2026-05-21
 
 Promotion of the `0.4.0-beta.1..beta.13` integration line on `next` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,437 +10,151 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-<<<<<<< HEAD
-=======
-## [0.4.1-beta.13] - 2026-05-21
+## [0.4.0] - 2026-05-21
+
+Promotion of the `0.4.1-beta.1..beta.13` integration line on `next` to a
+stable release. SemVer **minor** bump (not patch) — this window
+introduces multiple new public surfaces (`doiget_core::refs` module,
+`doiget_batch_from_bibliography` MCP tool, `FetchPaperOutcome` field
+additions, user-extensible capability gate, fetch chain) and one CLI
+flag set expansion, alongside several behavioural changes for the
+OA-PDF leg and batch JSONL wire shape. Beta-window detail is preserved
+in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
 
 ### Added
 
-- **[mcp]** New MCP tool `doiget_batch_from_bibliography` per
-  ADR-0030 D6 — accepts an absolute `path` to a CSL-JSON file
-  (BibTeX coming in the biblatex slice), parses it via
-  `doiget_core::refs::parse_input`, and fetches every resolvable
-  entry through the existing batch orchestrator. Each result row
-  carries the source bibliography's `entry_key` so a Zotero /
-  Mendeley plugin can bridge the fetched PDF back to the originating
-  reference.
+- **[core] ADR-0028 user-extensible capability gate** — new
+  `doiget_core::user_extension` module parses
+  `<config_dir>/doiget/config.toml`'s `[[network.additional_hosts]]`
+  entries (literal FQDN or single-suffix `*.<suffix>` wildcards) and
+  merges them into the `oa-publisher` redirect allowlist. The `host`
+  field is a `HostPattern` newtype whose `Deserialize` runs validation
+  so the "valid pattern" invariant is type-level. Both `doiget fetch`
+  and `doiget serve` honor the extension; `doiget config doctor`
+  reports health; `doiget capabilities` JSON exposes
+  `user_extension_count`. ToS+verified-curation framing rejects
+  WAF-bypass / impersonation proposals permanently (ADR-0028 D3 and
+  #223 close-rationale).
 
-  Output shape (ADR-0030 D6):
-  ```json
-  {
-    "ok": true,
-    "summary": {"total": 12, "ok": 10, "failed": 1, "parse_errors": 1},
-    "results": [
-      {"entry_key":"Foo2024","ref":"10.1234/foo","ok":true,"path":"...","license":"cc-by",...},
-      {"entry_key":"NoId2025","ref":null,"ok":false,
-       "error":{"code":"INVALID_REF","message":"entry has no DOI / arXiv id"}}
-    ]
-  }
-  ```
+- **[core] ADR-0029 fetch chain (slice 1)** — the DOI OA-PDF leg now
+  walks a multi-candidate chain from Unpaywall's `best_oa_location` +
+  `oa_locations[]` instead of trying only the single "best" URL. On
+  any non-PDF / 403 / network failure the chain advances; first
+  successful candidate wins. Each attempt emits its own
+  `oa-publisher` Fetch provenance row. Recovers the dogfood case
+  where a DOI hits a WAF-blocked publisher but the same record's
+  arXiv preprint is in `oa_locations[]`.
 
-  `strict` input field (default `false`) controls whether the FIRST
-  per-entry parse error aborts the whole call (`true`) or surfaces
-  as a row next to successful siblings (`false`). A whole-input
-  decode failure (malformed CSL-JSON) always aborts regardless of
-  `strict`.
+- **[core] ADR-0030 bibliography input adapters (slice 1)** — new
+  `doiget_core::refs` module exposes `Format`, `ParsedEntry`,
+  `ParseError`, and `parse_input(text, format, path)` that
+  auto-detect plain-refs / CSL-JSON / BibTeX (BibTeX returns
+  `UnsupportedFormat` until the biblatex follow-up slice).
+  Identifier priority is DOI > arXiv > PMID-parking. 23 unit tests
+  cover format detection, the priority rule, Zotero/Mendeley
+  wire-shape quirks, and malformed-input tolerance.
 
-  `doiget capabilities` JSON's `mcp_tools` array gains the new
-  `doiget_batch_from_bibliography` entry; the parity test is
-  updated in lockstep so the table cannot drift from the docs.
+- **[mcp] `doiget_batch_from_bibliography`** — new MCP tool per
+  ADR-0030 D6 accepting a CSL-JSON file path and returning structured
+  per-entry fetch outcomes with the source bibliography's `entry_key`
+  threaded through. Unlocks the Zotero distribution path: a plugin
+  author can hand a `.json` file to `doiget serve` and bridge
+  fetched PDFs back to the originating reference without shelling
+  out. `strict` input field controls per-entry parse-error abort;
+  malformed-input always aborts.
 
-  6 new MCP unit tests cover `parse_bibliography_format`'s token
-  acceptance (auto / refs / csl-json / bibtex / case-insensitivity /
-  underscore variants / unknown-token rejection).
+- **[cli] `doiget batch library.json`** — `doiget batch` now
+  auto-detects CSL-JSON inputs by file extension + content
+  fingerprint and dispatches through `refs::parse_input`. Plain refs
+  files (`.txt`) keep working unchanged. Malformed CSL-JSON aborts
+  with a loud whole-input error rather than silently behaving as an
+  empty batch.
 
->>>>>>> 01150e7 (feat(mcp): doiget_batch_from_bibliography MCP tool (ADR-0030 D6))
-## [0.4.1-beta.12] - 2026-05-21
+- **[cli] `doiget batch --json` structured outcomes (#210 / S4)** —
+  JSONL success records carry
+  `result.{safekey, store_path, canonical_digest}`; failure records
+  carry the typed `ErrorCode` wire string plus an ADR-0023
+  `denial_context` when applicable. `PdfLegStatus::Blocked` outcomes
+  surface as failures with the policy-class reclassification
+  (`effective_blocked_code`).
 
-### Added
+- **[cli] global flags `--store-root` / `--log-path` / `--color` /
+  `--progress` (#211 / S5)** — four new global CLI flags with
+  env-var precedence, ValueEnum drift guards, and 17 unit tests
+  covering precedence and validation.
 
-- **[core]** ADR-0029 fetch chain slice 1 — the DOI OA-PDF leg now
-  walks a multi-candidate chain instead of trying only
-  `best_oa_location` (#222). Candidate URLs are extracted from the
-  Unpaywall envelope in priority order (best_oa_location first, then
-  every distinct entry in `oa_locations[]`); the orchestrator
-  advances past any non-PDF / 403 / network failure until either one
-  candidate yields a valid PDF or every candidate is exhausted. Each
-  attempt emits its own `oa-publisher` Fetch provenance row, so the
-  audit trail captures every external request.
+- **[cli] `doiget config doctor` user-extension surface (ADR-0028
+  D2-3)** — adds a checklist entry reporting
+  `[ ok ] user-extension hosts loaded: N` or
+  `[FAIL] user-extension config invalid: <error>`. Missing config is
+  normal.
 
-  Recovers the dogfood case from the finite-temperature-MPS corpus:
-  a DOI hits `link.aps.org`, the publisher WAF returns 403, but the
-  same record's arXiv preprint is in `oa_locations[]`. Pre-slice-1
-  this surfaced as `PdfLegStatus::Blocked` + metadata-only; post-
-  slice-1 the chain advances to the arXiv preprint and writes a
-  real PDF.
+- **[cli] `doiget capabilities` JSON `user_extension_count` field
+  (ADR-0028 D2-4)** — additive top-level field reporting how many
+  user-extension hosts are loaded on the current host. Drift-guarded
+  by parity test.
 
-  New helper: `doiget_core::orchestrator::extract_oa_url_chain`
-  (private). Removes the now-superseded
-  `extract_best_oa_url_from_value` helper and migrates its tests to
-  the chain extractor; net + 3 unit tests covering ordering,
-  deduplication, fallback-on-no-best, and malformed-URL tolerance.
-  New e2e test
-  `fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403`
-  exercises the WAF-block fallback flow end-to-end.
+- **[core] `FetchPaperOutcome` field additions** —
+  `safekey: String` and `canonical_digest: String` are always-
+  populated additive fields on the `#[non_exhaustive]` struct
+  (#210).
 
-### Notes
-
-- Out of scope for slice 1 (deferred follow-ups):
-  - The structured `chain: Vec<AttemptOutcome>` field on
-    `FetchError` and the new `ALL_FALLBACKS_EXHAUSTED` closed-enum
-    variant (ADR-0029 D5). Today an all-failed chain still surfaces
-    as `PdfLegStatus::Blocked` with the *last* attempt's reason on
-    `denial`; the structured per-attempt list is reserved for the
-    MCP / CLI JSON wire-shape slice that follows #212 alignment.
-  - The schema-additive `chain_attempt` / `chain_total` /
-    `chain_terminal` / `verified_by` columns on the provenance log
-    (ADR-0029 D4). Today each chain attempt is logged as a
-    standalone Fetch row indistinguishable from the pre-slice-1
-    shape; the per-attempt enrichment is deferred.
-
-## [0.4.1-beta.11] - 2026-05-21
-
-### Added
-
-- **[core]** New `doiget_core::refs` module per ADR-0030 slice 1 —
-  bibliography input adapters. Exposes
-  `Format { Auto, Refs, CslJson, Bibtex }`,
-  `ParsedEntry { ref_, entry_key }`,
-  `ParseError { NoIdentifier, InvalidRef, Decode,
-  UnsupportedFormat }` (closed-enum, `#[non_exhaustive]`), and
-  `parse_input(text, format, path) -> Vec<Result<ParsedEntry,
-  ParseError>>` plus per-format helpers. Honors the ADR-0030 D3
-  identifier-pick priority: `DOI` > arXiv (`archivePrefix == "arXiv"`
-  + `eprint`, or `note: "arXiv:…"`) > (PMID parking). 23 unit tests
-  cover format detection, all parser branches, the priority rule,
-  case-insensitive field matching, and Zotero / Mendeley wire shape
-  quirks.
-
-- **[cli]** `doiget batch library.json` accepts a CSL-JSON export
-  directly. The format is auto-detected from the path extension
-  (`.json` / `.csl`) and the file's leading non-comment character;
-  callers writing plain refs files (`.txt`) keep working with no
-  change. A malformed CSL-JSON document aborts the batch with a
-  loud whole-input error rather than silently behaving as an empty
-  batch. New e2e tests
-  `batch_json_csl_input_yields_one_record_per_entry` and
-  `batch_malformed_csl_json_aborts_with_decode_error`.
+- **[core] `#[doc(hidden)] FetchPaperOutcome::for_test_synthetic`** —
+  test-only constructor exposed for downstream test code to drive
+  classification logic without running the full orchestrator.
 
 ### Changed
 
-- **[cli]** `batch` JSONL `ref` field is now the bare identifier per
-  `docs/PROVENANCE_LOG.md` §3 — `Ref::as_input_str()`'s canonical
-  form — rather than the raw file line. For an input line
-  `arxiv:2401.99999`, the failure record's `ref` is now
-  `"2401.99999"` (no URI scheme). DOI inputs were already in this
-  form. Wire-format-visible: CI consumers parsing the `ref` field
-  should switch from "string match input line" to "regex / parse as
-  DOI or arXiv id". Surfaced because the new `refs::parse_input`
-  pipeline normalises every entry through `Ref::parse` before
-  emitting; the pre-ADR-0030 flow echoed raw lines verbatim.
+- **[core/http] `http://` → `https://` URL upgrade (#220 / S2)** —
+  `fetch_inner` upgrades legacy `http://` URLs returned by metadata
+  sources to `https://` before sending, with case-insensitive
+  `localhost` literal + `.localhost` TLD detection, IPv6 loopback
+  (`::1` + IPv4-mapped) detection, and a `tracing::warn!` on the
+  `set_scheme` fallback. 12 unit tests pin the edge cases.
 
-### Notes
+- **[cli] ADR-0017 Amendment 1: explicit-vs-implicit Quiet (#220 /
+  S1)** — `OutputMode::Quiet` now distinguishes a user's explicit
+  `--quiet` / `--mode quiet` from the implicit TTY-detection
+  fallback. `doiget capabilities` (and `bib` / `csl`) — the artifact
+  commands — respect only explicit Quiet and emit their JSON
+  inventory on non-TTY pipes so an LLM cold-boot from a stripped
+  environment is not silently empty. `ResolvedOutput { mode,
+  quiet_was_explicit }` and `is_artifact_command()` helper added.
 
-- Out of scope for slice 1 (deferred to follow-up slices):
-  - BibTeX / `.bib` parsing — requires the `biblatex` crate
-    (+500 KB) and its cargo-vet transitive exemptions. Until that
-    ships, `Format::Bibtex` returns `ParseError::UnsupportedFormat`
-    with a helpful "re-export as CSL-JSON" hint, and `.bib` file
-    extensions surface that error on the first batch invocation.
-  - `--format` / `--strict` CLI flags.
-  - New MCP tool `doiget_batch_from_bibliography`.
-  - Plumbing `entry_key` into the JSONL `error` object as a typed
-    field (today the citation key is embedded in placeholder
-    `<no-identifier:KEY>` strings that the existing JSONL `ref`
-    surfaces verbatim).
+- **[cli] `FetchHarness::fetch_one` returns
+  `Result<FetchPaperOutcome, FetchError>` (#210)** — replaces the
+  prior `anyhow::Result<()>` so callers can render machine-readable
+  shapes from the same typed outcome. Rendering / `CliExit`
+  synthesis moves to per-caller paths.
 
-## [0.4.1-beta.10] - 2026-05-21
+- **[cli] `batch` JSONL `ref` field** — now the bare identifier per
+  `docs/PROVENANCE_LOG.md` §3 (`Ref::as_input_str()` canonical
+  form) rather than the raw file line. For an input line
+  `arxiv:2401.99999`, the JSONL `ref` is now `"2401.99999"`. DOI
+  inputs were already in this form. Wire-format-visible.
 
-### Added
+### Documentation
 
-- **[mcp]** MCP-server `build_http_client_for_fetch` now merges
-  user-extension hosts from `<config_dir>/doiget/config.toml` per
-  ADR-0028 D2, mirroring the CLI path that landed in beta.8 (#220).
-  Before this slice, a user who configured
-  `[[network.additional_hosts]]` and invoked via `doiget serve`
-  saw no effect — only `doiget fetch` honored the extension. The
-  MCP merge closes that asymmetry; both surfaces now read the same
-  config file with identical failure handling (silent on
-  not-found, `tracing::warn!` on malformed, curated allowlist
-  continues regardless).
+- **ADR-0017 Amendment 1, ADR-0028, ADR-0029, ADR-0030** — four new
+  design records covering quiet bifurcation, the user-extensible
+  capability gate, the fetch chain primitive, and the bibliography
+  input adapters.
 
-- **[cli]** `doiget config doctor` adds a user-extension health
-  check (ADR-0028 D2-3): on a green run the new line reads
-  `[ ok ] user-extension hosts loaded: N`; on a malformed
-  `config.toml` it emits `[FAIL] user-extension config invalid:
-  <error>` and exits 2. A missing `config.toml` is normal (count
-  = 0, no failure) — the user simply has not extended the gate.
+### Notes — deferred to follow-up slices
 
-- **[cli]** `doiget capabilities` JSON gains a top-level
-  `user_extension_count: usize` field (ADR-0028 D2-4) so an LLM
-  cold-booted into doiget can confirm at a glance whether the
-  curated allowlist has been extended on this host. The field
-  counts valid `[[network.additional_hosts]]` entries; parse
-  errors collapse to `0` (use `doiget config doctor` to
-  diagnose). `Capabilities` is `#[non_exhaustive]`, so adding the
-  field is additive for downstream Rust consumers; JSON consumers
-  should ignore unknown fields.
-
-### Changed
-
-- **[cli]** `commands::fetch::config_dir_utf8` lifted from private
-  to `pub(crate)` so sibling modules
-  (`commands::capabilities`, `commands::config`) resolve the same
-  `<config_dir>/doiget/` path the production HTTP-client builder
-  reads from. No behavior change.
-
-### Notes
-
-- Out of scope for this slice (still tracked under #220 / ADR-0028):
-  the `verified_by = "user"` provenance row field (D2-2). That
-  requires allowlist source-attribution plumbing through the
-  redirect closure and is deferred to a follow-up slice.
-
-## [0.4.1-beta.9] - 2026-05-21
-
-### Added
-
-- **[core]** `FetchPaperOutcome` (`doiget_core::orchestrator`) gains
-  two new fields: `safekey: String` and `canonical_digest: String`
-  (#210). Both are always populated — `safekey` from the input ref
-  (`Ref::safekey().as_str()`), `canonical_digest` from
-  `CanonicalRef::digest_hex()` under the outcome's
-  `resolver_profile`. Additive on a `#[non_exhaustive]` struct, so
-  downstream consumers continue to compile without changes.
-
-- **[cli]** `doiget batch --json` JSONL records carry the full
-  structured outcome per `docs/ERRORS.md` §3 (#210):
-  - **Success**: `{"ok":true,"ref":"...","result":{"safekey":"...","store_path":"...","canonical_digest":"..."}}`.
-    A CI consumer can now pull `safekey` to construct a store-relative
-    path and `canonical_digest` to deduplicate against an audit DB
-    without a follow-up `info` round-trip per ref.
-  - **Failure**: `{"ok":false,"ref":"...","error":{"code":"...","message":"...","denial_context":{...}}}`.
-    The `code` field is now the typed `ErrorCode` wire string (e.g.
-    `CAPABILITY_DENIED` / `NETWORK_ERROR` / `INTERNAL_ERROR`) — the
-    previous generic `FETCH_ERROR` only survives in the JoinSet
-    panic arm where no underlying `FetchError` exists. The
-    `denial_context` key is present only when the failure carries a
-    structured ADR-0023 denial; bare transport / config errors omit
-    the key entirely so consumers can use its presence as a typed-
-    denial discriminator.
-
-  A `PdfLegStatus::Blocked` outcome (an OA PDF was discovered but
-  could not be retrieved per #145) is now surfaced as a failure
-  record with the policy-class `denial_context`, rather than being
-  collapsed into the bare `{ok:true, ref}` shape that #205 left in
-  place. The `effective_blocked_code` reclassification (off-allowlist
-  / insecure-scheme / blocklisted-host → `CAPABILITY_DENIED`) is
-  shared between single-fetch and batch, so the wire code matches the
-  single-fetch CLI exit-code mapping.
-
-### Changed
-
-- **[cli]** `FetchHarness::fetch_one` signature changes from
-  `async fn (..., &Ref) -> anyhow::Result<()>` to
-  `async fn (..., &Ref) -> Result<FetchPaperOutcome, FetchError>`
-  (#210). The rendering + exit-code synthesis that used to live
-  inside `fetch_one` (Blocked-PDF reclassification, `error[CODE]:`
-  stderr, `CliExit` construction) now lives in the per-caller paths
-  (`commands::fetch::run_with_options` for single-fetch,
-  `commands::batch::classify_joined` for batch) so each surface can
-  emit its own machine-readable shape from the same typed outcome.
-  `pub(crate)`, not a public API.
-
-  - `commands::fetch::effective_blocked_code` is lifted from `fn` to
-    `pub(crate) fn` so the batch caller shares the single-fetch
-    reclassification rule.
-  - New `commands::fetch::outcome_is_clean_success` helper collapses
-    the typed `Result<FetchPaperOutcome, FetchError>` to the boolean
-    the `SessionEnd` row's `is_ok` field needs, so a Blocked PDF leg
-    never reads as a green session in the provenance log.
-
-- **[core]** New `#[doc(hidden)] pub fn FetchPaperOutcome::for_test_synthetic(...)`
-  test-only constructor in `doiget_core::orchestrator` so downstream
-  test code (`doiget-cli` batch unit tests) can drive
-  classification logic without running the full orchestrator. Not a
-  stable public API — the signature may change to fit test needs
-  without a `[BREAKING]` callout.
-
-### Notes
-
-- Out of scope (deferred to follow-up issues per #210's Out-of-scope
-  list):
-  - The MCP `doiget_fetch_paper` envelope upgrade to surface
-    `safekey` / `canonical_digest` (the FetchPaperOutcome fields
-    are populated; the envelope-side wire change is a separate
-    item).
-  - `canonical_digest` on `EntryInfo` (`info` / `list-recent` /
-    `search` JSON bodies).
-  - Single-fetch `--json` symmetric output (the CLI single-fetch JSON
-    branch mirroring batch JSONL's single record).
-
-## [0.4.1-beta.8] - 2026-05-21
-
-### Added
-
-- **[core]** New module `doiget_core::user_extension` per ADR-0028
-  D2 (#220). Users can extend the `oa-publisher` redirect allowlist
-  for their own deployment via `[[network.additional_hosts]]` in
-  `<config_dir>/doiget/config.toml`. Pattern grammar is restricted
-  (literal FQDN or single-suffix wildcard `*.<suffix>`); rejection
-  classes are surfaced as a closed-enum `PatternError` for
-  programmatic consumption by the future `doiget config doctor`
-  surface. The `host` field of `UserExtensionHost` is a
-  `HostPattern` newtype that runs validation through its serde
-  `Deserialize`, so the "valid pattern" invariant is type-level —
-  no `UserExtensionHost` value can exist with an invalid host. The
-  orchestrator's production HttpClient construction
-  (`commands::fetch::build_http_client`) loads and merges in one
-  pass; a missing config file is silent, a malformed config is
-  surfaced as `tracing::warn!` and the fetch continues with the
-  curated set.
-
-  Example:
-
-  ```toml
-  # ~/.config/doiget/config.toml
-  [[network.additional_hosts]]
-  host = "ruj.uj.edu.pl"
-  note = "Jagiellonian University Repository — Green OA"
-
-  [[network.additional_hosts]]
-  host = "*.uj.edu.pl"
-  ```
-
-  Out of scope for this slice (tracked as S3b): the
-  `verified_by = "user"` provenance row field (ADR-0028 D2-2),
-  the `doiget config doctor` surface (D2-3), the
-  `capability_gate.user_extension_count` field in `doiget
-  capabilities` JSON (D2-4), and the MCP-server-side merge in
-  `doiget-mcp` (a user who configures
-  `[[network.additional_hosts]]` and invokes via `doiget serve`
-  currently sees no effect; that is the load-bearing item S3b
-  closes).
-
-## [0.4.1-beta.7] - 2026-05-21
-
-### Fixed
-
-- **[core/http]** `http://` URLs returned by OpenAlex / Unpaywall
-  metadata for publishers that have since moved to HTTPS are
-  transparently upgraded to `https://` before the request leaves
-  the process (#220). Without this, the production
-  `https_only(true)` client refused to send and the fetch failed
-  with a generic builder error. The upgrade is skipped for
-  loopback hosts (`localhost`, the RFC 6761 `.localhost` TLD,
-  `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback) so the
-  `new_for_tests_allow_http*` wiremock path is unchanged. TLS
-  posture (ADR-0020) is preserved — the upgrade turns a
-  guaranteed-reject into a real TLS handshake, never a plaintext
-  fallback. Successful upgrades log at `tracing::info!` so the
-  rewrite appears in audit-level logs.
-
-## [0.4.1-beta.5] - 2026-05-21
-
-### Added
-
-- **[cli]** Four new global flags from CONFIG.md §5, completing the
-  documented surface (#211):
-  - `--store-root <PATH>` — overrides `DOIGET_STORE_ROOT` for the
-    on-disk paper store root. Path-shaped values; rejected at parse
-    time when empty or containing NUL bytes (review pass I6 / A4).
-  - `--log-path <PATH>` — overrides `DOIGET_LOG_PATH` for the
-    provenance-log file path. Same parse-time validation as
-    `--store-root`.
-  - `--color <auto|always|never>` — exposes the future ANSI emission
-    knob via the new `DOIGET_COLOR` env var. Surface-only in this
-    slice (no consumer emits ANSI today). The consumer-side resolver
-    will check `NO_COLOR` (present and non-empty per
-    <https://no-color.org/>, any value) **before** consulting
-    `DOIGET_COLOR`; the write boundary in
-    `apply_global_overrides` is intentionally simple and does NOT
-    inspect `NO_COLOR`.
-  - `--progress` / `--no-progress` — pair of mutually exclusive
-    flags writing `DOIGET_PROGRESS=1` / `0`. Surface-only: the
-    `fetch` / `batch` per-ref stderr line is unchanged here; the
-    consumer-side gate lands in a follow-up.
-
-  Each flag implements the CONFIG.md §1 precedence ladder
-  `flag > env > default` by overwriting the matching `DOIGET_*`
-  process env var at the very top of `run_dispatch`, BEFORE any
-  command resolver reads the environment. The existing resolvers
-  (`commands::fetch::resolve_store_root`, `resolve_log_path`,
-  `commands::audit_log::resolve_log_path`) keep their env-driven
-  shape and pick the new value up uniformly — no `ResolvedFlags`
-  struct threaded through eleven `run(..)` signatures.
-
-  Path flags use `camino::Utf8PathBuf` (workspace `clippy.toml`
-  disallowed-types policy bans `std::path::PathBuf`); validation
-  lives in `parse_utf8_path` and runs at clap's `value_parser`
-  layer so empty / NUL-byte inputs fail clean with exit 2.
-
-  Clap-level conflicts: `--progress` ↔ `--no-progress` (exit 2 on
-  both supplied); pre-existing `--mode` ↔ `--json` ↔ `--quiet`
-  conflicts unchanged.
-
-  19 new tests (15 unit on `apply_global_overrides`/`parse_utf8_path`
-  via `serial_test`; 4 e2e on clap conflicts, value acceptance, and
-  empty-value parse-time rejection). Includes a drift guard
-  (`output_color_env_strings_match_clap_parser_side`) that pairs
-  `OutputColor::as_env_value` against clap's `ValueEnum`
-  parser-side spelling — if `rename_all = "lower"` is ever changed,
-  the round-trip catches it.
-
-## [0.4.1-beta.2] - 2026-05-21
-
-### Fixed
-
-- **[cli]** `doiget capabilities` no longer silently exits with empty
-  stdout in non-TTY / agent execution contexts (#219, #220 ADR-0017
-  Amendment 1). The resolver now distinguishes **explicit** Quiet
-  (`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`) from
-  **implicit** Quiet (the non-TTY default), and `capabilities` —
-  classified as an *artifact* command — suppresses stdout only on
-  explicit Quiet. Closes the LLM cold-boot deadlock where an agent
-  ran `doiget capabilities` over a captured pipe and got nothing
-  back. `OutputMode` enum wire format (`DOIGET_MODE` strings, the
-  `modes` array in capabilities JSON) is unchanged; the
-  `quiet_was_explicit` discriminator lives only in-memory on the
-  new `ResolvedOutput` returned by `commands::output::resolve()`.
-  `bib` / `csl` were already correct (they ignore mode); their
-  classification is now documented via the new
-  `is_artifact_command()` helper.
-
-## [0.4.1-beta.1] - 2026-05-21
-
-Beta-lane open for the v0.4 design (ADR-0017 Amendment 1 +
-ADR-0028 / 0029 / 0030, design-only — no code change yet).
-Workspace version is bumped to satisfy the version-gate G5
-(non-empty CHANGELOG section for the prospective tag) while the
-implementation slices S1-S8 land separately.
-
-### Added
-
-- **[design]** ADR-0017 Amendment 1: distinguish *explicit* vs
-  *implicit* `Quiet`, classify commands as artifact vs
-  informational. Closes the LLM cold-boot deadlock reported in
-  #219 / #220 once the implementation slice (S1) lands.
-- **[design]** ADR-0028: the capability gate's purpose is
-  **ToS compliance + verified curation**; users may extend it via
-  `config.toml` (literal hosts or single-suffix wildcards) with
-  per-attempt `verified_by = "user"` recorded in the provenance
-  log. Impersonation / WAF bypass / embedded headless browser
-  (#223) are permanently out-of-scope.
-- **[design]** ADR-0029: `fetch_one` resolves to an ordered chain
-  of candidate URLs (OpenAlex `oa_locations[]` order); each
-  attempt becomes its own provenance row (schema-additive on v2).
-  New closed-enum `FetchError` variant `ALL_FALLBACKS_EXHAUSTED`
-  carries `Vec<AttemptOutcome>`.
-- **[design]** ADR-0030: bibliography input adapters
-  (`.bib` / CSL-JSON) live in `doiget-core`; new MCP tool
-  `doiget_batch_from_bibliography` enables the Zotero plugin
-  distribution path. One identifier per entry
-  (DOI > arXiv > PMID); skip-and-warn on parse error by default.
+- ADR-0028 D2-2 `verified_by = "user"` per-attempt provenance row
+  field.
+- ADR-0029 D4/D5: `chain: Vec<AttemptOutcome>` +
+  `ALL_FALLBACKS_EXHAUSTED` + schema-additive `chain_*` provenance
+  columns.
+- ADR-0030 D2/D5/D6: BibTeX/.bib parsing (needs `biblatex` crate +
+  cargo-vet exemptions), `--format` / `--strict` CLI flags,
+  structured `entry_key` on JSONL `error` object.
+- MCP `doiget_fetch_paper` envelope upgrade for `safekey` /
+  `canonical_digest`.
+- `canonical_digest` on `EntryInfo`.
+- Single-fetch `--json` symmetric output.
+- #212 MCP/CLI output shape alignment, #222 batch resumability.
 
 ## [0.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [0.4.0] - 2026-05-21
 
-Promotion of the `0.4.1-beta.1..beta.13` integration line on `next` to a
-stable release. SemVer **minor** bump (not patch) — this window
+Promotion of the `0.4.0-beta.1..beta.13` integration line on `next` to
+a stable release. SemVer **minor** bump (not patch) — this window
 introduces multiple new public surfaces (`doiget_core::refs` module,
 `doiget_batch_from_bibliography` MCP tool, `FetchPaperOutcome` field
 additions, user-extensible capability gate, fetch chain) and one CLI
 flag set expansion, alongside several behavioural changes for the
 OA-PDF leg and batch JSONL wire shape. Beta-window detail is preserved
-in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
+in the merge commits on `next` (see `git log --merges v0.3.0..HEAD`)
+and the ADR set under `docs/DECISIONS/`.
 
 ### Added
 
@@ -120,6 +121,11 @@ in `git log v0.3.0..v0.4.0` and the ADR set under `docs/DECISIONS/`.
   inventory on non-TTY pipes so an LLM cold-boot from a stripped
   environment is not silently empty. `ResolvedOutput { mode,
   quiet_was_explicit }` and `is_artifact_command()` helper added.
+  `audit-log --verify` is NOT routed through
+  `is_artifact_command()` — its `--mode json` body is produced by an
+  internal branch in the subcommand handler rather than by the
+  artifact-vs-informational discriminator; the wire shape is
+  unchanged on this release.
 
 - **[cli] `FetchHarness::fetch_one` returns
   `Result<FetchPaperOutcome, FetchError>` (#210)** — replaces the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.0"
+version = "0.4.1-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -512,6 +512,7 @@ dependencies = [
  "doiget-mcp",
  "flate2",
  "predicates",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -527,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.0"
+version = "0.4.1-beta.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.0"
+version = "0.4.1-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1954,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.13"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.13"
+version       = "0.4.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.13" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.13" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.13" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.0"
+version       = "0.4.1-beta.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -55,6 +55,8 @@ ulid               = { workspace = true }
 # URL parsing for the source-base env-var overrides
 # (`DOIGET_ARXIV_BASE` / `DOIGET_CROSSREF_BASE` / `DOIGET_UNPAYWALL_BASE`).
 url                = { workspace = true }
+# Used by `doiget version --check` to query the GitHub Releases API.
+reqwest            = { workspace = true }
 # Production dep: the orchestrator stages PDF bytes to a tempfile so the
 # existing `Store::write(_, _, Some(&Utf8Path))` atomic-rename code path
 # applies (Source impls return `Bytes`, Store takes a path).

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -134,8 +134,20 @@ pub async fn run_with_options(
             }
             // `ParseError` is `#[non_exhaustive]`; any future variant
             // surfaces as a generic invalid-ref entry so the batch
-            // does not silently swallow a new failure class.
-            Err(other) => inputs.push(format!("<unhandled parse error: {other}>")),
+            // does not silently swallow a new failure class. The
+            // `tracing::error!` makes the unknown variant LOUD in
+            // logs so an operator notices when this arm fires —
+            // otherwise the operator would only see an `INVALID_REF`
+            // JSONL row indistinguishable from any other parse
+            // failure.
+            Err(other) => {
+                tracing::error!(
+                    error = %other,
+                    "encountered unknown ParseError variant; batch continues with placeholder \
+                     INVALID_REF — this should never happen on a current doiget-core build"
+                );
+                inputs.push(format!("<unhandled parse error: {other}>"));
+            }
         }
     }
 

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -422,6 +422,7 @@ fn classify_joined(
                     code,
                     message,
                     denial,
+                    ..
                 } = &outcome.pdf_leg
                 {
                     let effective = effective_blocked_code(*code, denial.as_ref());
@@ -775,6 +776,7 @@ mod tests {
                 cap: None,
                 actual: None,
             }),
+            suggested_arxiv_id: None,
         };
         let outcome = classify_joined(
             Ok(TaskOutcome {

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -494,6 +494,15 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
             json_mode: JsonMode::Artifact,
             feature_gated: Some("citation"),
         },
+        "version" => SubcommandMeta {
+            examples: &[
+                "doiget version",
+                "doiget version --check",
+                "doiget version --check --mode json",
+            ],
+            json_mode: JsonMode::Supported,
+            feature_gated: None,
+        },
         "capabilities" => SubcommandMeta {
             examples: &["doiget capabilities | jq ."],
             // The whole point of capabilities IS JSON output.

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -373,14 +373,21 @@ mod tests {
     }
 
     /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`
-    /// causes `doiget config doctor` to FAIL (exit 2). POSIX-only
-    /// because `dirs::config_dir()` on Windows queries the Known
-    /// Folder API directly (ignores APPDATA env), so the test can't
-    /// redirect the config path in a child process the way it can
-    /// via `XDG_CONFIG_HOME` on POSIX. The malformed-config FAIL
-    /// path is platform-independent; this test covers the wiring
-    /// on the platform where it CAN be exercised.
-    #[cfg(unix)]
+    /// causes `doiget config doctor` to FAIL (exit 2). Linux-only
+    /// because `dirs::config_dir()` resolves differently on each
+    /// platform:
+    ///   - Linux: `$XDG_CONFIG_HOME` or `$HOME/.config` (env-driven,
+    ///     testable).
+    ///   - macOS: `~/Library/Application Support` (Known Folder via
+    ///     `NSSearchPathForDirectoriesInDomains`, ignores
+    ///     `XDG_CONFIG_HOME`).
+    ///   - Windows: `%FOLDERID_RoamingAppData%` (Known Folder API,
+    ///     ignores `APPDATA` env in child processes via
+    ///     `assert_cmd`).
+    /// The malformed-config FAIL path is platform-independent; this
+    /// test covers the wiring on the one platform where it CAN be
+    /// exercised in a hermetic test.
+    #[cfg(target_os = "linux")]
     #[test]
     #[serial_test::serial]
     fn doctor_fails_with_malformed_user_extension_config() {

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -56,7 +56,7 @@ use doiget_core::store::FsStore;
 use doiget_core::{CapabilityProfile, DenialContext, DenialReason, ErrorCode, RateLimits, Ref};
 
 /// Defer to docs/PROVENANCE_LOG.md §3: 26-char ULID per process invocation.
-fn new_session_id() -> String {
+pub(crate) fn new_session_id() -> String {
     ulid::Ulid::new().to_string()
 }
 
@@ -98,7 +98,7 @@ pub fn emit_dry_run_plan_to_stdout(ref_: &Ref, plan: &FetchPlan) -> Result<()> {
 /// Resolve the provenance log path. `DOIGET_LOG_PATH` wins; otherwise
 /// fall back to `<config>/doiget/access.jsonl` per `docs/PROVENANCE_LOG.md`
 /// §1.
-fn resolve_log_path() -> Result<Utf8PathBuf> {
+pub(crate) fn resolve_log_path() -> Result<Utf8PathBuf> {
     if let Some(s) = read_env_utf8("DOIGET_LOG_PATH")? {
         return Ok(Utf8PathBuf::from(s));
     }
@@ -169,7 +169,7 @@ pub(crate) fn config_dir_utf8() -> Result<Utf8PathBuf> {
 /// when `DOIGET_OA_PUBLISHER_BASE` is set — this lets the integration tests
 /// under `tests/fetch_doi_oa_pdf_e2e.rs` exercise the full PDF leg without
 /// touching the real network.
-fn build_http_client() -> Result<HttpClient> {
+pub(crate) fn build_http_client() -> Result<HttpClient> {
     let arxiv = std::env::var("DOIGET_ARXIV_BASE").ok();
     let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
     let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
@@ -499,11 +499,19 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
             code,
             message,
             denial,
+            suggested_arxiv_id,
         } => {
             // Same #145 reclassification as the primary interception in
             // `fetch_one`, so this fail-closed fallback stays consistent.
             let effective = effective_blocked_code(*code, denial.as_ref());
-            render_blocked_error(ref_, outcome, effective, message, denial.as_ref());
+            render_blocked_error(
+                ref_,
+                outcome,
+                effective,
+                message,
+                denial.as_ref(),
+                suggested_arxiv_id.as_deref(),
+            );
         }
         // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
         // degrades to the size-based wording rather than failing the
@@ -624,10 +632,18 @@ pub async fn run_with_options(
                 code,
                 message,
                 denial,
+                suggested_arxiv_id,
             } = &outcome.pdf_leg
             {
                 let effective = effective_blocked_code(*code, denial.as_ref());
-                render_blocked_error(&ref_, &outcome, effective, message, denial.as_ref());
+                render_blocked_error(
+                    &ref_,
+                    &outcome,
+                    effective,
+                    message,
+                    denial.as_ref(),
+                    suggested_arxiv_id.as_deref(),
+                );
                 return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
             }
             emit_success_line(&ref_, &outcome);
@@ -781,6 +797,7 @@ fn render_blocked_error(
     code: ErrorCode,
     message: &str,
     denial: Option<&DenialContext>,
+    suggested_arxiv_id: Option<&str>,
 ) {
     let label = match ref_ {
         Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
@@ -831,6 +848,12 @@ fn render_blocked_error(
         "  = note: metadata-only record written to {}",
         outcome.path
     ));
+    if let Some(arxiv_id) = suggested_arxiv_id {
+        print_err(format_args!(
+            "  = suggest: Try fetching the arXiv version: doiget fetch arxiv:{}",
+            arxiv_id
+        ));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -31,7 +31,9 @@ pub mod info;
 pub mod list_recent;
 pub mod output;
 pub mod provenance;
+pub mod resolve_citation;
 pub mod search;
+pub mod version;
 
 // Phase 4 / Slice 16. Compile-gated by the `citation` Cargo feature
 // (which itself enables `doiget-core/citation`).

--- a/crates/doiget-cli/src/commands/resolve_citation.rs
+++ b/crates/doiget-cli/src/commands/resolve_citation.rs
@@ -1,0 +1,112 @@
+//! `doiget resolve-citation` and `doiget batch-resolve-citations` subcommand.
+
+use std::io::{BufRead, Write};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use doiget_core::source::FetchContext;
+use doiget_core::sources::crossref::CrossrefSource;
+use doiget_core::{RateLimits, ResolveResult};
+
+use super::output::OutputMode;
+
+fn build_context() -> Result<FetchContext> {
+    let session_id = crate::commands::fetch::new_session_id();
+    let log_path = crate::commands::fetch::resolve_log_path()?;
+
+    let http = Arc::new(crate::commands::fetch::build_http_client()?);
+    let rate_limiter = Arc::new(doiget_core::rate_limiter::RateLimiter::new(
+        RateLimits::HARD_CODED,
+    ));
+    let log = Arc::new(
+        doiget_core::provenance::ProvenanceLog::open(log_path, session_id.clone())
+            .context("failed to open provenance log for citation resolution")?,
+    );
+
+    Ok(FetchContext {
+        http,
+        rate_limiter,
+        log,
+        session_id,
+    })
+}
+
+fn build_crossref_source() -> Result<CrossrefSource> {
+    let contact_email =
+        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    match std::env::var("DOIGET_CROSSREF_BASE").ok() {
+        Some(base_str) => {
+            let base = url::Url::parse(&base_str).context("invalid DOIGET_CROSSREF_BASE")?;
+            Ok(CrossrefSource::with_base(base, contact_email))
+        }
+        None => Ok(CrossrefSource::new(contact_email)),
+    }
+}
+
+/// Run a single citation lookup.
+pub async fn run(query: String, limit: u8, mode: OutputMode) -> Result<()> {
+    if mode == OutputMode::Quiet || mode == OutputMode::Mcp {
+        return Ok(());
+    }
+
+    let ctx = build_context()?;
+    let source = build_crossref_source()?;
+
+    let candidates = source
+        .resolve_citation(&query, limit, &ctx)
+        .await
+        .context("failed to resolve citation via Crossref")?;
+
+    let result = ResolveResult { query, candidates };
+    let s = serde_json::to_string_pretty(&result)?;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    writeln!(out, "{s}").context("failed to write resolution result to stdout")?;
+    Ok(())
+}
+
+/// Run batch citation lookup by reading queries line-by-line from stdin.
+pub async fn run_batch(limit: u8, mode: OutputMode) -> Result<()> {
+    // Collect all lines before entering the async loop — holding StdinLock
+    // (a blocking OS primitive) across `.await` yield points would stall
+    // the executor thread.
+    let queries: Vec<String> = {
+        let stdin = std::io::stdin();
+        stdin
+            .lock()
+            .lines()
+            .collect::<std::io::Result<_>>()
+            .context("failed to read lines from stdin")?
+    };
+
+    let ctx = build_context()?;
+    let source = build_crossref_source()?;
+
+    for raw in queries {
+        let query = raw.trim().to_string();
+        if query.is_empty() {
+            continue;
+        }
+
+        let candidates = source
+            .resolve_citation(&query, limit, &ctx)
+            .await
+            .context("failed to resolve citation in batch via Crossref")?;
+
+        if mode != OutputMode::Quiet {
+            let result = ResolveResult { query, candidates };
+            // In batch/JSONL mode, emit each result as a single line of minified JSON.
+            let s = serde_json::to_string(&result)?;
+            // Acquire and release stdout lock per iteration so it is never
+            // held across an `.await` point.
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            writeln!(out, "{s}").context("failed to write batch resolution result to stdout")?;
+            out.flush().context("failed to flush stdout")?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/doiget-cli/src/commands/version.rs
+++ b/crates/doiget-cli/src/commands/version.rs
@@ -1,0 +1,285 @@
+// allow: outbound-network
+//! `doiget version [--check]` — print the current version and optionally
+//! query GitHub Releases for the latest stable tag.
+//!
+//! Without `--check` the command prints the compiled-in version string and
+//! exits immediately (no network, no side-effects).
+//!
+//! With `--check` it queries the GitHub Releases API, compares with the
+//! compiled-in version, and emits a machine-readable JSON object:
+//!
+//! ```json
+//! {
+//!   "current":          "0.4.1-beta.0",
+//!   "latest":           "0.4.0",
+//!   "newer_available":  false,
+//!   "html_url":         "https://github.com/…/releases/tag/v0.4.0"
+//! }
+//! ```
+//!
+//! When the check fails (rate-limited, network down) the `latest` and
+//! `html_url` fields are `null` and an `error` key is populated instead,
+//! so callers never receive a hard error just because GitHub is slow.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use super::output::OutputMode;
+
+const CURRENT: &str = env!("CARGO_PKG_VERSION");
+
+const RELEASES_API: &str = "https://api.github.com/repos/sotashimozono/doiget/releases";
+
+/// Connect + read timeout for the version check HTTP request.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Return the releases endpoint URL, honouring `DOIGET_GITHUB_BASE` for
+/// integration tests (same override pattern as `DOIGET_CROSSREF_BASE` etc.).
+///
+/// Returns an error when `DOIGET_GITHUB_BASE` is set but not a valid URL.
+fn releases_url() -> anyhow::Result<String> {
+    match std::env::var("DOIGET_GITHUB_BASE").ok() {
+        Some(base) => {
+            url::Url::parse(&base)
+                .map_err(|e| anyhow::anyhow!("invalid DOIGET_GITHUB_BASE: {e}"))?;
+            Ok(format!(
+                "{}/repos/sotashimozono/doiget/releases",
+                base.trim_end_matches('/')
+            ))
+        }
+        None => Ok(RELEASES_API.to_string()),
+    }
+}
+
+/// Output shape for `--check` in JSON mode.
+///
+/// On failure `latest`, `newer_available`, and `html_url` are `null`;
+/// `error` carries a human-readable reason. These `null` fields are stable
+/// wire format — they are present, not absent, in the error path.
+#[derive(Debug, Serialize)]
+pub struct VersionCheckResult {
+    /// Current compiled-in version.
+    pub current: &'static str,
+    /// Latest stable tag without the `v` prefix (e.g. `"0.4.0"`).
+    /// `null` when the check could not complete.
+    pub latest: Option<String>,
+    /// `true` when `latest` is set and strictly newer than `current`.
+    /// `null` when `latest` is `null`.
+    pub newer_available: Option<bool>,
+    /// GitHub release page URL. `null` when the check could not complete.
+    pub html_url: Option<String>,
+    /// Human-readable error reason when the check failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Entry point for `doiget version [--check]`.
+pub async fn run(check: bool, mode: OutputMode) -> Result<()> {
+    if mode == OutputMode::Quiet || mode == OutputMode::Mcp {
+        return Ok(());
+    }
+
+    if !check {
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        if mode == OutputMode::Json {
+            writeln!(
+                out,
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({ "version": CURRENT }))?
+            )?;
+        } else {
+            writeln!(out, "doiget {CURRENT}")?;
+        }
+        return Ok(());
+    }
+
+    let result = fetch_latest().await;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    if mode == OutputMode::Json {
+        writeln!(out, "{}", serde_json::to_string_pretty(&result)?)?;
+    } else {
+        match (&result.latest, &result.newer_available) {
+            (Some(latest), Some(true)) => {
+                writeln!(out, "doiget {CURRENT} — update available: {latest}")?;
+                if let Some(url) = &result.html_url {
+                    writeln!(out, "  {url}")?;
+                }
+            }
+            (Some(latest), _) => {
+                writeln!(
+                    out,
+                    "doiget {CURRENT} — up to date (latest stable: {latest})"
+                )?;
+            }
+            (None, _) => {
+                let reason = result.error.as_deref().unwrap_or("unknown");
+                writeln!(out, "doiget {CURRENT} — version check failed: {reason}")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Query the GitHub Releases API and return the latest stable (non-prerelease,
+/// non-draft) release. Returns a populated `error` field on any failure so
+/// callers are never hard-blocked by a network hiccup.
+async fn fetch_latest() -> VersionCheckResult {
+    match try_fetch_latest().await {
+        Ok(r) => r,
+        Err(e) => VersionCheckResult {
+            current: CURRENT,
+            latest: None,
+            newer_available: None,
+            html_url: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+async fn try_fetch_latest() -> anyhow::Result<VersionCheckResult> {
+    doiget_core::http::init_tls();
+    let client = reqwest::Client::builder()
+        .user_agent(format!("doiget/{CURRENT}"))
+        .timeout(CHECK_TIMEOUT)
+        .build()?;
+
+    let url = releases_url()?;
+
+    let resp = client.get(url).send().await.map_err(|e| {
+        if e.is_connect() || e.is_timeout() {
+            anyhow::anyhow!("unreachable")
+        } else {
+            anyhow::anyhow!("{e}")
+        }
+    })?;
+
+    if resp.status().as_u16() == 403 {
+        return Err(anyhow::anyhow!("rate_limited"));
+    }
+
+    let releases: serde_json::Value = resp.error_for_status()?.json().await?;
+
+    let arr = releases
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("unexpected API shape"))?;
+
+    // First non-draft, non-prerelease release without a pre-release suffix.
+    let stable = arr.iter().find(|r| {
+        let draft = r.get("draft").and_then(|v| v.as_bool()).unwrap_or(true);
+        let prerelease = r
+            .get("prerelease")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        if draft || prerelease {
+            return false;
+        }
+        let tag = r.get("tag_name").and_then(|v| v.as_str()).unwrap_or("");
+        let bare = tag.strip_prefix('v').unwrap_or(tag);
+        !has_prerelease_suffix(bare)
+    });
+
+    let Some(release) = stable else {
+        return Err(anyhow::anyhow!("no stable release found"));
+    };
+
+    let tag = release
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing tag_name"))?;
+    let html_url = release
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let latest = tag.strip_prefix('v').unwrap_or(tag).to_string();
+
+    Ok(VersionCheckResult {
+        current: CURRENT,
+        newer_available: Some(is_newer(&latest, CURRENT)),
+        latest: Some(latest),
+        html_url,
+        error: None,
+    })
+}
+
+/// Return `true` when `candidate` is strictly newer than `current` by
+/// dot-separated numeric comparison on the version core (before any `-`
+/// pre-release suffix). Both vectors are padded to equal length so that
+/// `"1.0"` and `"1.0.0"` compare equal rather than the shorter one
+/// appearing lesser.
+fn is_newer(candidate: &str, current: &str) -> bool {
+    let parse = |s: &str| -> Vec<u64> {
+        let core = s.split('-').next().unwrap_or(s);
+        core.split('.').map(|p| p.parse().unwrap_or(0)).collect()
+    };
+    let mut a = parse(candidate);
+    let mut b = parse(current);
+    let len = a.len().max(b.len());
+    a.resize(len, 0);
+    b.resize(len, 0);
+    a > b
+}
+
+/// Return `true` when a version string has a known pre-release suffix.
+fn has_prerelease_suffix(version: &str) -> bool {
+    let lower = version.to_ascii_lowercase();
+    lower.contains("-beta") || lower.contains("-alpha") || lower.contains("-rc")
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_detects_upgrade() {
+        assert!(is_newer("0.5.0", "0.4.0"));
+        assert!(is_newer("0.4.1", "0.4.0"));
+        assert!(!is_newer("0.4.0", "0.4.0"));
+        assert!(!is_newer("0.3.9", "0.4.0"));
+    }
+
+    #[test]
+    fn is_newer_ignores_prerelease_suffix_in_current() {
+        assert!(!is_newer("0.4.0", "0.4.1-beta.0"));
+        assert!(is_newer("0.5.0", "0.4.1-beta.0"));
+    }
+
+    #[test]
+    fn is_newer_pads_mismatched_component_counts() {
+        // "1.0" and "1.0.0" must compare equal, not report "1.0" as older.
+        assert!(!is_newer("1.0", "1.0.0"));
+        assert!(!is_newer("1.0.0", "1.0"));
+        assert!(is_newer("1.0.1", "1.0"));
+    }
+
+    #[test]
+    fn has_prerelease_suffix_cases() {
+        assert!(has_prerelease_suffix("0.4.1-beta.0"));
+        assert!(has_prerelease_suffix("1.0.0-alpha"));
+        assert!(has_prerelease_suffix("1.0.0-rc.1"));
+        assert!(!has_prerelease_suffix("0.4.0"));
+    }
+
+    #[test]
+    fn releases_url_rejects_invalid_base() {
+        std::env::set_var("DOIGET_GITHUB_BASE", "not a url !!!");
+        let result = releases_url();
+        std::env::remove_var("DOIGET_GITHUB_BASE");
+        assert!(result.is_err(), "invalid base must return Err");
+    }
+
+    #[test]
+    fn releases_url_falls_back_to_production_when_unset() {
+        std::env::remove_var("DOIGET_GITHUB_BASE");
+        let url = releases_url().expect("fallback must succeed");
+        assert_eq!(url, RELEASES_API);
+    }
+}

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -288,6 +288,29 @@ enum Command {
         #[command(subcommand)]
         action: ProvenanceAction,
     },
+    /// Print the current version. With `--check`, query GitHub Releases for
+    /// the latest stable tag and report whether an update is available.
+    Version {
+        /// Check GitHub Releases for a newer stable release.
+        #[arg(long)]
+        check: bool,
+    },
+    /// Resolve a bibliographic citation string to ranked DOI candidates.
+    #[command(name = "resolve-citation")]
+    ResolveCitation {
+        /// Bibliographic citation query string (e.g. "Onsager 1944").
+        query: String,
+        /// Maximum number of candidates to return (default: 5).
+        #[arg(long, default_value_t = 5)]
+        limit: u8,
+    },
+    /// Batch resolve bibliographic citation strings from stdin.
+    #[command(name = "batch-resolve-citations")]
+    BatchResolveCitations {
+        /// Maximum number of candidates to return per citation (default: 5).
+        #[arg(long, default_value_t = 5)]
+        limit: u8,
+    },
     /// Run as an MCP server over stdio.
     Serve,
     /// Emit a single JSON inventory of the binary's full surface
@@ -488,6 +511,13 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_, mode),
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit, mode),
         Some(Command::Search { query }) => doiget_cli::commands::search::run(query, mode),
+        Some(Command::Version { check }) => doiget_cli::commands::version::run(check, mode).await,
+        Some(Command::ResolveCitation { query, limit }) => {
+            doiget_cli::commands::resolve_citation::run(query, limit, mode).await
+        }
+        Some(Command::BatchResolveCitations { limit }) => {
+            doiget_cli::commands::resolve_citation::run_batch(limit, mode).await
+        }
         Some(Command::Fetch { ref_, dry_run }) => {
             doiget_cli::commands::fetch::run_with_options(ref_, dry_run, mode).await
         }

--- a/crates/doiget-cli/tests/version_e2e.rs
+++ b/crates/doiget-cli/tests/version_e2e.rs
@@ -1,0 +1,447 @@
+// allow: outbound-network
+//! End-to-end tests for `doiget version [--check]`.
+//!
+//! The `--check` tests spin up a wiremock server and pass
+//! `DOIGET_GITHUB_BASE=<mock-uri>` to the subprocess so no real GitHub
+//! network calls are made.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        // Non-TTY implicit-quiet override — without this the ADR-0017
+        // resolver falls back to Quiet in captured-stdout contexts.
+        .env("DOIGET_MODE", "human");
+    cmd
+}
+
+fn releases_body(tag: &str, draft: bool, prerelease: bool) -> serde_json::Value {
+    serde_json::json!([{
+        "tag_name":  tag,
+        "html_url":  format!("https://github.com/sotashimozono/doiget/releases/tag/{tag}"),
+        "draft":     draft,
+        "prerelease": prerelease,
+    }])
+}
+
+// ---------------------------------------------------------------------------
+// doiget version (no --check)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_no_flag_prints_human_line() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .arg("version")
+        .assert()
+        .success()
+        .stdout(contains("doiget "));
+}
+
+#[test]
+fn version_json_mode_emits_version_key() {
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--mode", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).expect("stdout is valid JSON");
+    assert!(
+        v.get("version").and_then(|v| v.as_str()).is_some(),
+        "json output must have a `version` string field; got: {v}"
+    );
+}
+
+#[test]
+fn version_quiet_mode_produces_no_stdout() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--quiet"])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+// ---------------------------------------------------------------------------
+// doiget version --check  (wiremock-driven)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn version_check_newer_available_human_output() {
+    let server = MockServer::start().await;
+    // v1.0.0 is numerically greater than any 0.x.y build.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v1.0.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).unwrap();
+    assert!(
+        s.contains("update available") || s.contains("1.0.0"),
+        "expected update-available message; got: {s:?}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_up_to_date_human_output() {
+    let server = MockServer::start().await;
+    // v0.1.0 is older than any current build (>= 0.4.x).
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v0.1.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(out).unwrap();
+    assert!(
+        s.contains("up to date") || s.contains("0.1.0"),
+        "expected up-to-date message; got: {s:?}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_json_mode_emits_structured_object() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v1.0.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value =
+        serde_json::from_slice(&out).expect("--check --mode json stdout is valid JSON");
+    assert!(v.get("current").is_some(), "must have `current`; got: {v}");
+    assert!(v.get("latest").is_some(), "must have `latest`; got: {v}");
+    assert!(
+        v.get("newer_available").is_some(),
+        "must have `newer_available`; got: {v}"
+    );
+    assert!(
+        v.get("html_url").is_some(),
+        "must have `html_url`; got: {v}"
+    );
+    assert_eq!(
+        v["newer_available"],
+        serde_json::json!(true),
+        "v1.0.0 must be newer than current build; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_skips_draft_releases() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v9.0.0", true, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "draft releases must not surface as latest; got: {v}"
+    );
+    assert!(v.get("error").is_some(), "must report an error; got: {v}");
+}
+
+#[tokio::test]
+async fn version_check_skips_prerelease_flag_releases() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v9.0.0", false, true)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "prerelease=true releases must not surface; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_skips_tags_with_beta_suffix() {
+    let server = MockServer::start().await;
+    // draft=false, prerelease=false, but tag has -beta — must be filtered.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                "tag_name":   "v9.0.0-beta.1",
+                "html_url":   "https://github.com/sotashimozono/doiget/releases/tag/v9.0.0-beta.1",
+                "draft":      false,
+                "prerelease": false,
+            }])),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "-beta tag must be filtered even when prerelease=false; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_picks_first_stable_skipping_unstable() {
+    let server = MockServer::start().await;
+    // First entry is a draft; second is the stable release to pick.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "tag_name":   "v10.0.0",
+                "html_url":   "https://github.com/example/releases/tag/v10.0.0",
+                "draft":      true,
+                "prerelease": false,
+            },
+            {
+                "tag_name":   "v0.9.0",
+                "html_url":   "https://github.com/sotashimozono/doiget/releases/tag/v0.9.0",
+                "draft":      false,
+                "prerelease": false,
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(
+        v["latest"].as_str(),
+        Some("0.9.0"),
+        "must pick v0.9.0, skipping draft v10.0.0; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_rate_limited_json_reports_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success() // must never hard-fail on a network error
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["latest"].is_null(),
+        "rate-limited must return null latest; got: {v}"
+    );
+    assert_eq!(
+        v["error"].as_str(),
+        Some("rate_limited"),
+        "must report rate_limited; got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn version_check_rate_limited_human_exits_zero() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .stdout(contains("version check failed"));
+}
+
+#[tokio::test]
+async fn version_check_empty_releases_reports_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v.get("error").is_some(),
+        "empty releases must report error; got: {v}"
+    );
+    assert!(v["latest"].is_null(), "latest must be null; got: {v}");
+}
+
+#[tokio::test]
+async fn version_check_quiet_suppresses_network_call() {
+    // With --quiet the command must exit 0 and produce no stdout,
+    // even when --check is also passed. The mock is intentionally not
+    // mounted: if the subprocess made a network call it would fail or
+    // produce output, both of which would cause the assertion to fail.
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--check", "--quiet"])
+        // Point at localhost on a port with no listener; any actual
+        // network attempt would surface as an error, not silence.
+        .env("DOIGET_GITHUB_BASE", "http://127.0.0.1:1")
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[tokio::test]
+async fn version_check_newer_available_human_prints_release_url() {
+    let server = MockServer::start().await;
+    let tag = "v1.0.0";
+    let expected_url = format!("https://github.com/sotashimozono/doiget/releases/tag/{tag}");
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(releases_body(tag, false, false)))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["version", "--check"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .stdout(contains(&expected_url));
+}
+
+#[tokio::test]
+async fn version_check_json_up_to_date_newer_available_false() {
+    let server = MockServer::start().await;
+    // v0.1.0 is older than any current build — newer_available must be false.
+    Mock::given(method("GET"))
+        .and(path("/repos/sotashimozono/doiget/releases"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(releases_body("v0.1.0", false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let out = doiget(&dir)
+        .args(["version", "--check", "--mode", "json"])
+        .env("DOIGET_GITHUB_BASE", server.uri())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(
+        v["newer_available"],
+        serde_json::json!(false),
+        "v0.1.0 must not be reported as newer; got: {v}"
+    );
+    assert!(v.get("error").is_none(), "no error on success; got: {v}");
+}

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -1053,6 +1053,15 @@ fn ensure_crypto_provider() {
     });
 }
 
+/// Public entry point for callers that build their own `reqwest::Client`
+/// outside of [`HttpClient`] and need the process-default TLS provider
+/// installed first (ADR-0020 Amendment 1).
+///
+/// Safe to call multiple times; the underlying `Once` makes it idempotent.
+pub fn init_tls() {
+    ensure_crypto_provider();
+}
+
 /// Upgrade an `http://` URL to `https://` for legacy publisher
 /// metadata. Loopback hosts (`localhost`, any RFC 6761 `.localhost`
 /// TLD subdomain, `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback)

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -818,6 +818,36 @@ pub struct DenialContext {
 }
 
 // ---------------------------------------------------------------------------
+// ResolvedCandidate / ResolveResult (Issue #242)
+// ---------------------------------------------------------------------------
+
+/// A candidate paper resolved from a bibliographic citation string.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedCandidate {
+    /// Resolved DOI.
+    pub doi: String,
+    /// Title of the resolved candidate.
+    pub title: String,
+    /// First author or primary author representation.
+    pub author: String,
+    /// Publication year, if resolved.
+    pub year: Option<i32>,
+    /// Token similarity overlap score in `0.0..=1.0`.
+    pub score: f64,
+    /// Resolving metadata source (e.g. `"crossref"`).
+    pub source: String,
+}
+
+/// The result structure returned by bibliographic citation resolution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolveResult {
+    /// The original query bibliographic citation string.
+    pub query: String,
+    /// Ranked candidate list (highest score first, thresholded to >= 0.5).
+    pub candidates: Vec<ResolvedCandidate>,
+}
+
+// ---------------------------------------------------------------------------
 // CapabilityProfile (placeholder; full impl in Phase 1)
 // ---------------------------------------------------------------------------
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -868,9 +868,24 @@ async fn fetch_paper_doi(
             (r.license, label, chain)
         }
         Err(e) => {
+            // Unpaywall unreachable / errored. We continue with the
+            // Crossref-only metadata, but the resulting empty OA
+            // chain will be reported downstream as
+            // `PdfLegStatus::NoOaUrl` — semantically distinct from
+            // "Unpaywall confirmed no OA URL". The provenance log
+            // already carries an Unpaywall Fetch err row (the
+            // Unpaywall source impl logged its own attempt before
+            // returning), so the audit trail captures the cause; the
+            // tracing line below makes the orchestrator-level signal
+            // loud as well. Surfacing the distinction at the
+            // `PdfLegStatus` level (a new variant like
+            // `MetadataSourceUnavailable`) is a deliberate
+            // follow-up — see CHANGELOG `[0.4.0]` Notes.
             tracing::warn!(
                 error = %e,
-                "unpaywall fetch failed; continuing with crossref-only metadata"
+                doi = %doi.as_str(),
+                "unpaywall fetch failed; OA chain will be empty (downstream PdfLegStatus::NoOaUrl \
+                 is conservative — Unpaywall was unreachable, not authoritatively oa-free)"
             );
             ("unknown".to_string(), "crossref".to_string(), Vec::new())
         }
@@ -944,11 +959,33 @@ async fn fetch_paper_doi(
                     None,
                 )
             }
-            // Unreachable: `oa_chain` is non-empty in this branch, so
-            // at least one iteration set either `succeeded` or
-            // `last_err`. Conservative fallback if a future refactor
-            // breaks the invariant.
-            (None, None) => (PdfLegStatus::NoOaUrl, None),
+            // Defensive fallback. `oa_chain` is non-empty in this
+            // branch, so structurally at least one iteration must set
+            // either `succeeded` or `last_err`. If a future refactor
+            // breaks the invariant we fail CLOSED — surface a
+            // `Blocked` outcome with a self-describing message
+            // rather than `NoOaUrl` (which would falsely tell the
+            // caller no candidate URL was ever discovered). Routes
+            // to `INTERNAL_ERROR` so the CLI's exit-code mapping
+            // signals a doiget bug, not a remote failure.
+            (None, None) => {
+                tracing::error!(
+                    total = oa_chain.len(),
+                    "OA PDF chain walker exhausted without recording success or error \
+                     (defensive fallback — should be unreachable)"
+                );
+                (
+                    PdfLegStatus::Blocked {
+                        code: crate::ErrorCode::InternalError,
+                        message:
+                            "OA PDF chain walker exhausted without recording success or error \
+                             (orchestrator bug — please report)"
+                                .to_string(),
+                        denial: None,
+                    },
+                    None,
+                )
+            }
         }
     };
 
@@ -1104,11 +1141,17 @@ fn write_metadata_and_pdf(
         }
         Err(e) => {
             // Best-effort: record the StoreWrite failure before
-            // propagating. Surface as `SourceSchema` so the
+            // propagating the store.write error. We do NOT
+            // propagate the log-append error itself here — we're
+            // already in an error state from the store, and the
+            // primary failure is what the caller needs to act on.
+            // But the log-append failure is observable via tracing
+            // so an operator can spot a broken hash chain when
+            // both fail. Surface as `SourceSchema` so the
             // FetchError -> ErrorCode collapse routes it to
             // `INTERNAL_ERROR` (closest closed-set fit; `StoreError`
             // does not have a direct closed-set arm).
-            let _ = ctx.log.append(RowInput {
+            if let Err(log_err) = ctx.log.append(RowInput {
                 event: LogEvent::StoreWrite,
                 result: LogResult::Err,
                 capability: Capability::Oa,
@@ -1123,7 +1166,14 @@ fn write_metadata_and_pdf(
                 license: None,
                 store_path: Some(&store_path_relative),
                 canonical_digest: canonical_digest.as_deref(),
-            });
+            }) {
+                tracing::error!(
+                    store_err = %e,
+                    log_err = %log_err,
+                    "BOTH store.write AND provenance log append failed; \
+                     audit trail is broken for this attempt"
+                );
+            }
             Err(FetchError::SourceSchema {
                 hint: format!("store write failed: {e}"),
             })

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1764,7 +1764,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_oa_url_chain_skips_unparseable_urls() {
+    fn extract_oa_url_chain_skips_unparsable_urls() {
         // A malformed URL in oa_locations[] is dropped silently
         // rather than aborting the chain — the metadata source can
         // emit a stray entry without poisoning the whole fetch.

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -556,6 +556,9 @@ pub enum PdfLegStatus {
         /// Structured denial side-channel (ADR-0023) when the failure
         /// was an allowlist / scheme denial; `None` otherwise.
         denial: Option<crate::DenialContext>,
+        /// Actionable suggested arXiv ID for the same paper when Unpaywall
+        /// metadata includes an arXiv alternative but the PDF leg was blocked.
+        suggested_arxiv_id: Option<String>,
     },
 }
 
@@ -950,11 +953,13 @@ async fn fetch_paper_doi(
                 let denial: Option<crate::DenialContext> = (&fe).into();
                 let message = fe.to_string();
                 let code: crate::ErrorCode = fe.into();
+                let suggested_arxiv_id = oa_chain.iter().find_map(extract_arxiv_id_from_url);
                 (
                     PdfLegStatus::Blocked {
                         code,
                         message,
                         denial,
+                        suggested_arxiv_id,
                     },
                     None,
                 )
@@ -982,6 +987,7 @@ async fn fetch_paper_doi(
                              (orchestrator bug — please report)"
                                 .to_string(),
                         denial: None,
+                        suggested_arxiv_id: None,
                     },
                     None,
                 )
@@ -1331,18 +1337,18 @@ async fn try_fetch_oa_pdf(
 }
 
 /// Subset of Crossref `message` fields populated into the on-disk metadata.
-struct CrossrefFields {
-    title: Option<String>,
-    authors: Vec<String>,
-    year: Option<i32>,
-    venue: Option<String>,
-    type_: Option<String>,
+pub(crate) struct CrossrefFields {
+    pub(crate) title: Option<String>,
+    pub(crate) authors: Vec<String>,
+    pub(crate) year: Option<i32>,
+    pub(crate) venue: Option<String>,
+    pub(crate) type_: Option<String>,
 }
 
 /// Defensively pull bibliographic fields out of a Crossref envelope's
-/// `message` object. Every field is optional; malformed shapes degrade
-/// to `None` rather than panicking.
-fn extract_crossref_fields(msg: &Value) -> CrossrefFields {
+/// message object. Every field is optional; malformed shapes degrade
+/// to None rather than panicking.
+pub(crate) fn extract_crossref_fields(msg: &Value) -> CrossrefFields {
     let title = msg
         .get("title")
         .and_then(|v| v.as_array())
@@ -1461,6 +1467,51 @@ fn pull_oa_url_from_location(loc: &Value) -> Option<url::Url> {
     url::Url::parse(candidate).ok()
 }
 
+/// Helper to parse clean arXiv IDs from URLs like arxiv.org/pdf/1901.12345.pdf.
+///
+/// Strips the trailing `.pdf` extension and any version suffix (`v1`, `v2`, …)
+/// so the returned ID refers to the latest version rather than pinning a
+/// specific one. Returns `None` for non-arXiv hosts or unrecognised path shapes.
+fn extract_arxiv_id_from_url(url: &url::Url) -> Option<String> {
+    let host = url.host_str()?;
+    let is_arxiv = matches!(
+        host,
+        "arxiv.org" | "www.arxiv.org" | "export.arxiv.org" | "e-print.arxiv.org"
+    );
+    if !is_arxiv {
+        return None;
+    }
+    let path = url.path();
+    let raw = if path.starts_with("/pdf/") {
+        let s = path.strip_prefix("/pdf/")?;
+        s.strip_suffix(".pdf").unwrap_or(s)
+    } else if path.starts_with("/abs/") {
+        path.strip_prefix("/abs/")?
+    } else {
+        return None;
+    };
+    Some(strip_arxiv_version(raw).to_string())
+}
+
+/// Strip a trailing arXiv version suffix (`v1`, `v2`, …) from an ID string.
+///
+/// Recognises the suffix only when the `v` is **preceded by a digit** (ruling
+/// out category fragments like `quant-ph`) and followed by one or more ASCII
+/// digits. Leaves IDs without a recognisable version suffix unchanged.
+fn strip_arxiv_version(id: &str) -> &str {
+    if let Some(v_pos) = id.rfind('v') {
+        let before_v = id[..v_pos].chars().next_back();
+        let suffix = &id[v_pos + 1..];
+        if before_v.is_some_and(|c| c.is_ascii_digit())
+            && !suffix.is_empty()
+            && suffix.bytes().all(|b| b.is_ascii_digit())
+        {
+            return &id[..v_pos];
+        }
+    }
+    id
+}
+
 fn unpaywall_email_from_env(fallback_contact: &str) -> String {
     std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| fallback_contact.to_string())
 }
@@ -1571,6 +1622,60 @@ pub fn batch_fetch_plans(
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_extract_arxiv_id_from_url() {
+        let urls = [
+            // Basic new-style ID
+            ("https://arxiv.org/pdf/1901.12345.pdf", Some("1901.12345")),
+            ("https://arxiv.org/abs/1901.12345", Some("1901.12345")),
+            // Version suffix is stripped
+            ("https://arxiv.org/pdf/1901.12345v2.pdf", Some("1901.12345")),
+            ("https://arxiv.org/abs/1901.12345v3", Some("1901.12345")),
+            // Old-style category/ID
+            (
+                "https://www.arxiv.org/pdf/cond-mat/9501001.pdf",
+                Some("cond-mat/9501001"),
+            ),
+            (
+                "https://export.arxiv.org/abs/cond-mat/9501001",
+                Some("cond-mat/9501001"),
+            ),
+            // Old-style with version stripped
+            (
+                "https://arxiv.org/pdf/cond-mat/9501001v1.pdf",
+                Some("cond-mat/9501001"),
+            ),
+            // e-print subdomain
+            (
+                "https://e-print.arxiv.org/pdf/2401.12345.pdf",
+                Some("2401.12345"),
+            ),
+            // Non-arXiv host
+            ("https://example.org/pdf/1901.12345.pdf", None),
+        ];
+        for (url_str, expected) in urls {
+            let url = url::Url::parse(url_str).unwrap();
+            assert_eq!(
+                extract_arxiv_id_from_url(&url),
+                expected.map(String::from),
+                "url: {url_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strip_arxiv_version() {
+        assert_eq!(strip_arxiv_version("2401.12345v2"), "2401.12345");
+        assert_eq!(strip_arxiv_version("2401.12345v10"), "2401.12345");
+        assert_eq!(strip_arxiv_version("2401.12345"), "2401.12345");
+        assert_eq!(
+            strip_arxiv_version("cond-mat/9501001v3"),
+            "cond-mat/9501001"
+        );
+        // "v" not followed by digits — unchanged
+        assert_eq!(strip_arxiv_version("quant-phv5"), "quant-phv5");
+    }
 
     #[test]
     fn extract_crossref_oa_url_finds_first_url() {

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -3,6 +3,8 @@
 //! Spec: docs/SOURCES.md §4 (Crossref). No auth; polite-pool User-Agent
 //! contact email is REQUIRED — see [`CrossrefSource::new`].
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use serde::Deserialize;
 use url::Url;
@@ -14,6 +16,10 @@ use crate::{CapabilityProfile, Ref};
 /// Production Crossref REST API base URL. Hard-coded per `docs/SOURCES.md`
 /// §4; tests inject a wiremock origin via [`CrossrefSource::with_base`].
 const DEFAULT_BASE: &str = "https://api.crossref.org";
+
+/// Minimum token overlap similarity score to include a candidate in
+/// [`CrossrefSource::resolve_citation`] results.
+const MIN_CITATION_SCORE: f64 = 0.5;
 
 /// Crossref [`Source`] impl — DOI → metadata; OA URL via `message.link[]`.
 ///
@@ -76,6 +82,128 @@ impl CrossrefSource {
         self.base.join(&path).map_err(|e| FetchError::SourceSchema {
             hint: format!("crossref URL construction failed: {e}"),
         })
+    }
+
+    /// Resolves a free-form bibliographic citation string to ranked DOI candidates.
+    pub async fn resolve_citation(
+        &self,
+        query: &str,
+        rows: u8,
+        ctx: &FetchContext,
+    ) -> Result<Vec<crate::ResolvedCandidate>, FetchError> {
+        // 1. Rate limiter
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        // 2. Build works query URL
+        // /works?query.bibliographic=<query>&rows=<rows>&mailto=<email>
+        let mut url = self
+            .base
+            .join("/works")
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("crossref resolve_citation URL construction failed: {e}"),
+            })?;
+        url.query_pairs_mut()
+            .append_pair("query.bibliographic", query)
+            .append_pair("rows", &rows.to_string())
+            .append_pair("mailto", &self.contact_email);
+
+        // 3. HTTP fetch
+        let (body, _final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        // 4. Parse JSON
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("crossref returned non-JSON for search: {e}"),
+            })?;
+
+        let items = envelope
+            .get("message")
+            .and_then(|m| m.get("items"))
+            .and_then(|i| i.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: "crossref response missing message.items".to_string(),
+            })?;
+
+        // 5. Tokenize query (unique tokens, sorted)
+        let query_tokens = {
+            let mut t: Vec<String> = query
+                .split(|c: char| !c.is_alphanumeric())
+                .map(|s| s.to_lowercase())
+                .filter(|s| !s.is_empty())
+                .collect();
+            t.sort();
+            t.dedup();
+            t
+        };
+
+        if query_tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut candidates = Vec::new();
+
+        for item in items {
+            let doi = match item.get("DOI").and_then(|v| v.as_str()) {
+                Some(d) => d.to_string(),
+                None => continue,
+            };
+
+            let fields = crate::orchestrator::extract_crossref_fields(item);
+
+            // Construct search text from candidate
+            let mut candidate_text = String::new();
+            if let Some(t) = &fields.title {
+                candidate_text.push_str(&t.to_lowercase());
+                candidate_text.push(' ');
+            }
+            if let Some(author) = fields.authors.first() {
+                candidate_text.push_str(&author.to_lowercase());
+                candidate_text.push(' ');
+            }
+            if let Some(v) = &fields.venue {
+                candidate_text.push_str(&v.to_lowercase());
+                candidate_text.push(' ');
+            }
+            if let Some(y) = fields.year {
+                candidate_text.push_str(&y.to_string());
+                candidate_text.push(' ');
+            }
+
+            // Simple tokenize of candidate into a HashSet for O(1) lookup.
+            let candidate_tokens: HashSet<String> = candidate_text
+                .split(|c: char| !c.is_alphanumeric())
+                .map(|s| s.to_lowercase())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            let matched = query_tokens
+                .iter()
+                .filter(|q| candidate_tokens.contains(*q))
+                .count();
+
+            let score = matched as f64 / query_tokens.len() as f64;
+
+            if score >= MIN_CITATION_SCORE {
+                let first_author = fields.authors.first().cloned().unwrap_or_default();
+                candidates.push(crate::ResolvedCandidate {
+                    doi,
+                    title: fields.title.unwrap_or_default(),
+                    author: first_author,
+                    year: fields.year,
+                    score,
+                    source: "crossref".to_string(),
+                });
+            }
+        }
+
+        // 6. Sort candidates by score descending
+        candidates.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        Ok(candidates)
     }
 }
 
@@ -390,5 +518,64 @@ mod tests {
             }
             other => panic!("expected SourceSchema, got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_citation_success() {
+        let server = MockServer::start().await;
+        let mock_body = serde_json::json!({
+            "status": "ok",
+            "message": {
+                "items": [
+                    {
+                        "DOI": "10.1000/xyz123",
+                        "title": ["Lars Onsager, Crystal Statistics. I. A Two-Dimensional Model with an Order-Disorder Transition"],
+                        "author": [
+                            {"family": "Onsager", "given": "Lars"}
+                        ],
+                        "issued": {
+                            "date-parts": [[1944, 2, 1]]
+                        },
+                        "container-title": ["Physical Review"]
+                    },
+                    {
+                        "DOI": "10.1000/unrelated",
+                        "title": ["Some Unrelated Paper"],
+                        "author": [
+                            {"family": "Smith", "given": "John"}
+                        ],
+                        "issued": {
+                            "date-parts": [[2020]]
+                        }
+                    }
+                ]
+            }
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(mock_body))
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+
+        let candidates = s
+            .resolve_citation("Onsager 1944", 2, &ctx)
+            .await
+            .expect("resolve ok");
+
+        // The query "Onsager 1944" has tokens ["onsager", "1944"].
+        // The first candidate has both "onsager" (author family) and "1944" (issued year). Score is 1.0.
+        // The second candidate has neither. Score is 0.0, filtered out.
+        assert_eq!(candidates.len(), 1);
+        let cand = &candidates[0];
+        assert_eq!(cand.doi, "10.1000/xyz123");
+        assert_eq!(cand.title, "Lars Onsager, Crystal Statistics. I. A Two-Dimensional Model with an Order-Disorder Transition");
+        assert_eq!(cand.author, "Onsager, Lars");
+        assert_eq!(cand.year, Some(1944));
+        assert_eq!(cand.score, 1.0);
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -55,6 +55,7 @@ use doiget_core::orchestrator::{
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
 use doiget_core::source::{FetchContext, FetchError};
+use doiget_core::sources::crossref::CrossrefSource;
 use doiget_core::store::{EntryInfo, FsStore, Store};
 use doiget_core::{
     CapabilityProfile, DenialContext, ErrorCode, RateLimits, Ref, MAX_BATCH_REFS, SCHEMA_VERSION,
@@ -1528,6 +1529,119 @@ impl Server {
     ) -> Result<CallToolResult, ErrorData> {
         Ok(self.export_citations(&input.refs, CiteFmt::Csl))
     }
+
+    /// `doiget_resolve_citation` — resolve a free-form bibliographic citation string to ranked DOI candidates.
+    #[tool(
+        description = "WHEN TO USE: Resolve a free-form bibliographic citation string (e.g. 'Onsager 1944') to ranked DOI candidates.\n\
+                       INPUTS: query (bibliographic citation query string), limit (maximum number of candidates to return, default: 5).\n\
+                       OUTPUTS: { ok: true, query, candidates: [ { doi, title, author, year, score, source } ] } OR { ok: false, error }.\n\
+                       COSTS: 1-2 s round-trip.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Returns candidates with similarity score >= 0.5."
+    )]
+    async fn doiget_resolve_citation(
+        &self,
+        Parameters(input): Parameters<ResolveCitationInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let ctx = match build_fetch_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(serde_json::json!({
+                    "ok": false,
+                    "error": format!("context initialization failed: {e}"),
+                })));
+            }
+        };
+
+        let source = match crossref_source_from_env() {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(serde_json::json!({
+                    "ok": false,
+                    "error": e,
+                })));
+            }
+        };
+
+        match source
+            .resolve_citation(&input.query, input.limit, &ctx)
+            .await
+        {
+            Ok(candidates) => Ok(CallToolResult::structured(serde_json::json!({
+                "ok": true,
+                "query": input.query,
+                "candidates": candidates,
+            }))),
+            Err(e) => Ok(CallToolResult::structured(serde_json::json!({
+                "ok": false,
+                "error": format!("resolve failed: {e}"),
+            }))),
+        }
+    }
+
+    /// `doiget_batch_resolve_citations` — resolve multiple free-form bibliographic citation strings to ranked DOI candidates.
+    #[tool(
+        description = "WHEN TO USE: Resolve multiple free-form bibliographic citation strings in batch.\n\
+                       INPUTS: queries (array of query strings), limit (maximum number of candidates per query, default: 5).\n\
+                       OUTPUTS: { ok: true, results: [ { query, candidates: [ { doi, title, author, year, score, source } ] } ] } OR { ok: false, error }.\n\
+                       COSTS: 1-2 s round-trip per query.\n\
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: Returns candidates with similarity score >= 0.5. At most 50 queries per call."
+    )]
+    async fn doiget_batch_resolve_citations(
+        &self,
+        Parameters(input): Parameters<BatchResolveCitationsInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if input.queries.len() > 50 {
+            return Ok(CallToolResult::structured(serde_json::json!({
+                "ok": false,
+                "error": "At most 50 queries per call.",
+            })));
+        }
+
+        let ctx = match build_fetch_context() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(CallToolResult::structured(serde_json::json!({
+                    "ok": false,
+                    "error": format!("context initialization failed: {e}"),
+                })));
+            }
+        };
+
+        let source = match crossref_source_from_env() {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(serde_json::json!({
+                    "ok": false,
+                    "error": e,
+                })));
+            }
+        };
+
+        let mut results = Vec::new();
+        for query in &input.queries {
+            match source.resolve_citation(query, input.limit, &ctx).await {
+                Ok(candidates) => {
+                    results.push(serde_json::json!({
+                        "query": query,
+                        "candidates": candidates,
+                    }));
+                }
+                Err(e) => {
+                    results.push(serde_json::json!({
+                        "query": query,
+                        "error": format!("resolve failed: {e}"),
+                    }));
+                }
+            }
+        }
+
+        Ok(CallToolResult::structured(serde_json::json!({
+            "ok": true,
+            "results": results,
+        })))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1685,6 +1799,34 @@ pub struct CslExportInput {
     /// DOIs / arXiv ids to render. 1..=200; each validated via
     /// `Ref::parse` with per-ref error reporting.
     pub refs: Vec<String>,
+}
+
+/// JSON-schema-derived input for the `doiget_resolve_citation` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct ResolveCitationInput {
+    /// Bibliographic citation query string (e.g. "Onsager 1944").
+    pub query: String,
+    /// Maximum number of candidates to return (default: 5).
+    #[serde(default = "default_resolve_limit")]
+    pub limit: u8,
+}
+
+/// JSON-schema-derived input for the `doiget_batch_resolve_citations` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct BatchResolveCitationsInput {
+    /// Bibliographic citation query strings.
+    pub queries: Vec<String>,
+    /// Maximum number of candidates to return per query (default: 5).
+    #[serde(default = "default_resolve_limit")]
+    pub limit: u8,
+}
+
+fn default_resolve_limit() -> u8 {
+    5
 }
 
 /// Hard cap on refs accepted by a single `doiget_bibtex_export` /
@@ -2019,6 +2161,7 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
             code,
             message,
             denial,
+            suggested_arxiv_id,
         } => {
             let mut o = serde_json::Map::new();
             o.insert("status".into(), json!("blocked"));
@@ -2037,6 +2180,9 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
                     "denial_context".into(),
                     denial_context_to_value(dc, "fetch_paper_pdf_leg"),
                 );
+            }
+            if let Some(arxiv_id) = suggested_arxiv_id {
+                o.insert("suggested_arxiv_id".into(), json!(arxiv_id));
             }
             Value::Object(o)
         }
@@ -2405,6 +2551,23 @@ fn build_fetch_context() -> anyhow::Result<FetchContext> {
         log,
         session_id,
     })
+}
+
+/// Build a [`CrossrefSource`] from environment variables
+/// (`DOIGET_CROSSREF_BASE`, `DOIGET_CONTACT_EMAIL`).
+///
+/// Returns `Err(String)` — callers convert it into a structured tool error.
+fn crossref_source_from_env() -> Result<CrossrefSource, String> {
+    let contact_email =
+        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    match std::env::var("DOIGET_CROSSREF_BASE").ok() {
+        Some(base_str) => {
+            let base = url::Url::parse(&base_str)
+                .map_err(|e| format!("invalid DOIGET_CROSSREF_BASE: {e}"))?;
+            Ok(CrossrefSource::with_base(base, contact_email))
+        }
+        None => Ok(CrossrefSource::new(contact_email)),
+    }
 }
 
 /// HTTP client construction with the same `DOIGET_*_BASE` test-override

--- a/crates/doiget-mcp/tests/fetch_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/fetch_paper_e2e.rs
@@ -468,3 +468,118 @@ async fn batch_fetch_partial_failure_emits_per_ref_outcomes() -> anyhow::Result<
     drop(td);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// suggested_arxiv_id — issue #243
+// ---------------------------------------------------------------------------
+
+/// When all OA-chain PDF candidates fail and at least one candidate URL is
+/// hosted on arxiv.org, `doiget_fetch_paper` MUST include `suggested_arxiv_id`
+/// in the `pdf` object of the success envelope (the PDF leg is `blocked`).
+/// The version suffix (e.g. `v2`) must be stripped so the suggestion points
+/// to the latest version rather than a pinned one.
+#[tokio::test]
+#[serial_test::serial]
+async fn fetch_paper_doi_blocked_pdf_includes_suggested_arxiv_id() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+
+    // Crossref metadata — minimal envelope.
+    // Crossref uses `Url::join("/works/<doi>")` which does NOT percent-encode
+    // the `/` inside the DOI suffix, so wiremock matches the raw path.
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/suggest-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "message": {
+                "title": ["Suggestion Test Paper"],
+                "author": [{"family": "Doe", "given": "Jane"}],
+                "issued": {"date-parts": [[2024, 1, 1]]}
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    // Unpaywall metadata — `best_oa_location` points to a versioned arXiv URL.
+    // The arXiv host is off the `oa-publisher` allowlist (which only permits
+    // the wiremock host), so the PDF leg will be denied at the pre-fetch
+    // allowlist check, triggering PdfLegStatus::Blocked with a suggestion.
+    // Unpaywall uses `path_segments_mut().push()` which percent-encodes `/`.
+    Mock::given(method("GET"))
+        .and(path("/v2/10.1234%2Fsuggest-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "doi": "10.1234/suggest-test",
+            "is_oa": true,
+            "best_oa_location": {
+                "url_for_pdf": "https://arxiv.org/pdf/2401.99999v2.pdf",
+                "url": "https://arxiv.org/abs/2401.99999v2",
+                "license": "cc-by"
+            },
+            "oa_locations": [
+                {
+                    "url_for_pdf": "https://arxiv.org/pdf/2401.99999v2.pdf",
+                    "url": "https://arxiv.org/abs/2401.99999v2"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let temp_root = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", server.uri()));
+    // Register only the wiremock host for oa-publisher. arxiv.org is absent
+    // so the arXiv OA candidate is denied → PdfLegStatus::Blocked.
+    env.set("DOIGET_OA_PUBLISHER_BASE", &server.uri());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/suggest-test"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_fetch_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_fetch_paper uses CallToolResult::structured");
+
+    // Metadata fetch succeeds (ok:true) but PDF leg is blocked.
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "envelope should be ok:true (metadata was written); got: {structured:?}"
+    );
+    assert_eq!(
+        structured["pdf"]["status"],
+        serde_json::json!("blocked"),
+        "pdf leg must be blocked; got: {:?}",
+        structured["pdf"]
+    );
+    // Version suffix `v2` must be stripped — suggestion points to latest version.
+    assert_eq!(
+        structured["pdf"]["suggested_arxiv_id"],
+        serde_json::json!("2401.99999"),
+        "suggested_arxiv_id must be present and version-stripped; got: {:?}",
+        structured["pdf"]["suggested_arxiv_id"]
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}

--- a/crates/doiget-mcp/tests/resolve_citation_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_citation_e2e.rs
@@ -1,0 +1,207 @@
+//! E2E coverage for `doiget_resolve_citation` and `doiget_batch_resolve_citations`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use doiget_core::CapabilityProfile;
+use doiget_mcp::Server;
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&'static str]) -> Self {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self {
+            keys: keys.to_vec(),
+        }
+    }
+    fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for k in &self.keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+const ENV_KEYS: &[&str] = &[
+    "DOIGET_STORE_ROOT",
+    "DOIGET_LOG_PATH",
+    "DOIGET_CROSSREF_BASE",
+    "DOIGET_CONTACT_EMAIL",
+];
+
+async fn boot_in_memory_server() -> anyhow::Result<(
+    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+)> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+    Ok((client, server_handle))
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_doiget_resolve_citation_e2e() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let mock_body = serde_json::json!({
+        "status": "ok",
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/xyz123",
+                    "title": ["Lars Onsager, Crystal Statistics. I. A Two-Dimensional Model with an Order-Disorder Transition"],
+                    "author": [
+                        {"family": "Onsager", "given": "Lars"}
+                    ],
+                    "issued": {
+                        "date-parts": [[1944, 2, 1]]
+                    },
+                    "container-title": ["Physical Review"]
+                }
+            ]
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/works"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_body))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-resolve-citation.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("query".to_string(), serde_json::json!("Onsager 1944"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_citation").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_citation uses CallToolResult::structured");
+
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    assert_eq!(structured["query"], serde_json::json!("Onsager 1944"));
+    let candidates = &structured["candidates"];
+    assert_eq!(candidates.as_array().unwrap().len(), 1);
+    assert_eq!(candidates[0]["doi"], "10.1000/xyz123");
+    assert_eq!(candidates[0]["score"], 1.0);
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_doiget_batch_resolve_citations_e2e() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let mock_body = serde_json::json!({
+        "status": "ok",
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/xyz123",
+                    "title": ["Lars Onsager, Crystal Statistics. I. A Two-Dimensional Model with an Order-Disorder Transition"],
+                    "author": [
+                        {"family": "Onsager", "given": "Lars"}
+                    ],
+                    "issued": {
+                        "date-parts": [[1944, 2, 1]]
+                    },
+                    "container-title": ["Physical Review"]
+                }
+            ]
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/works"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_body))
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-batch-resolve-citation.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_CROSSREF_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("queries".to_string(), serde_json::json!(["Onsager 1944"]));
+
+    let result = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("doiget_batch_resolve_citations").with_arguments(args),
+        )
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_batch_resolve_citations uses CallToolResult::structured");
+
+    assert_eq!(structured["ok"], serde_json::json!(true));
+    let results = &structured["results"];
+    assert_eq!(results.as_array().unwrap().len(), 1);
+    assert_eq!(results[0]["query"], serde_json::json!("Onsager 1944"));
+    let candidates = &results[0]["candidates"];
+    assert_eq!(candidates.as_array().unwrap().len(), 1);
+    assert_eq!(candidates[0]["doi"], "10.1000/xyz123");
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -28,6 +28,8 @@ Additional tools:
 | `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. |
 | `doiget_bibtex_export` | BibTeX for one or many entries. |
 | `doiget_csl_export` | CSL JSON for one or many entries. |
+| `doiget_resolve_citation` | Resolve a free-form bibliographic citation string to ranked DOI candidates. |
+| `doiget_batch_resolve_citations` | Batch resolve bibliographic citation strings to ranked DOI candidates. |
 
 ## 2. Naming and convention
 
@@ -91,6 +93,8 @@ type FetchResult =
       license: string,
       size_bytes: number,
       schema_version: string,
+      // Issue #118 / #243: PDF leg status. Always present on ok:true responses.
+      pdf: PdfLeg,
     }
   | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
       rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
@@ -98,6 +102,22 @@ type FetchResult =
       ref: string,
       error: { code: ErrorCode, message: string, denial_context?: DenialContext }
     };
+
+type PdfLeg =
+  | { status: "fetched" }
+  | { status: "no_oa_url" }
+  | { status: "blocked",
+      code: ErrorCode,
+      message: string,
+      // Present when the failure was an allowlist / scheme denial (ADR-0023).
+      denial_context?: DenialContext,
+      // Present when Unpaywall metadata includes an arXiv alternative URL
+      // for the same paper. The version suffix (e.g. `v2`) is stripped so
+      // the ID refers to the latest version. Use as:
+      //   doiget fetch arxiv:<suggested_arxiv_id>
+      suggested_arxiv_id?: string,
+    }
+  | { status: "unknown" };
 
 type DenialContext = {
   reason: "redirect_not_in_allowlist" | "insecure_scheme"
@@ -296,3 +316,11 @@ type MetadataOnlyResult =
 Posture: covered by the same posture-lint check as ADR-0022 §5 — a
 `metadata_only` codepath that reaches `HttpClient::fetch_pdf` is a hard
 failure.
+
+## 12. `doiget_resolve_citation` and `doiget_batch_resolve_citations` (NORMATIVE)
+
+`doiget_resolve_citation` resolves a free-form bibliographic citation string to ranked DOI candidates via the Crossref works query API.
+
+`doiget_batch_resolve_citations` batch-resolves multiple citation strings (up to 50).
+
+Both tools calculate token-based overlap similarity scores, filter out results with a score < 0.5, and sort candidates by score descending. No local store writes or provenance logs are created.

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -639,7 +639,7 @@ version = "0.29.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]
-version = "1.0.149"
+version = "1.0.150"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]


### PR DESCRIPTION
Automated **back-merge** so the `next` beta lane does not regress behind the `main` stable lane (ADR-0025 §D6 rule 4). Opened by `.github/workflows/backmerge.yml` because `main` advanced (9 commit(s)) past `next`.

**Not auto-merged.** `next` is branch-protected; human review + CI required.

**Expected merge-time conflict (every back-merge):** `[workspace.package].version` and `Cargo.lock` conflict — `next` carries `X.Y.Z-beta.N`, `main` carries the clean stable `X.Y.Z`. **Keep `next`'s `-beta.N` version**; take `main`'s other changes. Resolve any non-version conflict on its merits.
