### PR TITLE
feat(bib,cite): offline store fallback + bulk BibTeX export (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.0-beta.4] - 2026-06-16
+
+### Added
+- **[bib]** bulk, offline BibTeX export from the local store (#305): `doiget bib --all` emits every store entry as one deduplicated `.bib`, and `doiget bib --from-file <FILE>` emits the refs listed in a file (plain refs / CSL-JSON / BibTeX), each rendered from the store. Missing entries are skipped with a stderr note; `--from-file` exits non-zero with the missing count (the `batch` failure-count convention) so a script can tell a complete export from a partial one. This turns "fetch a batch, then build a combined `.bib`" into a single offline command instead of a 100-call flaky loop.
+- **[cite]** `doiget cite --offline <ref>` renders from the local store only (no network).
+
+### Fixed
+- **[cite]** `doiget cite <ref>` now falls back to the local store when the live resolve fails (network hiccup / OpenAlex flake) instead of returning nothing — an already-fetched ref always cites, with a `note:` on stderr marking the offline path. A ref in neither place is a non-zero error carrying the resolve failure, never a silent empty stdout (#305, cf. #302/#304).
+
+### Notes
+- CSL-JSON parity (`csl --all` / `--from-file`) is a deferred follow-up; this change covers the BibTeX surface the issue describes.
+
 ## [0.7.0-beta.3] - 2026-06-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.0-beta.3"
+version = "0.7.0-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.0-beta.3"
+version = "0.7.0-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.0-beta.3"
+version = "0.7.0-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.0-beta.3"
+version       = "0.7.0-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -1,57 +1,206 @@
-//! `doiget bib <ref>` subcommand — emit a BibTeX entry for a stored entry.
+//! `doiget bib` subcommand — emit BibTeX from the **local store**, offline.
 //!
-//! Reads the stored [`Metadata`](doiget_core::store::Metadata) for a
-//! [`Ref`] and writes a BibTeX entry on stdout. The actual rendering
-//! lives in [`doiget_core::store::render::to_bibtex`] so the CLI and the
-//! `doiget_bibtex_export` MCP tool share one implementation (Slice 15b).
-//! See that function's docs for the field/entry-type mapping and the
-//! brace-stripping policy.
+//! Three shapes (issue #305):
+//! - `bib <ref>` — one stored entry (the original behavior).
+//! - `bib --all` — every entry in the store as one deduplicated `.bib`.
+//! - `bib --from-file <FILE>` — the refs listed in FILE, each rendered from
+//!   the store; entries not present are skipped and counted toward a
+//!   non-zero exit.
+//!
+//! All shapes are pure store reads — no network — so "fetch a batch, then
+//! emit a complete `.bib`" is a single offline command. The actual
+//! rendering lives in [`doiget_core::store::render::to_bibtex`] so the CLI
+//! and the `doiget_bibtex_export` MCP tool share one implementation.
 
 use std::io::Write;
+use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
+use camino::Utf8Path;
 
-use doiget_core::store::{render, FsStore, Store};
-use doiget_core::Ref;
+use doiget_core::refs::{self, Format};
+use doiget_core::store::{render, FsStore, Metadata, Store};
+use doiget_core::{Ref, Safekey};
 
+use super::fetch::CliExit;
 use super::resolve_store_root;
+
+/// Stderr sink for progress / skip notes (`docs/ERRORS.md` §3); stdout
+/// carries only the `.bib` artifact (ADR-0001).
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
 
 /// Run the `bib` subcommand against the configured store.
 ///
-/// `input` is the user-supplied ref string (e.g. `"10.1234/example"`,
-/// `"arxiv:2401.12345"`, or any of the schemes accepted by [`Ref::parse`]).
-///
-/// On success, a BibTeX entry derived from the entry's `Metadata` is
-/// written to stdout. On a missing entry, the function returns an error
-/// so the CLI exits non-zero.
-pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Bib's BibTeX output is
-    // product output (the requested artifact), not informational, so
-    // Quiet does NOT suppress it. No follow-up issue is needed here.
+/// Exactly one selector must be supplied: a positional `ref_`, `--all`, or
+/// `--from-file`. The BibTeX output is product output (the requested
+/// artifact), not informational, so Quiet does NOT suppress it. A missing
+/// single entry — or any missing ref under `--from-file` — yields a
+/// non-zero exit (never a silent empty stdout: the #302 / #304 contract).
+pub fn run(
+    ref_: Option<String>,
+    all: bool,
+    from_file: Option<PathBuf>,
+    _mode: super::output::OutputMode,
+) -> Result<()> {
+    // Exactly-one-of selector validation (clap leaves all three optional).
+    let selectors =
+        usize::from(ref_.is_some()) + usize::from(all) + usize::from(from_file.is_some());
+    if selectors == 0 {
+        bail!("specify a ref, `--all`, or `--from-file <FILE>`");
+    }
+    if selectors > 1 {
+        bail!("`--all`, `--from-file`, and a positional ref are mutually exclusive");
+    }
+
+    let store = FsStore::new(resolve_store_root()?)?;
+
+    if all {
+        return run_all(&store);
+    }
+    if let Some(path) = from_file {
+        return run_from_file(&store, &path);
+    }
+
+    // Single ref (the original behavior). Selector validation above
+    // guarantees `ref_` is Some here; match rather than `expect` (the
+    // workspace denies `expect`/`panic` in non-test code).
+    let input = match ref_ {
+        Some(r) => r,
+        None => bail!("specify a ref, `--all`, or `--from-file <FILE>`"),
+    };
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
-
-    let store_root = resolve_store_root()?;
-    let store = FsStore::new(store_root)?;
-
-    let metadata = store
-        .read(&safekey)
-        .with_context(|| format!("failed to read store entry for {input}"))?;
-
-    match metadata {
-        Some(m) => {
-            let bib = render::to_bibtex(safekey.as_str(), &m);
-            // Workspace lints deny `print_stdout` (the `print!`/`println!`
-            // macros) so JSON-RPC frames never collide with diagnostics.
-            // `write!` against an explicit `stdout().lock()` is the
-            // sanctioned escape hatch — `to_bibtex` already terminates
-            // the entry with `}\n`, so no extra newline is added.
-            // See `docs/SECURITY.md` §3 / ADR-0001.
-            let stdout = std::io::stdout();
-            let mut out = stdout.lock();
-            write!(out, "{bib}").context("failed to write BibTeX entry to stdout")?;
-            Ok(())
-        }
+    match store.read(&safekey)? {
+        Some(m) => write_all(&render::to_bibtex(safekey.as_str(), &m)),
         None => bail!("no entry for {input}"),
     }
+}
+
+/// `--all`: render every store entry, deduplicated by citation key, as one
+/// `.bib`. An empty store is not a failure — it exits 0 with a stderr note,
+/// since "nothing to export" is a valid outcome (no ref was requested).
+fn run_all(store: &FsStore) -> Result<()> {
+    // `usize::MAX` ⇒ every entry; `list_recent` already orders by recency.
+    let entries = store
+        .list_recent(usize::MAX)
+        .context("failed to enumerate the store")?;
+
+    if entries.is_empty() {
+        print_err(format_args!(
+            "bib --all: the store is empty; nothing to export"
+        ));
+        return Ok(());
+    }
+
+    let mut out = String::new();
+    let mut seen: Vec<String> = Vec::new();
+    let mut rendered = 0usize;
+    for e in &entries {
+        // An entry listed but unreadable (deleted/raced) is skipped loudly
+        // rather than aborting the whole export.
+        match store.read(&e.safekey) {
+            Ok(Some(m)) => push_entry(&mut out, &mut seen, &e.safekey, &m, &mut rendered),
+            Ok(None) => {}
+            Err(err) => print_err(format_args!(
+                "bib --all: skipping {} (read failed: {err})",
+                e.safekey.as_str()
+            )),
+        }
+    }
+
+    write_all(&out)?;
+    print_err(format_args!("bib --all: exported {rendered} entries"));
+    Ok(())
+}
+
+/// `--from-file`: render the refs listed in `path` from the store. Missing
+/// entries are skipped (with a stderr note) and counted; the process exits
+/// non-zero (failure count, capped at 255 — same convention as `batch`)
+/// when any requested ref could not be rendered, so a script can tell a
+/// complete export from a partial one.
+fn run_from_file(store: &FsStore, path: &Path) -> Result<()> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| anyhow!("--from-file path is not valid UTF-8: {}", path.display()))?;
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading --from-file list: {path_str}"))?;
+    // Same bibliography adapter `batch` uses: plain refs / CSL-JSON /
+    // BibTeX, auto-detected by extension + content.
+    let parsed = refs::parse_input(&raw, Format::Auto, Some(Utf8Path::new(path_str)));
+
+    let mut out = String::new();
+    let mut seen: Vec<String> = Vec::new();
+    let mut rendered = 0usize;
+    let mut missing = 0usize;
+    for entry in parsed {
+        let ref_ = match entry {
+            Ok(p) => p.ref_,
+            Err(e) => {
+                missing += 1;
+                print_err(format_args!(
+                    "bib --from-file: skipping unparseable entry ({e})"
+                ));
+                continue;
+            }
+        };
+        let safekey = ref_.safekey();
+        match store.read(&safekey)? {
+            Some(m) => push_entry(&mut out, &mut seen, &safekey, &m, &mut rendered),
+            None => {
+                missing += 1;
+                print_err(format_args!(
+                    "bib --from-file: no store entry for {} (skipped)",
+                    ref_.as_input_str()
+                ));
+            }
+        }
+    }
+
+    write_all(&out)?;
+    print_err(format_args!(
+        "bib --from-file: exported {rendered} entries, {missing} missing"
+    ));
+    if missing > 0 {
+        // `docs/ERRORS.md` §4: exit = number of failures, capped at 255.
+        let code = missing.min(255) as i32;
+        return Err(anyhow::Error::new(CliExit(code)));
+    }
+    Ok(())
+}
+
+/// Append one rendered entry to `out`, deduplicated by citation key
+/// (`safekey`): a ref list may name the same paper twice, and a deduped
+/// `.bib` avoids duplicate-key warnings in LaTeX.
+fn push_entry(
+    out: &mut String,
+    seen: &mut Vec<String>,
+    safekey: &Safekey,
+    m: &Metadata,
+    rendered: &mut usize,
+) {
+    let key = safekey.as_str();
+    if seen.iter().any(|k| k == key) {
+        return;
+    }
+    seen.push(key.to_string());
+    if !out.is_empty() {
+        // Blank line between entries for readability; entries already end
+        // with `}\n`.
+        out.push('\n');
+    }
+    out.push_str(&render::to_bibtex(key, m));
+    *rendered += 1;
+}
+
+/// Write the rendered BibTeX to stdout. Workspace lints deny
+/// `print!`/`println!`; `write!` against an explicit `stdout().lock()` is
+/// the sanctioned escape hatch (ADR-0001). Entries already terminate with
+/// `}\n`, so no trailing newline is added.
+fn write_all(bib: &str) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    write!(out, "{bib}").context("failed to write BibTeX to stdout")
 }

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -13,10 +13,9 @@
 //! and the `doiget_bibtex_export` MCP tool share one implementation.
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
-use camino::Utf8Path;
+use anyhow::{bail, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 
 use doiget_core::refs::{self, Format};
 use doiget_core::store::{render, FsStore, Metadata, Store};
@@ -42,7 +41,7 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 pub fn run(
     ref_: Option<String>,
     all: bool,
-    from_file: Option<PathBuf>,
+    from_file: Option<Utf8PathBuf>,
     _mode: super::output::OutputMode,
 ) -> Result<()> {
     // Exactly-one-of selector validation (clap leaves all three optional).
@@ -121,15 +120,12 @@ fn run_all(store: &FsStore) -> Result<()> {
 /// non-zero (failure count, capped at 255 — same convention as `batch`)
 /// when any requested ref could not be rendered, so a script can tell a
 /// complete export from a partial one.
-fn run_from_file(store: &FsStore, path: &Path) -> Result<()> {
-    let path_str = path
-        .to_str()
-        .ok_or_else(|| anyhow!("--from-file path is not valid UTF-8: {}", path.display()))?;
+fn run_from_file(store: &FsStore, path: &Utf8Path) -> Result<()> {
     let raw = std::fs::read_to_string(path)
-        .with_context(|| format!("reading --from-file list: {path_str}"))?;
+        .with_context(|| format!("reading --from-file list: {path}"))?;
     // Same bibliography adapter `batch` uses: plain refs / CSL-JSON /
     // BibTeX, auto-detected by extension + content.
-    let parsed = refs::parse_input(&raw, Format::Auto, Some(Utf8Path::new(path_str)));
+    let parsed = refs::parse_input(&raw, Format::Auto, Some(path));
 
     let mut out = String::new();
     let mut seen: Vec<String> = Vec::new();
@@ -141,7 +137,7 @@ fn run_from_file(store: &FsStore, path: &Path) -> Result<()> {
             Err(e) => {
                 missing += 1;
                 print_err(format_args!(
-                    "bib --from-file: skipping unparseable entry ({e})"
+                    "bib --from-file: skipping unparsable entry ({e})"
                 ));
                 continue;
             }

--- a/crates/doiget-cli/src/commands/cite.rs
+++ b/crates/doiget-cli/src/commands/cite.rs
@@ -9,6 +9,16 @@
 //! ([`doiget_core::orchestrator::cite_metadata`]) so the output carries
 //! year / journal / publisher / ISSN, not just the bare id.
 //!
+//! ## Offline resilience (issue #305)
+//!
+//! A live resolve that fails (network hiccup, OpenAlex flake) does NOT
+//! discard an already-fetched reference: `cite` falls back to the local
+//! store and renders the stored metadata, with a `note:` on stderr so the
+//! offline path is visible. `--offline` skips the live resolve entirely
+//! (store-only). Either way a total miss is a non-zero error, never a
+//! silent empty stdout (the #302 / #304 "never exit 0 with nothing"
+//! contract).
+//!
 //! Rendering (field mapping, brace-stripping, HTML/MathML tag scrubbing)
 //! is shared with `doiget bib` via
 //! [`doiget_core::store::render::to_bibtex`].
@@ -27,40 +37,92 @@
 
 use std::io::Write;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use doiget_core::orchestrator::{cite_metadata, resolve_only};
-use doiget_core::store::render;
+use doiget_core::store::{render, FsStore, Store};
 use doiget_core::{CapabilityProfile, Ref};
+
+use super::resolve_store_root;
+
+/// Stderr sink for the offline-fallback `note:` line (mirrors the
+/// `print_err` helper in sibling commands). Kept off stdout so the BibTeX
+/// artifact stays clean (ADR-0001).
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
 
 /// Run the `cite` subcommand.
 ///
 /// `input` is the user-supplied ref string (a DOI, `arxiv:<id>`, or any
-/// scheme accepted by [`Ref::parse`]).
+/// scheme accepted by [`Ref::parse`]). When `offline` is set the live
+/// resolve is skipped and the entry is rendered from the local store;
+/// otherwise a live resolve is attempted first and the store is used as a
+/// fallback when it fails.
 ///
 /// On success a BibTeX entry is written to stdout. Like `bib`, the BibTeX
 /// is the requested artifact (product output, not a diagnostic), so
-/// `--quiet` does NOT suppress it. A resolve failure returns an error so
-/// the CLI exits non-zero.
-pub async fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
+/// `--quiet` does NOT suppress it. A total miss (no live resolve and no
+/// store entry) returns an error so the CLI exits non-zero.
+pub async fn run(input: String, offline: bool, _mode: super::output::OutputMode) -> Result<()> {
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+
+    // `--offline`: render straight from the store, no network at all.
+    if offline {
+        let bib = bib_from_store(&ref_)?.ok_or_else(|| {
+            anyhow!(
+                "--offline: no local store entry for {input} (fetch it first with `doiget fetch`)"
+            )
+        })?;
+        return write_bib(&bib);
+    }
 
     let ctx = crate::commands::fetch::build_resolve_context()?;
     let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
 
-    let outcome = resolve_only(&ref_, &profile, &ctx)
-        .await
-        .with_context(|| format!("failed to resolve {input}"))?;
+    match resolve_only(&ref_, &profile, &ctx).await {
+        Ok(outcome) => {
+            let metadata = cite_metadata(&ref_, &outcome);
+            let bib = render::to_bibtex(ref_.safekey().as_str(), &metadata);
+            write_bib(&bib)
+        }
+        Err(e) => {
+            // Live resolve failed. Fall back to the store so an
+            // already-fetched ref still cites (issue #305) — but never a
+            // silent empty stdout: a ref that is in neither place is a
+            // non-zero error carrying the original resolve failure.
+            match bib_from_store(&ref_)? {
+                Some(bib) => {
+                    print_err(format_args!(
+                        "note: live resolve failed ({e}); citing offline from the local store"
+                    ));
+                    write_bib(&bib)
+                }
+                None => Err(anyhow::Error::new(e).context(format!(
+                    "failed to resolve {input}, and no local store entry to cite offline"
+                ))),
+            }
+        }
+    }
+}
 
-    let metadata = cite_metadata(&ref_, &outcome);
-    let bib = render::to_bibtex(ref_.safekey().as_str(), &metadata);
+/// Render the stored BibTeX for `ref_`, or `None` when the store has no
+/// entry. The citation key is the entry's safekey, matching `bib`.
+fn bib_from_store(ref_: &Ref) -> Result<Option<String>> {
+    let store = FsStore::new(resolve_store_root()?)?;
+    let safekey = ref_.safekey();
+    Ok(store
+        .read(&safekey)?
+        .map(|m| render::to_bibtex(safekey.as_str(), &m)))
+}
 
-    // Workspace lints deny the `print!`/`println!` macros so JSON-RPC
-    // frames never collide with diagnostics; `write!` against an explicit
-    // `stdout().lock()` is the sanctioned escape hatch. `to_bibtex` already
-    // terminates the entry with `}\n`, so no extra newline is added.
+/// Write a rendered BibTeX entry to stdout. `to_bibtex` already terminates
+/// the entry with `}\n`, so no extra newline is added. Workspace lints deny
+/// `print!`/`println!`; `write!` against an explicit `stdout().lock()` is
+/// the sanctioned escape hatch (ADR-0001).
+fn write_bib(bib: &str) -> Result<()> {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    write!(out, "{bib}").context("failed to write BibTeX entry to stdout")?;
-    Ok(())
+    write!(out, "{bib}").context("failed to write BibTeX entry to stdout")
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -322,8 +322,8 @@ enum Command {
         /// Export the refs listed in FILE (one per line, or CSL-JSON /
         /// BibTeX), each rendered from the store; missing entries are
         /// skipped (and counted toward the exit code).
-        #[arg(long, value_name = "FILE")]
-        from_file: Option<std::path::PathBuf>,
+        #[arg(long, value_name = "FILE", value_parser = parse_utf8_path)]
+        from_file: Option<camino::Utf8PathBuf>,
     },
     /// Resolve a ref live and print a clean BibTeX entry (doi2bib-style).
     /// Falls back to the local store when the live resolve fails, so an

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -310,15 +310,31 @@ enum Command {
         #[arg(long, value_enum, default_value = "relevance")]
         sort: doiget_cli::commands::search::SortArg,
     },
-    /// Export an entry as BibTeX.
+    /// Export stored entries as BibTeX. A single ref, the whole store
+    /// (`--all`), or a ref list (`--from-file`) — all rendered offline
+    /// from the local store (#305).
     Bib {
-        /// DOI or arXiv id.
-        ref_: String,
+        /// DOI or arXiv id. Omit when using `--all` or `--from-file`.
+        ref_: Option<String>,
+        /// Export every entry in the store as one deduplicated `.bib`.
+        #[arg(long)]
+        all: bool,
+        /// Export the refs listed in FILE (one per line, or CSL-JSON /
+        /// BibTeX), each rendered from the store; missing entries are
+        /// skipped (and counted toward the exit code).
+        #[arg(long, value_name = "FILE")]
+        from_file: Option<std::path::PathBuf>,
     },
     /// Resolve a ref live and print a clean BibTeX entry (doi2bib-style).
+    /// Falls back to the local store when the live resolve fails, so an
+    /// already-fetched ref always cites (#305).
     Cite {
         /// DOI or arXiv id.
         ref_: String,
+        /// Skip the live resolve and render from the local store only
+        /// (errors if the ref was never fetched).
+        #[arg(long)]
+        offline: bool,
     },
     /// Export an entry as CSL JSON.
     Csl {
@@ -659,8 +675,14 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Batch { path, dry_run }) => {
             doiget_cli::commands::batch::run_with_options(path, dry_run, mode).await
         }
-        Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_, mode),
-        Some(Command::Cite { ref_ }) => doiget_cli::commands::cite::run(ref_, mode).await,
+        Some(Command::Bib {
+            ref_,
+            all,
+            from_file,
+        }) => doiget_cli::commands::bib::run(ref_, all, from_file, mode),
+        Some(Command::Cite { ref_, offline }) => {
+            doiget_cli::commands::cite::run(ref_, offline, mode).await
+        }
         Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_, mode),
         Some(Command::Text {
             ref_,

--- a/crates/doiget-cli/tests/bib_e2e.rs
+++ b/crates/doiget-cli/tests/bib_e2e.rs
@@ -155,3 +155,114 @@ fn bib_emits_misc_for_missing_type() {
         .success()
         .stdout(predicate::str::contains("@misc{doi_10.1234_example,"));
 }
+
+/// Seed a `journal-article` entry for `doi` with the given `title` into the
+/// store at `root` (which must already exist).
+fn seed(root: &Utf8PathBuf, doi: &str, title: &str) {
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+    let ref_ = Ref::Doi(Doi::parse(doi).expect("valid DOI"));
+    let mut m = fixture(Some("journal-article"));
+    m.doi = Some(Doi::parse(doi).expect("valid DOI"));
+    m.title = title.to_string();
+    store.write(&ref_.safekey(), &m, None).expect("seed entry");
+}
+
+#[test]
+fn bib_all_exports_every_store_entry() {
+    // Issue #305: `bib --all` is a one-pass offline exporter of the whole
+    // store — no ref argument, no network.
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+    seed(&root, "10.1234/example", "First Paper");
+    seed(&root, "10.5678/another", "Second Paper");
+
+    doiget(&root)
+        .args(["bib", "--all"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("@article{doi_10.1234_example,"))
+        .stdout(predicate::str::contains("@article{doi_10.5678_another,"))
+        .stdout(predicate::str::contains("First Paper"))
+        .stdout(predicate::str::contains("Second Paper"));
+}
+
+#[test]
+fn bib_all_on_empty_store_succeeds_with_note() {
+    // An empty store is "nothing to export", not a failure (no ref was
+    // requested) — exit 0 with a stderr note, empty stdout.
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+
+    doiget(&root)
+        .args(["bib", "--all"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("store is empty"));
+}
+
+#[test]
+fn bib_from_file_renders_present_and_exits_nonzero_on_missing() {
+    // Issue #305: `bib --from-file` renders the refs present in the store
+    // and SKIPS the missing ones — but exits non-zero so a script can tell
+    // a complete export from a partial one (the #304 failure-count rule).
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+    seed(&root, "10.1234/example", "Present Paper");
+
+    let refs = utf8_path(&dir).join("refs.txt");
+    std::fs::write(
+        refs.as_std_path(),
+        "doi:10.1234/example\ndoi:10.9999/missing\n",
+    )
+    .expect("write refs file");
+
+    doiget(&root)
+        .args(["bib", "--from-file", refs.as_str()])
+        .assert()
+        .failure() // one ref missing → non-zero exit
+        .stdout(predicate::str::contains("Present Paper"))
+        .stderr(predicate::str::contains("1 missing"));
+}
+
+#[test]
+fn bib_no_selector_is_a_usage_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+
+    doiget(&root)
+        .args(["bib"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("specify a ref"));
+}
+
+#[test]
+fn bib_offline_via_cite_renders_from_store() {
+    // `cite --offline <ref>` renders the stored entry with no network
+    // (issue #305): an already-fetched ref always cites.
+    let (_dir_guard, root) = seeded_store(Some("journal-article"));
+
+    doiget(&root)
+        .args(["cite", "--offline", "doi:10.1234/example"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("@article{doi_10.1234_example,"))
+        .stdout(predicate::str::contains("title      = {Quantum Stuff},"));
+}
+
+#[test]
+fn cite_offline_missing_entry_fails() {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    FsStore::new(root.clone()).expect("FsStore::new");
+
+    doiget(&root)
+        .args(["cite", "--offline", "doi:10.9999/missing"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no local store entry"));
+}


### PR DESCRIPTION
## Problem (#305)

Building a `.bib` from an already-fetched store was slow and flaky because `cite`/`bib` were **per-ref and live**:
1. **No offline fallback** — `cite` does a live resolution every time; on a network hiccup / OpenAlex flake it returned **nothing** even for a ref whose PDF + metadata were already in the store. In a bulk run of 107 already-fetched refs, only ~55 `cite` calls produced output; ~52 silently returned nothing despite `fetch` having succeeded.
2. **No bulk export** — a combined `.bib` required looping `cite` over every ref: 100+ slow, individually-flaky network calls when the metadata was already on disk.

Last of the #302–#305 robustness cluster.

## Fix — leverage the store `fetch` already populates

**`cite` (offline resilience)**
- Live resolve fails → fall back to the local store and render the stored metadata, with a `note:` on stderr marking the offline path. An already-fetched ref **always cites**.
- `--offline` skips the live resolve entirely (store-only).
- A ref in **neither** place → non-zero error carrying the resolve failure; never a silent empty stdout (the #302/#304 contract).

**`bib` (bulk export)**
- `bib --all` → every store entry as one **deduplicated** `.bib` (one offline pass).
- `bib --from-file <FILE>` → the refs in FILE (plain refs / CSL-JSON / BibTeX, same adapter as `batch`), each rendered from the store. Missing entries skipped with a stderr note; **exit = missing count** (the `batch` failure-count convention) so a script can tell a complete export from a partial one.
- The positional `ref` is now optional and mutually exclusive with `--all`/`--from-file`.

```
fetch a batch  →  bib --all > out.bib      # one offline, deduped command
```

## Tests (`bib_e2e`, real binary via assert_cmd)
- `bib --all` exports every entry; empty store → exit 0 + stderr note (not a failure).
- `bib --from-file` with one present + one missing → present rendered on stdout, **non-zero** exit, `1 missing` on stderr.
- `bib` with no selector → usage error.
- `cite --offline` → renders the seeded entry (hit); missing entry → failure with `no local store entry`.

## Scope
Closes #305 (both asks: offline fallback + bulk export). **Deferred**: CSL-JSON parity (`csl --all`/`--from-file`) — the issue's surface is BibTeX; a follow-up can mirror it.

## Notes
- Version `0.7.0-beta.4`. Offline release-gate G0–G6 pass.
- Local `cargo build`/`test` not possible on this machine (no MSVC linker); `cargo fmt --check` + offline gate pass — relying on CI.

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)