### PR TITLE
feat(cli): add doiget verify — check references resolve (batch 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "biblatex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d0c374feba1b9a59042a7c1cf00ce7c34b977b9134fe7c42b08e5183729f66"
+dependencies = [
+ "paste",
+ "roman-numerals-rs",
+ "strum",
+ "unicode-normalization",
+ "unscanny",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +544,7 @@ name = "doiget-core"
 version = "0.4.1-beta.0"
 dependencies = [
  "async-trait",
+ "biblatex",
  "bytes",
  "camino",
  "chrono",
@@ -1360,6 +1374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1713,12 @@ dependencies = [
  "serde_json",
  "syn",
 ]
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "rustc_version"
@@ -2094,6 +2120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2234,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2461,10 +2523,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,14 @@ url = "2"
 # `deny.toml`'s banned list.
 quick-xml = { version = "0.40", default-features = false }
 
+# BibTeX / BibLaTeX bibliography input parser (ADR-0030 D2). Enabled in
+# the default feature set — `.bib` is the dominant export format from
+# Zotero / Mendeley / EndNote, and putting it behind a flag would mean
+# `cargo install doiget-cli` lacks `.bib` support out of the box. ~500 KB
+# compiled (~5% of the musl-static binary). MIT/Apache-2.0 — within
+# deny.toml's allow list.
+biblatex = "0.11"
+
 # Byte buffer + async stream combinators for streaming-with-cap body reads
 # (see crates/doiget-core/src/http.rs, docs/SECURITY.md §1.2 oversized PDF).
 bytes        = "1"

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -415,6 +415,17 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
             json_mode: JsonMode::Supported,
             feature_gated: None,
         },
+        "verify" => SubcommandMeta {
+            examples: &[
+                "doiget verify refs.bib",
+                "doiget verify library.bib --strict",
+                "doiget verify refs.txt --format refs",
+            ],
+            // Emits one JSON-Lines record per entry regardless of mode;
+            // the JSONL stream is the product output.
+            json_mode: JsonMode::Artifact,
+            feature_gated: None,
+        },
         "info" => SubcommandMeta {
             examples: &[
                 "doiget info 10.1234/foo",

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod output;
 pub mod provenance;
 pub mod resolve_citation;
 pub mod search;
+pub mod verify;
 pub mod version;
 
 // Phase 4 / Slice 16. Compile-gated by the `citation` Cargo feature

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -1,0 +1,184 @@
+//! `doiget verify <path>` — check that every DOI / arXiv reference in a
+//! bibliography file resolves to real metadata, WITHOUT downloading any
+//! PDF or writing to the store.
+//!
+//! Each entry is classified:
+//!
+//! - **valid** — the id resolved to metadata (Crossref / arXiv).
+//! - **illegal** — the id is malformed (`Ref::parse` rejected it, e.g. a
+//!   typo like `1O.1234`), or the whole file failed to parse. Always
+//!   counts toward the exit code: a malformed id is a definite source
+//!   error, independent of the network.
+//! - **unresolved** — a well-formed id that did not resolve (it does not
+//!   exist, OR a transient network failure). The current `ErrorCode` set
+//!   does not distinguish "404 absent" from "network blip", so this is a
+//!   warning by default and only fails the run under `--strict` (intended
+//!   for a network-stable CI lane).
+//! - **unverifiable** — the entry carried no DOI / arXiv id at all.
+//!   Warning by default; fails under `--strict`.
+//!
+//! Exit code = number of failing entries, capped at 255 (mirrors
+//! `doiget batch`). "Failing" = illegal, plus unresolved + unverifiable
+//! when `--strict` is set. JSON-Lines (one record per entry) is written
+//! to stdout regardless of mode; the summary goes to stderr unless
+//! `--quiet`.
+
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use camino::Utf8Path;
+
+use doiget_core::orchestrator::resolve_only;
+use doiget_core::refs::{parse_input, Format, ParseError};
+use doiget_core::source::FetchContext;
+use doiget_core::{CapabilityProfile, RateLimits};
+
+use super::fetch::CliExit;
+use super::output::OutputMode;
+
+/// Build a metadata-resolution context: HTTP client, rate limiter, and
+/// provenance log resolved from the environment. Mirrors
+/// `resolve_citation::build_context`; verify never persists to the store,
+/// so no store handle is constructed.
+fn build_context() -> Result<FetchContext> {
+    let session_id = crate::commands::fetch::new_session_id();
+    let log_path = crate::commands::fetch::resolve_log_path()?;
+    let http = Arc::new(crate::commands::fetch::build_http_client()?);
+    let rate_limiter = Arc::new(doiget_core::rate_limiter::RateLimiter::new(
+        RateLimits::HARD_CODED,
+    ));
+    let log = Arc::new(
+        doiget_core::provenance::ProvenanceLog::open(log_path, session_id.clone())
+            .context("failed to open provenance log for verify")?,
+    );
+    Ok(FetchContext {
+        http,
+        rate_limiter,
+        log,
+        session_id,
+    })
+}
+
+/// Map the `--format` flag token to a [`Format`].
+fn parse_format(s: &str) -> Result<Format> {
+    match s {
+        "auto" => Ok(Format::Auto),
+        "refs" => Ok(Format::Refs),
+        "csl-json" => Ok(Format::CslJson),
+        "bibtex" => Ok(Format::Bibtex),
+        other => bail!("unknown --format {other:?} (expected auto|refs|csl-json|bibtex)"),
+    }
+}
+
+/// Entry point for `doiget verify <path> [--format] [--strict]`.
+pub async fn run(path: String, format: String, strict: bool, mode: OutputMode) -> Result<()> {
+    let fmt = parse_format(&format)?;
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read reference file {path}"))?;
+    let entries = parse_input(&text, fmt, Some(Utf8Path::new(&path)));
+
+    let ctx = build_context()?;
+    let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
+
+    let mut valid = 0u32;
+    let mut illegal = 0u32;
+    let mut unresolved = 0u32;
+    let mut unverifiable = 0u32;
+
+    for entry in entries {
+        let record = match entry {
+            Ok(parsed) => {
+                let ref_ = parsed.ref_;
+                let entry_key = parsed.entry_key;
+                match resolve_only(&ref_, &profile, &ctx).await {
+                    Ok(_) => {
+                        valid += 1;
+                        serde_json::json!({
+                            "ok": true,
+                            "ref": ref_.as_input_str(),
+                            "status": "valid",
+                            "entry_key": entry_key,
+                        })
+                    }
+                    Err(e) => {
+                        unresolved += 1;
+                        let code: doiget_core::ErrorCode = (&e).into();
+                        serde_json::json!({
+                            "ok": false,
+                            "ref": ref_.as_input_str(),
+                            "status": "unresolved",
+                            "entry_key": entry_key,
+                            "error": { "code": code.as_wire(), "message": e.to_string() },
+                        })
+                    }
+                }
+            }
+            Err(ParseError::InvalidRef {
+                raw,
+                entry_key,
+                source,
+            }) => {
+                illegal += 1;
+                serde_json::json!({
+                    "ok": false,
+                    "ref": raw,
+                    "status": "illegal",
+                    "entry_key": entry_key,
+                    "error": { "code": "INVALID_REF", "message": source.to_string() },
+                })
+            }
+            Err(ParseError::NoIdentifier { entry_key }) => {
+                unverifiable += 1;
+                serde_json::json!({
+                    "ok": false,
+                    "ref": serde_json::Value::Null,
+                    "status": "unverifiable",
+                    "entry_key": entry_key,
+                    "error": { "code": "INVALID_REF", "message": "entry has no DOI / arXiv id" },
+                })
+            }
+            Err(ParseError::Decode { format, message }) => {
+                illegal += 1;
+                serde_json::json!({
+                    "ok": false,
+                    "status": "illegal",
+                    "error": {
+                        "code": "INVALID_REF",
+                        "message": format!("input did not parse as {format}: {message}"),
+                    },
+                })
+            }
+            Err(ParseError::UnsupportedFormat { format }) => {
+                bail!("{format} parsing is not supported for verification");
+            }
+            Err(_) => {
+                // `ParseError` is #[non_exhaustive]; a future variant is
+                // treated as a whole-input failure the operator must fix.
+                bail!("reference file could not be parsed");
+            }
+        };
+        #[allow(clippy::print_stdout)]
+        {
+            println!("{record}");
+        }
+    }
+
+    let total = valid + illegal + unresolved + unverifiable;
+    if mode != OutputMode::Quiet {
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!(
+                "verify: {total} entries — {valid} valid, {illegal} illegal, \
+                 {unresolved} unresolved, {unverifiable} unverifiable{}",
+                if strict { " (strict)" } else { "" }
+            );
+        }
+    }
+
+    let failing = illegal + if strict { unresolved + unverifiable } else { 0 };
+    if failing == 0 {
+        Ok(())
+    } else {
+        Err(anyhow::Error::new(CliExit(failing.min(255) as i32)))
+    }
+}

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -295,6 +295,21 @@ enum Command {
         #[arg(long)]
         check: bool,
     },
+    /// Verify that every DOI / arXiv reference in a bibliography file
+    /// (.bib / CSL-JSON / plain refs) resolves to real metadata. Does
+    /// not download PDFs or write to the store. Emits one JSON-Lines
+    /// record per entry; exits non-zero on failures.
+    Verify {
+        /// Path to the bibliography file to verify.
+        path: String,
+        /// Input format; auto-detected from extension / content by default.
+        #[arg(long, default_value = "auto")]
+        format: String,
+        /// Treat unresolved and id-less entries as failures (exit
+        /// non-zero), not just warnings. Use in a network-stable CI lane.
+        #[arg(long)]
+        strict: bool,
+    },
     /// Resolve a bibliographic citation string to ranked DOI candidates.
     #[command(name = "resolve-citation")]
     ResolveCitation {
@@ -512,6 +527,11 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit, mode),
         Some(Command::Search { query }) => doiget_cli::commands::search::run(query, mode),
         Some(Command::Version { check }) => doiget_cli::commands::version::run(check, mode).await,
+        Some(Command::Verify {
+            path,
+            format,
+            strict,
+        }) => doiget_cli::commands::verify::run(path, format, strict, mode).await,
         Some(Command::ResolveCitation { query, limit }) => {
             doiget_cli::commands::resolve_citation::run(query, limit, mode).await
         }

--- a/crates/doiget-cli/tests/verify_e2e.rs
+++ b/crates/doiget-cli/tests/verify_e2e.rs
@@ -1,0 +1,159 @@
+// allow: outbound-network
+//! End-to-end tests for `doiget verify <path>`.
+//!
+//! The network-touching cases (`valid` / `unresolved`) point the arXiv
+//! source at a wiremock origin via `DOIGET_ARXIV_BASE`, so no outbound
+//! call is made. The classification cases (`illegal` / `unverifiable`)
+//! need no network at all — a malformed id is rejected by `Ref::parse`
+//! and an id-less entry never reaches a resolver.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Reusable synthetic Atom payload (mirrors the core arXiv e2e fixture).
+const SAMPLE_ATOM_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <title>Example arXiv Paper Title</title>
+    <summary>This is an example abstract.</summary>
+    <author><name>Jane Doe</name></author>
+    <published>2024-01-15T00:00:00Z</published>
+  </entry>
+</feed>"#;
+
+/// Build a `doiget verify` command with a temp HOME / store / log so the
+/// developer's real config and store are never touched.
+fn doiget(dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = dir.path().to_str().expect("tempdir path utf-8");
+    let log_path = format!("{p}/log.jsonl");
+    cmd.env("HOME", p)
+        .env("USERPROFILE", p)
+        .env("DOIGET_STORE_ROOT", p)
+        .env("DOIGET_LOG_PATH", log_path);
+    cmd
+}
+
+/// Write `content` to `<dir>/<name>` and return the path string.
+fn write_bib(dir: &TempDir, name: &str, content: &str) -> String {
+    let path = dir.path().join(name);
+    std::fs::write(&path, content).expect("write bib fixture");
+    path.to_str().expect("utf-8 path").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Classification cases that need no network
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verify_typo_doi_is_illegal_and_fails() {
+    // `1O.1234` uses letter O — `Ref::parse` rejects it, so it is a
+    // definite source error regardless of the network.
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(&dir, "refs.bib", "@article{x, doi = {1O.1234/typo}}");
+    doiget(&dir)
+        .args(["verify", &bib])
+        .assert()
+        .failure()
+        .stdout(contains("\"status\":\"illegal\""));
+}
+
+#[test]
+fn verify_missing_id_warns_by_default() {
+    // An entry with no DOI / arXiv id is `unverifiable`; the default run
+    // reports it but exits 0.
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(&dir, "refs.bib", "@book{x, title = {A Book With No Id}}");
+    doiget(&dir)
+        .args(["verify", &bib])
+        .assert()
+        .success()
+        .stdout(contains("\"status\":\"unverifiable\""));
+}
+
+#[test]
+fn verify_missing_id_strict_fails() {
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(&dir, "refs.bib", "@book{x, title = {A Book With No Id}}");
+    doiget(&dir)
+        .args(["verify", &bib, "--strict"])
+        .assert()
+        .failure()
+        .stdout(contains("\"status\":\"unverifiable\""));
+}
+
+#[test]
+fn verify_unknown_format_flag_errors() {
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(&dir, "refs.bib", "@article{x, doi = {10.1234/foo}}");
+    doiget(&dir)
+        .args(["verify", &bib, "--format", "ris"])
+        .assert()
+        .failure();
+}
+
+// ---------------------------------------------------------------------------
+// Network-touching cases (wiremock arXiv)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verify_valid_arxiv_entry_passes() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ATOM_FEED))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "refs.bib",
+        "@article{x, eprint = {2401.12345}, archivePrefix = {arXiv}}",
+    );
+    doiget(&dir)
+        .args(["verify", &bib])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .success()
+        .stdout(contains("\"status\":\"valid\""));
+}
+
+#[tokio::test]
+async fn verify_unresolved_arxiv_warns_by_default_fails_strict() {
+    let server = MockServer::start().await;
+    // 404 for every query → the well-formed id does not resolve.
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let bib_content = "@article{x, eprint = {2401.99999}, archivePrefix = {arXiv}}";
+
+    // Default: unresolved is a warning → exit 0.
+    let dir1 = TempDir::new().expect("tempdir");
+    let bib1 = write_bib(&dir1, "refs.bib", bib_content);
+    doiget(&dir1)
+        .args(["verify", &bib1])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .success()
+        .stdout(contains("\"status\":\"unresolved\""));
+
+    // Strict: unresolved fails the run.
+    let dir2 = TempDir::new().expect("tempdir");
+    let bib2 = write_bib(&dir2, "refs.bib", bib_content);
+    doiget(&dir2)
+        .args(["verify", &bib2, "--strict"])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .failure()
+        .stdout(contains("\"status\":\"unresolved\""));
+}

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -59,6 +59,9 @@ futures-util = { workspace = true }
 # Streaming XML parser for the arXiv Atom feed. See B.1 in
 # `crates/doiget-core/src/sources/arxiv.rs::parse_atom_feed`.
 quick-xml    = { workspace = true }
+# BibTeX / BibLaTeX bibliography input parser (ADR-0030 D2). Default-on:
+# `.bib` → `ParsedEntry` in `src/refs.rs::parse_bibtex`.
+biblatex     = { workspace = true }
 
 [dev-dependencies]
 wiremock     = { workspace = true }

--- a/crates/doiget-core/src/refs.rs
+++ b/crates/doiget-core/src/refs.rs
@@ -10,10 +10,9 @@
 //!   `DOI`, and optionally `archivePrefix = "arXiv"` + `eprint`
 //!   fields. Parsed via the workspace's existing `serde_json` — no
 //!   new dependency.
-//! - **BibTeX / BibLaTeX (.bib)**: deferred to a follow-up slice (the
-//!   `biblatex` crate adds cargo-vet exemption churn that is
-//!   independent of the slice 1 wire shape; users with a `.bib`
-//!   library can re-export it as CSL-JSON from Zotero today).
+//! - **BibTeX / BibLaTeX (.bib)**: parsed via the `biblatex` crate
+//!   (ADR-0030 D2). One `@entrytype{KEY, …}` per entry; the `doi`
+//!   field is preferred, falling back to an arXiv `eprint`.
 //!
 //! Identifier-pick priority per ADR-0030 D3: `doi` > `arxiv` > `pmid`
 //! (PMID adapter parking until the `Ref::Pmid` variant lands in a
@@ -25,6 +24,7 @@
 //! decides whether to skip-and-warn (default) or fail-closed
 //! (`--strict`).
 
+use biblatex::{Bibliography, ChunksExt};
 use camino::Utf8Path;
 use thiserror::Error;
 
@@ -87,22 +87,19 @@ pub enum ParseError {
     /// it as the sole `Err` element of the result iterator.
     #[error("input did not deserialise as {format}: {message}")]
     Decode {
-        /// Which parser branch produced the failure (`"csl-json"`).
+        /// Which parser branch produced the failure (`"csl-json"` /
+        /// `"bibtex"`).
         format: &'static str,
         /// `serde_json::Error::to_string()`.
         message: String,
     },
-    /// Format requested or detected, but the parser for that format is
-    /// not yet shipped. Today this is the `.bib` / BibLaTeX path —
-    /// users should re-export their library as CSL-JSON from Zotero
-    /// until slice 2 ships.
-    #[error(
-        "{format} parsing is not yet implemented — \
-         re-export as CSL-JSON from your reference manager, \
-         or wait for the BibLaTeX slice (ADR-0030 D2 follow-up)"
-    )]
+    /// Format requested or detected, but no parser for it is shipped.
+    /// Retained as a forward-compatible variant for input shapes not
+    /// yet implemented (e.g. a future RIS adapter); the `bibtex` and
+    /// `csl-json` paths are both live today.
+    #[error("{format} parsing is not yet implemented")]
     UnsupportedFormat {
-        /// The format token (`"bibtex"`).
+        /// The format token naming the unsupported shape.
         format: &'static str,
     },
 }
