### PR TITLE
fix(cli): info/list-recent/search/link emit under non-TTY implicit Quiet (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.0-beta.0] - 2026-06-16
+
 ### Added
 - **[dist]** `scripts/install.sh` (POSIX `sh`, Linux/macOS) and `scripts/install.ps1` (Windows) — install the prebuilt, SHA-256-verified binary from the signed GitHub Release with no Rust toolchain required: `curl -fsSL https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.sh | sh`. `DOIGET_VERSION` pins a release (default: latest stable); `DOIGET_INSTALL_DIR` overrides the target (default `~/.local/bin` / `%LOCALAPPDATA%\Programs\doiget`). The binary's published `.sha256` sidecar is verified before install. First channel of the multi-platform distribution roadmap (#247); README gains an **Installation** section.
+
+### Fixed
+- **[cli]** `info` / `list-recent` / `search` / `link` no longer emit nothing under a non-TTY implicit Quiet (agent / pipe / ssh). They are now artifact-class and honor only **explicit** Quiet (`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`), per [ADR-0017 Amendment 2](docs/DECISIONS/0017-output-mode-resolution.md): their stdout rendering IS the requested artifact and must reach a captured / piped caller. Previously a fetch-then-`info` confirmation read as "fetch failed" or "store empty" when it had in fact succeeded (#301).
 
 ## [0.6.0] - 2026-06-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.6.0"
+version = "0.7.0-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.6.0"
+version = "0.7.0-beta.0"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.6.0"
+version = "0.7.0-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.6.0"
+version       = "0.7.0-beta.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.6.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.6.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.6.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.7.0-beta.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.7.0-beta.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.0-beta.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -25,12 +25,15 @@ use super::resolve_store_root;
 /// written to stdout as TOML. On a missing entry, the function returns an
 /// error so the CLI exits non-zero — the caller (a shell pipeline) can
 /// distinguish "entry not in store" from "entry was empty".
-pub fn run(input: String, mode: super::output::OutputMode) -> Result<()> {
-    // `mode` honors ADR-0017: `Quiet` skips emission but still
+pub fn run(input: String, mode: super::output::OutputMode, quiet_was_explicit: bool) -> Result<()> {
+    // `mode` honors ADR-0017: explicit `Quiet` skips emission but still
     // resolves the entry so the "not-found → exit non-zero" contract
-    // continues to hold (#203). `Json` serialises `Metadata` directly
-    // (it carries `Serialize`); the wire form is the field-name JSON of
-    // the on-disk TOML (#204).
+    // continues to hold (#203). The non-TTY *implicit* Quiet does NOT
+    // suppress — `info` is artifact-class (ADR-0017 Amendment 2 / #301):
+    // its stdout IS the requested metadata, which an agent / pipe / ssh
+    // caller needs. `Json` serialises `Metadata` directly (it carries
+    // `Serialize`); the wire form is the field-name JSON of the on-disk
+    // TOML (#204).
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
 
@@ -43,8 +46,9 @@ pub fn run(input: String, mode: super::output::OutputMode) -> Result<()> {
 
     match metadata {
         Some(m) => {
-            if mode == super::output::OutputMode::Quiet {
-                // Quiet: existence-check only; exit 0 with no stdout.
+            if mode == super::output::OutputMode::Quiet && quiet_was_explicit {
+                // Explicit Quiet only (--quiet / -q / --mode quiet /
+                // DOIGET_MODE=quiet): existence-check, exit 0, no stdout.
                 return Ok(());
             }
             // Workspace lints deny `print_stdout` (the `print!`/`println!`

--- a/crates/doiget-cli/src/commands/link.rs
+++ b/crates/doiget-cli/src/commands/link.rs
@@ -32,7 +32,7 @@ const OPENALEX_DEFAULT_BASE: &str = "https://api.openalex.org";
 /// A non-DOI ref is a usage error; OpenAlex failures surface a typed
 /// [`ErrorCode`] as a process exit code via [`CliExit`] (e.g. a DOI with no
 /// OpenAlex work → `NOT_FOUND`).
-pub async fn run(ref_: String, mode: OutputMode) -> Result<()> {
+pub async fn run(ref_: String, mode: OutputMode, quiet_was_explicit: bool) -> Result<()> {
     let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
     let doi = match parsed {
         Ref::Doi(d) => d,
@@ -63,7 +63,9 @@ pub async fn run(ref_: String, mode: OutputMode) -> Result<()> {
         }
     };
 
-    if mode == OutputMode::Quiet {
+    // Artifact-class (ADR-0017 Amendment 2 / #301): suppress only on
+    // explicit Quiet; the non-TTY implicit fallback still emits.
+    if mode == OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
 
@@ -142,7 +144,7 @@ mod tests {
 
     #[tokio::test]
     async fn link_rejects_arxiv_input() {
-        let err = run("arxiv:2401.12345".to_string(), OutputMode::Quiet)
+        let err = run("arxiv:2401.12345".to_string(), OutputMode::Quiet, true)
             .await
             .expect_err("arXiv input must be a usage error");
         assert!(err.to_string().contains("Pass a DOI"), "got: {err}");

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -28,17 +28,19 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// Emits a tab-separated table on stdout. The column order is intentionally
 /// stable for `cut(1)` consumption; future fields will be APPENDED, not
 /// inserted.
-pub fn run(limit: usize, mode: super::output::OutputMode) -> Result<()> {
-    // `mode` honors ADR-0017: `Quiet` suppresses the TSV table but the
-    // store read still runs (so I/O failures surface as exit 1) (#203).
-    // Json body is tracked in #204.
+pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bool) -> Result<()> {
+    // `mode` honors ADR-0017: explicit `Quiet` suppresses the TSV table
+    // but the store read still runs (so I/O failures surface as exit 1)
+    // (#203). The non-TTY *implicit* Quiet does NOT suppress —
+    // `list-recent` is artifact-class (ADR-0017 Amendment 2 / #301): the
+    // listing IS the requested output. Json body is tracked in #204.
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
     let entries = store
         .list_recent(limit)
         .context("failed to list recent store entries")?;
 
-    if mode == super::output::OutputMode::Quiet {
+    if mode == super::output::OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
 

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -25,12 +25,15 @@
 //!
 //! - `Human` — default for TTY stdout. Human-readable text, the
 //!   pre-#144 behaviour.
-//! - `Quiet` — informational stdout suppressed across the six
-//!   info-emitting commands (audit-log / info / list-recent / search /
-//!   config show / config path / provenance migrate) per #203.
-//!   Errors (stderr) and exit codes are unaffected. Product-output
-//!   commands (bib / csl / graph / *-dry-run / batch JSONL) are NOT
-//!   suppressed.
+//! - `Quiet` — stdout suppressed for *informational* commands whose
+//!   stdout is a status report (audit-log Human / config show / config
+//!   path / provenance migrate / fetch + batch status) per #203. Errors
+//!   (stderr) and exit codes are unaffected. *Artifact* commands —
+//!   whose stdout IS the requested product — suppress ONLY on
+//!   **explicit** Quiet, never on the non-TTY implicit fallback:
+//!   export/inventory (bib / csl / capabilities) per Amendment 1, and
+//!   read/inspection (info / list-recent / search / link) per
+//!   Amendment 2 (#301). See [`is_artifact_command`].
 //! - `Json` — structured JSON bodies for the human-table commands
 //!   (#204) plus the ERRORS.md §3 JSON-Lines per-ref shape for batch
 //!   (#205). Single-value-per-stdout for the table commands;
@@ -102,11 +105,14 @@ pub enum FlagInput {
 /// `DOIGET_MODE=quiet` / `--mode quiet`) from the resolver's
 /// **implicit** fallback to Quiet when stdout is not a TTY.
 ///
-/// Per ADR-0017 Amendment 1, *informational* commands (audit-log Human,
-/// list-recent, search, info, config show/path, provenance migrate,
-/// fetch/batch status) suppress on any Quiet; *artifact* commands
-/// (`bib` / `csl` / `capabilities` / `audit-log --verify --mode json`)
-/// suppress only on **explicit** Quiet. The wire format of
+/// Per ADR-0017 Amendment 1 (extended by Amendment 2, #301),
+/// *informational* commands whose stdout is a status report (audit-log
+/// Human, config show/path, provenance migrate, fetch/batch status)
+/// suppress on any Quiet; *artifact* commands whose stdout IS the
+/// product — `bib` / `csl` / `capabilities` plus the read/inspection
+/// commands `info` / `list-recent` / `search` / `link`, and
+/// `audit-log --verify --mode json` — suppress only on **explicit**
+/// Quiet. See [`is_artifact_command`]. The wire format of
 /// [`OutputMode`] (`DOIGET_MODE` string values, the `modes` array in
 /// `capabilities` JSON, the `--mode` clap values) is **unchanged**;
 /// this struct lives only in-memory.
@@ -122,15 +128,27 @@ pub struct ResolvedOutput {
 }
 
 /// `true` if `name` identifies an artifact-producing subcommand whose
-/// stdout output IS the deliverable (per ADR-0017 Amendment 1).
-/// Artifact commands suppress only on **explicit** Quiet
-/// ([`ResolvedOutput::quiet_was_explicit`] == `true`).
+/// stdout output IS the deliverable (per ADR-0017 Amendment 1, extended
+/// by Amendment 2). Artifact commands suppress only on **explicit** Quiet
+/// ([`ResolvedOutput::quiet_was_explicit`] == `true`), never on the
+/// non-TTY implicit fallback.
+///
+/// The set has two cohorts:
+/// - **Export / inventory** (`bib` / `csl` / `capabilities`) — Amendment 1.
+/// - **Read / inspection** (`info` / `list-recent` / `search` / `link`) —
+///   Amendment 2 (#301). For these the stdout rendering IS the requested
+///   data, not a status report, so a non-TTY caller (agent / pipe / ssh)
+///   must still receive it; silencing it reads as "fetch failed" or
+///   "store empty" when the data is present and correct.
 ///
 /// `audit-log` is omitted on purpose: it is *informational* in Human
 /// mode and *artifact* in Json mode; the command checks the resolved
 /// mode rather than its name, so this classifier doesn't apply.
 pub fn is_artifact_command(name: &str) -> bool {
-    matches!(name, "bib" | "csl" | "capabilities")
+    matches!(
+        name,
+        "bib" | "csl" | "capabilities" | "info" | "list-recent" | "search" | "link"
+    )
 }
 
 /// Resolve the effective [`OutputMode`] per ADR-0017 and the
@@ -370,15 +388,25 @@ mod tests {
     // ---- artifact-command classifier (ADR-0017 Am1) ------------------
 
     #[test]
-    fn artifact_command_classifier_covers_bib_csl_capabilities() {
+    fn artifact_command_classifier_covers_export_and_inspection_commands() {
+        // Amendment 1: export / inventory commands.
         assert!(is_artifact_command("bib"));
         assert!(is_artifact_command("csl"));
         assert!(is_artifact_command("capabilities"));
+        // Amendment 2 (#301): read / inspection commands — their stdout
+        // rendering IS the requested artifact, so the non-TTY implicit
+        // Quiet must NOT erase it.
+        assert!(is_artifact_command("info"));
+        assert!(is_artifact_command("list-recent"));
+        assert!(is_artifact_command("search"));
+        assert!(is_artifact_command("link"));
         // audit-log is informational-vs-artifact per resolved mode,
         // not per name; the classifier does NOT match it.
         assert!(!is_artifact_command("audit-log"));
+        // Informational status-only commands stay suppressible on any Quiet.
         assert!(!is_artifact_command("fetch"));
-        assert!(!is_artifact_command("info"));
+        assert!(!is_artifact_command("batch"));
+        assert!(!is_artifact_command("config"));
         assert!(!is_artifact_command(""));
     }
 }

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -114,26 +114,34 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 /// Propagates store-open / scan failures (local) or surfaces a typed
 /// [`ErrorCode`] as a process exit code (external); an empty query is a
 /// usage error.
-pub async fn run(query: String, local: bool, ext: ExternalArgs, mode: OutputMode) -> Result<()> {
+pub async fn run(
+    query: String,
+    local: bool,
+    ext: ExternalArgs,
+    mode: OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
     if query.trim().is_empty() {
         anyhow::bail!("search query is empty");
     }
     if local {
-        run_local(&query, mode)
+        run_local(&query, mode, quiet_was_explicit)
     } else {
-        run_external(&query, ext, mode).await
+        run_external(&query, ext, mode, quiet_was_explicit).await
     }
 }
 
 /// Local-store substring scan (legacy behaviour, now behind `--local`).
-fn run_local(query: &str, mode: OutputMode) -> Result<()> {
+fn run_local(query: &str, mode: OutputMode, quiet_was_explicit: bool) -> Result<()> {
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
     let entries = store
         .search(query, LOCAL_DEFAULT_LIMIT)
         .with_context(|| format!("search failed for query {query:?}"))?;
 
-    if mode == OutputMode::Quiet {
+    // Artifact-class (ADR-0017 Amendment 2 / #301): suppress only on
+    // explicit Quiet; the non-TTY implicit fallback still emits.
+    if mode == OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
 
@@ -165,7 +173,12 @@ fn run_local(query: &str, mode: OutputMode) -> Result<()> {
 }
 
 /// External OpenAlex discovery search (the default scope).
-async fn run_external(query: &str, ext: ExternalArgs, mode: OutputMode) -> Result<()> {
+async fn run_external(
+    query: &str,
+    ext: ExternalArgs,
+    mode: OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
     let q = PaperSearchQuery {
         query: query.to_string(),
         limit: ext.limit,
@@ -206,7 +219,9 @@ async fn run_external(query: &str, ext: ExternalArgs, mode: OutputMode) -> Resul
         }
     };
 
-    if mode == OutputMode::Quiet {
+    // Artifact-class (ADR-0017 Amendment 2 / #301): suppress only on
+    // explicit Quiet; the non-TTY implicit fallback still emits.
+    if mode == OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
 
@@ -355,17 +370,29 @@ mod tests {
 
     #[tokio::test]
     async fn external_rejects_limit_below_1() {
-        let err = run("q".into(), false, ext(0, None, None), OutputMode::Quiet)
-            .await
-            .expect_err("limit 0 must be rejected");
+        let err = run(
+            "q".into(),
+            false,
+            ext(0, None, None),
+            OutputMode::Quiet,
+            true,
+        )
+        .await
+        .expect_err("limit 0 must be rejected");
         assert!(err.to_string().contains("limit"), "got: {err}");
     }
 
     #[tokio::test]
     async fn external_rejects_limit_above_200() {
-        let err = run("q".into(), false, ext(201, None, None), OutputMode::Quiet)
-            .await
-            .expect_err("limit 201 must be rejected");
+        let err = run(
+            "q".into(),
+            false,
+            ext(201, None, None),
+            OutputMode::Quiet,
+            true,
+        )
+        .await
+        .expect_err("limit 201 must be rejected");
         assert!(err.to_string().contains("limit"), "got: {err}");
     }
 
@@ -376,6 +403,7 @@ mod tests {
             false,
             ext(25, Some(2025), Some(2010)),
             OutputMode::Quiet,
+            true,
         )
         .await
         .expect_err("from_year > to_year must be rejected");

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -607,8 +607,12 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             }
         },
         Some(Command::Config { action }) => doiget_cli::commands::config::run(action, mode),
-        Some(Command::Info { ref_ }) => doiget_cli::commands::info::run(ref_, mode),
-        Some(Command::ListRecent { limit }) => doiget_cli::commands::list_recent::run(limit, mode),
+        Some(Command::Info { ref_ }) => {
+            doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
+        }
+        Some(Command::ListRecent { limit }) => {
+            doiget_cli::commands::list_recent::run(limit, mode, out.quiet_was_explicit)
+        }
         Some(Command::Search {
             query,
             local,
@@ -634,7 +638,7 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
                 publisher,
                 sort,
             };
-            doiget_cli::commands::search::run(query, local, ext, mode).await
+            doiget_cli::commands::search::run(query, local, ext, mode, out.quiet_was_explicit).await
         }
         Some(Command::Version { check }) => doiget_cli::commands::version::run(check, mode).await,
         Some(Command::Verify {
@@ -663,7 +667,9 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             max_chars,
             no_cache,
         }) => doiget_cli::commands::text::run(ref_, max_chars, no_cache, mode).await,
-        Some(Command::Link { ref_ }) => doiget_cli::commands::link::run(ref_, mode).await,
+        Some(Command::Link { ref_ }) => {
+            doiget_cli::commands::link::run(ref_, mode, out.quiet_was_explicit).await
+        }
         // Phase 3 (MCP foundation). The MCP server runs on stdio per
         // ADR-0001. The `tracing_subscriber` installed at the top of
         // `main` is already redirected to stderr, so any rmcp / tool

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -273,3 +273,76 @@ fn list_recent_json_emits_array_of_entries() {
         assert!(entry["title"].is_string(), "title is a string");
     }
 }
+
+// ---- #301 / ADR-0017 Amendment 2: artifact-class honors only EXPLICIT Quiet
+
+/// `doiget` rooted at `root` WITHOUT forcing `DOIGET_MODE`, so the
+/// resolver sees a non-TTY captured stdout (assert_cmd pipes it) and
+/// falls through to the *implicit* Quiet branch. Pre-#301 this silenced
+/// `info` / `list-recent`; post-#301 they are artifact-class and emit.
+/// `DOIGET_MODE` is explicitly removed in case the parent environment
+/// has it set.
+fn doiget_implicit(root: &Utf8PathBuf) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("DOIGET_STORE_ROOT", root.as_str())
+        .env("HOME", root.as_str())
+        .env("USERPROFILE", root.as_str())
+        .env_remove("DOIGET_MODE");
+    cmd
+}
+
+#[test]
+fn info_emits_under_implicit_non_tty_quiet() {
+    // The #301 repro: agent / pipe / ssh caller (non-TTY, no flag, no
+    // DOIGET_MODE). `info` MUST still print its metadata.
+    let (_dir_guard, root) = seeded_store();
+    doiget_implicit(&root)
+        .args(["info", "10.1234/alpha"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("First Quantum Result"));
+}
+
+#[test]
+fn list_recent_emits_under_implicit_non_tty_quiet() {
+    let (_dir_guard, root) = seeded_store();
+    doiget_implicit(&root)
+        .args(["list-recent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("First Quantum Result"));
+}
+
+#[test]
+fn info_explicit_quiet_flag_suppresses_stdout() {
+    // Explicit `--quiet` still silences (the entry exists → exit 0); the
+    // not-found contract is unaffected.
+    let (_dir_guard, root) = seeded_store();
+    doiget_implicit(&root)
+        .args(["--quiet", "info", "10.1234/alpha"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn list_recent_explicit_quiet_flag_suppresses_stdout() {
+    let (_dir_guard, root) = seeded_store();
+    doiget_implicit(&root)
+        .args(["-q", "list-recent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn info_explicit_quiet_env_suppresses_stdout() {
+    // `DOIGET_MODE=quiet` is an explicit Quiet signal → suppress.
+    let (_dir_guard, root) = seeded_store();
+    doiget_implicit(&root)
+        .env("DOIGET_MODE", "quiet")
+        .args(["info", "10.1234/alpha"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}

--- a/crates/doiget-cli/tests/link_e2e.rs
+++ b/crates/doiget-cli/tests/link_e2e.rs
@@ -75,7 +75,7 @@ async fn link_resolves_doi_to_arxiv_and_logs() {
 
     // `Doi::parse` lower-cases nothing, but OpenAlex is case-insensitive;
     // the mock matches the lower-cased filter the command sends.
-    let res = run("10.1103/physrevb.1".to_string(), OutputMode::Quiet).await;
+    let res = run("10.1103/physrevb.1".to_string(), OutputMode::Quiet, true).await;
     assert!(res.is_ok(), "link run failed: {res:?}");
 
     // Provenance: one Metadata/Fetch row under source "openalex".
@@ -111,7 +111,7 @@ async fn link_unknown_doi_exits_nonzero() {
     guard.set("HOME", root.as_str());
     guard.set("USERPROFILE", root.as_str());
 
-    let err = run("10.0000/nope".to_string(), OutputMode::Quiet)
+    let err = run("10.0000/nope".to_string(), OutputMode::Quiet, true)
         .await
         .expect_err("an unmatched DOI must error");
     let exit = err
@@ -128,7 +128,7 @@ async fn link_rejects_arxiv_input_without_network() {
     let guard = EnvGuard::new(ENV_KEYS);
     let _ = &guard;
 
-    let err = run("arxiv:2401.12345".to_string(), OutputMode::Quiet)
+    let err = run("arxiv:2401.12345".to_string(), OutputMode::Quiet, true)
         .await
         .expect_err("arXiv input must be a usage error");
     assert!(err.to_string().contains("Pass a DOI"), "got: {err}");

--- a/crates/doiget-cli/tests/search_external_e2e.rs
+++ b/crates/doiget-cli/tests/search_external_e2e.rs
@@ -109,6 +109,7 @@ async fn external_search_runs_and_logs_openalex_fetch() {
         false, // local = false → external discovery
         ext,
         OutputMode::Quiet,
+        true,
     )
     .await;
     assert!(res.is_ok(), "external search run failed: {res:?}");

--- a/docs/DECISIONS/0017-output-mode-resolution.md
+++ b/docs/DECISIONS/0017-output-mode-resolution.md
@@ -1,7 +1,7 @@
 # 0017 - Output mode resolution (flag > env > implicit > TTY > quiet)
 
 - **Date:** 2026-05-05
-- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205. Amendment 1 (2026-05-21) distinguishes **explicit** vs **implicit** Quiet and adds an artifact-command classification so commands whose output is the product (`bib`/`csl`/`capabilities`/`audit-log --verify --mode json`) honor only explicit Quiet, fixing the LLM cold-boot deadlock reported in #219 / #220.
+- **Status:** Accepted — fully implemented (#144, 0.2.1-beta.7). The resolution ladder (`--mode` > `--json`/`--quiet` > `DOIGET_MODE` > subcommand-implicit > TTY) is wired through `crates/doiget-cli/src/commands/output.rs::resolve` and threaded into every command's `run(..)`; the load-bearing MCP / stdout-purity invariant (Slice 9 + Slice 1) remains in force, now backed by the `serve → forced Mcp` override in `commands::main::run_dispatch`. Per-mode command behaviour (Quiet stdout suppression, Json bodies for human-table commands, ERRORS.md §3 batch JSONL) is staged as follow-up issues #203 / #204 / #205. Amendment 1 (2026-05-21) distinguishes **explicit** vs **implicit** Quiet and adds an artifact-command classification so commands whose output is the product (`bib`/`csl`/`capabilities`/`audit-log --verify --mode json`) honor only explicit Quiet, fixing the LLM cold-boot deadlock reported in #219 / #220. Amendment 2 (2026-06-16) extends the artifact classification to the read/inspection commands (`info` / `list-recent` / `search` / `link`) so the non-TTY implicit Quiet no longer silences them (#301).
 - **Supersedes:** -
 - **Source:** Discussion #14
 
@@ -153,3 +153,75 @@ The implementation slice is a CLI-internal refactor; consumers
 *restoration* for artifact commands in pipes — no API change.
 The 0.3.0 non-TTY-default callout in CHANGELOG remains in force
 for informational commands.
+
+## Amendment — 2026-06-16 (2): read/inspection commands are artifact-class
+
+**Diagnosis (#301).** Amendment 1 split Quiet into explicit vs implicit
+and classified `bib` / `csl` / `capabilities` as *artifact* so the
+non-TTY implicit Quiet no longer silences them. But it left the
+read/inspection commands — `info`, `list-recent`, `search`, `link` —
+classified as *informational*, so they still emit **nothing** (exit 0,
+zero bytes on stdout AND stderr) whenever stdout is not a TTY (piped,
+redirected, or run from an agent / over ssh):
+
+```text
+$ doiget info 10.1103/PhysRevB.106.094409   # non-TTY -> implicit Quiet
+$ echo "exit=$?"
+exit=0                                       # stdout 0 bytes, stderr 0 bytes
+$ doiget info 10.1103/PhysRevB.106.094409 --json   # works
+{ "title": "...", ... }
+```
+
+Same ADR-0017 root cause as #219 / #220, but for the commands whose
+**stdout rendering IS the requested artifact**: the user fetches a paper,
+then runs `info` / `list-recent` to confirm it landed, and gets total
+silence — which reads as "the fetch failed" or "the store is empty",
+when in fact everything succeeded. For these commands the output is the
+product, not a status report, so the implicit (display-heuristic) Quiet
+must not erase it.
+
+**Decision.** Extend the *artifact* cohort of Amendment 1 to the
+read/inspection commands. The Quiet-honoring contract is unchanged (the
+table in Amendment 1 still binds); only the membership of the artifact
+set grows:
+
+| cohort                | commands                                    | added in |
+|-----------------------|---------------------------------------------|----------|
+| export / inventory    | `bib`, `csl`, `capabilities`                | Am 1     |
+| **read / inspection** | **`info`, `list-recent`, `search`, `link`** | **Am 2** |
+
+Artifact commands suppress stdout ONLY on **explicit** Quiet
+(`--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet`); the non-TTY
+implicit fallback emits. Informational status-report commands (audit-log
+Human, config show/path, provenance migrate, fetch/batch status) are
+unchanged: they suppress on any Quiet.
+
+### Implementation
+
+- `commands::output::is_artifact_command` gains `info` / `list-recent` /
+  `search` / `link` (the single source of truth for the classification).
+- `info::run`, `list_recent::run`, `search::run`, `link::run` receive the
+  `quiet_was_explicit` discriminator from the dispatcher (mirroring
+  `capabilities::run`) and guard on `mode == Quiet && quiet_was_explicit`
+  instead of `mode == Quiet`.
+- No wire-format change: `OutputMode`, the `--mode` values, `DOIGET_MODE`
+  semantics, and the `capabilities` JSON `modes` array are untouched;
+  `--mode json` / `--quiet` behaviour for these commands is unchanged.
+
+### Test plan
+
+- Unit (`output.rs`): `is_artifact_command` is `true` for
+  `info` / `list-recent` / `search` / `link`; still `false` for
+  `fetch` / `batch` / `config` / `audit-log`.
+- E2E (`info_list_recent_e2e.rs`): `info <doi>` and `list-recent` under a
+  non-TTY capture with **no** `DOIGET_MODE` emit their rendering (closes
+  #301); under `--quiet` / `-q` / `DOIGET_MODE=quiet` they emit empty
+  stdout with the unchanged exit-code contract.
+
+### Out of scope
+
+The secondary observation in #301 — `fetch` by arXiv id storing a
+degraded record (`title` = the verbatim id, `year` = null) versus the
+full Crossref metadata a DOI fetch carries — is a metadata-backfill
+concern on the arXiv fetch path, tracked separately; this amendment is
+limited to the output-mode classification.


### PR DESCRIPTION
## What & why

`doiget info` / `list-recent` / `search` / `link` print **nothing** (exit 0, zero bytes on stdout *and* stderr) whenever stdout is not a TTY — i.e. called from an agent, a pipe, or over ssh — even though the requested data is present and correct (`--json` works). The user fetches a paper, runs `info`/`list-recent` to confirm it landed, and gets total silence that reads as "fetch failed" or "store empty".

Same ADR-0017 root cause as #219/#220: non-TTY ⇒ implicit `Quiet` ⇒ suppressed. **Amendment 1** already fixed this for the export/inventory commands (`bib`/`csl`/`capabilities`) by honoring only *explicit* Quiet. The read/inspection commands were left as *informational* and stayed broken — even though, for them, **the stdout rendering IS the requested artifact**.

## Change (ADR-0017 Amendment 2)

| cohort | commands | honors |
|---|---|---|
| export / inventory (Am 1) | `bib`, `csl`, `capabilities` | explicit Quiet only |
| **read / inspection (Am 2)** | **`info`, `list-recent`, `search`, `link`** | **explicit Quiet only** |

- `is_artifact_command` gains the four commands (single source of truth).
- `quiet_was_explicit` is threaded into their `run()`; guard becomes `mode == Quiet && quiet_was_explicit`, mirroring `capabilities`.

| invocation | before | after |
|---|---|---|
| non-TTY, no flag (agent/pipe/ssh) | silent ❌ | **emits** ✅ |
| `--quiet` / `-q` / `--mode quiet` / `DOIGET_MODE=quiet` | silent | silent (unchanged) |
| `--json` / `--mode json` | JSON | JSON (unchanged) |
| missing entry (`info`) | exit≠0 | exit≠0 (unchanged) |

No wire-format change: `--mode json`, `capabilities` JSON, and `DOIGET_MODE` semantics are untouched.

## Tests
- Unit (`output.rs`): `is_artifact_command` true for the 4 commands; still false for `fetch`/`batch`/`config`/`audit-log`.
- E2E (`info_list_recent_e2e.rs`): non-TTY capture with **no** `DOIGET_MODE` → `info`/`list-recent` emit (the #301 repro); `--quiet`/`-q`/`DOIGET_MODE=quiet` → empty stdout, exit-code contract intact.

## Out of scope
The #301 secondary observation — arXiv-id `fetch` storing a degraded record (`title` = verbatim id, `year` = null) — is a metadata-backfill concern on the arXiv fetch path; tracked separately.

## Verification note
⚠️ Could not compile/test locally on this Windows box (no MSVC linker / Windows SDK; no `cargo` in WSL). `cargo fmt --check` passes (rustfmt parsed every file → no syntax errors). **Relying on CI for the compile + test gate.**

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)