### PR TITLE
fix(batch): auto-chunk instead of aborting the whole run above 100 refs (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+- **[batch]** `doiget batch <file>` no longer aborts the entire run when the input exceeds 100 refs. Previously it printed `Error: batch size N exceeds limit 100` and fetched **nothing** the moment a bibliography crossed 100 entries, forcing a manual `split`. The input is now processed in full, dispatched in bounded windows of `MCP_BATCH_MAX_SIZE` so the in-flight task count stays capped while the shared rate limiter keeps the 5-per-second politeness invariant across every window. The per-ref failure-count exit code is unchanged (non-zero when any ref fails). The `MCP_BATCH_MAX_SIZE` hard cap still applies to a single MCP `batch_fetch` request — that request-shape bound is unrelated to a local file handed to the CLI (#304).
+
 ## [0.7.0-beta.0] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.0-beta.1"
+version       = "0.7.0-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -15,7 +15,10 @@
 //!
 //! ## Failure semantics
 //!
-//! - File read / over-limit-size errors abort the batch BEFORE any fetch.
+//! - A file-read error (or a whole-input parse failure: `Decode` /
+//!   `UnsupportedFormat`) aborts the batch BEFORE any fetch. There is no
+//!   size cap: any number of refs is accepted and processed in bounded
+//!   windows of [`doiget_core::MCP_BATCH_MAX_SIZE`] (issue #304).
 //! - A single `Ref::parse` failure is non-fatal: the orchestrator emits a
 //!   `Resolve` row with `result=err` and continues with the remaining refs.
 //! - A single fetch failure is also non-fatal: per-task errors are recorded
@@ -151,15 +154,17 @@ pub async fn run_with_options(
         }
     }
 
-    // Step 3: enforce the hard cap before doing any work. The cap is the
-    // same one the MCP `batch_fetch` tool enforces (`MCP_BATCH_MAX_SIZE`).
-    if inputs.len() > MCP_BATCH_MAX_SIZE {
-        return Err(anyhow!(
-            "batch size {} exceeds limit {}",
-            inputs.len(),
-            MCP_BATCH_MAX_SIZE,
-        ));
-    }
+    // Step 3: no hard cap. A local refs file is the user's whole working
+    // set, so the CLI `batch` processes ALL of it (issue #304): a previous
+    // hard `> MCP_BATCH_MAX_SIZE` abort lost the entire run — fetching
+    // nothing — the moment a bibliography crossed 100 refs, forcing a manual
+    // `split`. Instead `MCP_BATCH_MAX_SIZE` becomes the dispatch **window**
+    // (Step 7): refs are processed in chunks of that size so the number of
+    // concurrently-spawned tasks stays bounded, while the shared
+    // `RateLimiter` keeps the 5-per-second politeness invariant across every
+    // window. (`MCP_BATCH_MAX_SIZE` still hard-caps a single MCP
+    // `batch_fetch` request — that request-shape bound is unrelated to a
+    // local file the operator hands to the CLI.)
 
     // Step 3a: dry-run branch (ADR-0022). Emit one `FetchPlan` envelope
     // per ref on stdout WITHOUT opening the provenance log, building the
@@ -209,97 +214,112 @@ pub async fn run_with_options(
     let max_concurrent = RateLimits::HARD_CODED.max_concurrent_fetches() as usize;
     let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
 
-    // Step 7: dispatch. We iterate sequentially to spawn (cheap), and the
-    // semaphore serializes the actual work to the bound. Parse errors are
-    // logged as `Resolve` rows directly off the harness's shared log.
+    // Step 7: dispatch in bounded windows. The ENTIRE input is processed —
+    // no ref is ever dropped (issue #304) — but at most `MCP_BATCH_MAX_SIZE`
+    // tasks exist at once: each window is spawned and then fully drained
+    // (Step 8) before the next window is spawned, so a large refs file never
+    // materialises one task per ref up front. The harness's shared
+    // `RateLimiter` enforces the 5-per-second + per-source backoff
+    // invariants across every window, so windowing changes only the
+    // spawn-side memory bound, never politeness. Counters accumulate across
+    // windows; parse errors are logged as `Resolve` rows off the shared log.
     let mut parse_errors: usize = 0;
-    let mut joins: tokio::task::JoinSet<TaskOutcome> = tokio::task::JoinSet::new();
-    for input in inputs {
-        let ref_ = match Ref::parse(&input) {
-            Ok(r) => r,
-            Err(e) => {
-                parse_errors += 1;
-                if json_mode {
-                    // #205: parse failures get an INVALID_REF JSONL line
-                    // with the human message in `error.message`. Per
-                    // ERRORS.md §3.1 there is no `denial_context` on
-                    // INVALID_REF (the input never reached a guard).
-                    emit_jsonl_failure(Some(&input), "INVALID_REF", &e.to_string());
-                }
-                // Best-effort `Resolve` row capturing the parse failure; we
-                // do NOT abort the batch on a single bad line.
-                let _ = harness.log.append(RowInput {
-                    event: LogEvent::Resolve,
-                    result: LogResult::Err,
-                    capability: Capability::Oa,
-                    ref_: Some(&input),
-                    source: None,
-                    error_code: Some("INVALID_REF"),
-                    size_bytes: None,
-                    license: None,
-                    store_path: None,
-                    // The input failed to parse as a Ref, so no
-                    // CanonicalRef can be minted (ADR-0021 §1 requires
-                    // a validated source_id).
-                    canonical_digest: None,
-                });
-                tracing::warn!(
-                    %input,
-                    error = %e,
-                    "skipping malformed batch entry",
-                );
-                continue;
-            }
-        };
-
-        let harness_task = Arc::clone(&harness);
-        let sem_task = Arc::clone(&semaphore);
-        joins.spawn(async move {
-            // `Semaphore::acquire_owned` only errors when the semaphore is
-            // closed; we never close it. The fallback maps that
-            // structurally-unreachable arm to a fetch failure rather than
-            // panicking.
-            let _permit = match sem_task.acquire_owned().await {
-                Ok(p) => p,
-                Err(_) => {
-                    // Map the semaphore-closed structural impossibility
-                    // to a typed `FetchError` (closest closed-set fit)
-                    // so `TaskOutcome::result` stays typed end-to-end.
-                    return TaskOutcome {
-                        input,
-                        result: Err(FetchError::SourceSchema {
-                            hint: "batch semaphore unexpectedly closed".to_string(),
-                        }),
-                    };
-                }
-            };
-            let result = harness_task.fetch_one(&ref_).await;
-            TaskOutcome { input, result }
-        });
-    }
-
-    // Step 8: drain the JoinSet. We collect all outcomes before deciding
-    // the session result so a single failure does not abort sibling tasks.
     let mut fetch_ok: usize = 0;
     let mut fetch_errors: usize = 0;
-    while let Some(joined) = joins.join_next().await {
-        let JoinedOutcome {
-            is_error,
-            json_record,
-            log_breadcrumb,
-        } = classify_joined(joined, json_mode);
-        if is_error {
-            fetch_errors += 1;
-        } else {
-            fetch_ok += 1;
+    let mut remaining = inputs.into_iter();
+    loop {
+        let window: Vec<String> = remaining.by_ref().take(MCP_BATCH_MAX_SIZE).collect();
+        if window.is_empty() {
+            break;
         }
-        if let Some(record) = json_record {
-            #[allow(clippy::print_stdout)]
-            {
-                println!("{record}");
+
+        let mut joins: tokio::task::JoinSet<TaskOutcome> = tokio::task::JoinSet::new();
+        for input in window {
+            let ref_ = match Ref::parse(&input) {
+                Ok(r) => r,
+                Err(e) => {
+                    parse_errors += 1;
+                    if json_mode {
+                        // #205: parse failures get an INVALID_REF JSONL line
+                        // with the human message in `error.message`. Per
+                        // ERRORS.md §3.1 there is no `denial_context` on
+                        // INVALID_REF (the input never reached a guard).
+                        emit_jsonl_failure(Some(&input), "INVALID_REF", &e.to_string());
+                    }
+                    // Best-effort `Resolve` row capturing the parse failure;
+                    // we do NOT abort the batch on a single bad line.
+                    let _ = harness.log.append(RowInput {
+                        event: LogEvent::Resolve,
+                        result: LogResult::Err,
+                        capability: Capability::Oa,
+                        ref_: Some(&input),
+                        source: None,
+                        error_code: Some("INVALID_REF"),
+                        size_bytes: None,
+                        license: None,
+                        store_path: None,
+                        // The input failed to parse as a Ref, so no
+                        // CanonicalRef can be minted (ADR-0021 §1 requires
+                        // a validated source_id).
+                        canonical_digest: None,
+                    });
+                    tracing::warn!(
+                        %input,
+                        error = %e,
+                        "skipping malformed batch entry",
+                    );
+                    continue;
+                }
+            };
+
+            let harness_task = Arc::clone(&harness);
+            let sem_task = Arc::clone(&semaphore);
+            joins.spawn(async move {
+                // `Semaphore::acquire_owned` only errors when the semaphore
+                // is closed; we never close it. The fallback maps that
+                // structurally-unreachable arm to a fetch failure rather
+                // than panicking.
+                let _permit = match sem_task.acquire_owned().await {
+                    Ok(p) => p,
+                    Err(_) => {
+                        // Map the semaphore-closed structural impossibility
+                        // to a typed `FetchError` (closest closed-set fit)
+                        // so `TaskOutcome::result` stays typed end-to-end.
+                        return TaskOutcome {
+                            input,
+                            result: Err(FetchError::SourceSchema {
+                                hint: "batch semaphore unexpectedly closed".to_string(),
+                            }),
+                        };
+                    }
+                };
+                let result = harness_task.fetch_one(&ref_).await;
+                TaskOutcome { input, result }
+            });
+        }
+
+        // Step 8: drain THIS window before spawning the next, so the
+        // in-flight task count stays bounded. Outcomes accumulate into the
+        // batch-wide counters; a single failure never aborts its siblings.
+        while let Some(joined) = joins.join_next().await {
+            let JoinedOutcome {
+                is_error,
+                json_record,
+                log_breadcrumb,
+            } = classify_joined(joined, json_mode);
+            if is_error {
+                fetch_errors += 1;
+            } else {
+                fetch_ok += 1;
             }
+            if let Some(record) = json_record {
+                #[allow(clippy::print_stdout)]
+                {
+                    println!("{record}");
+                }
+            }
+            log_breadcrumb.emit();
         }
-        log_breadcrumb.emit();
     }
 
     let total_errors = parse_errors + fetch_errors;
@@ -921,20 +941,33 @@ arxiv:2401.12346
     }
 
     #[test]
-    fn over_limit_input_is_rejected() {
-        // Verify that lengths above the documented cap surface the canonical
-        // error message before any fetch is dispatched.
+    fn over_limit_input_is_windowed_not_rejected() {
+        // Issue #304: an input above `MCP_BATCH_MAX_SIZE` is no longer
+        // rejected — it is dispatched in bounded windows of that size, and
+        // every ref is processed. This pins the windowing arithmetic that
+        // the dispatch loop relies on (`into_iter().take(MAX)` until empty):
+        // `n` refs split into `ceil(n / MAX)` windows, the last possibly
+        // short, with no ref lost.
         let n = MCP_BATCH_MAX_SIZE + 1;
-        let body: String = (0..n)
-            .map(|i| format!("arxiv:2401.{:05}\n", 10000 + i))
+        let inputs: Vec<String> = (0..n)
+            .map(|i| format!("arxiv:2401.{:05}", 10000 + i))
             .collect();
-        let lines: Vec<String> = body
-            .lines()
-            .map(str::trim)
-            .filter(|l| !l.is_empty() && !l.starts_with('#'))
-            .map(|s| s.to_string())
-            .collect();
-        assert_eq!(lines.len(), n);
-        assert!(lines.len() > MCP_BATCH_MAX_SIZE);
+
+        let mut remaining = inputs.clone().into_iter();
+        let mut windows: Vec<usize> = Vec::new();
+        loop {
+            let window: Vec<String> = remaining.by_ref().take(MCP_BATCH_MAX_SIZE).collect();
+            if window.is_empty() {
+                break;
+            }
+            windows.push(window.len());
+        }
+
+        // ceil(n / MAX) windows; every ref accounted for; each window within
+        // the bound.
+        assert_eq!(windows.len(), n.div_ceil(MCP_BATCH_MAX_SIZE));
+        assert_eq!(windows.iter().sum::<usize>(), n);
+        assert!(windows.iter().all(|&w| w <= MCP_BATCH_MAX_SIZE));
+        assert_eq!(*windows.last().unwrap(), n % MCP_BATCH_MAX_SIZE);
     }
 }

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -21,9 +21,10 @@ use camino::{Utf8Path, Utf8PathBuf};
 use doiget_cli::commands::batch;
 use doiget_cli::commands::output::OutputMode;
 use doiget_core::provenance::{LogEvent, LogResult, LogRow};
+use doiget_core::MCP_BATCH_MAX_SIZE;
 use serial_test::serial;
 use tempfile::TempDir;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
@@ -292,6 +293,85 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
     assert_eq!(store_ok, 1, "one StoreWrite(ok) for the good ref");
 
     // Hash chain still intact across the mixed-outcome session.
+    assert_chain_intact(&rows);
+
+    drop(env);
+    drop(td);
+}
+
+#[tokio::test]
+#[serial]
+async fn batch_above_window_size_fetches_every_ref() {
+    // Issue #304: a refs file LARGER than `MCP_BATCH_MAX_SIZE` must no longer
+    // abort fetching nothing — every ref is processed across multiple
+    // dispatch windows, under one session, with a single SessionStart /
+    // SessionEnd. This exercises the real multi-window dispatch loop (not
+    // just the windowing arithmetic), so it confirms counters accumulate
+    // across windows and the bookends are emitted exactly once.
+    //
+    // Slow by construction: `MCP_BATCH_MAX_SIZE + 2` real fetches through the
+    // hard-coded 5-per-second rate cap (~20 s). Kept `#[serial]` so it never
+    // contends with the other batch fixtures.
+    let server = MockServer::start().await;
+    let body = b"%PDF-1.7\n%batch-window-fixture\n".to_vec();
+    // One regex mock serves every generated arXiv id rather than mounting one
+    // mock per ref.
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/pdf/2401\.\d{5}\.pdf$"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&server)
+        .await;
+
+    let (td, store_root, log_path, env) = stage_env();
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ARXIV_BASE", &server.uri());
+
+    // Two past the window boundary → the second window carries the remaining
+    // 2 refs (the old hard cap aborted the whole run at this size).
+    let n = MCP_BATCH_MAX_SIZE + 2;
+    let ids: Vec<String> = (0..n).map(|i| format!("2401.{:05}", 10000 + i)).collect();
+    let refs_body: String = ids.iter().map(|id| format!("arxiv:{id}\n")).collect();
+    let refs_path = store_root.parent().unwrap().join("refs.txt");
+    std::fs::write(refs_path.as_std_path(), refs_body).expect("write refs file");
+
+    batch::run_with_options(refs_path.as_str().to_string(), false, OutputMode::Human)
+        .await
+        .expect("a batch above the window size must succeed, fetching every ref");
+
+    // Every ref's PDF landed — nothing was dropped by an over-limit abort.
+    for id in &ids {
+        let pdf_path = store_root.join(format!("arxiv_{id}.pdf"));
+        assert!(
+            pdf_path.exists(),
+            "missing PDF for {id} in a {n}-ref (multi-window) batch"
+        );
+    }
+
+    // Provenance: one Fetch(ok) per ref across all windows, framed by exactly
+    // one session bookend pair.
+    let rows = read_log_rows(&log_path);
+    let count_event = |evt: LogEvent| rows.iter().filter(|r| r.event == evt).count();
+    assert_eq!(
+        count_event(LogEvent::Fetch),
+        n,
+        "one Fetch row per ref, summed across every window"
+    );
+    assert_eq!(
+        count_event(LogEvent::SessionStart),
+        1,
+        "exactly one SessionStart for the whole multi-window batch"
+    );
+    assert_eq!(
+        count_event(LogEvent::SessionEnd),
+        1,
+        "exactly one SessionEnd for the whole multi-window batch"
+    );
+    assert_eq!(
+        rows.last().unwrap().result,
+        LogResult::Ok,
+        "all refs fetched → SessionEnd ok"
+    );
     assert_chain_intact(&rows);
 
     drop(env);


### PR DESCRIPTION
## Problem (#304)

`doiget batch <file>` with more than 100 refs **aborted the entire run** — it printed `Error: batch size N exceeds limit 100` and fetched **nothing**, forcing a manual `split -l`. From the ~130-paper bibliography dogfooding: 100 is easy to exceed, and the all-or-nothing abort is surprising.

Second of the #302–#305 robustness cluster.

## Root cause

The 100 cap is the MCP `batch_fetch` **request-shape** bound (`MCP_BATCH_MAX_SIZE`), wrongly applied to a local refs file — which is the operator's *whole working set*, not a single bounded request.

## Fix

Remove the hard abort. Dispatch the **full** input in bounded **windows** of `MCP_BATCH_MAX_SIZE`: each window is spawned and then fully drained before the next, so the in-flight task count stays capped (no task-per-ref blow-up on a huge file) while the harness's shared `RateLimiter` keeps the 5-per-second + per-source-backoff politeness invariant across every window.

```
inputs.into_iter() → take(MCP_BATCH_MAX_SIZE) per window → spawn → drain → accumulate → repeat
```

- The per-ref failure-count exit code (issue #143: exit = #failures, capped 255) is unchanged — still non-zero when any ref fails, and the all-or-nothing "fetched nothing" path is gone.
- `MCP_BATCH_MAX_SIZE` still hard-caps a single MCP `batch_fetch` request (unrelated path, untouched).
- dry-run (`--dry-run`) also now emits plans for >100 refs (it was blocked by the same removed cap).

## Tests
- **unit**: the former `over_limit_input_is_rejected` becomes `over_limit_input_is_windowed_not_rejected` — pins the windowing arithmetic (`ceil(n/MAX)` windows, every ref accounted for, each window within bound).
- **e2e** (`batch_above_window_size_fetches_every_ref`): a real `MCP_BATCH_MAX_SIZE + 2`-ref batch through one regex mock asserts **every** PDF lands in the store under a single SessionStart/SessionEnd and one Fetch row per ref — exercising the real multi-window dispatch loop, not just the arithmetic. (Slow by construction: 100+ real fetches through the hard-coded 5/s cap ≈ 20 s; `#[serial]`.)

## Notes
- No version bump / no `[0.7.0-beta.N]` section: this is a parallel PR off `next` alongside #308, so the entry goes under `## [Unreleased]` to stay merge-conflict-free; the beta is assigned at merge/release. Offline release-gate G0–G6 pass.
- Local `cargo build`/`test` not possible on this machine (no MSVC linker); `cargo fmt --check` + offline gate pass — relying on CI for the full build/test.

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)