@@ -122,8 +119,7 @@ pub enum Format {
     Refs,
     /// CSL-JSON array per <https://citationstyles.org/>.
     CslJson,
-    /// BibTeX / BibLaTeX. Currently unsupported — parser ships in a
-    /// follow-up slice.
+    /// BibTeX / BibLaTeX, parsed via the `biblatex` crate (ADR-0030 D2).
     Bibtex,
 }
 
@@ -195,7 +191,7 @@ pub fn parse_input(
     match resolved {
         Format::Refs | Format::Auto => parse_plain_refs(text),
         Format::CslJson => parse_csl_json(text),
-        Format::Bibtex => vec![Err(ParseError::UnsupportedFormat { format: "bibtex" })],
+        Format::Bibtex => parse_bibtex(text),
     }
 }
 
@@ -352,6 +348,99 @@ fn parse_csl_entry(
         }
     }
     Err(ParseError::NoIdentifier { entry_key })
+}
+
+/// Parse a BibTeX / BibLaTeX document via the `biblatex` crate
+/// (ADR-0030 D2). One `@entrytype{KEY, …}` produces one entry;
+/// `entry_key` is the citation key verbatim.
+///
+/// A whole-input parse failure (malformed BibTeX the `biblatex` crate
+/// rejects) is returned as a single-element [`ParseError::Decode`] so
+/// the caller's exit-code path counts it as one error rather than
+/// zero — matching the CSL-JSON behaviour.
+///
+/// Identifier-pick priority per ADR-0030 D3: `doi` field, then
+/// `eprint` (arXiv). See [`parse_bibtex_entry`].
+pub fn parse_bibtex(text: &str) -> Vec<Result<ParsedEntry, ParseError>> {
+    let bib = match Bibliography::parse(text) {
+        Ok(b) => b,
+        Err(e) => {
+            return vec![Err(ParseError::Decode {
+                format: "bibtex",
+                message: e.to_string(),
+            })]
+        }
+    };
+    bib.iter()
+        .map(|entry| parse_bibtex_entry(entry, Some(entry.key.clone())))
+        .collect()
+}
+
+/// Pick the highest-priority identifier on a single BibTeX entry and
+/// parse it. Honors ADR-0030 D3 priority (`doi` > arXiv `eprint`).
+fn parse_bibtex_entry(
+    entry: &biblatex::Entry,
+    entry_key: Option<String>,
+) -> Result<ParsedEntry, ParseError> {
+    // Priority 1: `doi` field. The typed accessor formats the chunk
+    // value to a `String`; `Err` means the field is absent or not a
+    // plain string, which we treat as "no DOI here" and fall through.
+    if let Ok(doi) = entry.doi() {
+        let raw = doi.trim();
+        if !raw.is_empty() {
+            return match Ref::parse(raw) {
+                Ok(ref_) => Ok(ParsedEntry { ref_, entry_key }),
+                Err(e) => Err(ParseError::InvalidRef {
+                    raw: raw.to_string(),
+                    entry_key,
+                    source: e,
+                }),
+            };
+        }
+    }
+    // Priority 2: arXiv via the `eprint` field. The BibTeX convention
+    // is `eprint = {2204.12345}` with `archivePrefix = {arXiv}` (or the
+    // BibLaTeX `eprinttype = {arxiv}`). We accept the eprint as an arXiv
+    // id when the prefix names arXiv OR is absent (the dominant
+    // single-preprint-server convention); a prefix that names something
+    // else (e.g. `eprinttype = {pubmed}`) is skipped rather than
+    // mis-parsed.
+    if let Ok(eprint) = entry.eprint() {
+        let raw = eprint.trim();
+        if !raw.is_empty() && arxiv_eligible(entry) {
+            let with_scheme = if raw.to_ascii_lowercase().starts_with("arxiv:") {
+                raw.to_string()
+            } else {
+                format!("arxiv:{raw}")
+            };
+            return match Ref::parse(&with_scheme) {
+                Ok(ref_) => Ok(ParsedEntry { ref_, entry_key }),
+                Err(e) => Err(ParseError::InvalidRef {
+                    raw: with_scheme,
+                    entry_key,
+                    source: e,
+                }),
+            };
+        }
+    }
+    Err(ParseError::NoIdentifier { entry_key })
+}
+
+/// Whether an `eprint` field should be interpreted as an arXiv id.
+/// True when `archivePrefix` / `eprinttype` names arXiv (case-
+/// insensitive) or is absent; false when it explicitly names a
+/// different preprint server.
+fn arxiv_eligible(entry: &biblatex::Entry) -> bool {
+    match entry
+        .get("archiveprefix")
+        .or_else(|| entry.get("eprinttype"))
+    {
+        Some(chunks) => chunks
+            .format_verbatim()
+            .to_ascii_lowercase()
+            .contains("arxiv"),
+        None => true,
+    }
 }
 
 #[cfg(test)]
