### PR TITLE
feat(verify): classify dead vs unreachable references (ErrorCode::NotFound)

### DIFF
--- a/.github/actions/verify/README.md
+++ b/.github/actions/verify/README.md
@@ -30,14 +30,15 @@ store.
 | Entry status | Default | `strict: "true"` |
 |---|---|---|
 | `illegal` (malformed id, e.g. typo `1O.1234`, or unparseable file) | ❌ fails | ❌ fails |
-| `absent` (well-formed id the source reports does not exist — HTTP 404 / 410) | ❌ fails | ❌ fails |
+| `absent` (well-formed id the source reports does not exist — HTTP 404 / 410 / 451, or an empty arXiv feed) | ❌ fails | ❌ fails |
 | `unreachable` (well-formed id, transient failure — network / 429 / 5xx / timeout) | ⚠️ warns | ❌ fails |
 | `unverifiable` (entry has no DOI / arXiv id) | ⚠️ warns | ❌ fails |
 | `valid` | ✅ | ✅ |
 
 `illegal` and `absent` always fail because they are definite, reproducible
 source errors independent of the network — a malformed id, or one the
-metadata source authoritatively reports does not exist (404 / 410).
+metadata source authoritatively reports does not exist (404 / 410 / 451,
+or an empty arXiv feed).
 `unreachable` is lenient by default so a transient network blip does not
 turn CI red over a reference that is probably fine; enable `strict` in a
 network-stable lane to demand that every id resolve.

--- a/.github/actions/verify/README.md
+++ b/.github/actions/verify/README.md
@@ -22,7 +22,7 @@ store.
 |---|---|---|---|
 | `path` | yes | — | Bibliography file to verify (`.bib` / CSL-JSON / plain refs). |
 | `format` | no | `auto` | `auto` \| `refs` \| `csl-json` \| `bibtex`. Auto-detected from extension / content. |
-| `strict` | no | `"false"` | Fail on unresolved and id-less entries, not just malformed ones. |
+| `strict` | no | `"false"` | Also fail on `unreachable` (transient) and id-less entries, not just definite errors. |
 | `contact-email` | no | a no-reply address | Polite-pool `mailto` sent to Crossref / Unpaywall. Set your project's address. |
 
 ## What fails the job
@@ -30,14 +30,17 @@ store.
 | Entry status | Default | `strict: "true"` |
 |---|---|---|
 | `illegal` (malformed id, e.g. typo `1O.1234`, or unparseable file) | ❌ fails | ❌ fails |
-| `unresolved` (well-formed id that does not resolve) | ⚠️ warns | ❌ fails |
+| `absent` (well-formed id the source reports does not exist — HTTP 404 / 410) | ❌ fails | ❌ fails |
+| `unreachable` (well-formed id, transient failure — network / 429 / 5xx / timeout) | ⚠️ warns | ❌ fails |
 | `unverifiable` (entry has no DOI / arXiv id) | ⚠️ warns | ❌ fails |
 | `valid` | ✅ | ✅ |
 
-`illegal` always fails because a malformed id is a definite source error,
-independent of the network. `unresolved` is lenient by default so a
-transient network blip does not turn CI red; enable `strict` in a
-network-stable lane.
+`illegal` and `absent` always fail because they are definite, reproducible
+source errors independent of the network — a malformed id, or one the
+metadata source authoritatively reports does not exist (404 / 410).
+`unreachable` is lenient by default so a transient network blip does not
+turn CI red over a reference that is probably fine; enable `strict` in a
+network-stable lane to demand that every id resolve.
 
 A `[verify]` section in the repo's `config.toml` can set
 `on_missing_id = "error"` to fail id-less entries without `strict`, or

--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -2,8 +2,9 @@ name: "doiget verify references"
 description: >-
   Check that every DOI / arXiv reference in a bibliography file
   (.bib / CSL-JSON / plain refs) resolves to real metadata via Crossref /
-  arXiv. Does not download PDFs. Fails the job on malformed ids, and —
-  with strict — on unresolved or id-less entries.
+  arXiv. Does not download PDFs. Fails the job on malformed ids and
+  definitely-absent ids (HTTP 404 / 410), and — with strict — on transient
+  (unreachable) or id-less entries.
 author: "sotashimozono"
 branding:
   icon: "check-circle"
@@ -19,9 +20,9 @@ inputs:
     default: "auto"
   strict:
     description: >-
-      Fail the job on unresolved (well-formed but non-resolving) and
-      id-less entries, not just malformed ones. Set to "true" in a
-      network-stable lane.
+      Also fail the job on unreachable (transient: network / 429 / 5xx /
+      timeout) and id-less entries — not just illegal and absent ones.
+      Set to "true" in a network-stable lane.
     required: false
     default: "false"
   contact-email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ## [0.4.2-beta.0] - 2026-06-02
 
 Opens the 0.4.2 beta development cycle on `next` after the 0.4.1 stable
-release. No user-facing changes yet — new entries land here as work
-merges to `next`.
+release.
+
+### Added
+- **[core]** `ErrorCode::NotFound` (wire `"NOT_FOUND"`) — a metadata source authoritatively reported the identifier does not exist (HTTP 404 / 410), distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. Additive variant on the `#[non_exhaustive]` enum.
+
+### Changed
+- **[cli]** `doiget verify` now classifies a non-resolving id by *why* it failed instead of a single `unresolved` bucket. **`absent`** (404 / 410 → `NotFound`, a definite dead reference) **always** counts toward the exit code, independent of `--strict`; **`unreachable`** (transient transport / 429 / 5xx / timeout) is tolerated by default and fails only under `--strict`. This lets the default lane catch genuinely dead references while staying green through network blips. The JSON-Lines `status` field gains `absent` / `unreachable` and no longer emits `unresolved`.
+
+### Fixed
+- **[core]** `doiget verify` no longer aborts when its provenance log's parent directory does not yet exist; the parent is created on open (#274).
 
 ## [0.4.1] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ Opens the 0.4.2 beta development cycle on `next` after the 0.4.1 stable
 release.
 
 ### Added
