### PR TITLE
feat: reference verification — verify CLI config, composite Action, docs (batches 3–5)

### DIFF
--- a/.github/actions/verify/README.md
+++ b/.github/actions/verify/README.md
@@ -1,0 +1,55 @@
+# `doiget verify` GitHub Action
+
+Check that every DOI / arXiv reference in a bibliography file resolves to
+real metadata, as a CI gate. Backed by `doiget verify` — it resolves each
+id through Crossref / arXiv **without downloading PDFs** or writing to any
+store.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v4
+- uses: sotashimozono/doiget/.github/actions/verify@v0
+  with:
+    path: docs/references.bib
+    strict: "true"
+    contact-email: you@example.org
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `path` | yes | — | Bibliography file to verify (`.bib` / CSL-JSON / plain refs). |
+| `format` | no | `auto` | `auto` \| `refs` \| `csl-json` \| `bibtex`. Auto-detected from extension / content. |
+| `strict` | no | `"false"` | Fail on unresolved and id-less entries, not just malformed ones. |
+| `contact-email` | no | a no-reply address | Polite-pool `mailto` sent to Crossref / Unpaywall. Set your project's address. |
+
+## What fails the job
+
+| Entry status | Default | `strict: "true"` |
+|---|---|---|
+| `illegal` (malformed id, e.g. typo `1O.1234`, or unparseable file) | ❌ fails | ❌ fails |
+| `unresolved` (well-formed id that does not resolve) | ⚠️ warns | ❌ fails |
+| `unverifiable` (entry has no DOI / arXiv id) | ⚠️ warns | ❌ fails |
+| `valid` | ✅ | ✅ |
+
+`illegal` always fails because a malformed id is a definite source error,
+independent of the network. `unresolved` is lenient by default so a
+transient network blip does not turn CI red; enable `strict` in a
+network-stable lane.
+
+A `[verify]` section in the repo's `config.toml` can set
+`on_missing_id = "error"` to fail id-less entries without `strict`, or
+`skip` to ignore them. See `docs/CONFIG.md`.
+
+## Output
+
+One JSON-Lines record per entry on stdout:
+
+```json
+{"ok":true,"ref":"10.1103/PhysRev.65.117","status":"valid","entry_key":"Onsager1944"}
+{"ok":false,"ref":"1O.1234/typo","status":"illegal","entry_key":"bad","error":{"code":"INVALID_REF","message":"…"}}
+```
+
+The job exit code is the number of failing entries, capped at 255.

--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -1,0 +1,63 @@
+name: "doiget verify references"
+description: >-
+  Check that every DOI / arXiv reference in a bibliography file
+  (.bib / CSL-JSON / plain refs) resolves to real metadata via Crossref /
+  arXiv. Does not download PDFs. Fails the job on malformed ids, and —
+  with strict — on unresolved or id-less entries.
+author: "sotashimozono"
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  path:
+    description: "Path to the bibliography file to verify."
+    required: true
+  format:
+    description: "Input format: auto | refs | csl-json | bibtex."
+    required: false
+    default: "auto"
+  strict:
+    description: >-
+      Fail the job on unresolved (well-formed but non-resolving) and
+      id-less entries, not just malformed ones. Set to "true" in a
+      network-stable lane.
+    required: false
+    default: "false"
+  contact-email:
+    description: >-
+      Polite-pool contact email sent to Crossref / Unpaywall as the
+      mailto parameter. Override with your project's contact address.
+    required: false
+    default: "doiget-verify@users.noreply.github.com"
+
+runs:
+  using: "composite"
+  steps:
+    # Pinned to the same stable toolchain SHA the doiget workspace CI uses.
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    # Build the doiget binary from THIS action's checked-out ref, so the
+    # version that runs always matches the `uses: …@ref` the caller pinned.
+    # `$GITHUB_ACTION_PATH` is `<repo>/.github/actions/verify`; three levels
+    # up is the workspace root.
+    - name: Build & install doiget
+      shell: bash
+      run: |
+        set -euo pipefail
+        cargo install --path "$GITHUB_ACTION_PATH/../../../crates/doiget-cli" --locked
+    - name: Verify references
+      shell: bash
+      # Inputs are passed via env, never interpolated into the script body,
+      # to avoid GitHub Actions expression-injection.
+      env:
+        DOIGET_CONTACT_EMAIL: ${{ inputs.contact-email }}
+        VERIFY_PATH: ${{ inputs.path }}
+        VERIFY_FORMAT: ${{ inputs.format }}
+        VERIFY_STRICT: ${{ inputs.strict }}
+      run: |
+        set -euo pipefail
+        args=(verify "$VERIFY_PATH" --format "$VERIFY_FORMAT" --mode json)
+        if [ "$VERIFY_STRICT" = "true" ]; then
+          args+=(--strict)
+        fi
+        doiget "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+- **[core]** BibTeX / BibLaTeX (`.bib`) bibliography input via the `biblatex` crate, completing the ADR-0030 D2 parser slice. `doiget batch` and `doiget verify` now accept `.bib` files; identifier priority is `doi` > arXiv `eprint`.
+- **[cli]** `doiget verify <path>` — check that every DOI / arXiv reference in a `.bib` / CSL-JSON / plain-refs file resolves to real metadata, **without** downloading PDFs or writing to the store. Emits one JSON-Lines record per entry; exit code is the failing-entry count (capped at 255).
+- **[cli]** `[verify]` config section (`on_missing_id = "warn" | "error" | "skip"`, `strict`) controlling how id-less and unresolved entries affect the exit code. `--strict` overrides the config.
+- **[ci]** `doiget-verify` composite GitHub Action (`.github/actions/verify`) so other repositories can gate their bibliography references in CI.
+
 ## [0.4.1-beta.0] - 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ doiget fetch arXiv:2401.12345
 # Batch fetch
 doiget batch refs.txt
 
