### PR TITLE
chore(release): cut 0.6.0 stable (drop -beta.1 dev marker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `doiget-core` is the only crate with strict semver guarantees during the 0.x line; CLI
 flag changes and `doiget-mcp` tool spec changes will be called out explicitly here.
 
-## [0.6.0-beta.1] - 2026-06-05
+## [0.6.0] - 2026-06-07
 
 Discovery — the front half of the agent research loop (#281). `doiget search` becomes
 a literature **discovery** tool, not just a local-store re-finder. See

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.6.0-beta.1"
+version       = "0.6.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.6.0-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.6.0-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.6.0-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.6.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.6.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.6.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
Promote the #281 discovery epic from the `0.6.0-beta.1` development marker to the **stable `0.6.0`** release.

Shipped in this version (already on `next`): `paper_search` / `paper_text` / `link` (+ the mirrored MCP tools `doiget_paper_search` / `doiget_paper_text` / `doiget_link`) and OA transparency (`oa_status` end-to-end).

### Change
- `[workspace.package] version` + the 3 internal path-dep version reqs: `0.6.0-beta.1` → `0.6.0` (Cargo.toml + Cargo.lock).
- CHANGELOG `## [0.6.0]` header date finalized to 2026-06-07.
- `scripts/release-version-gate.sh v0.6.0 --offline-skip-crates-io` passes G0–G2/G5/G6 locally (G3/G4/G7 run in CI on the pushed tag).

This is the prep commit; the `next → main` promote PR + `v0.6.0` tag follow.

Refs #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)