-- **[core]** `ErrorCode::NotFound` (wire `"NOT_FOUND"`) — a metadata source authoritatively reported the identifier does not exist (HTTP 404 / 410), distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. Additive variant on the `#[non_exhaustive]` enum.
+- **[core]** `ErrorCode::NotFound` (wire `"NOT_FOUND"`) — a metadata source authoritatively reported the identifier does not exist (HTTP 404 / 410 / 451, or a source-specific absence such as arXiv's empty `<feed>` for an unknown id), distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. Additive variant on the `#[non_exhaustive]` enum. A matching `source::FetchError::NotFound` variant carries the non-HTTP absence signal.
 
 ### Changed
-- **[cli]** `doiget verify` now classifies a non-resolving id by *why* it failed instead of a single `unresolved` bucket. **`absent`** (404 / 410 → `NotFound`, a definite dead reference) **always** counts toward the exit code, independent of `--strict`; **`unreachable`** (transient transport / 429 / 5xx / timeout) is tolerated by default and fails only under `--strict`. This lets the default lane catch genuinely dead references while staying green through network blips. The JSON-Lines `status` field gains `absent` / `unreachable` and no longer emits `unresolved`.
+- **[cli]** `doiget verify` now classifies a non-resolving id by *why* it failed instead of a single `unresolved` bucket. **`absent`** (HTTP 404/410/451 or an empty arXiv feed → `NotFound`, a definite dead reference) **always** counts toward the exit code, independent of `--strict`; **`unreachable`** (transient transport / 429 / 5xx / timeout) is tolerated by default and fails only under `--strict`. This lets the default lane catch genuinely dead references — including unknown arXiv ids — while staying green through network blips. An `InternalError` from resolution now aborts the run (a bug signal, not a tolerable blip), alongside the existing `LogError` abort. The JSON-Lines `status` field gains `absent` / `unreachable` and no longer emits `unresolved`.
 
 ### Fixed
 - **[core]** `doiget verify` no longer aborts when its provenance log's parent directory does not yet exist; the parent is created on open (#274).

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -27,10 +27,11 @@
 //! still passing when the network merely hiccuped on a real id.
 //!
 //! Exit code = number of failing entries, capped at 255 (mirrors
-//! `doiget batch`). "Failing" = illegal + absent, plus unreachable +
-//! unverifiable when `--strict` is set. JSON-Lines (one record per entry)
-//! is written to stdout regardless of mode; the summary goes to stderr
-//! unless `--quiet`.
+//! `doiget batch`). "Failing" = illegal + absent always; plus unreachable
+//! when `--strict`; plus unverifiable when `--strict` **or**
+//! `on_missing_id = "error"`. JSON-Lines (one record per entry) is written
+//! to stdout regardless of mode; the summary goes to stderr unless
+//! `--quiet`.
 
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
@@ -82,7 +83,7 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
     let entries = parse_input(&text, fmt, Some(Utf8Path::new(&path)));
 
     // Resolve effective policy: CLI `--strict` is the strictest setting,
-    // forcing both unresolved and id-less entries to fail and overriding
+    // forcing both unreachable and id-less entries to fail and overriding
     // the `[verify]` config.
     let config = load_verify_config();
     let strict = cli_strict || config.strict;
@@ -90,7 +91,7 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
         // CLI --strict is the strictest setting: id-less entries fail.
         OnMissingId::Error
     } else if strict {
-        // strict came from `[verify] strict = true`: unresolved ids fail.
+        // strict came from `[verify] strict = true`: unreachable ids fail.
         // Do not let `skip` silently drop id-less entries in a strict run —
         // surface them at least as a warning so the summary is honest.
         match config.on_missing_id {
@@ -143,10 +144,19 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
                                 "provenance log error during verify (aborting): {e}"
                             ));
                         }
-                        // A 404 / 410 (NotFound) is an authoritative dead
-                        // reference — always counts. Every other resolve
-                        // error is transient (unreachable): tolerated
-                        // unless --strict. See the module-level taxonomy.
+                        // An InternalError is a bug, not a property of the
+                        // reference; aborting (rather than silently bucketing
+                        // it as a tolerable `unreachable`) surfaces it.
+                        if code == doiget_core::ErrorCode::InternalError {
+                            return Err(anyhow::anyhow!(
+                                "internal error during verify (aborting; please report): {e}"
+                            ));
+                        }
+                        // A NotFound (HTTP 404/410/451 or a source-specific
+                        // absence) is an authoritative dead reference — always
+                        // counts. Every other resolve error is transient
+                        // (unreachable): tolerated unless --strict. See the
+                        // module-level taxonomy.
                         let status = if code == doiget_core::ErrorCode::NotFound {
                             absent += 1;
                             "absent"
@@ -214,7 +224,11 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
         }
     }
 
