### PR TITLE
fix(provenance): create the log's parent dir on open (verify ENOENT)

### DIFF
--- a/crates/doiget-core/src/provenance.rs
+++ b/crates/doiget-core/src/provenance.rs
@@ -1491,6 +1491,11 @@ mod tests {
         log.append(empty_input())
             .expect("append after auto-created dir");
         assert!(path.exists(), "log file written under the auto-created dir");
+        // End-to-end: the row the verify path would write is actually
+        // readable back (exercises the full OpenOptions/flush/sync write,
+        // not just that the file exists).
+        let rows = read_rows(&path);
+        assert_eq!(rows.len(), 1, "exactly one row in the auto-created log");
     }
 
     fn empty_input() -> RowInput<'static> {

--- a/crates/doiget-core/src/provenance.rs
+++ b/crates/doiget-core/src/provenance.rs
@@ -615,6 +615,19 @@ impl ProvenanceLog {
     ) -> Result<Self, LogError> {
         let path: Utf8PathBuf = path.into();
 
+        // Ensure the parent directory exists. The provenance log defaults to
+        // `<config>/doiget/access.jsonl`, and on a fresh machine (e.g. a CI
+        // runner where `~/.config/doiget` was never created) neither the
+        // recover-state read nor the first append can open the file — the
+        // append fails with ENOENT and `verify` fail-closes on the LogError.
+        // `create_dir_all` is idempotent; a genuine permission failure still
+        // surfaces as a `LogError` (the correct fail-closed signal).
+        if let Some(parent) = path.parent() {
+            if !parent.as_str().is_empty() {
+                std::fs::create_dir_all(parent.as_std_path())?;
+            }
+        }
+
         // Reject obvious non-files up front so later `OpenOptions::append`
         // doesn't produce a confusing platform-dependent error.
         if path.exists() {
@@ -1456,6 +1469,28 @@ mod tests {
 
     fn open_log(path: &Utf8Path) -> ProvenanceLog {
         ProvenanceLog::open(path, TEST_SESSION_ID.to_string()).expect("open")
+    }
+
+    #[test]
+    fn open_creates_missing_parent_dir() {
+        // Regression: opening a log whose parent dir does not yet exist must
+        // create the dir and succeed (then a row appends cleanly), not abort
+        // with ENOENT. This is the `doiget verify` failure on a fresh CI
+        // runner where `<config>/doiget/` was never created.
+        let dir = TempDir::new().expect("tempdir");
+        let path = tmp_dir_utf8(&dir)
+            .join("nested")
+            .join("doiget")
+            .join("access.jsonl");
+        assert!(
+            !path.parent().expect("has parent").exists(),
+            "parent dir must not pre-exist for this test to be meaningful"
+        );
+        let log = ProvenanceLog::open(&path, TEST_SESSION_ID.to_string())
+            .expect("open must create the parent dir and succeed");
+        log.append(empty_input())
+            .expect("append after auto-created dir");
+        assert!(path.exists(), "log file written under the auto-created dir");
     }
 
     fn empty_input() -> RowInput<'static> {


### PR DESCRIPTION
## Symptom

QAtlas's `doiget-verify@next` action fails:

```
Error: provenance log error during verify (aborting): provenance log io error: No such file or directory (os error 2)
```

## Root cause

The provenance log defaults to `<config>/doiget/access.jsonl`. On a fresh machine (e.g. a CI runner where `~/.config/doiget/` was never created), `ProvenanceLog::open` neither created the dir nor did the first append — so the append failed with **ENOENT**, and `doiget verify` (correctly) **fail-closes** on a `LogError`. So a perfectly valid bibliography turned the run red, purely because the log directory didn't pre-exist.

This is independent of #264 (arXiv 429); the QAtlas workflow had soft-failed verify pending a fix.

## Fix

`ProvenanceLog::open` now `create_dir_all`s the log's parent directory up front. Idempotent; a genuine permission failure still surfaces as a fail-closed `LogError` (the correct signal). No format / hash-chain change.

Regression test: open a log under a non-existent nested dir, then append a row — both succeed.

Once on `next`, the QAtlas `…/actions/verify@next` action picks this up and the reference-verification step passes (it can then re-enable hard-fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)