### PR TITLE
feat(csl): --all / --from-file bulk export, at parity with bib (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+- **[csl]** bulk, offline CSL-JSON export from the local store, at parity with `bib` (#305): `doiget csl --all` emits every store entry as one deduplicated CSL-JSON array, and `doiget csl --from-file <FILE>` emits the refs listed in a file (plain refs / CSL-JSON / BibTeX), each rendered from the store. Missing entries are skipped; `--from-file` exits non-zero with the missing count. The positional ref is now optional and mutually exclusive with the two flags.
+
 ## [0.7.0-beta.5] - 2026-06-16
 
 ### Changed

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -1,57 +1,173 @@
-//! `doiget csl <ref>` — emit a CSL JSON 1.0 array for a stored Metadata.
+//! `doiget csl` — emit CSL JSON 1.0 from the **local store**, offline.
 //!
-//! Reads the stored [`Metadata`](doiget_core::store::Metadata) for a
-//! [`Ref`] and writes a single-element CSL JSON 1.0 **array** (a drop-in
-//! for citeproc-js / pandoc `--csl-json` consumers that expect a list)
-//! on stdout. Rendering lives in
+//! Three shapes (parity with `bib`, issue #305):
+//! - `csl <ref>` — a single-element CSL JSON array for one stored entry.
+//! - `csl --all` — every store entry as one deduplicated CSL JSON array.
+//! - `csl --from-file <FILE>` — the refs listed in FILE (plain refs /
+//!   CSL-JSON / BibTeX), each rendered from the store; missing entries are
+//!   skipped and counted toward a non-zero exit.
+//!
+//! All shapes are pure store reads — no network. Rendering lives in
 //! [`doiget_core::store::render::to_csl_array`] so the CLI and the
-//! `doiget_csl_export` MCP tool share one implementation (Slice 15b).
-//!
-//! Reads go through [`Store::read`]; network access is never required.
+//! `doiget_csl_export` MCP tool share one implementation.
 
 use std::io::Write;
 
 use anyhow::{bail, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use serde_json::Value;
 
-use doiget_core::store::{render, FsStore, Store};
-use doiget_core::Ref;
+use doiget_core::refs::{self, Format};
+use doiget_core::store::{render, FsStore, Metadata, Store};
+use doiget_core::{Ref, Safekey};
 
+use super::fetch::CliExit;
 use super::resolve_store_root;
+
+/// Stderr sink for progress / skip notes (`docs/ERRORS.md` §3); stdout
+/// carries only the CSL JSON artifact (ADR-0001).
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
 
 /// Run the `csl` subcommand against the configured store.
 ///
-/// `input` is the user-supplied ref string (anything accepted by
-/// [`Ref::parse`]). On success a single-element CSL JSON 1.0 array is
-/// written to stdout; a missing entry returns an error so the CLI exits
-/// non-zero (pipelines can distinguish "not in store" from "empty").
-pub fn run(input: String, _mode: super::output::OutputMode) -> Result<()> {
-    // `_mode` is threaded per ADR-0017 / #144. Csl's JSON output is
-    // product output, not informational; Quiet does NOT suppress it.
+/// Exactly one selector must be supplied: a positional `ref_`, `--all`, or
+/// `--from-file`. CSL JSON is product output, so Quiet does NOT suppress
+/// it. A missing single entry — or any missing ref under `--from-file` —
+/// yields a non-zero exit (the array still serializes, possibly empty).
+pub fn run(
+    ref_: Option<String>,
+    all: bool,
+    from_file: Option<Utf8PathBuf>,
+    _mode: super::output::OutputMode,
+) -> Result<()> {
+    let selectors =
+        usize::from(ref_.is_some()) + usize::from(all) + usize::from(from_file.is_some());
+    if selectors > 1 {
+        bail!("`--all`, `--from-file`, and a positional ref are mutually exclusive");
+    }
+
+    let store = FsStore::new(resolve_store_root()?)?;
+
+    if all {
+        return run_all(&store);
+    }
+    if let Some(path) = from_file {
+        return run_from_file(&store, &path);
+    }
+
+    // Single ref (the original behavior): a one-element array.
+    let input = match ref_ {
+        Some(r) => r,
+        None => bail!("specify a ref, `--all`, or `--from-file <FILE>`"),
+    };
     let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
     let safekey = ref_.safekey();
-
-    let store_root = resolve_store_root()?;
-    let store = FsStore::new(store_root)?;
-
-    let metadata = store
-        .read(&safekey)
-        .with_context(|| format!("failed to read store entry for {input}"))?;
-
-    let metadata = match metadata {
-        Some(m) => m,
+    match store.read(&safekey)? {
+        Some(m) => write_array(&render::to_csl_array(safekey.as_str(), &m)),
         None => bail!("no entry for {input}"),
-    };
+    }
+}
 
-    let array = render::to_csl_array(safekey.as_str(), &metadata);
+/// `--all`: every store entry as one deduplicated CSL JSON array. An empty
+/// store emits `[]` with a stderr note (exit 0 — no ref was requested).
+fn run_all(store: &FsStore) -> Result<()> {
+    let entries = store
+        .list_recent(usize::MAX)
+        .context("failed to enumerate the store")?;
+
+    let mut items: Vec<Value> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    for e in &entries {
+        match store.read(&e.safekey) {
+            Ok(Some(m)) => push_item(&mut items, &mut seen, &e.safekey, &m),
+            Ok(None) => {}
+            Err(err) => print_err(format_args!(
+                "csl --all: skipping {} (read failed: {err})",
+                e.safekey.as_str()
+            )),
+        }
+    }
+
+    write_array(&Value::Array(items))?;
+    print_err(format_args!("csl --all: exported {} entries", seen.len()));
+    Ok(())
+}
+
+/// `--from-file`: render the refs listed in `path` from the store. Missing
+/// entries are skipped (stderr note) and counted; the process exits
+/// non-zero (failure count, capped at 255 — same convention as `batch` /
+/// `bib`) when any requested ref could not be rendered.
+fn run_from_file(store: &FsStore, path: &Utf8Path) -> Result<()> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading --from-file list: {path}"))?;
+    // Same bibliography adapter `batch` / `bib` use: plain refs / CSL-JSON
+    // / BibTeX, auto-detected by extension + content.
+    let parsed = refs::parse_input(&raw, Format::Auto, Some(path));
+
+    let mut items: Vec<Value> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    let mut missing = 0usize;
+    for entry in parsed {
+        let ref_ = match entry {
+            Ok(p) => p.ref_,
+            Err(e) => {
+                missing += 1;
+                print_err(format_args!(
+                    "csl --from-file: skipping unparsable entry ({e})"
+                ));
+                continue;
+            }
+        };
+        let safekey = ref_.safekey();
+        match store.read(&safekey)? {
+            Some(m) => push_item(&mut items, &mut seen, &safekey, &m),
+            None => {
+                missing += 1;
+                print_err(format_args!(
+                    "csl --from-file: no store entry for {} (skipped)",
+                    ref_.as_input_str()
+                ));
+            }
+        }
+    }
+
+    write_array(&Value::Array(items))?;
+    print_err(format_args!(
+        "csl --from-file: exported {} entries, {missing} missing",
+        seen.len()
+    ));
+    if missing > 0 {
+        let code = missing.min(255) as i32;
+        return Err(anyhow::Error::new(CliExit(code)));
+    }
+    Ok(())
+}
+
+/// Append one entry's CSL item(s) to `items`, deduplicated by citation key
+/// (`safekey`). `to_csl_array` returns a single-element array; its elements
+/// are flattened into the combined array so the output is one flat CSL
+/// list (what citeproc-js / pandoc expect).
+fn push_item(items: &mut Vec<Value>, seen: &mut Vec<String>, safekey: &Safekey, m: &Metadata) {
+    let key = safekey.as_str();
+    if seen.iter().any(|k| k == key) {
+        return;
+    }
+    seen.push(key.to_string());
+    if let Value::Array(rendered) = render::to_csl_array(key, m) {
+        items.extend(rendered);
+    }
+}
+
+/// Serialize and write a CSL JSON array to stdout. Workspace lints deny
+/// `print!`/`println!`; `writeln!` against an explicit `stdout().lock()` is
+/// the sanctioned escape hatch (ADR-0001).
+fn write_array(array: &Value) -> Result<()> {
     let json =
-        serde_json::to_string_pretty(&array).context("failed to serialize CSL JSON for stdout")?;
-
-    // Workspace lints deny `print_stdout` (`println!`/`print!`); the
-    // sanctioned escape hatch is `writeln!(stdout().lock(), ...)`.
-    // See `docs/SECURITY.md` §3 / ADR-0001 — guarantees JSON-RPC frames
-    // never collide with diagnostics.
+        serde_json::to_string_pretty(array).context("failed to serialize CSL JSON for stdout")?;
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    writeln!(out, "{json}").context("failed to write CSL JSON to stdout")?;
-    Ok(())
+    writeln!(out, "{json}").context("failed to write CSL JSON to stdout")
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -336,10 +336,20 @@ enum Command {
         #[arg(long)]
         offline: bool,
     },
-    /// Export an entry as CSL JSON.
+    /// Export stored entries as CSL JSON. A single ref, the whole store
+    /// (`--all`), or a ref list (`--from-file`) — all rendered offline
+    /// from the local store (#305).
     Csl {
-        /// DOI or arXiv id.
-        ref_: String,
+        /// DOI or arXiv id. Omit when using `--all` or `--from-file`.
+        ref_: Option<String>,
+        /// Export every store entry as one deduplicated CSL JSON array.
+        #[arg(long)]
+        all: bool,
+        /// Export the refs listed in FILE (one per line, or CSL-JSON /
+        /// BibTeX), each rendered from the store; missing entries are
+        /// skipped (and counted toward the exit code).
+        #[arg(long, value_name = "FILE", value_parser = parse_utf8_path)]
+        from_file: Option<camino::Utf8PathBuf>,
     },
     /// Extract a paper's full text from ar5iv as sectioned plain text
     /// (the #281 "read" step; ADR-0032). Takes an arXiv id; the PDF blob
@@ -683,7 +693,11 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Cite { ref_, offline }) => {
             doiget_cli::commands::cite::run(ref_, offline, mode).await
         }
-        Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_, mode),
+        Some(Command::Csl {
+            ref_,
+            all,
+            from_file,
+        }) => doiget_cli::commands::csl::run(ref_, all, from_file, mode),
         Some(Command::Text {
             ref_,
             max_chars,

--- a/crates/doiget-cli/tests/csl_e2e.rs
+++ b/crates/doiget-cli/tests/csl_e2e.rs
@@ -286,3 +286,75 @@ fn csl_fails_for_invalid_ref_string() {
         .failure()
         .stderr(predicate::str::contains("invalid ref"));
 }
+
+/// Seed a temp store with BOTH the journal-article and comma-form
+/// fixtures (two distinct DOIs / safekeys).
+fn seeded_store_both() -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+    let (k1, m1) = journal_article_fixture();
+    let (k2, m2) = comma_form_fixture();
+    store.write(&k1, &m1, None).expect("seed entry 1");
+    store.write(&k2, &m2, None).expect("seed entry 2");
+    (dir, root)
+}
+
+#[test]
+fn csl_all_exports_every_store_entry_in_one_array() {
+    // Issue #305 (CSL parity): `csl --all` emits one flat CSL JSON array
+    // of every store entry — no ref argument, no network.
+    let (_dir_guard, root) = seeded_store_both();
+
+    let assert = doiget(&root).args(["csl", "--all"]).assert().success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf-8");
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("not valid JSON: {e}\nstdout:\n{stdout}"));
+    let array = value
+        .as_array()
+        .unwrap_or_else(|| panic!("expected a JSON array, got: {value}"));
+    assert_eq!(array.len(), 2, "one item per store entry: {value}");
+
+    let ids: Vec<&str> = array.iter().filter_map(|i| i["id"].as_str()).collect();
+    assert!(ids.contains(&"doi_10.1234_example"), "ids: {ids:?}");
+    assert!(ids.contains(&"doi_10.5678_comma"), "ids: {ids:?}");
+}
+
+#[test]
+fn csl_from_file_renders_present_and_exits_nonzero_on_missing() {
+    // Issue #305: `csl --from-file` renders the present refs into one array
+    // and exits non-zero when a requested ref is missing (batch convention).
+    let (dir_guard, root) = seeded_store_journal();
+    let refs = utf8_path(&dir_guard).join("refs.txt");
+    std::fs::write(
+        refs.as_std_path(),
+        "doi:10.1234/example\ndoi:10.9999/missing\n",
+    )
+    .expect("write refs file");
+
+    let assert = doiget(&root)
+        .args(["csl", "--from-file", refs.as_str()])
+        .assert()
+        .failure(); // one ref missing → non-zero exit
+    let out = assert.get_output();
+    let stdout = String::from_utf8(out.stdout.clone()).expect("stdout utf-8");
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("not valid JSON: {e}\nstdout:\n{stdout}"));
+    assert_eq!(
+        value.as_array().map(|a| a.len()),
+        Some(1),
+        "only the present ref renders: {value}"
+    );
+    let stderr = String::from_utf8(out.stderr.clone()).expect("stderr utf-8");
+    assert!(stderr.contains("1 missing"), "stderr digest: {stderr}");
+}
+
+#[test]
+fn csl_no_selector_is_a_usage_error() {
+    let (_dir_guard, root) = seeded_store_journal();
+    doiget(&root)
+        .args(["csl"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("specify a ref"));
+}


### PR DESCRIPTION
Follow-up to #305 (merged via #311): bring `csl` to the same offline bulk-export surface `bib` gained, so a CSL-JSON library export is one offline command instead of a per-ref loop.

## Added
- **`csl --all`** → every store entry as one **deduplicated** CSL-JSON array.
- **`csl --from-file <FILE>`** → the refs in FILE (plain refs / CSL-JSON / BibTeX, same ADR-0030 adapter as `batch`/`bib`), each rendered from the store. Missing entries skipped (stderr note); **exit = missing count** (batch convention).
- The positional `ref` is now optional and mutually exclusive with `--all`/`--from-file`.

Each entry's `to_csl_array` items are flattened into one array, deduped by safekey. An empty `--all` store emits `[]` + a stderr note (exit 0 — no ref requested). Pure store reads, no network.

## Tests (`csl_e2e`, real binary)
- `csl --all` over a two-entry store → a 2-item array with both ids.
- `csl --from-file` (one present + one missing) → 1-item array on stdout, **non-zero** exit, `1 missing` on stderr.
- `csl` with no selector → usage error.

## Scope
`Refs #305` — the issue is already closed by #311; this lands the CSL parity I deferred there. The `to_csl_array` arXiv-field mapping (eprint/archivePrefix — the #303 CSL parity) remains a separate item, since the correct CSL variable mapping is contestable.

## Notes
- No version bump (added under `## [Unreleased]`, conflict-free parallel PR). Offline release-gate G0–G6 pass.
- Local `cargo build`/`test` not possible here (no MSVC linker); `cargo fmt --check` + offline gate pass — relying on CI. `--from-file` uses `camino::Utf8PathBuf` via `parse_utf8_path` (the workspace `disallowed_types` policy bans `std::path`).

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)