-    let total = valid + illegal + absent + unreachable + unverifiable;
+    let total = valid
+        .saturating_add(illegal)
+        .saturating_add(absent)
+        .saturating_add(unreachable)
+        .saturating_add(unverifiable);
     if mode != OutputMode::Quiet {
         #[allow(clippy::print_stderr)]
         {
@@ -227,16 +241,13 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
     }
 
     // illegal + absent always fail (definite source errors, network-
-    // independent). unreachable (transient) and unverifiable (no id) fail
-    // only under the stricter policies.
+    // independent). unreachable (transient) fails only under --strict;
+    // unverifiable (no id) fails only when the on_missing policy is Error
+    // (which --strict forces).
     let failing = illegal
-        + absent
-        + if strict { unreachable } else { 0 }
-        + if on_missing == OnMissingId::Error {
-            unverifiable
-        } else {
-            0
-        };
+        .saturating_add(absent)
+        .saturating_add(unreachable * u32::from(strict))
+        .saturating_add(unverifiable * u32::from(on_missing == OnMissingId::Error));
     if failing == 0 {
         Ok(())
     } else {

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -11,7 +11,7 @@
 //!   error, independent of the network.
 //! - **absent** — a well-formed id that the metadata source
 //!   authoritatively reports does not exist (HTTP 404 / 410, surfaced as
-//!   [`ErrorCode::NotFound`]). Network-independent and reproducible, so
+//!   `ErrorCode::NotFound`). Network-independent and reproducible, so
 //!   it is a definite dead reference and **always** counts toward the
 //!   exit code — independent of `--strict`.
 //! - **unreachable** — a well-formed id whose resolution failed for any

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -9,19 +9,28 @@
 //!   typo like `1O.1234`), or the whole file failed to parse. Always
 //!   counts toward the exit code: a malformed id is a definite source
 //!   error, independent of the network.
-//! - **unresolved** — a well-formed id that did not resolve (it does not
-//!   exist, OR a transient network failure). The current `ErrorCode` set
-//!   does not distinguish "404 absent" from "network blip", so this is a
-//!   warning by default and only fails the run under `--strict` (intended
-//!   for a network-stable CI lane).
+//! - **absent** — a well-formed id that the metadata source
+//!   authoritatively reports does not exist (HTTP 404 / 410, surfaced as
+//!   [`ErrorCode::NotFound`]). Network-independent and reproducible, so
+//!   it is a definite dead reference and **always** counts toward the
+//!   exit code — independent of `--strict`.
+//! - **unreachable** — a well-formed id whose resolution failed for any
+//!   transient reason (transport / DNS / TLS error, 429, 5xx, timeout).
+//!   This is tolerated by default (a flaky network must not fail a build
+//!   over a reference that is probably fine) and fails the run only under
+//!   `--strict` (the network-stable lane that demands every id resolve).
 //! - **unverifiable** — the entry carried no DOI / arXiv id at all.
-//!   Warning by default; fails under `--strict`.
+//!   Warning by default; fails under `--strict` / `on_missing_id="error"`.
+//!
+//! The split between **absent** and **unreachable** is the load-bearing
+//! distinction: it lets the default mode catch a genuinely dead DOI while
+//! still passing when the network merely hiccuped on a real id.
 //!
 //! Exit code = number of failing entries, capped at 255 (mirrors
-//! `doiget batch`). "Failing" = illegal, plus unresolved + unverifiable
-//! when `--strict` is set. JSON-Lines (one record per entry) is written
-//! to stdout regardless of mode; the summary goes to stderr unless
-//! `--quiet`.
+//! `doiget batch`). "Failing" = illegal + absent, plus unreachable +
+//! unverifiable when `--strict` is set. JSON-Lines (one record per entry)
+//! is written to stdout regardless of mode; the summary goes to stderr
+//! unless `--quiet`.
 
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
@@ -97,7 +106,8 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
 
     let mut valid = 0u32;
     let mut illegal = 0u32;
-    let mut unresolved = 0u32;
+    let mut absent = 0u32;
+    let mut unreachable = 0u32;
     let mut unverifiable = 0u32;
 
     for entry in entries {
@@ -133,11 +143,21 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
                                 "provenance log error during verify (aborting): {e}"
                             ));
                         }
-                        unresolved += 1;
+                        // A 404 / 410 (NotFound) is an authoritative dead
+                        // reference — always counts. Every other resolve
+                        // error is transient (unreachable): tolerated
+                        // unless --strict. See the module-level taxonomy.
+                        let status = if code == doiget_core::ErrorCode::NotFound {
+                            absent += 1;
+                            "absent"
+                        } else {
+                            unreachable += 1;
+                            "unreachable"
+                        };
                         serde_json::json!({
                             "ok": false,
                             "ref": ref_.as_input_str(),
-                            "status": "unresolved",
+                            "status": status,
                             "entry_key": entry_key,
                             "error": { "code": code.as_wire(), "message": e.to_string() },
                         })
@@ -194,20 +214,24 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
         }
     }
 
-    let total = valid + illegal + unresolved + unverifiable;
+    let total = valid + illegal + absent + unreachable + unverifiable;
     if mode != OutputMode::Quiet {
         #[allow(clippy::print_stderr)]
         {
             eprintln!(
                 "verify: {total} entries — {valid} valid, {illegal} illegal, \
-                 {unresolved} unresolved, {unverifiable} unverifiable{}",
+                 {absent} absent, {unreachable} unreachable, {unverifiable} unverifiable{}",
                 if strict { " (strict)" } else { "" }
             );
         }
     }
 
+    // illegal + absent always fail (definite source errors, network-
+    // independent). unreachable (transient) and unverifiable (no id) fail
+    // only under the stricter policies.
     let failing = illegal
