### PR TITLE
fix(text): TEXT_UNAVAILABLE instead of a silent exit-0 empty render (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.0-beta.1] - 2026-06-16
+
+### Fixed
+- **[text]** `doiget text <arxiv-id>` no longer exits **0 with empty output** when ar5iv has no usable render. A 200 with no extractable prose (`char_count == 0` — the paper was never converted to HTML, including the case where the body parses to heading shells with empty bodies) now surfaces the new `TEXT_UNAVAILABLE` code on a non-zero exit, with an actionable `= note:` pointing at `doiget fetch arxiv:<id>`. Agents and the MCP `doiget_paper_text` tool can now tell **"text unavailable (fetch the PDF)"** apart from **"wrong identifier"** (`NOT_FOUND`) and **"no OA at all"** (`NO_OA_AVAILABLE`) instead of misreading the silent empty output as a bad DOI (#302).
+
+### Added
+- **[core]** `ErrorCode::TextUnavailable` (wire `"TEXT_UNAVAILABLE"`) and `FetchError::TextUnavailable { arxiv_id }` — the id is valid and resolvable but the requested representation is missing. Minor, additive (`ErrorCode` is `#[non_exhaustive]`). See `docs/ERRORS.md` §2.
+
 ## [0.7.0-beta.0] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.0-beta.0"
+version       = "0.7.0-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/text.rs
+++ b/crates/doiget-cli/src/commands/text.rs
@@ -40,7 +40,9 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 ///
 /// Surfaces a typed [`ErrorCode`] as a process exit code via
 /// [`CliExit`]: an invalid ref is a usage error; a DOI yields
-/// `NO_OA_AVAILABLE`; extraction failures map through
+/// `NO_OA_AVAILABLE`; an ar5iv render with no extractable prose yields
+/// `TEXT_UNAVAILABLE` (never a silent exit-0 — issue #302) with an
+/// actionable "fetch the PDF" note; other extraction failures map through
 /// [`ErrorCode::from`].
 pub async fn run(
     ref_: String,
@@ -79,6 +81,17 @@ pub async fn run(
         Err(e) => {
             let code = ErrorCode::from(&e);
             print_err(format_args!("error[{}]: {e}", code.as_wire()));
+            // `text unavailable` is the one read-step failure with a
+            // concrete next action: the id is valid and the PDF may well be
+            // fetchable, so spell the exact command out (issue #302) rather
+            // than leave the agent to infer it. Mirrors the `= note:` line
+            // `render_fetch_error` attaches to denial-class failures.
+            if code == ErrorCode::TextUnavailable {
+                print_err(format_args!(
+                    "  = note: the arXiv id is valid — fetch the PDF instead: `doiget fetch arxiv:{}`",
+                    id.as_str()
+                ));
+            }
             return Err(anyhow::Error::new(CliExit(cli_exit_code(code))));
         }
     };

--- a/crates/doiget-cli/tests/text_e2e.rs
+++ b/crates/doiget-cli/tests/text_e2e.rs
@@ -159,3 +159,49 @@ async fn text_for_doi_reports_no_oa_available() {
         .expect("DOI path must yield a CliExit");
     assert_ne!(exit.0, 0, "exit code must be non-zero for a DOI");
 }
+
+#[tokio::test]
+#[serial]
+async fn text_unconverted_render_exits_non_zero_never_silent() {
+    // Issue #302: when ar5iv returns a 200 with no readable prose (the paper
+    // was never converted to HTML), `text` MUST NOT exit 0 with empty output
+    // — that is the silent-success that agents misread as a bad identifier.
+    // It must surface as a non-zero `CliExit` (the `TEXT_UNAVAILABLE` code is
+    // asserted at the core/MCP layers; here we pin the never-exit-0 contract).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/html/2012.03644"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("<html><head></head><body></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+
+    let guard = EnvGuard::new(ENV_KEYS);
+    guard.set("DOIGET_AR5IV_BASE", &server.uri());
+    guard.set("DOIGET_CACHE_ROOT", root.join("cache").as_str());
+    guard.set("DOIGET_STORE_ROOT", root.join("papers").as_str());
+    guard.set("DOIGET_LOG_PATH", root.join("access.jsonl").as_str());
+    guard.set("DOIGET_MODE", "quiet");
+    guard.set("HOME", root.as_str());
+    guard.set("USERPROFILE", root.as_str());
+
+    let err = run(
+        "arxiv:2012.03644".to_string(),
+        None,
+        true, // no_cache: exercise the live render path, not a cache hit
+        OutputMode::Quiet,
+    )
+    .await
+    .expect_err("an unconverted render must error, never silently succeed");
+    let exit = err
+        .downcast_ref::<doiget_cli::commands::fetch::CliExit>()
+        .expect("unavailable text must yield a CliExit");
+    assert_ne!(
+        exit.0, 0,
+        "exit code must be non-zero when no text is produced"
+    );
+}

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -688,6 +688,19 @@ pub enum ErrorCode {
     /// next minor release" rather than "report a bug" or "tweak my
     /// capability profile". Wire form: `"NOT_IMPLEMENTED"`.
     NotImplemented,
+    /// The identifier is valid and resolvable, but the **requested
+    /// representation** is not available from its source — currently the
+    /// ar5iv HTML render consulted by `doiget text` (a 200 with no
+    /// extractable prose: the paper was never converted to HTML).
+    ///
+    /// Deliberately distinct from the neighbouring codes so an agent does
+    /// not misdiagnose a missing render as a bad reference (issue #302):
+    /// it is NOT [`Self::NotFound`] (the id *does* exist), NOT
+    /// [`Self::NoOaAvailable`] (the paper may well be OA — only this one
+    /// representation is missing), and NOT [`Self::NetworkError`] (the
+    /// fetch succeeded). The actionable branch is "fetch the PDF instead",
+    /// not "fix the identifier". Wire form: `"TEXT_UNAVAILABLE"`.
+    TextUnavailable,
 }
 
 impl ErrorCode {
@@ -715,6 +728,7 @@ impl ErrorCode {
             ErrorCode::LockTimeout => "LOCK_TIMEOUT",
             ErrorCode::InternalError => "INTERNAL_ERROR",
             ErrorCode::NotImplemented => "NOT_IMPLEMENTED",
+            ErrorCode::TextUnavailable => "TEXT_UNAVAILABLE",
         }
     }
 }

--- a/crates/doiget-core/src/paper_text.rs
+++ b/crates/doiget-core/src/paper_text.rs
@@ -136,11 +136,14 @@ pub struct PaperText {
 ///
 /// # Errors
 ///
-/// - [`FetchError::Http`] for transport / status failures (a 404 / 410 for
-///   a paper ar5iv has not converted collapses to `NOT_FOUND` at the
-///   boundary).
-/// - [`FetchError::NotFound`] when ar5iv returns a body with no extractable
-///   text (an authoritative "nothing to read here").
+/// - [`FetchError::Http`] for transport / status failures (a 404 / 410
+///   collapses to `NOT_FOUND` at the boundary — the id is genuinely absent
+///   from ar5iv).
+/// - [`FetchError::TextUnavailable`] when ar5iv returns a **200** with no
+///   extractable prose (`char_count == 0`: the paper was never converted to
+///   HTML). Distinct from `NotFound`: the id is valid and the PDF may be
+///   fetchable, so an agent should fetch rather than treat the ref as wrong
+///   (issue #302).
 /// - [`FetchError::SourceSchema`] if the ar5iv URL cannot be constructed
 ///   from `base` + the id. (HTML parsing itself is best-effort and
 ///   infallible on content — see the `parse_ar5iv` helper.)
@@ -185,16 +188,22 @@ async fn fetch_and_parse(
 
     let (title, sections) = parse_ar5iv(&body)?;
 
-    // A 200 with no extractable content (e.g. ar5iv's "not converted"
-    // placeholder) is an authoritative "nothing to read", surfaced as
-    // NotFound so an agent can branch on it rather than receive an empty
-    // success.
-    if sections.is_empty() && title.is_none() {
-        return Err(FetchError::NotFound {
-            hint: format!(
-                "ar5iv returned no extractable text for {} (paper may not be converted to HTML)",
-                id.as_str()
-            ),
+    // A 200 with no readable prose (ar5iv's "not converted" placeholder, or
+    // a stub that parses to section shells with empty bodies) is an
+    // authoritative "nothing to read". Gate on the total extractable char
+    // count — NOT just `sections.is_empty()` — so the empty-bodied-section
+    // case (issue #302's repro: a non-empty `sections` whose text is all
+    // blank) is caught too and never escapes as an empty `Ok` (a silent
+    // exit-0 the caller misreads as a bad identifier).
+    //
+    // Surfaced as `TextUnavailable`, NOT `NotFound`: the arXiv id was
+    // already validated and resolved, so the honest signal is "this
+    // representation is missing — fetch the PDF", not "the id does not
+    // exist" (which would send an agent down a wrong debugging path).
+    let char_count: usize = sections.iter().map(|s| s.text.chars().count()).sum();
+    if char_count == 0 {
+        return Err(FetchError::TextUnavailable {
+            arxiv_id: id.as_str().to_string(),
         });
     }
 
@@ -217,12 +226,13 @@ async fn fetch_and_parse(
         canonical_digest: Some(&canonical),
     })?;
 
-    let char_count = sections.iter().map(|s| s.text.chars().count()).sum();
     Ok(PaperText {
         arxiv_id: id.as_str().to_string(),
         source: TextSource::Ar5iv,
         title,
         sections,
+        // Computed above (the non-empty gate); reused here so the count is
+        // derived exactly once.
         char_count,
         truncated: false,
         retrieved_from: final_url.to_string(),
@@ -343,7 +353,7 @@ fn normalize(s: &str) -> String {
 /// document is recovered (the reader runs with `check_end_names = false`,
 /// and a hard syntax error stops the walk while keeping the partial
 /// result rather than discarding it — ADR-0032 D3). An empty result is
-/// handled by the caller (→ `NotFound`). Returns `Result` only to keep the
+/// handled by the caller (→ `TextUnavailable`). Returns `Result` only to keep the
 /// call-site uniform; it does not currently produce an `Err`.
 fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchError> {
     let mut reader = Reader::from_reader(html);
@@ -486,7 +496,7 @@ fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchE
                 // Best-effort (ADR-0032 D3): a syntax error deep in the
                 // document must not discard everything already collected.
                 // Stop here and return the partial result — an empty result
-                // still maps to NotFound upstream. The error is observable
+                // still maps to TextUnavailable upstream. The error is observable
                 // on stderr, never on the stdout JSON-RPC channel.
                 tracing::debug!(error = %e, "ar5iv HTML parse error; returning best-effort partial text");
                 break;
@@ -1045,7 +1055,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn paper_text_empty_body_is_not_found() {
+    async fn paper_text_empty_body_is_text_unavailable() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path_matcher("/html/2401.99999"))
@@ -1066,10 +1076,59 @@ mod tests {
         let base = Url::parse(&server.uri()).expect("uri");
         let id = ArxivId::parse("2401.99999").unwrap();
 
+        // A 200 that parses to nothing is "this representation is missing",
+        // NOT "the id does not exist" (issue #302): the arXiv id was already
+        // validated, so it must surface as TextUnavailable / TEXT_UNAVAILABLE
+        // so an agent fetches the PDF rather than treating the ref as wrong.
         let err = paper_text(&base, &id, None, &ctx)
             .await
-            .expect_err("empty body must be NotFound");
-        assert!(matches!(err, FetchError::NotFound { .. }), "got {err:?}");
+            .expect_err("empty body must be TextUnavailable");
+        assert!(
+            matches!(err, FetchError::TextUnavailable { .. }),
+            "got {err:?}"
+        );
+        assert_eq!(
+            crate::ErrorCode::from(&err),
+            crate::ErrorCode::TextUnavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn paper_text_prose_free_body_is_text_unavailable() {
+        // Issue #302's actual repro: a 200 whose body parses to a NON-empty
+        // `sections` vec (a heading shell) but zero extractable prose
+        // (`char_count == 0`). The old gate keyed on `sections.is_empty()`,
+        // so this slipped through as an empty `Ok` → a silent exit-0 the
+        // caller misread as a bad identifier. The `char_count == 0` gate
+        // catches it.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_matcher("/html/2012.03644"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(
+                    "<html><head></head><body><h2>1 Introduction</h2></body></html>",
+                ),
+            )
+            .mount(&server)
+            .await;
+        let host = server
+            .uri()
+            .parse::<Url>()
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let (_td, ctx) = build_test_context(&host, None);
+        let base = Url::parse(&server.uri()).expect("uri");
+        let id = ArxivId::parse("2012.03644").unwrap();
+
+        let err = paper_text(&base, &id, None, &ctx)
+            .await
+            .expect_err("a body with headings but no prose must be TextUnavailable");
+        assert!(
+            matches!(err, FetchError::TextUnavailable { .. }),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -156,6 +156,24 @@ pub enum FetchError {
         /// The hard cap ([`crate::MAX_BATCH_REFS`]).
         max: usize,
     },
+    /// A source returned a successful response that contained no usable
+    /// representation of the requested kind — currently `doiget text`'s
+    /// ar5iv leg returning a 200 with no extractable prose (the paper was
+    /// never converted to HTML). The identifier is valid; only this one
+    /// representation is missing. Surfaces as
+    /// [`crate::ErrorCode::TextUnavailable`] so an agent fetches the PDF
+    /// instead of concluding the reference is wrong (issue #302) — NOT
+    /// [`Self::NotFound`], which means the id itself does not exist.
+    #[error(
+        "no readable text for arXiv:{arxiv_id} (no ar5iv HTML render); \
+         the PDF may be fetchable instead"
+    )]
+    TextUnavailable {
+        /// The arXiv id whose ar5iv render was empty; echoed into the
+        /// human/MCP message so the actionable `doiget fetch <id>` hint is
+        /// self-contained.
+        arxiv_id: String,
+    },
 }
 
 /// Map [`FetchError`] to the closed [`crate::ErrorCode`] set surfaced at
@@ -198,6 +216,10 @@ impl From<&FetchError> for crate::ErrorCode {
             // `#[non_exhaustive]` wildcard below would otherwise route
             // it to `INTERNAL_ERROR`, which would mislead agents.
             FetchError::TooManyRefs { .. } => crate::ErrorCode::InvalidRef,
+            // The id resolved; only the ar5iv text representation is
+            // missing. Its own code so an agent fetches the PDF rather
+            // than conclude the reference is wrong (issue #302).
+            FetchError::TextUnavailable { .. } => crate::ErrorCode::TextUnavailable,
         }
     }
 }
@@ -237,7 +259,8 @@ impl From<&FetchError> for Option<crate::DenialContext> {
             | FetchError::Log(_)
             | FetchError::InvalidRef(_)
             | FetchError::SourceSchema { .. }
-            | FetchError::TooManyRefs { .. } => None,
+            | FetchError::TooManyRefs { .. }
+            | FetchError::TextUnavailable { .. } => None,
         }
     }
 }

--- a/crates/doiget-mcp/tests/paper_text_e2e.rs
+++ b/crates/doiget-mcp/tests/paper_text_e2e.rs
@@ -208,9 +208,11 @@ async fn paper_text_doi_maps_to_no_oa_available() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn paper_text_unconverted_paper_maps_to_not_found() -> anyhow::Result<()> {
-    // ar5iv returns a 200 with no extractable text → NOT_FOUND (the paper
-    // is not converted), distinct from a transport error.
+async fn paper_text_unconverted_paper_maps_to_text_unavailable() -> anyhow::Result<()> {
+    // ar5iv returns a 200 with no extractable text → TEXT_UNAVAILABLE (the
+    // paper is not converted to HTML), distinct from both a transport error
+    // and a bad identifier. The MCP `text` tool must surface this so an
+    // agent fetches the PDF instead of misreading it as a wrong DOI (#302).
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/html/2401.99999"))
@@ -239,7 +241,7 @@ async fn paper_text_unconverted_paper_maps_to_not_found() -> anyhow::Result<()> 
     let s = result.structured_content.as_ref().expect("structured");
 
     assert_eq!(s["ok"], serde_json::json!(false), "envelope: {s:?}");
-    assert_eq!(s["error"]["code"], serde_json::json!("NOT_FOUND"));
+    assert_eq!(s["error"]["code"], serde_json::json!("TEXT_UNAVAILABLE"));
 
     client.cancel().await?;
     server_handle.await??;

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -49,6 +49,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | Retry; another process holds it. |
 | `INTERNAL_ERROR` | Bug. | Report at <https://github.com/sotashimozono/doiget/issues>. |
 | `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | Wait for next minor release; do not retry. |
+| `TEXT_UNAVAILABLE` | The id is valid and resolvable, but the **requested representation** is missing: `doiget text` got a 200 from ar5iv with no extractable prose (the paper was never converted to HTML). Distinct from `NOT_FOUND` (the id *does* exist) and `NO_OA_AVAILABLE` (the paper may still be OA — only the HTML render is missing). Issue #302. | Yes — fetch the PDF instead (`doiget fetch <id>`); do not "fix" the identifier. |
 
 ## 3. Persona × error matrix
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -55,6 +55,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | Retry; another process holds it. |
 | `INTERNAL_ERROR` | Bug. | Report at <https://github.com/sotashimozono/doiget/issues>. |
 | `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | Wait for next minor release; do not retry. |
+| `TEXT_UNAVAILABLE` | The id is valid and resolvable, but the **requested representation** is missing: `doiget text` got a 200 from ar5iv with no extractable prose (the paper was never converted to HTML). Distinct from `NOT_FOUND` (the id *does* exist) and `NO_OA_AVAILABLE` (the paper may still be OA — only the HTML render is missing). Issue #302. | Yes — fetch the PDF instead (`doiget fetch <id>`); do not "fix" the identifier. |
 
 ## 3. Persona × error matrix
 


### PR DESCRIPTION
## Problem (#302)

`doiget text <arxiv-id>` exited **0 with zero bytes** on both stdout and stderr when ar5iv had no usable render. LLM/agent callers (and the MCP server) misread the empty output as **"the DOI is wrong"** and went down a wrong debugging path — when `doiget fetch` on the same id would have worked. This came up repeatedly building a ~130-paper bibliography.

This is the first of the #302–#305 bibliography-robustness cluster, all sharing one principle: **an agent must distinguish "not available" from "wrong identifier" from "success" without guessing.**

## Root cause

`paper_text` only treated `sections.is_empty() && title.is_none()` as "nothing to read". A 200 that parsed to **heading shells with empty bodies** (`char_count == 0`) slipped through as an empty `Ok` → a silent exit-0. (Even the existing empty-case mapped to `NotFound`, which itself reads as "wrong id" to an agent.)

## Fix

- **Gate on total extractable `char_count`**, not just `sections.is_empty()`, so the prose-free render is caught.
- Surface it as a **new, distinct signal** — `TextUnavailable`, *not* `NotFound`: the arXiv id is valid and resolvable; only this one representation is missing, so the actionable branch is "fetch the PDF", not "fix the identifier".

| layer | change |
|---|---|
| core | `ErrorCode::TextUnavailable` (wire `TEXT_UNAVAILABLE`, additive — `#[non_exhaustive]`) + `FetchError::TextUnavailable { arxiv_id }`, via the canonical `From<&FetchError>` collapses |
| cli `text` | `error[TEXT_UNAVAILABLE]: …` on a **non-zero** exit + actionable `= note: … doiget fetch arxiv:<id>` |
| mcp `doiget_paper_text` | already routes via `ErrorCode::from` → emits `{ok:false, error:{code:"TEXT_UNAVAILABLE", …}}` for free |
| docs | `docs/ERRORS.md` §2 code row |

## Tests
- **core unit**: empty `<body>` → `TextUnavailable`; the **prose-free heading-shell repro** (`<h2>…</h2>`, non-empty `sections`, zero prose) → `TextUnavailable` (the case the old gate missed).
- **cli e2e**: an unconverted render yields a non-zero `CliExit` — the never-exit-0 contract.
- **mcp e2e**: wire `code == "TEXT_UNAVAILABLE"`.

## Notes
- Version: `0.7.0-beta.1` (next/beta lane). Offline release-gate G0–G6 pass locally.
- `pdf_available` enrichment (a live PDF check) is intentionally deferred — the hint is static (`doiget fetch …`) to avoid a flaky extra network call.
- Local `cargo build`/`test` is not possible on this machine (no MSVC linker); `cargo fmt --check` and the offline release gate pass — relying on CI for the full build/test.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)