### PR TITLE
fix(fetch): store real arXiv Atom metadata, not a placeholder title (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[csl]** bulk, offline CSL-JSON export from the local store, at parity with `bib` (#305): `doiget csl --all` emits every store entry as one deduplicated CSL-JSON array, and `doiget csl --from-file <FILE>` emits the refs listed in a file (plain refs / CSL-JSON / BibTeX), each rendered from the store. Missing entries are skipped; `--from-file` exits non-zero with the missing count. The positional ref is now optional and mutually exclusive with the two flags.
 - **[batch]** end-of-batch **failure digest** on stderr: after the count summary, `doiget batch` lists each failed ref and its primary error code (`<ref> -> <ERROR_CODE>`), so a human / agent sees which refs failed and why without grepping the JSONL provenance log. stdout stays clean (`--mode json` JSON-Lines remains the machine channel) (#222).
 
+### Fixed
+- **[fetch]** `doiget fetch <arxiv-id>` now stores the **real** title / authors / year / subject categories from the Atom feed (which the fetch already retrieves) instead of an `arxiv:<id>` placeholder title. A later `doiget bib` / `info` on a fetched arXiv entry shows a usable reference rather than the bare id. The Atom leg stays best-effort — if it fails, the placeholder is kept so a successful PDF fetch always stores a valid entry (#303).
+
 ## [0.7.0-beta.5] - 2026-06-16
 
 ### Changed

--- a/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
@@ -151,3 +151,78 @@ async fn arxiv_2401_12345_end_to_end() {
     drop(env);
     drop(td);
 }
+
+/// Issue #303: when the Atom feed is available, the PDF-fetch path stores
+/// the REAL title / authors / year / categories (not the `arxiv:<id>`
+/// placeholder), so a later `bib` / `info` shows a usable entry. The arXiv
+/// source fetches the Atom feed from the same `DOIGET_ARXIV_BASE`, so one
+/// mock serves both `/api/query` and `/pdf/...`.
+#[tokio::test]
+#[serial]
+async fn arxiv_fetch_stores_real_atom_metadata() {
+    const ATOM: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <title>A Real Paper Title</title>
+    <summary>Abstract text.</summary>
+    <author><name>Jane Doe</name></author>
+    <author><name>John Roe</name></author>
+    <published>2024-01-15T00:00:00Z</published>
+    <category term="cond-mat.str-el" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="cond-mat.dis-nn" scheme="http://arxiv.org/schemas/atom"/>
+  </entry>
+</feed>"#;
+
+    let server = MockServer::start().await;
+    let body = b"%PDF-1.7\n%fixture-bytes\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(ATOM))
+        .mount(&server)
+        .await;
+
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_STORE_ROOT",
+        "DOIGET_LOG_PATH",
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CONTACT_EMAIL",
+    ]);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", temp_root.join("log.jsonl").as_str());
+    env.set("DOIGET_ARXIV_BASE", &server.uri());
+
+    fetch::run_with_options("arxiv:2401.12345".to_string(), false, OutputMode::Human)
+        .await
+        .expect("fetch succeeds");
+
+    let meta_path = store_root.join(".metadata").join("arxiv_2401.12345.toml");
+    let meta_raw = std::fs::read_to_string(meta_path.as_std_path()).expect("read metadata toml");
+    let metadata: Metadata = toml::from_str(&meta_raw).expect("metadata round-trips");
+
+    // The placeholder `arxiv:<id>` is gone; real Atom fields landed.
+    assert_eq!(metadata.title, "A Real Paper Title");
+    assert_eq!(
+        metadata.authors,
+        vec!["Jane Doe".to_string(), "John Roe".to_string()]
+    );
+    assert_eq!(metadata.year, Some(2024));
+    assert_eq!(
+        metadata.arxiv_categories,
+        vec!["cond-mat.str-el".to_string(), "cond-mat.dis-nn".to_string()]
+    );
+
+    drop(env);
+    drop(td);
+}

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -429,17 +429,7 @@ pub fn cite_metadata(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Metadata {
             .get("published")
             .and_then(Value::as_str)
             .and_then(parse_rfc3339_year);
-        m.arxiv_categories = outcome
-            .metadata
-            .get("categories")
-            .and_then(Value::as_array)
-            .map(|a| {
-                a.iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_string)
-                    .collect()
-            })
-            .unwrap_or_default();
+        m.arxiv_categories = extract_arxiv_categories(&outcome.metadata);
     }
     m
 }
@@ -452,6 +442,23 @@ fn parse_rfc3339_year(s: &str) -> Option<i32> {
     chrono::DateTime::parse_from_rfc3339(s)
         .ok()
         .map(|dt| chrono::Datelike::year(&dt))
+}
+
+/// The arXiv subject categories (primary first) from an Atom-feed JSON's
+/// `categories` array, e.g. `["cond-mat.str-el", "cond-mat.dis-nn"]`.
+/// Empty when absent. Shared by `cite_metadata` (live resolve) and
+/// `fetch_paper_arxiv` (PDF-fetch path) so both populate
+/// `Metadata.arxiv_categories` identically (issue #303).
+fn extract_arxiv_categories(atom: &Value) -> Vec<String> {
+    atom.get("categories")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Convert a Crossref `page` value to BibTeX page-range form: a single
@@ -935,6 +942,7 @@ async fn fetch_paper_arxiv(
         license,
         pdf_bytes,
         final_url,
+        metadata_json,
         ..
     } = source.fetch(ref_, profile, ctx).await?;
     let pdf = pdf_bytes.ok_or_else(|| FetchError::SourceSchema {
@@ -942,21 +950,37 @@ async fn fetch_paper_arxiv(
     })?;
     let size_bytes = pdf.len() as u64;
 
-    // Phase 1 minimal metadata. Full Atom-feed extraction (title /
-    // authors) lives in `ArxivSource::fetch_metadata_only` and the
-    // metadata-only orchestrator; the fetch path keeps the placeholder
-    // for now (a follow-up slice may chain in Atom-parse here).
+    // Real bibliographic metadata from the Atom feed that `fetch` already
+    // retrieved (issue #303). The Atom leg is best-effort — `metadata_json`
+    // is `None` when the feed fetch failed — so an absent/empty title falls
+    // back to the id placeholder, guaranteeing a successful PDF fetch always
+    // stores a VALID entry. `bib` / `info` on the result now show the real
+    // title / authors / year / categories instead of `arxiv:<id>`.
+    let (title, authors, year, arxiv_categories) = match &metadata_json {
+        Some(atom) => (
+            extract_metadata_title(atom).unwrap_or_else(|| format!("arxiv:{}", id.as_str())),
+            extract_metadata_authors(atom),
+            atom.get("published")
+                .and_then(Value::as_str)
+                .and_then(parse_rfc3339_year),
+            extract_arxiv_categories(atom),
+        ),
+        None => (
+            format!("arxiv:{}", id.as_str()),
+            Vec::new(),
+            None,
+            Vec::new(),
+        ),
+    };
+
     let metadata = Metadata {
         schema_version: SCHEMA_VERSION.to_string(),
-        title: format!("arxiv:{}", id.as_str()),
-        authors: Vec::new(),
-        year: None,
+        title,
+        authors,
+        year,
         doi: None,
         arxiv_id: Some(id.clone()),
-        // The PDF-fetch path still writes placeholder metadata (see the
-        // title note above); real Atom categories land with the metadata
-        // chaining follow-up (issue #303).
-        arxiv_categories: Vec::new(),
+        arxiv_categories,
         abstract_: None,
         venue: None,
         volume: None,


### PR DESCRIPTION
## Problem (#303)

`doiget fetch <arxiv-id>` stored `title: "arxiv:<id>"` with empty authors/year/categories. So `doiget bib` / `info` on a fetched arXiv entry showed only the bare id — the "placeholder title" regression called out in #303.

## Root cause

`ArxivSource::fetch` **already retrieves the Atom feed** (into `FetchResult.metadata_json`, fetched before the PDF), but `fetch_paper_arxiv` discarded it with `..` and hard-coded the placeholder.

## Fix

Capture `metadata_json` and populate the real `title` / `authors` / `year` / `arxiv_categories`, using the same primitives `cite_metadata` uses (`extract_metadata_title`/`_authors`, `parse_rfc3339_year`, and a new shared `extract_arxiv_categories`). 

**Best-effort preserved**: the Atom leg can be `None` (feed fetch failed); that falls back to the id placeholder, so a successful PDF fetch *always* stores a valid entry. No new network call — the feed was already fetched.

```mermaid
flowchart LR
  S["ArxivSource::fetch → FetchResult"] --> M{metadata_json?}
  M -- Some --> R["real title/authors/year/categories"]
  M -- None --> P["placeholder (PDF still stored)"]
```

## Tests
- `fetch_arxiv_e2e`: a new both-endpoints case (one mock serves `/api/query` + `/pdf/...`) asserts the stored `title == "A Real Paper Title"`, `authors`, `year == 2024`, `arxiv_categories`. The existing PDF-only test now exercises the `None → placeholder` fallback.
- `cite_metadata` refactored to call `extract_arxiv_categories` (behavior identical).

## Scope
`Refs #303` — with this + the cite enrichment (#310, merged), the only remaining #303 piece is **published-version merge** (`@article` via the DOI↔arXiv `link`, +1 OpenAlex call), a larger separate follow-up.

## Notes
- No version bump (added under `## [Unreleased]`). Offline release-gate G0–G6 pass.
- Local `cargo build`/`test` not possible here (no MSVC linker); `cargo fmt --check` + offline gate pass — relying on CI.

Refs #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)