### PR TITLE
Fix #318 second-pass review findings; cut stable 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-16
+
+Promotes the cumulative `0.7.0-beta.0`–`0.7.0-beta.6` line to a stable release
+(next → main, #318). Highlights since 0.6.0: discovery-search relevance-only
+ranking with impact/recency filters (#290), arXiv published-version `cite`
+merge (#303), bulk offline `bib` / `csl` export (#305), batch failure digest
+and auto-chunking (#222 / #304), `TEXT_UNAVAILABLE` signalling (#302), and
+real arXiv fetch metadata (#303). See the `0.7.0-beta.*` sections below for the
+per-change detail.
+
+### Fixed
+- **[review #318]** second-pass promotion-review fixes:
+  - **[text]** `doiget text <arxiv-id>` now emits its extracted prose under a
+    non-TTY *implicit* Quiet — piping `doiget text … > paper.txt` no longer
+    writes an empty file. `text` joins the artifact-command set (ADR-0017
+    Amendment 2); only an **explicit** `--quiet` / `DOIGET_MODE=quiet`
+    suppresses it.
+  - **[search]** `--min-fwci` / `--min-percentile` are now validated: a
+    negative or non-finite FWCI floor, or a percentile above 100, is rejected
+    up front instead of composing a malformed OpenAlex `filter` clause (#290).
+  - **[docs]** corrected the `output` module's Amendment 2 artifact-command
+    list and the `csl --from-file` partial-array contract wording.
+  - **Tests**: `text` piped / explicit-Quiet / unavailable-note behaviors,
+    `cite` arXiv-shaped cross-ref guard (no spurious second resolve),
+    `--min-fwci` / `--min-percentile` filter-clause e2e, out-of-range
+    validation, and tightened `bib` / `csl --from-file` digest assertions.
+
 ## [0.7.0-beta.6] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.0-beta.6"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.0-beta.6"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.0-beta.6"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.0-beta.6"
+version       = "0.7.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -36,7 +36,9 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 /// Exactly one selector must be supplied: a positional `ref_`, `--all`, or
 /// `--from-file`. CSL JSON is product output, so Quiet does NOT suppress
 /// it. A missing single entry — or any missing ref under `--from-file` —
-/// yields a non-zero exit (the array still serializes, possibly empty).
+/// yields a non-zero exit. Under `--from-file` the partial array is still
+/// written to stdout before the failure (a possibly-empty array); a missing
+/// single positional ref produces no stdout at all.
 pub fn run(
     ref_: Option<String>,
     all: bool,

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -1,5 +1,5 @@
 //! Output-mode resolution for the `doiget` CLI (ADR-0017, #144;
-//! Amendment 1 = #219/#220).
+//! Amendment 1 = #219/#220; Amendment 2 = #301).
 //!
 //! ADR-0017 specifies the precedence ladder
 //! `--mode > --json/--quiet > DOIGET_MODE env > subcommand-implicit > TTY > quiet`.
@@ -11,11 +11,13 @@
 //!
 //! [`resolve`] returns a [`ResolvedOutput`] carrying the [`OutputMode`]
 //! plus a `quiet_was_explicit` discriminator. The distinction is
-//! load-bearing per ADR-0017 Amendment 1: artifact-producing commands
-//! (`bib` / `csl` / `capabilities` / `audit-log --verify --mode json`)
-//! suppress only on **explicit** Quiet (`--quiet` / `-q` /
-//! `DOIGET_MODE=quiet` / `--mode quiet`), not on the non-TTY default.
-//! Informational commands continue to suppress on any Quiet.
+//! load-bearing per ADR-0017 Amendment 1 (extended by Amendment 2, #301):
+//! artifact-producing commands — export/inventory (`bib` / `csl` /
+//! `capabilities`) and read/inspection (`info` / `list-recent` / `search` /
+//! `link` / `text`), plus `audit-log --verify --mode json` — suppress only
+//! on **explicit** Quiet (`--quiet` / `-q` / `DOIGET_MODE=quiet` /
+//! `--mode quiet`), not on the non-TTY default. Informational commands
+//! continue to suppress on any Quiet. See [`is_artifact_command`].
 //!
 //! Resolution is split into a pure function ([`resolve`]) plus a thin
 //! TTY-detection wrapper ([`stdout_is_tty`]) so the ladder is fully
@@ -32,7 +34,7 @@
 //!   whose stdout IS the requested product — suppress ONLY on
 //!   **explicit** Quiet, never on the non-TTY implicit fallback:
 //!   export/inventory (bib / csl / capabilities) per Amendment 1, and
-//!   read/inspection (info / list-recent / search / link) per
+//!   read/inspection (info / list-recent / search / link / text) per
 //!   Amendment 2 (#301). See [`is_artifact_command`].
 //! - `Json` — structured JSON bodies for the human-table commands
 //!   (#204) plus the ERRORS.md §3 JSON-Lines per-ref shape for batch
@@ -110,7 +112,7 @@ pub enum FlagInput {
 /// Human, config show/path, provenance migrate, fetch/batch status)
 /// suppress on any Quiet; *artifact* commands whose stdout IS the
 /// product — `bib` / `csl` / `capabilities` plus the read/inspection
-/// commands `info` / `list-recent` / `search` / `link`, and
+/// commands `info` / `list-recent` / `search` / `link` / `text`, and
 /// `audit-log --verify --mode json` — suppress only on **explicit**
 /// Quiet. See [`is_artifact_command`]. The wire format of
 /// [`OutputMode`] (`DOIGET_MODE` string values, the `modes` array in
@@ -135,11 +137,13 @@ pub struct ResolvedOutput {
 ///
 /// The set has two cohorts:
 /// - **Export / inventory** (`bib` / `csl` / `capabilities`) — Amendment 1.
-/// - **Read / inspection** (`info` / `list-recent` / `search` / `link`) —
-///   Amendment 2 (#301). For these the stdout rendering IS the requested
-///   data, not a status report, so a non-TTY caller (agent / pipe / ssh)
-///   must still receive it; silencing it reads as "fetch failed" or
-///   "store empty" when the data is present and correct.
+/// - **Read / inspection** (`info` / `list-recent` / `search` / `link` /
+///   `text`) — Amendment 2 (#301). For these the stdout rendering IS the
+///   requested data, not a status report, so a non-TTY caller (agent / pipe
+///   / ssh) must still receive it; silencing it reads as "fetch failed" or
+///   "store empty" when the data is present and correct. `text` in
+///   particular is almost always piped (`doiget text arxiv:… > paper.txt`),
+///   so the implicit-Quiet fallback would otherwise blank the output.
 ///
 /// `audit-log` is omitted on purpose: it is *informational* in Human
 /// mode and *artifact* in Json mode; the command checks the resolved
@@ -147,7 +151,7 @@ pub struct ResolvedOutput {
 pub fn is_artifact_command(name: &str) -> bool {
     matches!(
         name,
-        "bib" | "csl" | "capabilities" | "info" | "list-recent" | "search" | "link"
+        "bib" | "csl" | "capabilities" | "info" | "list-recent" | "search" | "link" | "text"
     )
 }
 
@@ -400,6 +404,9 @@ mod tests {
         assert!(is_artifact_command("list-recent"));
         assert!(is_artifact_command("search"));
         assert!(is_artifact_command("link"));
+        // `text` extracts paper prose to stdout — almost always piped, so
+        // implicit non-TTY Quiet must not blank it (review #318).
+        assert!(is_artifact_command("text"));
         // audit-log is informational-vs-artifact per resolved mode,
         // not per name; the classifier does NOT match it.
         assert!(!is_artifact_command("audit-log"));

--- a/crates/doiget-cli/src/commands/text.rs
+++ b/crates/doiget-cli/src/commands/text.rs
@@ -49,6 +49,7 @@ pub async fn run(
     max_chars: Option<usize>,
     no_cache: bool,
     mode: OutputMode,
+    quiet_was_explicit: bool,
 ) -> Result<()> {
     let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
     let id: ArxivId = match parsed {
@@ -96,7 +97,11 @@ pub async fn run(
         }
     };
 
-    if mode == OutputMode::Quiet {
+    // Extracted paper prose IS the requested artifact (like `bib` / `info`),
+    // so an *implicit* non-TTY Quiet (e.g. `doiget text arxiv:… > paper.txt`)
+    // must NOT swallow it — only an explicit `--quiet` / `DOIGET_MODE=quiet`
+    // does. This is ADR-0017 Amendment 2 (#301), extended to `text`.
+    if mode == OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
     }
 

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -716,7 +716,10 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             ref_,
             max_chars,
             no_cache,
-        }) => doiget_cli::commands::text::run(ref_, max_chars, no_cache, mode).await,
+        }) => {
+            doiget_cli::commands::text::run(ref_, max_chars, no_cache, mode, out.quiet_was_explicit)
+                .await
+        }
         Some(Command::Link { ref_ }) => {
             doiget_cli::commands::link::run(ref_, mode, out.quiet_was_explicit).await
         }

--- a/crates/doiget-cli/tests/bib_e2e.rs
+++ b/crates/doiget-cli/tests/bib_e2e.rs
@@ -224,7 +224,12 @@ fn bib_from_file_renders_present_and_exits_nonzero_on_missing() {
         .assert()
         .failure() // one ref missing → non-zero exit
         .stdout(predicate::str::contains("Present Paper"))
-        .stderr(predicate::str::contains("1 missing"));
+        // Full summary line: 1 of 2 refs rendered, 1 skipped. Asserting both
+        // counts (not just the loose "1 missing" substring) pins the digest
+        // so a wording or count regression is caught (review #318).
+        .stderr(predicate::str::contains(
+            "bib --from-file: exported 1 entries, 1 missing",
+        ));
 }
 
 #[test]

--- a/crates/doiget-cli/tests/cite_e2e.rs
+++ b/crates/doiget-cli/tests/cite_e2e.rs
@@ -196,6 +196,48 @@ async fn cite_arxiv_with_published_doi_merges_to_article() {
 }
 
 #[tokio::test]
+async fn cite_arxiv_shaped_cross_ref_is_ignored_no_second_resolve() {
+    // Fix #318-D: the published-version merge must trigger ONLY on a bare
+    // DOI cross-ref. An `<arxiv:doi>` carrying an arXiv-shaped value (a
+    // malformed feed) parses as `Ref::Arxiv` and must hit the `=> None`
+    // guard arm — NOT be resolved as if it were a published DOI — so cite
+    // keeps the `@misc` preprint and makes no spurious second arXiv call.
+    let atom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.12345v1</id>
+    <title>Preprint Title</title>
+    <author><name>Jane Doe</name></author>
+    <published>2024-01-15T00:00:00Z</published>
+    <category term="cond-mat.str-el" scheme="http://arxiv.org/schemas/atom"/>
+    <arxiv:doi>arxiv:2401.99999</arxiv:doi>
+  </entry>
+</feed>"#;
+
+    let arxiv = MockServer::start().await;
+    // `expect(1)`: the feed is fetched exactly once. A broken guard would
+    // resolve the arXiv-shaped cross-ref and hit `/api/query` a second time,
+    // failing this expectation on server drop.
+    Mock::given(method("GET"))
+        .and(path("/api/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(atom))
+        .expect(1)
+        .mount(&arxiv)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .args(["cite", "arxiv:2401.12345"])
+        .env("DOIGET_ARXIV_BASE", arxiv.uri())
+        // No Crossref base: a correct guard never reaches a DOI resolver.
+        .assert()
+        .success()
+        // Kept the preprint @misc, with its primary class from the feed.
+        .stdout(contains("@misc{"))
+        .stdout(contains("primaryClass = {cond-mat.str-el},"));
+}
+
+#[tokio::test]
 async fn cite_unresolved_doi_fails() {
     let server = MockServer::start().await;
     // 404 for the works endpoint and the unpaywall fallback → unresolved.

--- a/crates/doiget-cli/tests/csl_e2e.rs
+++ b/crates/doiget-cli/tests/csl_e2e.rs
@@ -346,7 +346,12 @@ fn csl_from_file_renders_present_and_exits_nonzero_on_missing() {
         "only the present ref renders: {value}"
     );
     let stderr = String::from_utf8(out.stderr.clone()).expect("stderr utf-8");
-    assert!(stderr.contains("1 missing"), "stderr digest: {stderr}");
+    // Full summary line (not the loose "1 missing" substring): 1 rendered,
+    // 1 skipped, so a wording or count regression is caught (review #318).
+    assert!(
+        stderr.contains("csl --from-file: exported 1 entries, 1 missing"),
+        "stderr digest: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/doiget-cli/tests/search_external_e2e.rs
+++ b/crates/doiget-cli/tests/search_external_e2e.rs
@@ -138,3 +138,66 @@ async fn external_search_runs_and_logs_openalex_fetch() {
         "missing session_end row in:\n{log}"
     );
 }
+
+#[tokio::test]
+#[serial]
+async fn external_search_min_fwci_and_percentile_become_filter_clauses() {
+    // Review #318 / #290: the `--min-fwci` / `--min-percentile` triage flags
+    // must travel CLI args → ExternalArgs → PaperSearchQuery → the OpenAlex
+    // `filter=` value as AND-joined clauses. Exercise the whole chain end to
+    // end so a typo in the mapping cannot pass unnoticed. The mock only
+    // answers if the exact composed filter arrives.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works"))
+        .and(query_param(
+            "filter",
+            "title_and_abstract.search:tropical tensor networks,fwci:>2.5,cited_by_percentile_year.min:75",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    let store_root = root.join("papers");
+    let log_path = root.join("access.jsonl");
+
+    let guard = EnvGuard::new(ENV_KEYS);
+    guard.set("DOIGET_OPENALEX_BASE", &server.uri());
+    guard.set("DOIGET_STORE_ROOT", store_root.as_str());
+    guard.set("DOIGET_LOG_PATH", log_path.as_str());
+    guard.set("DOIGET_CONTACT_EMAIL", "doiget@localhost");
+    guard.set("DOIGET_MODE", "quiet");
+    guard.set("HOME", root.as_str());
+    guard.set("USERPROFILE", root.as_str());
+
+    let ext = ExternalArgs {
+        limit: 25,
+        from_year: None,
+        to_year: None,
+        oa_only: false,
+        min_citations: None,
+        min_fwci: Some(2.5),
+        min_percentile: Some(75),
+        author: None,
+        venue: None,
+        publisher: None,
+        sort: SortArg::Relevance,
+    };
+
+    let res = run(
+        "tropical tensor networks".to_string(),
+        false,
+        ext,
+        OutputMode::Quiet,
+        true,
+    )
+    .await;
+    // The mock only matches the fully-composed filter, so a successful run
+    // proves both clauses were appended in the documented order.
+    assert!(
+        res.is_ok(),
+        "external search with impact filters failed: {res:?}"
+    );
+}

--- a/crates/doiget-cli/tests/text_e2e.rs
+++ b/crates/doiget-cli/tests/text_e2e.rs
@@ -20,7 +20,9 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
+use assert_cmd::Command;
 use camino::Utf8PathBuf;
+use predicates::str::contains;
 use serial_test::serial;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
@@ -90,6 +92,7 @@ async fn text_extracts_logs_and_caches() {
         None,
         false, // no_cache = false → cache enabled
         OutputMode::Quiet,
+        true, // DOIGET_MODE=quiet → explicit Quiet, output suppressed
     )
     .await;
     assert!(res.is_ok(), "text run failed: {res:?}");
@@ -123,6 +126,7 @@ async fn text_extracts_logs_and_caches() {
         None,
         false,
         OutputMode::Quiet,
+        true,
     )
     .await;
     assert!(res2.is_ok(), "second (cached) text run failed: {res2:?}");
@@ -150,6 +154,7 @@ async fn text_for_doi_reports_no_oa_available() {
         None,
         false,
         OutputMode::Quiet,
+        true,
     )
     .await
     .expect_err("a DOI must error (no full-text source)");
@@ -194,6 +199,7 @@ async fn text_unconverted_render_exits_non_zero_never_silent() {
         None,
         true, // no_cache: exercise the live render path, not a cache hit
         OutputMode::Quiet,
+        true,
     )
     .await
     .expect_err("an unconverted render must error, never silently succeed");
@@ -204,4 +210,93 @@ async fn text_unconverted_render_exits_non_zero_never_silent() {
         exit.0, 0,
         "exit code must be non-zero when no text is produced"
     );
+}
+
+/// Build env for a subprocess `doiget` run against `server`, isolated to
+/// `root`. Deliberately does NOT set `DOIGET_MODE`, so the piped (non-TTY)
+/// child resolves to *implicit* Quiet — the exact condition the artifact
+/// rule must override.
+fn doiget_subprocess(root: &Utf8PathBuf, server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    let p = root.as_str();
+    cmd.env("DOIGET_AR5IV_BASE", server_uri)
+        .env("DOIGET_CACHE_ROOT", root.join("cache").as_str())
+        .env("DOIGET_STORE_ROOT", root.join("papers").as_str())
+        .env("DOIGET_LOG_PATH", root.join("access.jsonl").as_str())
+        .env("HOME", p)
+        .env("USERPROFILE", p);
+    cmd
+}
+
+#[tokio::test]
+#[serial]
+async fn text_piped_non_tty_still_emits_prose() {
+    // Review #318: extracted paper prose IS the artifact. Piped without an
+    // explicit `--quiet`, the mode is *implicit* Quiet; the artifact rule
+    // (ADR-0017 Amendment 2, extended to `text`) must still emit, or
+    // `doiget text arxiv:… > paper.txt` would silently write an empty file.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/html/2401.12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_AR5IV))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    doiget_subprocess(&root, &server.uri())
+        .args(["text", "arxiv:2401.12345"])
+        .assert()
+        .success()
+        // The rendered prose reaches stdout — not blanked by implicit Quiet.
+        .stdout(contains("Extracted Paper"))
+        .stdout(contains("Intro body."));
+}
+
+#[tokio::test]
+#[serial]
+async fn text_explicit_quiet_still_suppresses_prose() {
+    // The flip side: an *explicit* `--quiet` DOES suppress the artifact
+    // (exit 0, empty stdout) — the artifact rule only overrides the implicit
+    // non-TTY fallback, not a deliberate quiet request.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/html/2401.12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_AR5IV))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    doiget_subprocess(&root, &server.uri())
+        .args(["text", "arxiv:2401.12345", "--quiet"])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[tokio::test]
+#[serial]
+async fn text_unavailable_prints_actionable_fetch_note() {
+    // Review #318 / #302: an ar5iv 200 with no extractable prose must fail
+    // with the ACTIONABLE `= note:` naming the exact fetch command, not just
+    // a bare non-zero exit. Pins the note string a human / agent acts on.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/html/2012.03644"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("<html><head></head><body></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    doiget_subprocess(&root, &server.uri())
+        .args(["text", "arxiv:2012.03644"])
+        .assert()
+        .failure()
+        .stderr(contains(
+            "fetch the PDF instead: `doiget fetch arxiv:2012.03644`",
+        ));
 }

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -188,8 +188,9 @@ impl PaperSearchQuery {
     /// (`paper_search` itself stays permissive — see its docs); keeping it
     /// here prevents the two surfaces from drifting.
     ///
-    /// Checks: non-empty `query`, `limit` in `1..=`[`MAX_PER_PAGE`], and a
-    /// non-inverted `from_year`/`to_year` range.
+    /// Checks: non-empty `query`, `limit` in `1..=`[`MAX_PER_PAGE`], a
+    /// non-inverted `from_year`/`to_year` range, a finite non-negative
+    /// `min_fwci`, and a `min_percentile` in `0..=100`.
     ///
     /// # Errors
     ///
@@ -208,6 +209,27 @@ impl PaperSearchQuery {
         if let (Some(from), Some(to)) = (self.from_year, self.to_year) {
             if from > to {
                 return Err(format!("from_year ({from}) is after to_year ({to})"));
+            }
+        }
+        // `min_fwci` becomes a literal `fwci:>{f}` filter clause; a negative
+        // or non-finite value would be a malformed OpenAlex request that the
+        // API rejects (or silently ignores). Reject it here, at the same
+        // boundary as the year range, rather than emit a bad filter (#290).
+        if let Some(f) = self.min_fwci {
+            if !f.is_finite() || f < 0.0 {
+                return Err(format!(
+                    "min_fwci must be a finite, non-negative number (got {f})"
+                ));
+            }
+        }
+        // The percentile is a 0–100 cohort rank; `u8` already excludes
+        // negatives, but 101–255 would emit a `cited_by_percentile_year.min`
+        // clause OpenAlex cannot satisfy (empty result, no error).
+        if let Some(p) = self.min_percentile {
+            if p > 100 {
+                return Err(format!(
+                    "min_percentile must be between 0 and 100 (got {p})"
+                ));
             }
         }
         Ok(())
@@ -1727,6 +1749,33 @@ mod tests {
         assert!(q.validate().unwrap_err().contains("after"));
         // Equal bounds are valid (inclusive range).
         q.to_year = Some(2025);
+        assert!(q.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_impact_filters() {
+        // #290 / review #318: a negative or non-finite `min_fwci`, or a
+        // percentile above 100, would compose a malformed OpenAlex filter
+        // clause. `validate()` must reject them at the boundary instead.
+        let mut q = PaperSearchQuery::new("topic");
+        q.min_fwci = Some(-1.0);
+        assert!(q.validate().unwrap_err().contains("min_fwci"));
+        q.min_fwci = Some(f64::NAN);
+        assert!(q.validate().unwrap_err().contains("min_fwci"));
+        q.min_fwci = Some(f64::INFINITY);
+        assert!(q.validate().unwrap_err().contains("min_fwci"));
+        // A valid floor passes.
+        q.min_fwci = Some(2.5);
+        assert!(q.validate().is_ok());
+
+        let mut q = PaperSearchQuery::new("topic");
+        q.min_percentile = Some(101);
+        assert!(q.validate().unwrap_err().contains("min_percentile"));
+        // Boundary value 100 is valid (top 0%, i.e. the single best cohort
+        // rank); 0 is valid (no floor).
+        q.min_percentile = Some(100);
+        assert!(q.validate().is_ok());
+        q.min_percentile = Some(0);
         assert!(q.validate().is_ok());
     }
 }


### PR DESCRIPTION
Resolves the actionable findings from the re-review of the `next → main` promotion (#318), and drops the beta suffix to cut **stable 0.7.0**. Merging this into `next` makes #318 promote 0.7.0 stable to `main`.

## Fixes

### `text` — silent empty stdout when piped (Important; pre-existing)
`doiget text <arxiv-id>` was excluded from the artifact-command set, so under a non-TTY **implicit** Quiet (`doiget text … | jq`, `> paper.txt`) it returned `Ok(())` with empty stdout, exit 0 — the same silent-failure class #301 fixed for `info`/`link`/`search`/`list-recent`. `text` now joins the artifact set (ADR-0017 Amendment 2); only an **explicit** `--quiet` / `DOIGET_MODE=quiet` suppresses. `text::run` takes `quiet_was_explicit`, threaded from `main`.

### `search` — malformed OpenAlex filter from bad triage values (Important; #290)
`PaperSearchQuery::validate()` now rejects a negative / non-finite `--min-fwci` and a `--min-percentile` above 100, instead of composing a `fwci:>-1` / `cited_by_percentile_year.min:200` clause the API cannot satisfy (silent bad request).

### docs
`output` module's Amendment-2 artifact list (now includes `text`) and the `csl --from-file` partial-array contract wording corrected.

## Tests
- `text`: piped non-TTY emits prose; explicit `--quiet` still suppresses; `TEXT_UNAVAILABLE` prints the actionable fetch note (subprocess via `assert_cmd`).
- `cite`: an arXiv-shaped `<arxiv:doi>` cross-ref is ignored — `Ref::Arxiv => None` guard — with **no spurious second resolve** (`expect(1)` on the feed mock).
- `--min-fwci` / `--min-percentile` compose the expected filter clause end-to-end through `run()`; `validate()` rejects out-of-range values (unit).
- `bib` / `csl --from-file` digest assertions tightened from the loose `"1 missing"` substring to the full `"exported 1 entries, 1 missing"` summary line.

## Versioning
`0.7.0-beta.6 → 0.7.0` (stable). CHANGELOG gains a `[0.7.0]` section promoting the `0.7.0-beta.*` line. Local `release-version-gate.sh v0.7.0` passes G0–G6 (lane: stable).

> Deferred (advisory, larger): the `ArxivCategory` / bounded-percentile newtypes, the `Vec→HashSet` dedup, and the `bib`/`csl` `run_from_file` shared-helper extraction — churn on already-reviewed code, tracked for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)