### PR TITLE
feat(ci): add doiget-verify composite GitHub Action (batch 4)

### DIFF
--- a/.github/actions/verify/README.md
+++ b/.github/actions/verify/README.md
@@ -1,0 +1,55 @@
+# `doiget verify` GitHub Action
+
+Check that every DOI / arXiv reference in a bibliography file resolves to
+real metadata, as a CI gate. Backed by `doiget verify` — it resolves each
+id through Crossref / arXiv **without downloading PDFs** or writing to any
+store.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v4
+- uses: sotashimozono/doiget/.github/actions/verify@v0
+  with:
+    path: docs/references.bib
+    strict: "true"
+    contact-email: you@example.org
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `path` | yes | — | Bibliography file to verify (`.bib` / CSL-JSON / plain refs). |
+| `format` | no | `auto` | `auto` \| `refs` \| `csl-json` \| `bibtex`. Auto-detected from extension / content. |
+| `strict` | no | `"false"` | Fail on unresolved and id-less entries, not just malformed ones. |
+| `contact-email` | no | a no-reply address | Polite-pool `mailto` sent to Crossref / Unpaywall. Set your project's address. |
+
+## What fails the job
+
+| Entry status | Default | `strict: "true"` |
+|---|---|---|
+| `illegal` (malformed id, e.g. typo `1O.1234`, or unparseable file) | ❌ fails | ❌ fails |
+| `unresolved` (well-formed id that does not resolve) | ⚠️ warns | ❌ fails |
+| `unverifiable` (entry has no DOI / arXiv id) | ⚠️ warns | ❌ fails |
+| `valid` | ✅ | ✅ |
+
+`illegal` always fails because a malformed id is a definite source error,
+independent of the network. `unresolved` is lenient by default so a
+transient network blip does not turn CI red; enable `strict` in a
+network-stable lane.
+
+A `[verify]` section in the repo's `config.toml` can set
+`on_missing_id = "error"` to fail id-less entries without `strict`, or
+`skip` to ignore them. See `docs/CONFIG.md`.
+
+## Output
+
+One JSON-Lines record per entry on stdout:
+
+```json
+{"ok":true,"ref":"10.1103/PhysRev.65.117","status":"valid","entry_key":"Onsager1944"}
+{"ok":false,"ref":"1O.1234/typo","status":"illegal","entry_key":"bad","error":{"code":"INVALID_REF","message":"…"}}
+```
+
+The job exit code is the number of failing entries, capped at 255.

--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -1,0 +1,63 @@
+name: "doiget verify references"
+description: >-
+  Check that every DOI / arXiv reference in a bibliography file
+  (.bib / CSL-JSON / plain refs) resolves to real metadata via Crossref /
+  arXiv. Does not download PDFs. Fails the job on malformed ids, and —
+  with strict — on unresolved or id-less entries.
+author: "sotashimozono"
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  path:
+    description: "Path to the bibliography file to verify."
+    required: true
+  format:
+    description: "Input format: auto | refs | csl-json | bibtex."
+    required: false
+    default: "auto"
+  strict:
+    description: >-
+      Fail the job on unresolved (well-formed but non-resolving) and
+      id-less entries, not just malformed ones. Set to "true" in a
+      network-stable lane.
+    required: false
+    default: "false"
+  contact-email:
+    description: >-
+      Polite-pool contact email sent to Crossref / Unpaywall as the
+      mailto parameter. Override with your project's contact address.
+    required: false
+    default: "doiget-verify@users.noreply.github.com"
+
+runs:
+  using: "composite"
+  steps:
+    # Pinned to the same stable toolchain SHA the doiget workspace CI uses.
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    # Build the doiget binary from THIS action's checked-out ref, so the
+    # version that runs always matches the `uses: …@ref` the caller pinned.
+    # `$GITHUB_ACTION_PATH` is `<repo>/.github/actions/verify`; three levels
+    # up is the workspace root.
+    - name: Build & install doiget
+      shell: bash
+      run: |
+        set -euo pipefail
+        cargo install --path "$GITHUB_ACTION_PATH/../../../crates/doiget-cli" --locked
+    - name: Verify references
+      shell: bash
+      # Inputs are passed via env, never interpolated into the script body,
+      # to avoid GitHub Actions expression-injection.
+      env:
+        DOIGET_CONTACT_EMAIL: ${{ inputs.contact-email }}
+        VERIFY_PATH: ${{ inputs.path }}
+        VERIFY_FORMAT: ${{ inputs.format }}
+        VERIFY_STRICT: ${{ inputs.strict }}
+      run: |
+        set -euo pipefail
+        args=(verify "$VERIFY_PATH" --format "$VERIFY_FORMAT" --mode json)
+        if [ "$VERIFY_STRICT" = "true" ]; then
+          args+=(--strict)
+        fi
+        doiget "${args[@]}"


### PR DESCRIPTION
## Summary

**Batch 4** (chained on #260). A reusable composite GitHub Action — the #246 deliverable — that other repos pin to gate a bibliography file's references in CI:

```yaml
- uses: actions/checkout@v4
- uses: sotashimozono/doiget/.github/actions/verify@v0
  with:
    path: docs/references.bib
    strict: "true"
    contact-email: you@example.org
```

## Design

- **Version-faithful build:** installs the doiget binary from the action's *own* checked-out ref (`$GITHUB_ACTION_PATH/../../../crates/doiget-cli`), so the binary that runs always matches the `@ref` the caller pinned — no drift between the action version and the CLI version, no second clone.
- **Injection-safe:** all inputs flow through `env:` into the script; none are interpolated into the `run:` body (avoids GitHub Actions expression-injection).
- **Pinned toolchain:** `dtolnay/rust-toolchain` at the same stable SHA the workspace CI uses.

## Fail matrix (documented in the action README)

| status | default | `strict` |
|---|---|---|
| `illegal` (malformed id / unparseable) | ❌ | ❌ |
| `unresolved` | ⚠️ | ❌ |
| `unverifiable` | ⚠️ | ❌ |
| `valid` | ✅ | ✅ |

`[verify].on_missing_id = "error"` (batch 3) also fails id-less entries without `strict`.

## Notes

- No dogfooding workflow in this repo (doiget's own docs carry no `.bib`); the real consumer is QAtlas.jl's `docs/references.bib`.
- YAML validated locally (`yaml.safe_load`).

## Chain

Base = `feat/verify-config` (#260). Retargets to `next` as the chain merges down.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)