### PR TITLE
chore(dependabot): target `next` instead of `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@
 #     individual PRs (Dependabot's default for ungrouped updates).
 #   - GitHub Actions SHAs are bumped as a separate ecosystem; pinning by SHA
 #     is required by docs/SECURITY.md §1.9.
+#   - PRs target `next`, not `main`: `next` is the integration branch and
+#     `main` only advances via the next -> main promotion. Dependabot reads
+#     this file from the default branch (main), so the retarget takes effect
+#     once this change is promoted to main.
 
 version: 2
 
@@ -25,7 +29,7 @@ updates:
       time: "07:00"
       timezone: UTC
     open-pull-requests-limit: 5
-    target-branch: main
+    target-branch: next
     commit-message:
       prefix: "chore(deps)"
       include: scope
@@ -53,7 +57,7 @@ updates:
       time: "07:00"
       timezone: UTC
     open-pull-requests-limit: 3
-    target-branch: main
+    target-branch: next
     commit-message:
       prefix: "chore(ci)"
       include: scope

--- a/crates/doiget-core/src/resolver_cache.rs
+++ b/crates/doiget-core/src/resolver_cache.rs
@@ -53,7 +53,7 @@ pub fn cache_file(cache_root: &Utf8Path, ref_: &Ref) -> Utf8PathBuf {
 
 /// Read a cached outcome for `ref_` if present and still within its TTL.
 ///
-/// Returns `None` on any miss condition: file absent, unparseable,
+/// Returns `None` on any miss condition: file absent, unparsable,
 /// expired, or a `response` blob that no longer deserializes. `now` is
 /// injected so tests can pin expiry without touching the clock.
 #[must_use]


### PR DESCRIPTION
## What

Flip Dependabot's `target-branch` from `main` to `next` for both ecosystems (cargo, github-actions), so dependency PRs land on the integration branch and ride the normal **next → main** promotion instead of opening directly against `main`.

## How it takes effect

Dependabot reads `.github/dependabot.yml` from the repository's **default branch (`main`)**. So this retarget is live only after the change reaches `main` via the usual next → main promotion. On the first Dependabot run after that:

- the current `main`-targeted PRs (**#267** cargo group, **#268** actions group) are closed by Dependabot, and
- the equivalent updates are reopened against `next`.

No manual retarget of #267/#268 is needed (and retargeting a Dependabot PR's base by hand is discouraged — Dependabot would just rebase it back). They'll be superseded automatically.

## Notes

- Auto-merge remains intentionally off (ADR-0013) — each bump is still hand-reviewed/merged.
- Policy comment updated to document the choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)