### PR TITLE
feat(cli): add `doiget lint` — structural BibTeX validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Opens the 0.4.2 beta development cycle on `next` after the 0.4.1 stable
 release.
 
 ### Added
-- **[cli]** `doiget lint <path>` — structural validation of a BibTeX bibliography, independent of DOI resolution (`doiget verify`'s job) and the network. Flags missing expected fields per entry type, blank fields, and `$$` display-math titles that break some downstream renderers (e.g. DocumenterCitations). **Read-only and math-aware**: inline `$...$` titles are never touched or flagged. Emits one JSON-Lines finding per issue; structural rules are warnings (exit 0) while an unparseable file is an error, and `--strict` promotes warnings so any finding fails the run.
+- **[cli]** `doiget lint <path>` — structural validation of a BibTeX bibliography, independent of DOI resolution (`doiget verify`'s job) and the network. Flags missing expected fields per entry type, blank fields, and `$$` display-math titles that break some downstream renderers (e.g. DocumenterCitations). **Read-only and math-aware**: inline `$...$` titles are never touched or flagged. Emits one JSON-Lines finding per issue; structural rules are warnings (exit 0) while an unparsable file is an error, and `--strict` promotes warnings so any finding fails the run.
 
 ## [0.4.1] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ## [0.4.2-beta.0] - 2026-06-02
 
 Opens the 0.4.2 beta development cycle on `next` after the 0.4.1 stable
-release. No user-facing changes yet — new entries land here as work
-merges to `next`.
+release.
+
+### Added
+- **[cli]** `doiget lint <path>` — structural validation of a BibTeX bibliography, independent of DOI resolution (`doiget verify`'s job) and the network. Flags missing expected fields per entry type, blank fields, and `$$` display-math titles that break some downstream renderers (e.g. DocumenterCitations). **Read-only and math-aware**: inline `$...$` titles are never touched or flagged. Emits one JSON-Lines finding per issue; structural rules are warnings (exit 0) while an unparseable file is an error, and `--strict` promotes warnings so any finding fails the run.
 
 ## [0.4.1] - 2026-06-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ version = "0.4.2-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "biblatex",
  "camino",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,6 @@ version = "0.4.2-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "biblatex",
  "camino",
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ doiget batch refs.txt
 # Verify a bibliography's references resolve (no PDF download) — CI gate
 doiget verify docs/references.bib --strict
 
+# Lint a .bib for structural issues (no network): missing fields,
+# blank fields, $$-display-math titles. Read-only and math-aware.
+doiget lint docs/references.bib
+
 # Inspect what was fetched
 doiget info 10.1103/PhysRevLett.130.200601
 

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -30,6 +30,9 @@ tdm-springer = ["doiget-core/tdm-springer"]
 
 [dependencies]
 doiget-core        = { workspace = true }
+# `doiget lint` parses BibTeX entries directly for structural checks
+# (field presence / duplicate keys), beyond core's DOI-only extraction.
+biblatex            = { workspace = true }
 # `doiget serve` (Phase 3 MCP foundation) hands off to the MCP server.
 # Stdio-only per ADR-0001; transitive features are constrained by the
 # workspace-root `rmcp` dep declaration.

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -426,6 +426,13 @@ fn metadata_for(subcommand: &str) -> Option<SubcommandMeta> {
             json_mode: JsonMode::Artifact,
             feature_gated: None,
         },
+        "lint" => SubcommandMeta {
+            examples: &["doiget lint refs.bib", "doiget lint library.bib --strict"],
+            // Emits one JSON-Lines finding per issue; the JSONL stream is
+            // the product output (mirrors verify).
+            json_mode: JsonMode::Artifact,
+            feature_gated: None,
+        },
         "info" => SubcommandMeta {
             examples: &[
                 "doiget info 10.1234/foo",

--- a/crates/doiget-cli/src/commands/lint.rs
+++ b/crates/doiget-cli/src/commands/lint.rs
@@ -1,0 +1,220 @@
+//! `doiget lint <path>` — structural validation of a BibTeX bibliography,
+//! independent of DOI resolution (`doiget verify`'s job).
+//!
+//! **Read-only**: lint never rewrites the file. It is also **math-aware** —
+//! inline `$...$` in a title is content, not a malformed field — so a
+//! hand-edited maths title (e.g. `$T\bar{T}$`) survives untouched and is
+//! never flagged.
+//!
+//! One JSON-Lines record per finding on stdout:
+//! `{"key","entry_type","rule","severity","message"}`. The summary goes to
+//! stderr unless `--quiet`.
+//!
+//! Rules and default severity:
+//!
+//! - `parse_error` (**error**) — the file is not parseable BibTeX. The
+//!   `biblatex` parser also rejects duplicate / blank citation keys at
+//!   this stage, so those surface as a `parse_error` (with a descriptive
+//!   message) rather than via a dedicated rule.
+//! - `missing_required_field` (**warning**) — an expected field for the
+//!   entry type is absent. Advisory: real-world `.bib` files are often
+//!   loose, so this is a comment, not a failure.
+//! - `empty_field` (**warning**) — a present field is blank / whitespace.
+//! - `title_math_hazard` (**warning**) — a `title` carries `$$` display
+//!   math, which some downstream renderers (e.g. DocumenterCitations)
+//!   cannot process; inline `$...$` is fine. Best-effort, advisory.
+//!
+//! Exit code = number of `error` findings (capped at 255). `--strict`
+//! promotes warnings so that ANY finding fails the run.
+
+use anyhow::{Context, Result};
+use biblatex::{Bibliography, ChunksExt, Entry, EntryType};
+
+use super::fetch::CliExit;
+use super::output::OutputMode;
+
+/// Finding severity. The label is intrinsic to the rule; `--strict` only
+/// changes whether warnings count toward the exit code (mirrors `verify`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Severity {
+    Error,
+    Warning,
+}
+
+impl Severity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        }
+    }
+}
+
+/// A required-field slot: presence of ANY listed field satisfies it. This
+/// absorbs BibTeX/BibLaTeX spelling variants (`journal` vs `journaltitle`,
+/// `year` vs `date`, `author` vs `editor`).
+type Req = &'static [&'static str];
+
+/// Required-field sets per entry type. Deliberately modest — the goal is
+/// to flag obviously-incomplete entries, not to enforce the full BibLaTeX
+/// data model. Unknown / other types require only a title.
+fn required_fields(t: &EntryType) -> Vec<Req> {
+    match t {
+        EntryType::Article => vec![
+            &["author"],
+            &["title"],
+            &["journal", "journaltitle"],
+            &["year", "date"],
+        ],
+        EntryType::Book | EntryType::MvBook => vec![
+            &["author", "editor"],
+            &["title"],
+            &["publisher"],
+            &["year", "date"],
+        ],
+        EntryType::InProceedings | EntryType::InCollection | EntryType::InBook => {
+            vec![&["author"], &["title"], &["booktitle"], &["year", "date"]]
+        }
+        EntryType::Proceedings | EntryType::MvProceedings => {
+            vec![&["title"], &["year", "date"]]
+        }
+        EntryType::PhdThesis | EntryType::MastersThesis | EntryType::Thesis => vec![
+            &["author"],
+            &["title"],
+            &["school", "institution"],
+            &["year", "date"],
+        ],
+        EntryType::TechReport | EntryType::Report => {
+            vec![&["author"], &["title"], &["institution"], &["year", "date"]]
+        }
+        _ => vec![&["title"]],
+    }
+}
+
+/// `true` when at least one of `names` is present on `entry` with a
+/// non-empty value.
+fn has_any(entry: &Entry, names: Req) -> bool {
+    names.iter().any(|n| {
+        entry
+            .fields
+            .get(*n)
+            .is_some_and(|c| !c.format_verbatim().trim().is_empty())
+    })
+}
+
+/// Canonical lowercase entry-type label for the JSON record (informational).
+fn entry_type_label(t: &EntryType) -> String {
+    format!("{t:?}").to_ascii_lowercase()
+}
+
+/// Entry point for `doiget lint <path> [--strict]`.
+pub fn run(path: String, strict: bool, mode: OutputMode) -> Result<()> {
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read bibliography file {path}"))?;
+
+    let mut errors = 0u32;
+    let mut warnings = 0u32;
+
+    // Tally + emit one JSON-Lines record. Severity is intrinsic to the
+    // rule; `strict` is applied only to the exit code below.
+    let mut emit = |key: &str, entry_type: &str, rule: &str, sev: Severity, message: String| {
+        match sev {
+            Severity::Error => errors += 1,
+            Severity::Warning => warnings += 1,
+        }
+        let record = serde_json::json!({
+            "key": key,
+            "entry_type": entry_type,
+            "rule": rule,
+            "severity": sev.as_str(),
+            "message": message,
+        });
+        #[allow(clippy::print_stdout)]
+        {
+            println!("{record}");
+        }
+    };
+
+    match Bibliography::parse(&text) {
+        Err(e) => {
+            emit(
+                "",
+                "",
+                "parse_error",
+                Severity::Error,
+                format!("file did not parse as BibTeX: {e}"),
+            );
+        }
+        Ok(bib) => {
+            for entry in bib.iter() {
+                let key = entry.key.clone();
+                let et = entry_type_label(&entry.entry_type);
+
+                for slot in required_fields(&entry.entry_type) {
+                    if !has_any(entry, slot) {
+                        emit(
+                            &key,
+                            &et,
+                            "missing_required_field",
+                            Severity::Warning,
+                            format!("missing expected field for `{et}`: {}", slot.join(" / ")),
+                        );
+                    }
+                }
+
+                for (name, chunks) in &entry.fields {
+                    if chunks.format_verbatim().trim().is_empty() {
+                        emit(
+                            &key,
+                            &et,
+                            "empty_field",
+                            Severity::Warning,
+                            format!("field `{name}` is present but empty"),
+                        );
+                    }
+                }
+
+                // Math-aware title hazard: inline `$...$` is fine, but `$$`
+                // display math breaks some renderers (DocumenterCitations).
+                // Best-effort: inspect the re-serialised title.
+                if let Some(chunks) = entry.fields.get("title") {
+                    let rendered = chunks.to_biblatex_string(false);
+                    let dollars = rendered.matches('$').count();
+                    if rendered.contains("$$") || dollars % 2 == 1 {
+                        emit(
+                            &key,
+                            &et,
+                            "title_math_hazard",
+                            Severity::Warning,
+                            "title math is not clean inline `$...$` (found `$$` or an unbalanced \
+                             `$`); some renderers (e.g. DocumenterCitations) cannot process it"
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    let total = errors + warnings;
+    if mode != OutputMode::Quiet {
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!(
+                "lint: {total} findings — {errors} error, {warnings} warning{}",
+                if strict {
+                    " (strict: warnings fail)"
+                } else {
+                    ""
+                }
+            );
+        }
+    }
+
+    let failing = errors + if strict { warnings } else { 0 };
+    if failing == 0 {
+        Ok(())
+    } else {
+        Err(anyhow::Error::new(CliExit(failing.min(255) as i32)))
+    }
+}

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod config;
 pub mod csl;
 pub mod fetch;
 pub mod info;
+pub mod lint;
 pub mod list_recent;
 pub mod output;
 pub mod provenance;

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -316,6 +316,17 @@ enum Command {
         #[arg(long)]
         strict: bool,
     },
+    /// Structurally validate a BibTeX bibliography (duplicate keys,
+    /// missing fields, blank entries, `$$` title math) WITHOUT resolving
+    /// DOIs or touching the network. Read-only; emits one JSON-Lines
+    /// finding per issue and exits non-zero on errors.
+    Lint {
+        /// Path to the BibTeX file to lint.
+        path: String,
+        /// Promote warnings to errors so any finding fails the run.
+        #[arg(long)]
+        strict: bool,
+    },
     /// Resolve a bibliographic citation string to ranked DOI candidates.
     #[command(name = "resolve-citation")]
     ResolveCitation {
@@ -538,6 +549,7 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             format,
             strict,
         }) => doiget_cli::commands::verify::run(path, format, strict, mode).await,
+        Some(Command::Lint { path, strict }) => doiget_cli::commands::lint::run(path, strict, mode),
         Some(Command::ResolveCitation { query, limit }) => {
             doiget_cli::commands::resolve_citation::run(query, limit, mode).await
         }

--- a/crates/doiget-cli/tests/lint_e2e.rs
+++ b/crates/doiget-cli/tests/lint_e2e.rs
@@ -1,0 +1,116 @@
+//! End-to-end tests for `doiget lint <path>`.
+//!
+//! `lint` touches no network and no store — it only reads the given file —
+//! so these tests need no wiremock or temp HOME, just a fixture `.bib`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+/// Write `content` to `<dir>/refs.bib` and return the path string.
+fn write_bib(dir: &TempDir, content: &str) -> String {
+    let path = dir.path().join("refs.bib");
+    std::fs::write(&path, content).expect("write bib fixture");
+    path.to_str().expect("utf-8 path").to_string()
+}
+
+fn doiget() -> Command {
+    Command::cargo_bin("doiget").expect("locate doiget binary")
+}
+
+#[test]
+fn lint_clean_article_has_no_findings() {
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "@article{ok, author={A. Author}, title={A Clean Title}, journal={Phys. Rev.}, year={2020}}",
+    );
+    doiget().args(["lint", &bib]).assert().success();
+}
+
+#[test]
+fn lint_missing_fields_warns_but_passes_by_default() {
+    let dir = TempDir::new().expect("tempdir");
+    // @article with no journal and no year → two missing-field warnings.
+    let bib = write_bib(
+        &dir,
+        "@article{miss, author={A}, title={No Journal No Year}}",
+    );
+    doiget().args(["lint", &bib]).assert().success().stdout(
+        contains("\"rule\":\"missing_required_field\"").and(contains("\"severity\":\"warning\"")),
+    );
+}
+
+#[test]
+fn lint_missing_fields_strict_fails() {
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "@article{miss, author={A}, title={No Journal No Year}}",
+    );
+    doiget()
+        .args(["lint", &bib, "--strict"])
+        .assert()
+        .failure()
+        .stdout(contains("\"rule\":\"missing_required_field\""));
+}
+
+#[test]
+fn lint_empty_field_warns() {
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "@article{e, author={A}, title={T}, journal={ }, year={2020}}",
+    );
+    doiget()
+        .args(["lint", &bib])
+        .assert()
+        .success()
+        .stdout(contains("\"rule\":\"empty_field\""));
+}
+
+#[test]
+fn lint_flags_display_math_title_but_not_inline_math() {
+    // `$$ ... $$` display math is a hazard for downstream renderers; plain
+    // inline `$...$` must NOT be flagged (the hand-edited-maths case).
+    let dir = TempDir::new().expect("tempdir");
+    let hazard = write_bib(
+        &dir,
+        "@article{haz, author={A}, title={Bad $$\\mathrm{T}$$ math}, journal={J}, year={2001}}",
+    );
+    doiget()
+        .args(["lint", &hazard])
+        .assert()
+        .success()
+        .stdout(contains("\"rule\":\"title_math_hazard\""));
+
+    let dir2 = TempDir::new().expect("tempdir");
+    let inline = write_bib(
+        &dir2,
+        "@article{inl, author={A}, title={Good $T\\bar{T}$ inline}, journal={J}, year={2002}}",
+    );
+    doiget()
+        .args(["lint", &inline])
+        .assert()
+        .success()
+        .stdout(contains("title_math_hazard").not());
+}
+
+#[test]
+fn lint_unparseable_file_is_a_parse_error() {
+    // The biblatex parser rejects duplicate keys, which surfaces as a
+    // `parse_error` (error severity) and fails the run.
+    let dir = TempDir::new().expect("tempdir");
+    let bib = write_bib(
+        &dir,
+        "@article{dup, title={One}}\n@book{dup, title={Two}, author={B}, publisher={P}, year={1999}}",
+    );
+    doiget()
+        .args(["lint", &bib])
+        .assert()
+        .failure()
+        .stdout(contains("\"rule\":\"parse_error\"").and(contains("\"severity\":\"error\"")));
+}

--- a/crates/doiget-cli/tests/lint_e2e.rs
+++ b/crates/doiget-cli/tests/lint_e2e.rs
@@ -100,7 +100,7 @@ fn lint_flags_display_math_title_but_not_inline_math() {
 }
 
 #[test]
-fn lint_unparseable_file_is_a_parse_error() {
+fn lint_unparsable_file_is_a_parse_error() {
     // The biblatex parser rejects duplicate keys, which surfaces as a
     // `parse_error` (error severity) and fails the run.
     let dir = TempDir::new().expect("tempdir");

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -539,7 +539,7 @@ version = "0.8.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.reqwest]]
-version = "0.13.3"
+version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
@@ -659,11 +659,11 @@ version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
-version = "3.4.0"
+version = "3.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.serial_test_derive]]
-version = "3.4.0"
+version = "3.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.sha2]]
@@ -775,7 +775,7 @@ version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_edit]]
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_parser]]
@@ -851,7 +851,7 @@ version = "2.5.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.23.1"
+version = "1.23.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]


