### PR TITLE
feat(batch): per-ref failure digest on stderr (#222 §1.B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+- **[batch]** end-of-batch **failure digest** on stderr: after the count summary, `doiget batch` lists each failed ref and its primary error code (`<ref> -> <ERROR_CODE>`), so a human / agent sees which refs failed and why without grepping the JSONL provenance log. stdout stays clean (`--mode json` JSON-Lines remains the machine channel) (#222).
+
 ## [0.7.0-beta.5] - 2026-06-16
 
 ### Changed

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -27,6 +27,11 @@
 //! - Exit code: `Ok(())` only when **every** parse + fetch succeeded; any
 //!   parse-error or per-ref-fetch-error returns `Err(...)` so the binary
 //!   surfaces a non-zero exit.
+//! - After the one-line count summary, a per-ref **failure digest**
+//!   (`<ref> -> <ERROR_CODE>`) is written to stderr (issue #222) so a
+//!   human / agent sees which refs failed and why without grepping the
+//!   JSONL provenance log. stdout stays clean (the `--mode json` JSON-Lines
+//!   is the machine channel).
 //! - The bookend rows are always emitted: one `SessionStart` at the top, one
 //!   `SessionEnd` at the bottom, regardless of per-ref outcome.
 
@@ -226,6 +231,9 @@ pub async fn run_with_options(
     let mut parse_errors: usize = 0;
     let mut fetch_ok: usize = 0;
     let mut fetch_errors: usize = 0;
+    // `(ref, error_code)` per failed entry, drained into the end-of-batch
+    // stderr failure digest (issue #222).
+    let mut failures: Vec<(String, &'static str)> = Vec::new();
     let mut remaining = inputs.into_iter();
     loop {
         let window: Vec<String> = remaining.by_ref().take(MCP_BATCH_MAX_SIZE).collect();
@@ -239,6 +247,7 @@ pub async fn run_with_options(
                 Ok(r) => r,
                 Err(e) => {
                     parse_errors += 1;
+                    failures.push((input.clone(), "INVALID_REF"));
                     if json_mode {
                         // #205: parse failures get an INVALID_REF JSONL line
                         // with the human message in `error.message`. Per
@@ -306,11 +315,15 @@ pub async fn run_with_options(
                 is_error,
                 json_record,
                 log_breadcrumb,
+                failure,
             } = classify_joined(joined, json_mode);
             if is_error {
                 fetch_errors += 1;
             } else {
                 fetch_ok += 1;
+            }
+            if let Some(f) = failure {
+                failures.push(f);
             }
             if let Some(record) = json_record {
                 #[allow(clippy::print_stdout)]
@@ -336,6 +349,17 @@ pub async fn run_with_options(
         "batch: {} OK, {} failed ({} parse errors, {} fetch errors)",
         fetch_ok, total_errors, parse_errors, fetch_errors,
     ));
+
+    // Issue #222: a per-ref failure digest on stderr so a human / agent
+    // sees WHICH refs failed and WHY (the primary error code) without
+    // grepping the JSONL provenance log. stdout stays clean (ADR-0001 /
+    // #205 JSON-Lines is the machine channel).
+    if !failures.is_empty() {
+        print_summary(format_args!("batch failures ({}):", failures.len()));
+        for (ref_, code) in &failures {
+            print_summary(format_args!("  {ref_} -> {code}"));
+        }
+    }
 
     if all_ok {
         Ok(())
@@ -392,6 +416,12 @@ struct JoinedOutcome {
     /// here so `classify_joined` stays pure and the loop just calls
     /// `.log()` on the outcome.
     log_breadcrumb: LogBreadcrumb,
+    /// `(ref, error_code)` for a failed entry, collected into the
+    /// end-of-batch stderr failure digest (issue #222) so a human / agent
+    /// sees WHICH refs failed and WHY without grepping the JSONL log.
+    /// `None` on success. The ref is a sentinel only for a task panic
+    /// (the `JoinSet` lost the input).
+    failure: Option<(String, &'static str)>,
 }
 
 enum LogBreadcrumb {
@@ -457,10 +487,12 @@ fn classify_joined(
                     });
                     let error_dbg =
                         format!("pdf_leg=Blocked code={effective:?} message={message:?}");
+                    let failure = Some((input.clone(), effective.as_wire()));
                     return JoinedOutcome {
                         is_error: true,
                         json_record: record,
                         log_breadcrumb: LogBreadcrumb::FetchFailed { input, error_dbg },
+                        failure,
                     };
                 }
                 let result_value = json_mode.then(|| outcome_to_result_value(&outcome));
@@ -469,6 +501,7 @@ fn classify_joined(
                     json_record: json_mode
                         .then(|| build_jsonl_success(&input, result_value.clone().flatten())),
                     log_breadcrumb: LogBreadcrumb::None,
+                    failure: None,
                 }
             }
             Err(e) => {
@@ -481,10 +514,12 @@ fn classify_joined(
                 let record = json_mode.then(|| {
                     build_jsonl_failure(Some(&input), code.as_wire(), &json_msg, denial_value)
                 });
+                let failure = Some((input.clone(), code.as_wire()));
                 JoinedOutcome {
                     is_error: true,
                     json_record: record,
                     log_breadcrumb: LogBreadcrumb::FetchFailed { input, error_dbg },
+                    failure,
                 }
             }
         },
@@ -502,6 +537,7 @@ fn classify_joined(
                 is_error: true,
                 json_record: record,
                 log_breadcrumb: LogBreadcrumb::TaskPanicked { error_dbg },
+                failure: Some(("(task panicked — ref lost)".to_string(), "FETCH_ERROR")),
             }
         }
     }
@@ -776,6 +812,11 @@ mod tests {
             outcome.log_breadcrumb,
             LogBreadcrumb::FetchFailed { .. }
         ));
+        // #222: the digest entry carries the ref + the same typed code.
+        assert_eq!(
+            outcome.failure,
+            Some(("arxiv:2401.99999".to_string(), "INTERNAL_ERROR"))
+        );
     }
 
     #[test]

--- a/crates/doiget-cli/tests/batch_jsonl_e2e.rs
+++ b/crates/doiget-cli/tests/batch_jsonl_e2e.rs
@@ -120,6 +120,39 @@ fn batch_json_fetch_failure_emits_fetch_error_jsonl() {
     );
 }
 
+#[test]
+fn batch_failure_digest_names_ref_and_code_on_stderr() {
+    // Issue #222: the end-of-batch stderr digest names WHICH refs failed
+    // and their primary error code, so a human / agent need not grep the
+    // JSONL provenance log. Human mode (no `--json`) so the digest is the
+    // visible failure surface.
+    let dir = TempDir::new().expect("tempdir");
+    let refs = dir.path().join("refs.txt");
+    std::fs::File::create(&refs)
+        .expect("create refs file")
+        .write_all(b"arxiv:2401.99999\n")
+        .expect("write refs");
+
+    let stderr = doiget(&dir)
+        // Closed port → connect-refused → NETWORK_ERROR.
+        .env("DOIGET_ARXIV_BASE", "http://127.0.0.1:1/")
+        .args(["batch", refs.to_str().unwrap()])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(stderr).expect("stderr utf-8");
+    assert!(
+        stderr.contains("batch failures"),
+        "digest header missing: {stderr}"
+    );
+    assert!(
+        stderr.contains("2401.99999 -> NETWORK_ERROR"),
+        "digest must name the ref and its primary error code: {stderr}"
+    );
+}
+
 /// #210: a successful single-arxiv batch produces a structured success
 /// JSONL record carrying `result.{safekey, store_path, canonical_digest}`.
 /// Wiremock-driven so no real network traffic; the subprocess inherits


### PR DESCRIPTION
## Problem (#222 §1.B)

When `doiget batch` finishes with failures it prints only a bare count: `batch: 10 OK, 5 failed (0 parse errors, 5 fetch errors)`. Finding **why** each paper failed means manually grepping the JSONL provenance log — inefficient for agents, frustrating for humans.

## Fix

After the count summary, emit a per-ref **failure digest** to stderr:

```
batch failures (2):
  10.1234/x -> CAPABILITY_DENIED
  2401.99999 -> NETWORK_ERROR
```

- Each parse/fetch failure's `(ref, error_code)` is captured as it's classified (`JoinedOutcome.failure`), so the digest carries the **same typed wire code** as the `--mode json` JSON-Lines record (`FetchError → ErrorCode`).
- **stdout stays clean** — the digest is stderr-only; JSON-Lines remains the machine channel (ADR-0001 / #205). In `--mode json` the consumer already has per-ref records on stdout; the stderr digest is a harmless human convenience.

## Tests
- `classify_joined` unit: a `SourceSchema` failure yields `failure == Some(("arxiv:2401.99999", "INTERNAL_ERROR"))`.
- `batch_jsonl_e2e`: a connect-refused batch surfaces `batch failures` + `2401.99999 -> NETWORK_ERROR` on stderr.

## Scope
`Refs #222` (not Closes) — this is sub-item **§1.B** of the multi-part issue. Remaining #222 items (batch resumability / `--resume`, auto-preprint fallback, `--delay` + custom UA) are separate follow-ups. (Note: §2.B "BibTeX/CSL batch inputs" is already shipped — `batch` parses `.bib`/CSL-JSON via the ADR-0030 adapter.)

## Notes
- No version bump — added under `## [Unreleased]` to stay conflict-free as a parallel PR (the beta number can be assigned at merge). Offline release-gate G0–G6 pass.
- Local `cargo build`/`test` not possible here (no MSVC linker); `cargo fmt --check` + offline gate pass — relying on CI.

Refs #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)