### PR TITLE
chore(supply-chain): vet-certify dependabot bumps; 0.7.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.0-beta.5] - 2026-06-16
+
+### Changed
+- **[deps]** dependency bumps merged from Dependabot: `biblatex` 0.11.0 → 0.12.0, `chrono` 0.4.44 → 0.4.45, `uuid` 1.23.2 → 1.23.3 (#298, #306), and the `codecov/codecov-action` CI action 6.0.1 → 7.0.0 (#300). `cargo-vet` `safe-to-deploy` exemptions updated to the new versions.
+
 ## [0.7.0-beta.4] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.0-beta.4"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.0-beta.4"
+version = "0.7.0-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.0-beta.4"
+version = "0.7.0-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.0-beta.4"
+version       = "0.7.0-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -83,7 +83,7 @@ version = "0.40.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.biblatex]]
-version = "0.11.0"
+version = "0.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.block-buffer]]
@@ -111,7 +111,7 @@ version = "1.2.61"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
-version = "0.4.44"
+version = "0.4.45"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
@@ -851,7 +851,7 @@ version = "2.5.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.23.2"
+version = "1.23.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]


### PR DESCRIPTION
Follow-up to merging the open Dependabot PRs (#298, #300, #306).

Merging the Rust dependency bumps left `next`'s `cargo vet` red — the new versions weren't in the `safe-to-deploy` exemption set (`biblatex:0.12.0 missing ["safe-to-deploy"]`, etc.). This bumps the three exemptions to the versions now in `Cargo.lock`:

- `biblatex` 0.11.0 → **0.12.0** (#298)
- `chrono` 0.4.44 → **0.4.45** (#306)
- `uuid` 1.23.2 → **1.23.3** (#306)

and rolls the workspace to **0.7.0-beta.5** to capture the dependency milestone. (#300 codecov-action is a CI-action bump only — no Rust dep, no vet.)

The `cargo vet` CI job on this PR is the authoritative check that the exemption set is now complete (incl. any transitive versions the bumps pulled in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)