@@ -570,15 +659,146 @@ doi:10.1234/foo
         ));
     }
 
+    // ---- BibTeX parsing (ADR-0030 D2) -----------------------------
+
     #[test]
-    fn parse_input_bibtex_returns_unsupported_format_error() {
-        let body = "@article{foo, doi={10.1234/x}}";
-        let parsed = parse_input(body, Format::Bibtex, None);
+    fn bibtex_picks_doi_and_preserves_key() {
+        let body = r#"@article{Onsager1944,
+            author = {Onsager, Lars},
+            title  = {Crystal Statistics},
+            doi    = {10.1103/PhysRev.65.117}
+        }"#;
+        let parsed = parse_bibtex(body);
+        assert_eq!(parsed.len(), 1);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
+        assert_eq!(entry.entry_key.as_deref(), Some("Onsager1944"));
+    }
+
+    #[test]
+    fn bibtex_picks_arxiv_via_eprint() {
+        let body = r#"@article{Pollmann2012,
+            title         = {Detection of SPT order},
+            eprint        = {1010.3732},
+            archivePrefix = {arXiv}
+        }"#;
+        let entry = parse_bibtex(body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Arxiv(_)));
+    }
+
+    #[test]
+    fn bibtex_bare_eprint_without_prefix_is_arxiv() {
+        // The dominant convention: a lone `eprint` field is an arXiv id.
+        let body = "@misc{x, eprint = {2204.12345}}";
+        let entry = parse_bibtex(body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Arxiv(_)));
+    }
+
+    #[test]
+    fn bibtex_non_arxiv_eprinttype_is_skipped() {
+        // eprinttype names a different server → not an arXiv id, and
+        // there is no DOI, so the entry has no resolvable identifier.
+        let body = "@article{x, eprint = {12345678}, eprinttype = {pubmed}}";
+        let res = parse_bibtex(body).into_iter().next().unwrap();
+        assert!(matches!(res, Err(ParseError::NoIdentifier { .. })));
+    }
+
+    #[test]
+    fn bibtex_doi_beats_arxiv_when_both_present() {
+        // ADR-0030 D3: priority is DOI > arXiv > PMID.
+        let body = r#"@article{both,
+            doi           = {10.1234/foo},
+            eprint        = {2401.12345},
+            archivePrefix = {arXiv}
+        }"#;
+        let entry = parse_bibtex(body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
+    }
+
+    #[test]
+    fn bibtex_multiple_entries_each_yield_a_result() {
+        let body = r#"
+            @article{a, doi = {10.1103/PhysRev.65.117}}
+            @article{b, eprint = {1010.3732}, archivePrefix = {arXiv}}
+            @article{c, title = {no identifier here}}
+        "#;
+        let parsed = parse_bibtex(body);
+        assert_eq!(parsed.len(), 3);
+        assert!(matches!(
+            parsed[0],
+            Ok(ParsedEntry {
+                ref_: Ref::Doi(_),
+                ..
+            })
+        ));
+        assert!(matches!(
+            parsed[1],
+            Ok(ParsedEntry {
+                ref_: Ref::Arxiv(_),
+                ..
+            })
+        ));
+        assert!(matches!(parsed[2], Err(ParseError::NoIdentifier { .. })));
+    }
+
+    #[test]
+    fn bibtex_entry_without_identifier_yields_no_identifier_error() {
+        let body = "@book{nodoi, title = {A Book}, author = {Author, A.}}";
+        let res = parse_bibtex(body).into_iter().next().unwrap();
+        assert!(matches!(res, Err(ParseError::NoIdentifier { .. })));
+    }
+
+    #[test]
+    fn bibtex_invalid_doi_surfaces_as_invalid_ref_per_entry() {
+        let body = "@article{bad, doi = {not-a-doi}}";
+        let res = parse_bibtex(body).into_iter().next().unwrap();
+        assert!(matches!(res, Err(ParseError::InvalidRef { .. })));
+    }
+
+    #[test]
+    fn bibtex_malformed_input_yields_single_decode_error() {
+        // A truncated entry the biblatex parser rejects outright.
+        let body = "@article{unterminated, doi = {10.1234/x}";
+        let parsed = parse_bibtex(body);
         assert_eq!(parsed.len(), 1);
         assert!(matches!(
             parsed[0],
-            Err(ParseError::UnsupportedFormat { format: "bibtex" })
+            Err(ParseError::Decode {
+                format: "bibtex",
+                ..
+            })
         ));
+    }
+
+    #[test]
+    fn parse_input_bibtex_dispatches_and_parses() {
+        let body = "@article{foo, doi = {10.1234/foo}}";
+        let parsed = parse_input(body, Format::Bibtex, None);
+        assert_eq!(parsed.len(), 1);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
+        assert_eq!(entry.entry_key.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn parse_input_auto_dispatches_bibtex_by_content() {
+        // Leading `@article{` fingerprint routes to the BibTeX parser.
+        let body = "@article{auto, doi = {10.1234/auto}}";
+        let parsed = parse_input(body, Format::Auto, None);
+        let entry = parsed.into_iter().next().unwrap().expect("entry parses");
+        assert!(matches!(entry.ref_, Ref::Doi(_)));
     }
 
     #[test]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -82,6 +82,10 @@ criteria = "safe-to-deploy"
 version = "0.40.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.biblatex]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.block-buffer]]
 version = "0.12.0"
 criteria = "safe-to-deploy"
@@ -446,6 +450,10 @@ criteria = "safe-to-deploy"
 version = "0.9.12"
 criteria = "safe-to-deploy"
 
+[[exemptions.paste]]
+version = "1.0.15"
+criteria = "safe-to-deploy"
+
 [[exemptions.pastey]]
 version = "0.2.2"
 criteria = "safe-to-deploy"
@@ -552,6 +560,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rmcp-macros]]
 version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.roman-numerals-rs]]