-        + if strict { unresolved } else { 0 }
+        + absent
+        + if strict { unreachable } else { 0 }
         + if on_missing == OnMissingId::Error {
             unverifiable
         } else {

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -85,7 +85,7 @@ fn parse_format(s: &str) -> Result<Format> {
 enum VerifyStatus {
     /// Resolved to real metadata.
     Valid,
-    /// Malformed id / unparseable input — a definite source error.
+    /// Malformed id / unparsable input — a definite source error.
     Illegal,
     /// Authoritatively does not exist (`ErrorCode::NotFound`).
     Absent,

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -75,6 +75,74 @@ fn parse_format(s: &str) -> Result<Format> {
     }
 }
 
+/// Outcome class for one bibliography entry.
+///
+/// Single source of truth for the JSON-Lines `status` string
+/// ([`Self::as_wire`]) and the exit-code policy ([`Self::is_failing`]),
+/// so the wire format and the fail rule cannot drift apart as the
+/// taxonomy evolves.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum VerifyStatus {
+    /// Resolved to real metadata.
+    Valid,
+    /// Malformed id / unparseable input — a definite source error.
+    Illegal,
+    /// Authoritatively does not exist (`ErrorCode::NotFound`).
+    Absent,
+    /// Well-formed id, transient resolution failure.
+    Unreachable,
+    /// Entry carried no DOI / arXiv id.
+    Unverifiable,
+}
+
+impl VerifyStatus {
+    /// Every status, in summary-display order.
+    const ALL: [VerifyStatus; 5] = [
+        VerifyStatus::Valid,
+        VerifyStatus::Illegal,
+        VerifyStatus::Absent,
+        VerifyStatus::Unreachable,
+        VerifyStatus::Unverifiable,
+    ];
+
+    /// The public JSON-Lines `status` field value.
+    fn as_wire(self) -> &'static str {
+        match self {
+            VerifyStatus::Valid => "valid",
+            VerifyStatus::Illegal => "illegal",
+            VerifyStatus::Absent => "absent",
+            VerifyStatus::Unreachable => "unreachable",
+            VerifyStatus::Unverifiable => "unverifiable",
+        }
+    }
+
+    /// Stable index into a per-status counts array.
+    fn index(self) -> usize {
+        match self {
+            VerifyStatus::Valid => 0,
+            VerifyStatus::Illegal => 1,
+            VerifyStatus::Absent => 2,
+            VerifyStatus::Unreachable => 3,
+            VerifyStatus::Unverifiable => 4,
+        }
+    }
+
+    /// Does this outcome count toward the non-zero exit code?
+    ///
+    /// `illegal` + `absent` are definite, network-independent source
+    /// errors → always fail. `unreachable` is transient → fails only in
+    /// the network-stable `--strict` lane. `unverifiable` (no id) fails
+    /// only when the id-less policy is `Error` (which `--strict` forces).
+    fn is_failing(self, strict: bool, on_missing: OnMissingId) -> bool {
+        match self {
+            VerifyStatus::Valid => false,
+            VerifyStatus::Illegal | VerifyStatus::Absent => true,
+            VerifyStatus::Unreachable => strict,
+            VerifyStatus::Unverifiable => on_missing == OnMissingId::Error,
+        }
+    }
+}
+
 /// Entry point for `doiget verify <path> [--format] [--strict]`.
 pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMode) -> Result<()> {
     let fmt = parse_format(&format)?;
@@ -105,11 +173,8 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
     let ctx = crate::commands::fetch::build_resolve_context()?;
     let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
 
-    let mut valid = 0u32;
-    let mut illegal = 0u32;
-    let mut absent = 0u32;
-    let mut unreachable = 0u32;
-    let mut unverifiable = 0u32;
+    // One counter per VerifyStatus, indexed by `VerifyStatus::index`.
+    let mut counts = [0u32; VerifyStatus::ALL.len()];
 
     for entry in entries {
         // `on_missing_id = "skip"` drops id-less entries entirely —
@@ -118,27 +183,27 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
         {
             continue;
         }
-        let record = match entry {
+        let (status, record) = match entry {
             Ok(parsed) => {
                 let ref_ = parsed.ref_;
                 let entry_key = parsed.entry_key;
                 match resolve_only(&ref_, &profile, &ctx).await {
-                    Ok(_) => {
-                        valid += 1;
+                    Ok(_) => (
+                        VerifyStatus::Valid,
                         serde_json::json!({
                             "ok": true,
                             "ref": ref_.as_input_str(),
-                            "status": "valid",
+                            "status": VerifyStatus::Valid.as_wire(),
                             "entry_key": entry_key,
-                        })
-                    }
+                        }),
+                    ),
                     Err(e) => {
                         let code: doiget_core::ErrorCode = (&e).into();
                         // A provenance-log write failure is fail-closed
                         // (docs/SECURITY.md §1.8): it is an operator-side
                         // fault, NOT a "this reference doesn't resolve"
                         // signal, so it must abort the run rather than be
-                        // counted as a soft `unresolved` that CI passes.
+                        // counted as a soft outcome that CI passes.
                         if code == doiget_core::ErrorCode::LogError {
                             return Err(anyhow::anyhow!(
                                 "provenance log error during verify (aborting): {e}"
@@ -153,24 +218,24 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
                             ));
                         }
                         // A NotFound (HTTP 404/410/451 or a source-specific
-                        // absence) is an authoritative dead reference — always
-                        // counts. Every other resolve error is transient
-                        // (unreachable): tolerated unless --strict. See the
-                        // module-level taxonomy.
+                        // absence) is an authoritative dead reference. Every
+                        // other resolve error is transient (unreachable). See
+                        // the module-level taxonomy.
                         let status = if code == doiget_core::ErrorCode::NotFound {
-                            absent += 1;
-                            "absent"
+                            VerifyStatus::Absent
                         } else {
-                            unreachable += 1;
-                            "unreachable"
+                            VerifyStatus::Unreachable
                         };
-                        serde_json::json!({
-                            "ok": false,
-                            "ref": ref_.as_input_str(),
-                            "status": status,
-                            "entry_key": entry_key,
-                            "error": { "code": code.as_wire(), "message": e.to_string() },
-                        })
+                        (
+                            status,
+                            serde_json::json!({
+                                "ok": false,
+                                "ref": ref_.as_input_str(),
+                                "status": status.as_wire(),
+                                "entry_key": entry_key,
+                                "error": { "code": code.as_wire(), "message": e.to_string() },
+                            }),
+                        )
                     }
                 }
             }
@@ -178,37 +243,37 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
                 raw,
                 entry_key,
                 source,
-            }) => {
-                illegal += 1;
+            }) => (
+                VerifyStatus::Illegal,
                 serde_json::json!({
                     "ok": false,
                     "ref": raw,
-                    "status": "illegal",
+                    "status": VerifyStatus::Illegal.as_wire(),
                     "entry_key": entry_key,
                     "error": { "code": "INVALID_REF", "message": source.to_string() },
-                })
-            }
-            Err(ParseError::NoIdentifier { entry_key }) => {
-                unverifiable += 1;
+                }),
+            ),
+            Err(ParseError::NoIdentifier { entry_key }) => (
+                VerifyStatus::Unverifiable,
                 serde_json::json!({
                     "ok": false,
                     "ref": serde_json::Value::Null,
-                    "status": "unverifiable",
+                    "status": VerifyStatus::Unverifiable.as_wire(),
                     "entry_key": entry_key,
                     "error": { "code": "INVALID_REF", "message": "entry has no DOI / arXiv id" },
-                })
-            }
-            Err(ParseError::Decode { format, message }) => {
-                illegal += 1;
+                }),
+            ),
+            Err(ParseError::Decode { format, message }) => (
+                VerifyStatus::Illegal,
                 serde_json::json!({
                     "ok": false,
-                    "status": "illegal",
+                    "status": VerifyStatus::Illegal.as_wire(),
                     "error": {
                         "code": "INVALID_REF",
                         "message": format!("input did not parse as {format}: {message}"),
                     },
-                })
-            }
+                }),
+            ),
             Err(ParseError::UnsupportedFormat { format }) => {
                 bail!("{format} parsing is not supported for verification");
             }