+# Verify a bibliography's references resolve (no PDF download) — CI gate
+doiget verify docs/references.bib --strict
+
 # Inspect what was fetched
 doiget info 10.1103/PhysRevLett.130.200601
 

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -104,7 +104,16 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
     let config = load_verify_config();
     let strict = cli_strict || config.strict;
     let on_missing = if cli_strict {
+        // CLI --strict is the strictest setting: id-less entries fail.
         OnMissingId::Error
+    } else if strict {
+        // strict came from `[verify] strict = true`: unresolved ids fail.
+        // Do not let `skip` silently drop id-less entries in a strict run —
+        // surface them at least as a warning so the summary is honest.
+        match config.on_missing_id {
+            OnMissingId::Skip => OnMissingId::Warn,
+            other => other,
+        }
     } else {
         config.on_missing_id
     };
@@ -139,8 +148,18 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
                         })
                     }
                     Err(e) => {
-                        unresolved += 1;
                         let code: doiget_core::ErrorCode = (&e).into();
+                        // A provenance-log write failure is fail-closed
+                        // (docs/SECURITY.md §1.8): it is an operator-side
+                        // fault, NOT a "this reference doesn't resolve"
+                        // signal, so it must abort the run rather than be
+                        // counted as a soft `unresolved` that CI passes.
+                        if code == doiget_core::ErrorCode::LogError {
+                            return Err(anyhow::anyhow!(
+                                "provenance log error during verify (aborting): {e}"
+                            ));
+                        }
+                        unresolved += 1;
                         serde_json::json!({
                             "ok": false,
                             "ref": ref_.as_input_str(),

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -31,10 +31,31 @@ use camino::Utf8Path;
 use doiget_core::orchestrator::resolve_only;
 use doiget_core::refs::{parse_input, Format, ParseError};
 use doiget_core::source::FetchContext;
+use doiget_core::verify_config::{self, OnMissingId};
 use doiget_core::{CapabilityProfile, RateLimits};
 
 use super::fetch::CliExit;
 use super::output::OutputMode;
+
+/// Resolve the `[verify]` config from `<config_dir>/doiget/config.toml`.
+/// Best-effort: a missing file is defaults; a malformed file degrades to
+/// defaults with a stderr warning rather than aborting the run.
+fn load_verify_config() -> verify_config::VerifyConfig {
+    let path = match crate::commands::fetch::config_dir_utf8() {
+        Ok(dir) => dir.join("doiget").join("config.toml"),
+        Err(_) => return verify_config::VerifyConfig::default(),
+    };
+    match verify_config::load(&path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("warning: ignoring [verify] config: {e}");
+            }
+            verify_config::VerifyConfig::default()
+        }
+    }
+}
 
 /// Build a metadata-resolution context: HTTP client, rate limiter, and
 /// provenance log resolved from the environment. Mirrors
@@ -71,11 +92,22 @@ fn parse_format(s: &str) -> Result<Format> {
 }
 
 /// Entry point for `doiget verify <path> [--format] [--strict]`.
-pub async fn run(path: String, format: String, strict: bool, mode: OutputMode) -> Result<()> {
+pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMode) -> Result<()> {
     let fmt = parse_format(&format)?;
     let text = std::fs::read_to_string(&path)
         .with_context(|| format!("failed to read reference file {path}"))?;
     let entries = parse_input(&text, fmt, Some(Utf8Path::new(&path)));
+
+    // Resolve effective policy: CLI `--strict` is the strictest setting,
+    // forcing both unresolved and id-less entries to fail and overriding
+    // the `[verify]` config.
+    let config = load_verify_config();
+    let strict = cli_strict || config.strict;
+    let on_missing = if cli_strict {
+        OnMissingId::Error
+    } else {
+        config.on_missing_id
+    };
 
     let ctx = build_context()?;
     let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
@@ -86,6 +118,12 @@ pub async fn run(path: String, format: String, strict: bool, mode: OutputMode) -
     let mut unverifiable = 0u32;
 
     for entry in entries {
+        // `on_missing_id = "skip"` drops id-less entries entirely —
+        // before they are counted or emitted.
+        if matches!(&entry, Err(ParseError::NoIdentifier { .. })) && on_missing == OnMissingId::Skip
+        {
+            continue;
+        }
         let record = match entry {
             Ok(parsed) => {
                 let ref_ = parsed.ref_;
@@ -175,7 +213,13 @@ pub async fn run(path: String, format: String, strict: bool, mode: OutputMode) -
         }
     }
 
-    let failing = illegal + if strict { unresolved + unverifiable } else { 0 };
+    let failing = illegal
+        + if strict { unresolved } else { 0 }
+        + if on_missing == OnMissingId::Error {
+            unverifiable
+        } else {
+            0
+        };
     if failing == 0 {
         Ok(())
     } else {

--- a/crates/doiget-cli/tests/verify_e2e.rs
+++ b/crates/doiget-cli/tests/verify_e2e.rs
@@ -130,6 +130,22 @@ fn verify_config_on_missing_id_skip_drops_entry() {
 }
 
 #[test]
+fn verify_config_strict_does_not_let_skip_drop_idless_entries() {
+    // `[verify] strict = true` + `on_missing_id = "skip"`: a strict run
+    // must not silently drop id-less entries — they surface (as a warning)
+    // so the summary stays honest. The run still exits 0 (skip→warn, not
+    // error), but the record IS emitted.
+    let dir = TempDir::new().expect("tempdir");
+    write_config(&dir, "[verify]\nstrict = true\non_missing_id = \"skip\"\n");
+    let bib = write_bib(&dir, "refs.bib", "@book{x, title = {No Id}}");
+    doiget(&dir)
+        .args(["verify", &bib])
+        .assert()
+        .success()
+        .stdout(contains("\"status\":\"unverifiable\""));
+}
+
+#[test]
 fn verify_unknown_format_flag_errors() {
     let dir = TempDir::new().expect("tempdir");
     let bib = write_bib(&dir, "refs.bib", "@article{x, doi = {10.1234/foo}}");

--- a/crates/doiget-cli/tests/verify_e2e.rs
+++ b/crates/doiget-cli/tests/verify_e2e.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
@@ -35,6 +36,10 @@ fn doiget(dir: &TempDir) -> Command {
     let log_path = format!("{p}/log.jsonl");
     cmd.env("HOME", p)
         .env("USERPROFILE", p)
+        // Pin the config dir to the temp dir on both POSIX and Windows so
+        // a written `<temp>/doiget/config.toml` is the one verify reads.
+        .env("XDG_CONFIG_HOME", p)
+        .env("APPDATA", p)
         .env("DOIGET_STORE_ROOT", p)
         .env("DOIGET_LOG_PATH", log_path);
     cmd
@@ -45,6 +50,15 @@ fn write_bib(dir: &TempDir, name: &str, content: &str) -> String {
     let path = dir.path().join(name);
     std::fs::write(&path, content).expect("write bib fixture");
     path.to_str().expect("utf-8 path").to_string()
+}
+
+/// Write a `<dir>/doiget/config.toml` so the temp HOME resolves a
+/// `[verify]` section. `doiget()` sets `XDG_CONFIG_HOME` to the temp dir,
+/// so the config dir is `<dir>/doiget/`.
+fn write_config(dir: &TempDir, body: &str) {
+    let cfg_dir = dir.path().join("doiget");
+    std::fs::create_dir_all(&cfg_dir).expect("mkdir config dir");
+    std::fs::write(cfg_dir.join("config.toml"), body).expect("write config.toml");
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +100,33 @@ fn verify_missing_id_strict_fails() {
         .assert()
         .failure()
         .stdout(contains("\"status\":\"unverifiable\""));
+}
+
+#[test]
+fn verify_config_on_missing_id_error_fails_without_strict() {
+    // `[verify] on_missing_id = "error"` makes an id-less entry fail the
+    // run even without the `--strict` CLI flag.
+    let dir = TempDir::new().expect("tempdir");
+    write_config(&dir, "[verify]\non_missing_id = \"error\"\n");
+    let bib = write_bib(&dir, "refs.bib", "@book{x, title = {No Id}}");
+    doiget(&dir)
+        .args(["verify", &bib])
+        .assert()
+        .failure()
+        .stdout(contains("\"status\":\"unverifiable\""));
+}
+
+#[test]
+fn verify_config_on_missing_id_skip_drops_entry() {
+    // `skip` drops the id-less entry: no record emitted, run exits 0.
+    let dir = TempDir::new().expect("tempdir");
+    write_config(&dir, "[verify]\non_missing_id = \"skip\"\n");
+    let bib = write_bib(&dir, "refs.bib", "@book{x, title = {No Id}}");
+    doiget(&dir)
+        .args(["verify", &bib])
+        .assert()
+        .success()
+        .stdout(contains("unverifiable").not());
 }
 
 #[test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod source;
 pub mod sources;
 pub mod store;
 pub mod user_extension;
+pub mod verify_config;
 
 // Phase 4 citation graph (ADR-0010). Compile-gated by the `citation`
 // Cargo feature, which itself enables the `metadata` feature so the

--- a/crates/doiget-core/src/refs.rs
+++ b/crates/doiget-core/src/refs.rs
@@ -360,7 +360,7 @@ fn parse_csl_entry(
 /// zero — matching the CSL-JSON behaviour.
 ///
 /// Identifier-pick priority per ADR-0030 D3: `doi` field, then
-/// `eprint` (arXiv). See [`parse_bibtex_entry`].
+/// `eprint` (arXiv). See `parse_bibtex_entry`.
 pub fn parse_bibtex(text: &str) -> Vec<Result<ParsedEntry, ParseError>> {
     let bib = match Bibliography::parse(text) {
         Ok(b) => b,
@@ -404,7 +404,7 @@ fn parse_bibtex_entry(
     // id when the prefix names arXiv OR is absent (the dominant
     // single-preprint-server convention); a prefix that names something
     // else (e.g. `eprinttype = {pubmed}`) is skipped rather than
-    // mis-parsed.
+    // parsed incorrectly.
     if let Ok(eprint) = entry.eprint() {
         let raw = eprint.trim();
         if !raw.is_empty() && arxiv_eligible(entry) {

--- a/crates/doiget-core/src/verify_config.rs
+++ b/crates/doiget-core/src/verify_config.rs
@@ -1,0 +1,184 @@
+//! `[verify]` section of the user `config.toml`, read by `doiget verify`.
+//!
+//! Mirrors [`crate::user_extension`]: this is a minimal, section-scoped
+//! reader (NOT the full `docs/CONFIG.md` resolution ladder). It parses
+//! only the `[verify]` table, tolerates every other section, and treats
+//! a missing file as "all defaults" rather than an error. CLI flags
+//! (`--strict`) layer on top in the command handler; this module knows
+//! nothing about flags or env vars.
+//!
+//! ```toml
+//! [verify]
+//! # How to treat an entry that carries no DOI / arXiv id:
+//! #   "warn"  — report it, do not fail the run (default)
+//! #   "error" — count it as a failure (exit non-zero)
+//! #   "skip"  — do not emit a record for it at all
+//! on_missing_id = "warn"
+//! # Treat a well-formed id that does not resolve as a failure.
+//! strict = false
+//! ```
+
+use camino::Utf8Path;
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Policy for an entry with no DOI / arXiv identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OnMissingId {
+    /// Report the entry but do not fail the run.
+    #[default]
+    Warn,
+    /// Count the entry as a failure (non-zero exit).
+    Error,
+    /// Do not emit a record for the entry at all.
+    Skip,
+}
+
+/// Resolved `[verify]` configuration.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VerifyConfig {
+    /// Treat a well-formed-but-non-resolving id as a failure.
+    pub strict: bool,
+    /// Policy for id-less entries.
+    pub on_missing_id: OnMissingId,
+}
+
+/// Why loading the `[verify]` section failed.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum VerifyConfigError {
+    /// Filesystem error other than not-found (which is not an error).
+    #[error("reading verify config {path}: {source}")]
+    Io {
+        /// The config path that could not be read.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file is not valid TOML, or `[verify]` has an unknown key /
+    /// an invalid `on_missing_id` value.
+    #[error("parsing verify config {path}: {message}")]
+    Parse {
+        /// The config path that failed to parse.
+        path: String,
+        /// `toml::de::Error::to_string()`.
+        message: String,
+    },
+}
+
+/// Top-level shape; only `[verify]` is load-bearing. Other sections
+/// (e.g. `[network]`) are tolerated so this reader can run against the
+/// same `config.toml` the user-extension loader reads.
+#[derive(Debug, Default, Deserialize)]
+struct RawConfig {
+    #[serde(default)]
+    verify: Option<RawVerify>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+/// The `[verify]` table. `deny_unknown_fields` so a typo
+/// (`on_missing_ids = …`) fails loudly rather than silently defaulting.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawVerify {
+    #[serde(default)]
+    strict: bool,
+    #[serde(default)]
+    on_missing_id: OnMissingId,
+}
+
+/// Load the `[verify]` section from `config_path`.
+///
+/// A missing file yields [`VerifyConfig::default`] (not an error), so a
+/// user who never wrote a `config.toml` gets the lenient defaults. A
+/// present-but-malformed file is an error the caller surfaces (verify
+/// degrades to defaults with a warning rather than aborting).
+pub fn load(config_path: &Utf8Path) -> Result<VerifyConfig, VerifyConfigError> {
+    let text = match std::fs::read_to_string(config_path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(VerifyConfig::default());
+        }
+        Err(e) => {
+            return Err(VerifyConfigError::Io {
+                path: config_path.to_string(),
+                source: e,
+            });
+        }
+    };
+    let raw: RawConfig = toml::from_str(&text).map_err(|e| VerifyConfigError::Parse {
+        path: config_path.to_string(),
+        message: e.to_string(),
+    })?;
+    Ok(match raw.verify {
+        Some(v) => VerifyConfig {
+            strict: v.strict,
+            on_missing_id: v.on_missing_id,
+        },
+        None => VerifyConfig::default(),
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+
+    fn write(dir: &tempfile::TempDir, body: &str) -> Utf8PathBuf {
+        let p = Utf8PathBuf::try_from(dir.path().join("config.toml")).expect("utf-8");
+        std::fs::write(&p, body).expect("write config");
+        p
+    }
+
+    #[test]
+    fn missing_file_is_defaults() {
+        let cfg = load(Utf8Path::new("/no/such/config.toml")).expect("missing is ok");
+        assert_eq!(cfg, VerifyConfig::default());
+        assert_eq!(cfg.on_missing_id, OnMissingId::Warn);
+        assert!(!cfg.strict);
+    }
+
+    #[test]
+    fn empty_or_unrelated_sections_are_defaults() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = write(&dir, "[network]\nadditional_hosts = []\n");
+        let cfg = load(&p).expect("parses");
+        assert_eq!(cfg, VerifyConfig::default());
+    }
+
+    #[test]
+    fn reads_on_missing_id_and_strict() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = write(&dir, "[verify]\non_missing_id = \"error\"\nstrict = true\n");
+        let cfg = load(&p).expect("parses");
+        assert_eq!(cfg.on_missing_id, OnMissingId::Error);
+        assert!(cfg.strict);
+    }
+
+    #[test]
+    fn skip_value_parses() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = write(&dir, "[verify]\non_missing_id = \"skip\"\n");
+        let cfg = load(&p).expect("parses");
+        assert_eq!(cfg.on_missing_id, OnMissingId::Skip);
+    }
+
+    #[test]
+    fn unknown_key_in_verify_is_an_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = write(&dir, "[verify]\non_missing_ids = \"warn\"\n");
+        assert!(matches!(load(&p), Err(VerifyConfigError::Parse { .. })));
+    }
+
+    #[test]
+    fn invalid_on_missing_id_value_is_an_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = write(&dir, "[verify]\non_missing_id = \"sometimes\"\n");
+        assert!(matches!(load(&p), Err(VerifyConfigError::Parse { .. })));
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,6 +30,8 @@ A value set higher in the chain overrides any value set lower.
 | `output.color` | `auto` (honors `NO_COLOR` env) |
 | `output.progress` | `false` |
 | `output.emoji` | `false` |
+| `verify.on_missing_id` | `warn` |
+| `verify.strict` | `false` |
 
 ## 3. config.toml schema
 
@@ -58,6 +60,10 @@ mode = "human"          # human | json | quiet | mcp
 color = "auto"          # auto | always | never
 progress = false
 emoji = false
+
+[verify]                 # consumed by `doiget verify`
+on_missing_id = "warn"   # warn | error | skip — policy for id-less entries
+strict = false           # treat unresolved (well-formed, non-resolving) ids as failures
 ```
 
 doiget reads only the keys it knows about. Unknown keys cause a startup warning but do

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -16,6 +16,9 @@ A single-binary CLI plus stdio MCP server that:
    (see [`STORE.md`](STORE.md)).
 4. Exposes a stdio MCP server with a fixed set of structured tools to agent hosts (see
    [`MCP_TOOLS.md`](MCP_TOOLS.md)).
+5. Verifies that the DOI / arXiv references in a bibliography file (`.bib` / CSL-JSON /
+   plain refs) resolve to real metadata, as a CI gate (`doiget verify`), without
+   downloading PDFs — resolution-only reuse of (1).
 
 That is the totality of doiget's intended scope. All other functionality is either
 explicitly out of scope below or requires a new ADR.

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -36,6 +36,8 @@ A value set higher in the chain overrides any value set lower.
 | `output.color` | `auto` (honors `NO_COLOR` env) |
 | `output.progress` | `false` |
 | `output.emoji` | `false` |
+| `verify.on_missing_id` | `warn` |
+| `verify.strict` | `false` |
 
 ## 3. config.toml schema
 
@@ -64,6 +66,10 @@ mode = "human"          # human | json | quiet | mcp
 color = "auto"          # auto | always | never
 progress = false
 emoji = false
+
+[verify]                 # consumed by `doiget verify`
+on_missing_id = "warn"   # warn | error | skip — policy for id-less entries
+strict = false           # treat unresolved (well-formed, non-resolving) ids as failures
 ```
 
 doiget reads only the keys it knows about. Unknown keys cause a startup warning but do

--- a/site/content/use/scope.md
+++ b/site/content/use/scope.md
@@ -22,6 +22,9 @@ A single-binary CLI plus stdio MCP server that:
    (see [`STORE.md`](STORE.md)).
 4. Exposes a stdio MCP server with a fixed set of structured tools to agent hosts (see
    [`MCP_TOOLS.md`](MCP_TOOLS.md)).
+5. Verifies that the DOI / arXiv references in a bibliography file (`.bib` / CSL-JSON /
+   plain refs) resolve to real metadata, as a CI gate (`doiget verify`), without
+   downloading PDFs — resolution-only reuse of (1).
 
 That is the totality of doiget's intended scope. All other functionality is either
 explicitly out of scope below or requires a new ADR.


### PR DESCRIPTION
## Summary

Consolidated PR carrying the remaining reference-verification work on top of #258 (BibTeX parser) and #259 (verify CLI), which are already on `next`. #261/#262 were merged with the wrong base (`feat/verify-config` instead of `next`) so their content never reached `next`; this PR re-applies all of it cleanly, rebased onto current `next`.

Four commits:
- **batch 3** — `[verify]` config section (`on_missing_id`, `strict`).
- **batch 4** — `doiget-verify` composite GitHub Action (#246).
- **batch 5** — docs (CHANGELOG / SCOPE / CONFIG / README + site sync).
- **review fixup** — fail-closed `LogError`; strict+skip no longer drops id-less entries (from the /review-pr pass).

## Verification

- `cargo clippy --workspace --all-targets --no-default-features --features oa-only -- -D warnings` ✓
- `verify_e2e` 9/9, `verify_config` unit 6/6 ✓
- site/content in sync (no Zola drift) ✓

## Note on #261/#262

They show as MERGED but their diffs did not land on `next` (wrong base). Their content is fully contained here. After this merges, #261/#262 can be left as-is (historical) — no further action needed.

Closes #246
Refs #222 (§2A/§2B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)