### PR DESCRIPTION
## Why
`doiget verify` checks whether references **resolve** (DOI/arXiv exists). It says nothing about whether the `.bib` itself is **structurally sound**. This adds the missing structural layer — entirely offline.

## What: `doiget lint <path>`
One JSON-Lines finding per issue (`{key, entry_type, rule, severity, message}`); summary on stderr.

| rule | severity | catches |
|---|---|---|
| `parse_error` | error | unparseable BibTeX (the biblatex parser also rejects duplicate / blank keys here) |
| `missing_required_field` | warning | entry-type-aware expected fields, tolerant of spelling variants (`journal`/`journaltitle`, `year`/`date`, `author`/`editor`) |
| `empty_field` | warning | present-but-blank field |
| `title_math_hazard` | warning | `$$` display math / unbalanced `$` in a title (breaks DocumenterCitations etc.) |

- **Read-only & math-aware**: inline `$...$` titles (e.g. `$T\bar{T}$`) are never flagged or modified — hand-edited maths survives untouched. *(Directly addresses the "don't break my manually-edited title maths" requirement.)*
- Structural findings are **warnings** (exit 0, advisory comments); only an unparseable file is an **error**. `--strict` promotes warnings so any finding fails the run.
- Output contract mirrors `verify` (JSON-Lines + exit = failing count, capped 255).

## Tests
`lint_e2e`: clean / missing-field(default-warn) / missing-field(`--strict`-fail) / empty-field / **display-math-flagged-but-inline-math-not** / duplicate-key→parse_error. Clippy clean, full `doiget-cli` suite (incl. the `capabilities` metadata regression) passes.

## Notes
- New CLI surface only (`doiget-core` semver untouched). `biblatex` added as a `doiget-cli` dep (already a workspace dep via core).
- Independent of #275 (verify error-classification); both branch off `next`. Trivial CHANGELOG overlap on the 0.4.2-beta.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)