### PR TITLE
feat(dist): curl/iwr install scripts (#247, channel 1/n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `doiget-core` is the only crate with strict semver guarantees during the 0.x line; CLI
 flag changes and `doiget-mcp` tool spec changes will be called out explicitly here.
 
+## [Unreleased]
+
+### Added
+- **[dist]** `scripts/install.sh` (POSIX `sh`, Linux/macOS) and `scripts/install.ps1` (Windows) — install the prebuilt, SHA-256-verified binary from the signed GitHub Release with no Rust toolchain required: `curl -fsSL https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.sh | sh`. `DOIGET_VERSION` pins a release (default: latest stable); `DOIGET_INSTALL_DIR` overrides the target (default `~/.local/bin` / `%LOCALAPPDATA%\Programs\doiget`). The binary's published `.sha256` sidecar is verified before install. First channel of the multi-platform distribution roadmap (#247); README gains an **Installation** section.
+
 ## [0.6.0] - 2026-06-07
 
 Discovery — the front half of the agent research loop (#281). `doiget search` becomes

--- a/README.md
+++ b/README.md
@@ -61,12 +61,40 @@ Permanent non-goals: [docs/SCOPE.md](docs/SCOPE.md)
 Phase plan: [docs/PHASES.md](docs/PHASES.md)
 ADRs: [docs/DECISIONS/](docs/DECISIONS/)
 
-## Quick start (will be available after Phase 1)
+## Installation
+
+doiget ships a single self-contained binary — the Linux build is fully static
+(musl), so it runs on old glibc / HPC boxes too. Every channel installs the
+**same checksum-verified binary** from the signed GitHub Release.
+
+### Shell installer (Linux / macOS)
 
 ```sh
-# Install (after Phase 6 release)
-cargo install doiget
+curl -fsSL https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.sh | sh
+```
 
+Installs to `~/.local/bin` (override with `DOIGET_INSTALL_DIR`); pin a version with
+`DOIGET_VERSION=0.6.0`. The script verifies the published SHA-256 sidecar before installing.
+
+### PowerShell installer (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.ps1 | iex
+```
+
+### From crates.io (Rust toolchain)
+
+```sh
+cargo install doiget
+```
+
+Further prebuilt-binary channels (Homebrew tap, `cargo binstall`, npm/npx, Nix flake,
+`.deb`) are tracked in [#247](https://github.com/sotashimozono/doiget/issues/247). Every
+release asset is cosign-keyless signed (`<asset>.cosign.bundle`) for optional verification.
+
+## Quick start
+
+```sh
 # Fetch a paper by DOI (Open Access only by default)
 doiget fetch 10.1103/PhysRevLett.130.200601
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    doiget installer for Windows — downloads the prebuilt, checksum-verified
+    binary from the latest (or a pinned) GitHub Release. No Rust toolchain or
+    compilation required.
+
+.DESCRIPTION
+    Usage:
+      irm https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.ps1 | iex
+
+    Environment overrides:
+      $env:DOIGET_VERSION      version WITHOUT the leading 'v' (default: latest stable)
+      $env:DOIGET_INSTALL_DIR  install directory (default: %LOCALAPPDATA%\Programs\doiget)
+
+    The published `.sha256` sidecar is verified before install; a mismatch
+    aborts. cosign bundles are also published — see the README for optional
+    keyless signature verification.
+#>
+#Requires -Version 5
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repo = 'sotashimozono/doiget'
+$version = if ($env:DOIGET_VERSION) { $env:DOIGET_VERSION } else { 'latest' }
+$installDir = if ($env:DOIGET_INSTALL_DIR) { $env:DOIGET_INSTALL_DIR } else { "$env:LOCALAPPDATA\Programs\doiget" }
+
+if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
+    throw "doiget-install: unsupported architecture '$env:PROCESSOR_ARCHITECTURE' — only x86_64/AMD64 is published for Windows (target tracked in #247)"
+}
+$asset = 'doiget-windows-x86_64.exe'
+
+if ($version -eq 'latest') {
+    $base = "https://github.com/$repo/releases/latest/download"
+} else {
+    $base = "https://github.com/$repo/releases/download/v$version"
+}
+
+$tmpDir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP ("doiget-install-" + [Guid]::NewGuid().ToString('N')))).FullName
+try {
+    $binPath = Join-Path $tmpDir $asset
+    $shaPath = "$binPath.sha256"
+
+    Write-Host "doiget-install: downloading $asset ($version)"
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset" -OutFile $binPath
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset.sha256" -OutFile $shaPath
+
+    # The sidecar is `openssl dgst -sha256 -r` output: "<hex>  *<filename>".
+    $expected = (((Get-Content $shaPath -Raw).Trim() -split '\s+')[0]).ToLower()
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $binPath).Hash.ToLower()
+    if ([string]::IsNullOrWhiteSpace($expected)) { throw "doiget-install: empty expected checksum in $asset.sha256" }
+    if ($expected -ne $actual) { throw "doiget-install: checksum mismatch: expected $expected, got $actual" }
+    Write-Host "doiget-install: checksum OK ($actual)"
+
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    $dest = Join-Path $installDir 'doiget.exe'
+    Move-Item -Force -Path $binPath -Destination $dest
+    Write-Host "doiget-install: installed to $dest"
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $userPath -or ($userPath -split ';') -notcontains $installDir) {
+        Write-Host "doiget-install: note: $installDir is not on your PATH. Add it (new shells) with:"
+        Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$installDir;`" + [Environment]::GetEnvironmentVariable('Path','User'), 'User')"
+    }
+    Write-Host "doiget-install: done - run: doiget --version"
+} finally {
+    Remove-Item -Recurse -Force -Path $tmpDir -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# doiget installer — download the prebuilt, checksum-verified binary for this
+# host from the latest (or a pinned) GitHub Release and install it. No Rust
+# toolchain or compilation required.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.sh | sh
+#
+# Environment overrides:
+#   DOIGET_VERSION      version to install WITHOUT the leading 'v' (default: latest stable)
+#   DOIGET_INSTALL_DIR  install directory (default: $HOME/.local/bin)
+#
+# POSIX sh on purpose (not the repo's bash house style): a script piped to `sh`
+# must run under any POSIX shell. The published `.sha256` sidecar is verified
+# before install; a mismatch aborts. cosign bundles are also published — see
+# the README for optional keyless signature verification.
+set -eu
+
+REPO="sotashimozono/doiget"
+VERSION="${DOIGET_VERSION:-latest}"
+INSTALL_DIR="${DOIGET_INSTALL_DIR:-$HOME/.local/bin}"
+
+err() { printf 'doiget-install: error: %s\n' "$1" >&2; exit 1; }
+info() { printf 'doiget-install: %s\n' "$1"; }
+
+# --- detect target -> release asset name ---------------------------------
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+  Linux)
+    case "$arch" in
+      x86_64 | amd64) asset="doiget-linux-x86_64" ;;
+      aarch64 | arm64) err "linux-aarch64 is not published yet — use 'cargo binstall doiget' or 'cargo install doiget' (target tracked in #247)" ;;
+      *) err "unsupported Linux architecture: $arch" ;;
+    esac
+    ;;
+  Darwin)
+    case "$arch" in
+      arm64 | aarch64) asset="doiget-macos-aarch64" ;;
+      x86_64) err "macos-x86_64 (Intel) is not published yet — use 'cargo binstall doiget' or 'cargo install doiget' (target tracked in #247)" ;;
+      *) err "unsupported macOS architecture: $arch" ;;
+    esac
+    ;;
+  *) err "unsupported OS: $os — on Windows use scripts/install.ps1" ;;
+esac
+
+# --- resolve release URLs ------------------------------------------------
+if [ "$VERSION" = "latest" ]; then
+  base="https://github.com/$REPO/releases/latest/download"
+else
+  base="https://github.com/$REPO/releases/download/v$VERSION"
+fi
+
+# --- pick a downloader ---------------------------------------------------
+if command -v curl >/dev/null 2>&1; then
+  dl() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  dl() { wget -qO "$2" "$1"; }
+else
+  err "need curl or wget to download"
+fi
+
+# --- portable sha256 of a file (first field = hex digest) ----------------
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{print $NF}'
+  else
+    err "need sha256sum, shasum, or openssl to verify the download"
+  fi
+}
+
+tmp="$(mktemp -d)"
+# shellcheck disable=SC2064  # expand $tmp now so the trap removes this exact dir
+trap "rm -rf '$tmp'" EXIT INT TERM
+
+info "downloading $asset ($VERSION)"
+dl "$base/$asset" "$tmp/$asset" || err "download failed: $base/$asset"
+dl "$base/$asset.sha256" "$tmp/$asset.sha256" || err "checksum download failed: $base/$asset.sha256"
+
+# The sidecar is `openssl dgst -sha256 -r` output: "<hex>  *<filename>".
+expected="$(awk '{print $1}' "$tmp/$asset.sha256")"
+actual="$(sha256_of "$tmp/$asset")"
+[ -n "$expected" ] || err "empty expected checksum in $asset.sha256"
+[ "$expected" = "$actual" ] || err "checksum mismatch: expected $expected, got $actual"
+info "checksum OK ($actual)"
+
+# --- install -------------------------------------------------------------
+mkdir -p "$INSTALL_DIR"
+mv "$tmp/$asset" "$INSTALL_DIR/doiget"
+chmod +x "$INSTALL_DIR/doiget"
+info "installed to $INSTALL_DIR/doiget"
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *) info "note: $INSTALL_DIR is not on your PATH — add: export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
+esac
+
+info "done — run: doiget --version"


### PR DESCRIPTION
First channel of the multi-platform distribution roadmap (#247): a **shell installer** so users get doiget without a Rust toolchain or compilation.

## What
- `scripts/install.sh` — POSIX `sh` (Linux/macOS). Detects host via `uname`, maps to the release asset (`doiget-linux-x86_64` / `doiget-macos-aarch64`), downloads from the GitHub Release, **verifies the published `.sha256` sidecar**, installs to `~/.local/bin`.
- `scripts/install.ps1` — Windows (`doiget-windows-x86_64.exe`), `Get-FileHash` verification, installs to `%LOCALAPPDATA%\Programs\doiget`.
- `README.md` — new **Installation** section (curl / PowerShell / `cargo install`); also removed the stale "after Phase 6 release" install note.
- `CHANGELOG.md` — `## [Unreleased]` entry (no version bump, per the feature-PR convention).

## Design
- **Single source of truth = the existing cosign-signed Release assets** (`doiget-<os>-<arch>` + `.sha256`). No per-channel rebuild; every future channel (brew/npm/nix/deb) reuses the same artifacts.
- `DOIGET_VERSION` pins a release (default: latest stable, via the `releases/latest/download` redirect); `DOIGET_INSTALL_DIR` overrides the target.
- Verification is **mandatory** (sha256); cosign bundles documented for optional keyless verify — matches doiget's provenance posture.

## Honest limitation
The release currently builds **3 targets** (linux-x86_64 musl-static, macos-aarch64, windows-x86_64). The installer **errors clearly** on unbuilt hosts (Intel mac, ARM Linux) pointing to `cargo install`. Expanding the build matrix (`x86_64-apple-darwin`, `aarch64-unknown-linux-*`) is the next PR and widens coverage for this installer + Homebrew + binstall.

## Verification
- `sh -n scripts/install.sh` ✓ ; install.ps1 parses clean via the PS AST parser ✓
- `install.sh` committed mode `100755`.

Refs #247
🤖 Generated with [Claude Code](https://claude.com/claude-code)