### PR TITLE
fix(site): check PR-branch staleness instead of origin/main on pull_request

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -73,16 +73,25 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
 
+      # ---- Staleness check: PR branch or main depending on trigger -----------
+      # On `push` to main (deploy path): verify origin/main is not stale.
+      # On `pull_request`: verify the PR's own branch is not stale.
+      # This allows next-branch PRs to pass even when main is temporarily
+      # stale between a docs update and its next→main promotion.
+      - name: Check site/content is in sync with docs
+        run: |
+          set -euo pipefail
+          bash scripts/sync_docs_to_site.sh
+          if ! git diff --exit-code site/content/; then
+            echo "::error::site/content/ is stale; run scripts/sync_docs_to_site.sh and commit." >&2
+            exit 1
+          fi
+
       # ---- Stable site, deterministically from origin/main -----------------
       - name: Build the Zola site from origin/main
         run: |
           set -euo pipefail
           git checkout --force origin/main
-          bash scripts/sync_docs_to_site.sh
-          if ! git diff --exit-code site/content/; then
-            echo "::error::site/content/ is stale on main; run scripts/sync_docs_to_site.sh and commit." >&2
-            exit 1
-          fi
           ( cd site && zola build --base-url "https://codes.sota-shimozono.com/doiget/" )
           # Stash the built site outside the worktree so the next checkout
           # (origin/next) does not clobber it.

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -34,6 +34,8 @@ Additional tools:
 | `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. |
 | `doiget_bibtex_export` | BibTeX for one or many entries. |
 | `doiget_csl_export` | CSL JSON for one or many entries. |
+| `doiget_resolve_citation` | Resolve a free-form bibliographic citation string to ranked DOI candidates. |
+| `doiget_batch_resolve_citations` | Batch resolve bibliographic citation strings to ranked DOI candidates. |
 
 ## 2. Naming and convention
 
@@ -97,6 +99,8 @@ type FetchResult =
       license: string,
       size_bytes: number,
       schema_version: string,
+      // Issue #118 / #243: PDF leg status. Always present on ok:true responses.
+      pdf: PdfLeg,
     }
   | { ok: true, dry_run: true, ref: RefShape, plan: FetchPlan,
       rate_limit_budget: { global_per_sec: number, per_source_min_gap_ms: number } }
@@ -104,6 +108,22 @@ type FetchResult =
       ref: string,
       error: { code: ErrorCode, message: string, denial_context?: DenialContext }
     };
+
+type PdfLeg =
+  | { status: "fetched" }
+  | { status: "no_oa_url" }
+  | { status: "blocked",
+      code: ErrorCode,
+      message: string,
+      // Present when the failure was an allowlist / scheme denial (ADR-0023).
+      denial_context?: DenialContext,
+      // Present when Unpaywall metadata includes an arXiv alternative URL
+      // for the same paper. The version suffix (e.g. `v2`) is stripped so
+      // the ID refers to the latest version. Use as:
+      //   doiget fetch arxiv:<suggested_arxiv_id>
+      suggested_arxiv_id?: string,
+    }
+  | { status: "unknown" };
 
 type DenialContext = {
   reason: "redirect_not_in_allowlist" | "insecure_scheme"
@@ -302,3 +322,11 @@ type MetadataOnlyResult =
 Posture: covered by the same posture-lint check as ADR-0022 §5 — a
 `metadata_only` codepath that reaches `HttpClient::fetch_pdf` is a hard
 failure.
+
+## 12. `doiget_resolve_citation` and `doiget_batch_resolve_citations` (NORMATIVE)
+
+`doiget_resolve_citation` resolves a free-form bibliographic citation string to ranked DOI candidates via the Crossref works query API.
+
+`doiget_batch_resolve_citations` batch-resolves multiple citation strings (up to 50).
+
+Both tools calculate token-based overlap similarity scores, filter out results with a score < 0.5, and sort candidates by score descending. No local store writes or provenance logs are created.


### PR DESCRIPTION
## Problem

The `build (zola + dev rustdoc)` CI always checked `origin/main` for `site/content/` staleness, even on PRs targeting `next`. This meant any PR on `next` would fail whenever `main` had a docs update that hadn't been promoted yet — a window that is unavoidable with the `next → main`-only policy.

## Fix

Split the staleness gate from the build step:

**New step** — "Check site/content is in sync with docs": runs `sync_docs_to_site.sh` on the currently checked-out commit (the PR branch). This ensures the contributor's own branch is self-consistent.

**Existing step** — "Build the Zola site from origin/main": still checks out `origin/main` for the actual Zola build (the deployed site is always `main`), but no longer does the staleness gate.

This preserves the invariant that the deployed site is always built from `main`, while allowing `next`-branch PRs to pass independently of `main`'s staleness.

## Also

Syncs `site/content/developer/mcp-tools.md` with the `PdfLeg` type added to `docs/MCP_TOOLS.md` in PR #248 (the change that caused the current staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)