### PR TITLE
chore(release): promote next -> main (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `doiget-core` is the only crate with strict semver guarantees during the 0.x line; CLI
 flag changes and `doiget-mcp` tool spec changes will be called out explicitly here.
 
-## [0.4.2-beta.0] - 2026-06-02
+## [0.5.0] - 2026-06-02
 
-Opens the 0.4.2 beta development cycle on `next` after the 0.4.1 stable
-release.
+Promotion of the `next` integration line to a stable release. A **minor**
+bump (not patch) because it adds new public surface: the `doiget lint`
+subcommand and the `ErrorCode::NotFound` / `source::FetchError::NotFound`
+variants, on top of the `doiget verify` reference-classification work.
 
 ### Added
 - **[core]** `ErrorCode::NotFound` (wire `"NOT_FOUND"`) — a metadata source authoritatively reported the identifier does not exist (HTTP 404 / 410 / 451, or a source-specific absence such as arXiv's empty `<feed>` for an unknown id), distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. Additive variant on the `#[non_exhaustive]` enum. A matching `source::FetchError::NotFound` variant carries the non-HTTP absence signal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.2-beta.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.2-beta.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.2-beta.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.2-beta.0"
+version       = "0.5.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.2-beta.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.2-beta.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.2-beta.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.5.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.5.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.5.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
Promote the `next` integration line to a stable **v0.5.0** release.

## Version
**Minor** bump `0.4.1 → 0.5.0` (not patch) — new public surface since v0.4.1:
- **[cli]** `doiget lint` (#276) — structural BibTeX validation (read-only, math-aware).
- **[cli]** `doiget verify` dead-vs-unreachable classification (#275): `absent` (404/410/451 or empty arXiv feed → `NotFound`, always fails) vs `unreachable` (transient, `--strict`-only).
- **[core]** new `ErrorCode::NotFound` + `source::FetchError::NotFound` variants.
- **[core]** provenance-log parent-dir fix (#274).

(`verify` / `cite` / `.bib` input / resolver cache already shipped in v0.4.1.)

## Changes in this PR
- `[workspace.package].version` `0.4.2-beta.0 → 0.5.0` (+ inter-crate pins + `Cargo.lock`).
- `CHANGELOG.md`: `[0.4.2-beta.0]` retitled `[0.5.0] - 2026-06-02`.

## Release mechanics (ADR-0025)
The release is minted by a **human-pushed signed tag `v0.5.0` on `main`**, not by merging this PR. Local version gate passes (G0–G6; G7 runs on the pushed tag):
```
version gate PASSED for v0.5.0 (lane: stable)
```

⚠️ **Do not auto-merge.** Review → merge → then `git tag -s v0.5.0 && git push` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)