+version = "3.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustc-hash]]
@@ -686,6 +698,14 @@ criteria = "safe-to-deploy"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.strum]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.strum_macros]]
+version = "0.27.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.syn]]
 version = "2.0.117"
 criteria = "safe-to-deploy"
@@ -712,6 +732,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tinyvec]]
 version = "1.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinyvec]]
+version = "1.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinyvec_macros]]
+version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
@@ -804,6 +832,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.unicode-ident]]
 version = "1.0.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-normalization]]
+version = "0.1.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.unscanny]]
+version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.untrusted]]


### PR DESCRIPTION
## Summary

**Batch 2** of the reference-verification work (chained on #258). Adds `doiget verify <path>` — checks that every DOI / arXiv reference in a `.bib` / CSL-JSON / plain-refs file resolves to real metadata, **without downloading PDFs or writing to the store** (`orchestrator::resolve_only`).

This is the engine behind the QAtlas.jl goal: a `references.bib` whose every entry is CI-verified to point at a real paper.

## Classification

| status | meaning | exit impact |
|---|---|---|
| `valid` | resolved to metadata | — |
| `illegal` | malformed id (`Ref::parse` reject, e.g. `1O.1234`) or unparseable file | **always** counts (network-independent) |
| `unresolved` | well-formed id that didn't resolve | warn by default, fails `--strict` |
| `unverifiable` | entry had no DOI/arXiv id | warn by default, fails `--strict` |

**Why `unresolved` is lenient by default:** the current `ErrorCode` set can't distinguish "404 absent" from "network blip", so failing on it would make CI flaky. `--strict` opts into failing (for a network-stable lane). When `core` later gains a `NotFound` code, `unresolved`-absent can be promoted to `illegal`.

## Output / exit

- One JSON-Lines record per entry on stdout (product output, all modes): `{ok, ref, status, entry_key, error?}`.
- Summary to stderr unless `--quiet`.
- Exit = failing count capped at 255 (mirrors `doiget batch`).

## Tests

6 e2e (assert_cmd + wiremock arXiv, no real network): illegal typo, unverifiable default/strict, unknown-format error, valid arXiv, unresolved default/strict.

## Local verification

- `cargo clippy --workspace --all-targets --no-default-features --features oa-only -- -D warnings` ✓
- `cargo test --workspace --no-default-features --features oa-only` ✓

## Chain

- **Base = `feat/bibtex-input` (#258)** — verify reuses `parse_input` for `.bib`. GitHub will retarget this PR to `next` once #258 merges.
- **Next (batch 3):** `[verify]` config section (`id_fields`, `on_missing_id`), then a composite GitHub Action (#246) and the QAtlas.jl `references.bib` migration.

Refs #246 (CI reference verification), #222 (§2A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)