@@ -218,36 +283,36 @@ pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMod
                 bail!("reference file could not be parsed");
             }
         };
+        counts[status.index()] += 1;
         #[allow(clippy::print_stdout)]
         {
             println!("{record}");
         }
     }
 
-    let total = valid
-        .saturating_add(illegal)
-        .saturating_add(absent)
-        .saturating_add(unreachable)
-        .saturating_add(unverifiable);
+    let total = counts.iter().copied().fold(0u32, u32::saturating_add);
     if mode != OutputMode::Quiet {
         #[allow(clippy::print_stderr)]
         {
             eprintln!(
-                "verify: {total} entries — {valid} valid, {illegal} illegal, \
-                 {absent} absent, {unreachable} unreachable, {unverifiable} unverifiable{}",
+                "verify: {total} entries — {} valid, {} illegal, {} absent, \
+                 {} unreachable, {} unverifiable{}",
+                counts[VerifyStatus::Valid.index()],
+                counts[VerifyStatus::Illegal.index()],
+                counts[VerifyStatus::Absent.index()],
+                counts[VerifyStatus::Unreachable.index()],
+                counts[VerifyStatus::Unverifiable.index()],
                 if strict { " (strict)" } else { "" }
             );
         }
     }
 
-    // illegal + absent always fail (definite source errors, network-
-    // independent). unreachable (transient) fails only under --strict;
-    // unverifiable (no id) fails only when the on_missing policy is Error
-    // (which --strict forces).
-    let failing = illegal
-        .saturating_add(absent)
-        .saturating_add(unreachable * u32::from(strict))
-        .saturating_add(unverifiable * u32::from(on_missing == OnMissingId::Error));
+    // Sum the counts of every status whose policy marks it failing.
+    let failing = VerifyStatus::ALL
+        .iter()
+        .filter(|s| s.is_failing(strict, on_missing))
+        .map(|s| counts[s.index()])
+        .fold(0u32, u32::saturating_add);
     if failing == 0 {
         Ok(())
     } else {

--- a/crates/doiget-cli/tests/verify_e2e.rs
+++ b/crates/doiget-cli/tests/verify_e2e.rs
@@ -186,18 +186,47 @@ async fn verify_valid_arxiv_entry_passes() {
 }
 
 #[tokio::test]
-async fn verify_unresolved_arxiv_warns_by_default_fails_strict() {
+async fn verify_absent_arxiv_404_fails_by_default() {
+    // A 404 from the metadata source is an authoritative "this id does
+    // not exist" → status "absent". Being network-independent, it fails
+    // the run even WITHOUT --strict (a definite dead reference).
     let server = MockServer::start().await;
-    // 404 for every query → the well-formed id does not resolve.
     Mock::given(method("GET"))
         .and(path("/api/query"))
         .respond_with(ResponseTemplate::new(404))
         .mount(&server)
         .await;
 
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "refs.bib",
+        "@article{x, eprint = {2401.99999}, archivePrefix = {arXiv}}",
+    );
+    doiget(&dir)
+        .args(["verify", &bib])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .failure()
+        .stdout(contains("\"status\":\"absent\""));
+}
+
+#[tokio::test]
+async fn verify_unreachable_arxiv_5xx_warns_by_default_fails_strict() {
+    // A transient upstream failure (503) is "unreachable": it does NOT
+    // prove the id is dead, so it is tolerated by default (a flaky
+    // network must not fail a build over a real id) and fails only under
+    // --strict (the network-stable lane).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
     let bib_content = "@article{x, eprint = {2401.99999}, archivePrefix = {arXiv}}";
 
-    // Default: unresolved is a warning → exit 0.
+    // Default: unreachable is a warning → exit 0.
     let dir1 = TempDir::new().expect("tempdir");
     let bib1 = write_bib(&dir1, "refs.bib", bib_content);
     doiget(&dir1)
@@ -205,9 +234,9 @@ async fn verify_unresolved_arxiv_warns_by_default_fails_strict() {
         .env("DOIGET_ARXIV_BASE", server.uri())
         .assert()
         .success()
-        .stdout(contains("\"status\":\"unresolved\""));
+        .stdout(contains("\"status\":\"unreachable\""));
 
-    // Strict: unresolved fails the run.
+    // Strict: unreachable fails the run.
     let dir2 = TempDir::new().expect("tempdir");
     let bib2 = write_bib(&dir2, "refs.bib", bib_content);
     doiget(&dir2)
@@ -215,7 +244,7 @@ async fn verify_unresolved_arxiv_warns_by_default_fails_strict() {
         .env("DOIGET_ARXIV_BASE", server.uri())
         .assert()
         .failure()
-        .stdout(contains("\"status\":\"unresolved\""));
+        .stdout(contains("\"status\":\"unreachable\""));
 }
 
 #[tokio::test]

--- a/crates/doiget-cli/tests/verify_e2e.rs
+++ b/crates/doiget-cli/tests/verify_e2e.rs
@@ -186,14 +186,53 @@ async fn verify_valid_arxiv_entry_passes() {
 }
 
 #[tokio::test]
-async fn verify_absent_arxiv_404_fails_by_default() {
-    // A 404 from the metadata source is an authoritative "this id does
-    // not exist" → status "absent". Being network-independent, it fails
-    // the run even WITHOUT --strict (a definite dead reference).
+async fn verify_absent_arxiv_404_fails_by_default_and_under_strict() {
+    // An HTTP 404 from the metadata source is an authoritative "this id
+    // does not exist" → status "absent" + error code NOT_FOUND. Being
+    // network-independent, it fails the run with exit code 1 (one failing
+    // entry) WITHOUT --strict, and equally under --strict.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/api/query"))
         .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let content = "@article{x, eprint = {2401.99999}, archivePrefix = {arXiv}}";
+
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(&dir, "refs.bib", content);
+    doiget(&dir)
+        .args(["verify", &bib])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .code(1)
+        .stdout(contains("\"status\":\"absent\"").and(contains("\"code\":\"NOT_FOUND\"")));
+
+    // --strict must NOT downgrade or change the verdict: absent always fails.
+    let dir2 = TempDir::new().expect("tempdir");
+    let bib2 = write_bib(&dir2, "refs.bib", content);
+    doiget(&dir2)
+        .args(["verify", &bib2, "--strict"])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .code(1)
+        .stdout(contains("\"status\":\"absent\""));
+}
+
+#[tokio::test]
+async fn verify_absent_arxiv_empty_feed_fails_by_default() {
+    // The REALISTIC arXiv "unknown id" case: HTTP 200 with an empty
+    // `<feed>` (no `<entry>`), not a 404. This must still classify as
+    // `absent` (NOT_FOUND) and fail the default run — otherwise a dead
+    // arXiv reference would silently pass.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>"#,
+        ))
         .mount(&server)
         .await;
 
@@ -207,8 +246,8 @@ async fn verify_absent_arxiv_404_fails_by_default() {
         .args(["verify", &bib])
         .env("DOIGET_ARXIV_BASE", server.uri())
         .assert()
-        .failure()
-        .stdout(contains("\"status\":\"absent\""));
+        .code(1)
+        .stdout(contains("\"status\":\"absent\"").and(contains("\"code\":\"NOT_FOUND\"")));
 }
 
 #[tokio::test]
@@ -234,7 +273,7 @@ async fn verify_unreachable_arxiv_5xx_warns_by_default_fails_strict() {
         .env("DOIGET_ARXIV_BASE", server.uri())
         .assert()
         .success()
-        .stdout(contains("\"status\":\"unreachable\""));
+        .stdout(contains("\"status\":\"unreachable\"").and(contains("\"code\":\"NETWORK_ERROR\"")));
 
     // Strict: unreachable fails the run.
     let dir2 = TempDir::new().expect("tempdir");
@@ -282,4 +321,31 @@ async fn verify_with_base_override_does_not_write_cache() {
         entries, 0,
         "base override must bypass the cache; found {entries} cache entries in {resolver_dir:?}"
     );
+}
+
+#[tokio::test]
+async fn verify_mixed_illegal_and_absent_emits_both_records_and_fails() {
+    // A two-entry file exercises the per-entry loop and counter
+    // accumulation: a malformed id (illegal, no network) plus a 404'd id
+    // (absent). Both must be emitted and the run must fail (exit 2).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "refs.bib",
+        "@article{bad, doi = {1O.1234/typo}}\n\
+         @article{gone, eprint = {2401.99999}, archivePrefix = {arXiv}}",
+    );
+    doiget(&dir)
+        .args(["verify", &bib])
+        .env("DOIGET_ARXIV_BASE", server.uri())
+        .assert()
+        .code(2)
+        .stdout(contains("\"status\":\"illegal\"").and(contains("\"status\":\"absent\"")));
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -639,11 +639,22 @@ pub enum ErrorCode {
     /// Transport / DNS / TLS failure.
     NetworkError,
     /// A metadata source authoritatively reported that the identifier
-    /// does not exist (HTTP 404 / 410). Distinct from
-    /// [`Self::NetworkError`] (a transient transport failure) and
-    /// [`Self::RateLimited`]: a `NotFound` is network-independent and
-    /// reproducible, so `doiget verify` treats it as a definite dead
-    /// reference (fails the run) rather than a tolerable blip.
+    /// does not exist. Network-independent and reproducible, so `doiget
+    /// verify` treats it as a definite dead reference (fails the run even
+    /// without `--strict`) rather than a tolerable blip — distinct from
+    /// the transient [`Self::NetworkError`], [`Self::RateLimited`], and
+    /// [`Self::FetchTimeout`].
+    ///
+    /// Sources: an HTTP `404` / `410` / `451` from a metadata API, or a
+    /// source-specific absence signal (e.g. arXiv returns HTTP 200 with an
+    /// empty `<feed>` for an unknown id, surfaced via `FetchError::NotFound`).
+    ///
+    /// Caveat (DOI fan-out): for a DOI this is emitted only when the
+    /// configured metadata sources (Crossref, then Unpaywall) all fail to
+    /// resolve it and at least one authoritatively 404s. A DOI registered
+    /// only outside that set (e.g. a DataCite-only dataset DOI) can
+    /// therefore be reported `NotFound` even though it exists in a
+    /// registry doiget does not query.
     NotFound,
     /// Filesystem write failed.
     StoreError,

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -638,6 +638,13 @@ pub enum ErrorCode {
     RateLimited,
     /// Transport / DNS / TLS failure.
     NetworkError,
+    /// A metadata source authoritatively reported that the identifier
+    /// does not exist (HTTP 404 / 410). Distinct from
+    /// [`Self::NetworkError`] (a transient transport failure) and
+    /// [`Self::RateLimited`]: a `NotFound` is network-independent and
+    /// reproducible, so `doiget verify` treats it as a definite dead
+    /// reference (fails the run) rather than a tolerable blip.
+    NotFound,
     /// Filesystem write failed.
     StoreError,
     /// Provenance log write failed; the fetch was aborted.
@@ -677,6 +684,7 @@ impl ErrorCode {
             ErrorCode::NoOaAvailable => "NO_OA_AVAILABLE",
             ErrorCode::RateLimited => "RATE_LIMITED",
             ErrorCode::NetworkError => "NETWORK_ERROR",
+            ErrorCode::NotFound => "NOT_FOUND",
             ErrorCode::StoreError => "STORE_ERROR",
             ErrorCode::LogError => "LOG_ERROR",
             ErrorCode::CapabilityDenied => "CAPABILITY_DENIED",

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -103,6 +103,17 @@ pub enum FetchError {
     /// Tier 1 sources reported no OA URL for this ref.
     #[error("Tier 1 sources reported no OA URL for this ref")]
     NoOaAvailable,
+    /// A metadata source authoritatively reported that the identifier does
+    /// not exist — distinct from a transport failure. Surfaces as
+    /// [`crate::ErrorCode::NotFound`]. Used for sources whose
+    /// "absent" signal is NOT an HTTP 404/410 (e.g. the arXiv Atom API
+    /// returns HTTP 200 with an empty `<feed>` for an unknown id).
+    #[error("identifier not found: {hint}")]
+    NotFound {
+        /// Human-readable detail (which source, and how it signalled
+        /// absence); not parsed.
+        hint: String,
+    },
     /// Underlying HTTP / network failure. See [`HttpError`].
     #[error("network error: {0}")]
     Http(#[from] HttpError),
@@ -155,14 +166,13 @@ impl From<&FetchError> for crate::ErrorCode {
         match e {
             FetchError::NotEligible { .. } => crate::ErrorCode::CapabilityDenied,
             FetchError::NoOaAvailable => crate::ErrorCode::NoOaAvailable,
-            // A 404 / 410 from a metadata source is an authoritative
-            // "this id does not exist" — network-independent and
-            // reproducible — so it maps to `NotFound`, distinct from a
-            // transient transport failure. This is what lets `doiget
-            // verify` fail a genuinely dead reference while still
-            // tolerating a network blip on a real-but-unreachable id.
+            FetchError::NotFound { .. } => crate::ErrorCode::NotFound,
+            // 404 / 410 / 451 are authoritative, reproducible "this id is
+            // not (and will not be) here" signals → `NotFound`; see
+            // `ErrorCode::NotFound`. Everything else is transient.
             FetchError::Http(HttpError::HttpStatus {
-                status: 404 | 410, ..
+                status: 404 | 410 | 451,
+                ..
             }) => crate::ErrorCode::NotFound,
             FetchError::Http(_) => crate::ErrorCode::NetworkError,
             FetchError::Log(_) => crate::ErrorCode::LogError,
@@ -207,6 +217,7 @@ impl From<&FetchError> for Option<crate::DenialContext> {
             // `TooManyRefs` is a request-shape failure, not a denial —
             // adding it to the None arm keeps the mapping table consistent.)
             FetchError::NoOaAvailable
+            | FetchError::NotFound { .. }
             | FetchError::Log(_)
             | FetchError::InvalidRef(_)
             | FetchError::SourceSchema { .. }
@@ -380,9 +391,9 @@ mod tests {
         .into();
         assert_eq!(e, ErrorCode::NetworkError);
 
-        // 404 / 410 from a metadata source is an authoritative "id does
+        // 404 / 410 / 451 from a metadata source are authoritative "id does
         // not exist" → NotFound (network-independent), NOT NetworkError.
-        for status in [404u16, 410] {
+        for status in [404u16, 410, 451] {
             let e: ErrorCode = FetchError::Http(HttpError::HttpStatus {
                 status,
                 url: "https://api.crossref.org/works/10.5555/absent".into(),
@@ -394,6 +405,13 @@ mod tests {
                 "status {status} should map to NotFound"
             );
         }
+        // A non-HTTP authoritative absence (e.g. arXiv's empty Atom feed)
+        // also maps to NotFound.
+        let e: ErrorCode = FetchError::NotFound {
+            hint: "arxiv empty feed".into(),
+        }
+        .into();
+        assert_eq!(e, ErrorCode::NotFound);
         // A transient upstream status (e.g. 503) stays NetworkError so
         // `doiget verify` tolerates it rather than failing a live id.
         let e: ErrorCode = FetchError::Http(HttpError::HttpStatus {

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -155,6 +155,15 @@ impl From<&FetchError> for crate::ErrorCode {
         match e {
             FetchError::NotEligible { .. } => crate::ErrorCode::CapabilityDenied,
             FetchError::NoOaAvailable => crate::ErrorCode::NoOaAvailable,
+            // A 404 / 410 from a metadata source is an authoritative
+            // "this id does not exist" — network-independent and
+            // reproducible — so it maps to `NotFound`, distinct from a
+            // transient transport failure. This is what lets `doiget
+            // verify` fail a genuinely dead reference while still
+            // tolerating a network blip on a real-but-unreachable id.
+            FetchError::Http(HttpError::HttpStatus {
+                status: 404 | 410, ..
+            }) => crate::ErrorCode::NotFound,
             FetchError::Http(_) => crate::ErrorCode::NetworkError,
             FetchError::Log(_) => crate::ErrorCode::LogError,
             FetchError::InvalidRef(_) => crate::ErrorCode::InvalidRef,
@@ -367,6 +376,29 @@ mod tests {
 
         let e: ErrorCode = FetchError::Http(HttpError::UnknownSource {
             source_key: "mock".into(),
+        })
+        .into();
+        assert_eq!(e, ErrorCode::NetworkError);
+
+        // 404 / 410 from a metadata source is an authoritative "id does
+        // not exist" → NotFound (network-independent), NOT NetworkError.
+        for status in [404u16, 410] {
+            let e: ErrorCode = FetchError::Http(HttpError::HttpStatus {
+                status,
+                url: "https://api.crossref.org/works/10.5555/absent".into(),
+            })
+            .into();
+            assert_eq!(
+                e,
+                ErrorCode::NotFound,
+                "status {status} should map to NotFound"
+            );
+        }
+        // A transient upstream status (e.g. 503) stays NetworkError so
+        // `doiget verify` tolerates it rather than failing a live id.
+        let e: ErrorCode = FetchError::Http(HttpError::HttpStatus {
+            status: 503,
+            url: "https://api.crossref.org/works/10.5555/down".into(),
         })
         .into();
         assert_eq!(e, ErrorCode::NetworkError);

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -352,8 +352,9 @@ impl Source for ArxivSource {
 /// # Errors
 ///
 /// Returns [`FetchError::SourceSchema`] if the XML is malformed (parser
-/// reports a syntax error) or if no `<entry>` element is present (arXiv
-/// returns an empty `<feed>` on an unknown id).
+/// reports a syntax error), or [`FetchError::NotFound`] if no `<entry>`
+/// element is present (arXiv returns HTTP 200 with an empty `<feed>` on an
+/// unknown id — an authoritative absence, not a parse error).
 pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
     let mut reader = Reader::from_reader(xml);
     let config = reader.config_mut();
@@ -516,7 +517,11 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
     }
 
     if !saw_entry {
-        return Err(FetchError::SourceSchema {
+        // arXiv signals an unknown id with HTTP 200 + an empty `<feed>`
+        // (no `<entry>`), NOT a 404. Surface it as an authoritative
+        // absence so `doiget verify` classifies it `absent` (a dead
+        // reference) rather than a tolerable transport blip.
+        return Err(FetchError::NotFound {
             hint: "arxiv Atom feed had no <entry> element (unknown id?)".into(),
         });
     }
@@ -929,18 +934,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_atom_feed_empty_feed_errors_source_schema() {
+    fn parse_atom_feed_empty_feed_is_not_found() {
+        // An unknown arXiv id yields HTTP 200 + an empty `<feed>`. That is
+        // an authoritative absence (→ `FetchError::NotFound` →
+        // `ErrorCode::NotFound` → verify `absent`), NOT a schema error.
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom"></feed>"#;
         let err = parse_atom_feed(xml.as_bytes()).expect_err("empty feed must error");
         match err {
-            FetchError::SourceSchema { hint } => {
+            FetchError::NotFound { hint } => {
                 assert!(
                     hint.contains("entry"),
                     "expected mention of <entry>; got {hint}"
                 );
             }
-            other => panic!("expected SourceSchema, got {other:?}"),
+            other => panic!("expected NotFound, got {other:?}"),
         }
     }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,7 +63,7 @@ emoji = false
 
 [verify]                 # consumed by `doiget verify`
 on_missing_id = "warn"   # warn | error | skip — policy for id-less entries
-strict = false           # treat unresolved (well-formed, non-resolving) ids as failures
+strict = false           # also fail on unreachable (transient) ids; absent (404/410) ids fail regardless
 ```
 
 doiget reads only the keys it knows about. Unknown keys cause a startup warning but do

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -37,6 +37,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
 | `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
+| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist (HTTP 404 / 410). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). | No (the id is wrong or retracted). |
 | `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
 | `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
 | `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -16,6 +16,7 @@ pub enum ErrorCode {
     NoOaAvailable,
     RateLimited,
     NetworkError,
+    NotFound,
     StoreError,
     LogError,
     CapabilityDenied,
@@ -37,7 +38,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
 | `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
-| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist (HTTP 404 / 410). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). | No (the id is wrong or retracted). |
+| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | No (the id is wrong or retracted). |
 | `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
 | `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
 | `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -69,7 +69,7 @@ emoji = false
 
 [verify]                 # consumed by `doiget verify`
 on_missing_id = "warn"   # warn | error | skip — policy for id-less entries
-strict = false           # treat unresolved (well-formed, non-resolving) ids as failures
+strict = false           # also fail on unreachable (transient) ids; absent (404/410) ids fail regardless
 ```
 
 doiget reads only the keys it knows about. Unknown keys cause a startup warning but do

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -22,6 +22,7 @@ pub enum ErrorCode {
     NoOaAvailable,
     RateLimited,
     NetworkError,
+    NotFound,
     StoreError,
     LogError,
     CapabilityDenied,
@@ -43,6 +44,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
 | `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
+| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | No (the id is wrong or retracted). |
 | `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
 | `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
 | `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |


### PR DESCRIPTION
## Why
`doiget verify` collapsed every non-resolving id into one `unresolved` bucket. Consequences:
- **Default lane passed dead DOIs** — no real verification of reference existence.
- The only way to fail on dead refs (`--strict`) **also failed on transient network blips** → flaky CI.

This is the gap that forced QAtlas's `verify@next` step to stay `continue-on-error: true` / `strict: "false"`.

## What
Split the bucket by *why* resolution failed (the load-bearing distinction):

| status | cause | default | `--strict` |
|---|---|---|---|
| `illegal` | malformed id | **fail** | fail |
| **`absent`** | 404/410 → `NotFound` (definitely doesn't exist) | **fail** | fail |
| **`unreachable`** | transient (network / 429 / 5xx / timeout) | pass (tolerated) | fail |
| `unverifiable` | no DOI/arXiv id | `on_missing_id` | fail |
| `valid` | resolved | pass | pass |

- **core**: new `ErrorCode::NotFound` (`"NOT_FOUND"`), additive on the `#[non_exhaustive]` enum.
- **core**: `FetchError::Http(HttpStatus { 404 | 410 })` → `NotFound`; all other statuses stay `NetworkError`.
- **cli**: `verify` emits `absent` / `unreachable` and computes the exit code accordingly.

Net effect: **the default lane catches genuinely dead references while staying green through network hiccups on real ids** — exactly what a `uses: .../verify@next` caller (QAtlas) wants, no `--strict` needed.

## Tests
- `source.rs`: 404/410 → `NotFound`, 503 → `NetworkError`.
- `verify_e2e.rs`: `absent`(404) fails by default; `unreachable`(503) warns by default / fails under `--strict`.
- Full workspace: clippy clean, all tests pass.

## Docs
ERRORS.md (new `NOT_FOUND` row), CONFIG.md, verify action README + action.yml, CHANGELOG (0.4.2-beta.0).

## Notes
- Also lands the missing CHANGELOG line for the provenance-log fix (#274) under 0.4.2-beta.0.
- Version-check is advisory; workspace stays `0.4.2-beta.0`. Whether the eventual release is 0.4.2 or 0.5.0 (this adds a public `ErrorCode` variant) is a release-time call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)