### PR TITLE
feat(cite): merge the published version for arXiv preprints (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ## [Unreleased]
 
 ### Added
+- **[cite]** published-version merge for arXiv preprints (#303): when `doiget cite <arxiv-id>`'s Atom feed cross-references a published journal DOI (`<arxiv:doi>`), the entry now cites as the rich `@article` (journal / volume / issue / pages / publisher / issn / doi from Crossref) with the arXiv preprint identity retained (`eprint` / `archivePrefix` / `primaryClass`). No extra OpenAlex call — the DOI comes from the already-fetched feed. Best-effort: an absent or unresolvable cross-ref keeps the `@misc` preprint entry.
 - **[csl]** bulk, offline CSL-JSON export from the local store, at parity with `bib` (#305): `doiget csl --all` emits every store entry as one deduplicated CSL-JSON array, and `doiget csl --from-file <FILE>` emits the refs listed in a file (plain refs / CSL-JSON / BibTeX), each rendered from the store. Missing entries are skipped; `--from-file` exits non-zero with the missing count. The positional ref is now optional and mutually exclusive with the two flags.
 - **[batch]** end-of-batch **failure digest** on stderr: after the count summary, `doiget batch` lists each failed ref and its primary error code (`<ref> -> <ERROR_CODE>`), so a human / agent sees which refs failed and why without grepping the JSONL provenance log. stdout stays clean (`--mode json` JSON-Lines remains the machine channel) (#222).
 

--- a/crates/doiget-cli/src/commands/cite.rs
+++ b/crates/doiget-cli/src/commands/cite.rs
@@ -39,8 +39,8 @@ use std::io::Write;
 
 use anyhow::{anyhow, Context, Result};
 
-use doiget_core::orchestrator::{cite_metadata, resolve_only};
-use doiget_core::store::{render, FsStore, Store};
+use doiget_core::orchestrator::{cite_metadata, resolve_only, MetadataOnlyOutcome};
+use doiget_core::store::{render, FsStore, Metadata, Store};
 use doiget_core::{CapabilityProfile, Ref};
 
 use super::resolve_store_root;
@@ -83,7 +83,21 @@ pub async fn run(input: String, offline: bool, _mode: super::output::OutputMode)
 
     match resolve_only(&ref_, &profile, &ctx).await {
         Ok(outcome) => {
-            let metadata = cite_metadata(&ref_, &outcome);
+            let mut metadata = cite_metadata(&ref_, &outcome);
+            // #303 published-version merge: when an arXiv preprint's Atom
+            // feed cross-references a published journal DOI (`<arxiv:doi>`),
+            // resolve that DOI (Crossref) and prefer its rich `@article`
+            // fields (journal / volume / issue / pages / publisher / issn /
+            // doi) while RETAINING the arXiv preprint identity
+            // (eprint / archivePrefix / primaryClass). Best-effort: a
+            // missing or unresolvable cross-ref keeps the `@misc` preprint
+            // entry, never failing the cite. No extra OpenAlex call — the
+            // DOI comes free from the Atom feed already fetched.
+            if let Some(doi_ref) = published_doi_ref(&ref_, &outcome) {
+                if let Ok(doi_outcome) = resolve_only(&doi_ref, &profile, &ctx).await {
+                    metadata = merge_published(cite_metadata(&doi_ref, &doi_outcome), metadata);
+                }
+            }
             let bib = render::to_bibtex(ref_.safekey().as_str(), &metadata);
             write_bib(&bib)
         }
@@ -105,6 +119,30 @@ pub async fn run(input: String, offline: bool, _mode: super::output::OutputMode)
             }
         }
     }
+}
+
+/// The published-journal DOI an arXiv Atom feed cross-references via
+/// `<arxiv:doi>` (issue #303), as a `Ref::Doi`. `None` for a DOI input, an
+/// absent cross-ref, or a malformed DOI (a bad cross-ref is simply ignored
+/// rather than failing the cite).
+fn published_doi_ref(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Option<Ref> {
+    if !matches!(ref_, Ref::Arxiv(_)) {
+        return None;
+    }
+    let doi = outcome.metadata.get("doi").and_then(|v| v.as_str())?;
+    Ref::parse(doi).ok()
+}
+
+/// Merge the arXiv preprint identity into the published DOI's `@article`
+/// metadata: keep the rich Crossref entry and graft on the arXiv id +
+/// categories so `to_bibtex` still emits `eprint` / `archivePrefix` /
+/// `primaryClass`. The published record wins on every shared field — it is
+/// the version a reader should cite — with the preprint retained for
+/// discoverability.
+fn merge_published(mut article: Metadata, arxiv: Metadata) -> Metadata {
+    article.arxiv_id = arxiv.arxiv_id;
+    article.arxiv_categories = arxiv.arxiv_categories;
+    article
 }
 
 /// Render the stored BibTeX for `ref_`, or `None` when the store has no

--- a/crates/doiget-cli/tests/cite_e2e.rs
+++ b/crates/doiget-cli/tests/cite_e2e.rs
@@ -145,6 +145,57 @@ async fn cite_arxiv_emits_bibtex() {
 }
 
 #[tokio::test]
+async fn cite_arxiv_with_published_doi_merges_to_article() {
+    // Issue #303 published-version merge: an arXiv Atom feed that
+    // cross-references a published journal DOI (`<arxiv:doi>`) cites as the
+    // rich `@article` (journal / volume / doi from Crossref) with the arXiv
+    // preprint identity retained (eprint / archivePrefix / primaryClass).
+    let atom = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <title>Preprint Title</title>
+    <author><name>Jane Doe</name></author>
+    <published>2024-01-15T00:00:00Z</published>
+    <category term="cond-mat.str-el" scheme="http://arxiv.org/schemas/atom"/>
+    <arxiv:doi>{TEST_DOI}</arxiv:doi>
+  </entry>
+</feed>"#
+    );
+
+    let arxiv = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(atom))
+        .mount(&arxiv)
+        .await;
+    let crossref = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/works/{TEST_DOI}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(crossref_body()))
+        .mount(&crossref)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["cite", "arxiv:2401.12345"])
+        .env("DOIGET_ARXIV_BASE", arxiv.uri())
+        .env("DOIGET_CROSSREF_BASE", crossref.uri())
+        .assert()
+        .success()
+        // Merged to the published @article (Crossref fields win) ...
+        .stdout(contains("@article{"))
+        .stdout(contains("journal    = {Synthetic Journal of Physics},"))
+        .stdout(contains("volume     = {42},"))
+        .stdout(contains("doi        = {10.1234/cite.test},"))
+        // ... with the arXiv preprint identity retained.
+        .stdout(contains("archivePrefix = {arXiv},"))
+        .stdout(contains("= {2401.12345},")) // eprint
+        .stdout(contains("primaryClass = {cond-mat.str-el},"));
+}
+
+#[tokio::test]
 async fn cite_unresolved_doi_fails() {
     let server = MockServer::start().await;
     // 404 for the works endpoint and the unpaywall fallback → unresolved.


### PR DESCRIPTION
## Problem (#303, point 2)

`doiget cite <arxiv-id>` emitted a bare `@misc` even when the paper had a published journal version — so an arXiv reference never carried the journal / volume / DOI a reader should cite.

## Fix

The arXiv Atom feed **already cross-references** the published version's DOI (`<arxiv:doi>`), so the merge needs no OpenAlex reverse-link call:

```mermaid
flowchart LR
  A["resolve arXiv (Atom)"] --> D{"&lt;arxiv:doi&gt;?"}
  D -- no --> M["@misc (current)"]
  D -- yes --> R["resolve that DOI (Crossref)"]
  R -- ok --> X["@article (journal/vol/doi) + arXiv eprint retained"]
  R -- fail --> M
```

- Resolve the cross-referenced DOI (Crossref) and prefer its rich `@article` fields (journal / volume / issue / pages / publisher / issn / doi), **retaining** the arXiv preprint identity (`eprint` / `archivePrefix` / `primaryClass`) via a small `merge_published`.
- **Best-effort**: an absent / malformed / unresolvable cross-ref keeps the `@misc` preprint — the cite never fails on the merge. Live-only (skipped under `--offline` / the store fallback).

## Completes #303
- arXiv BibTeX enrichment — eprint/archivePrefix/primaryClass/year (#310, merged)
- `bib` placeholder-title fix on the fetch path (#315, merged)
- **published-version merge** (this PR)

## Tests
- `cite_e2e`: a new arXiv-feed-with-`<arxiv:doi>` + Crossref-mock case asserts `@article{` with `journal`/`volume`/`doi` **and** the retained `eprint`/`archivePrefix`/`primaryClass`. The existing no-DOI feed test still renders `@misc`.

## Notes
- No version bump (added under `## [Unreleased]`). Offline release-gate G0–G6 pass.
- Local `cargo build`/`test` not possible here (no MSVC linker); `cargo fmt --check` + offline gate pass — relying on CI.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)