### PR TITLE
feat(326): batch --delay and --user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.4.2-beta.0] - 2026-06-20
+
+### Added
+- **[batch]** `--delay <SECS>` — sleep between individual fetches in a batch
+  run. Complements the internal per-source rate-limiting (#264) for hosts that
+  throttle below the HTTP 429 threshold (APS, Springer, …) (#326).
+- **[batch]** `--user-agent <STRING>` — override the `User-Agent` header for
+  every HTTP request in the batch. Default behaviour is unchanged; the flag
+  only takes effect when explicitly set (#326).
+- **[core]** `HttpClient::new_with_user_agent` — companion to `HttpClient::new`
+  that accepts a caller-supplied UA string, used by the batch UA override path.
+
 ## [0.4.1-beta.0] - 2026-05-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.4.1-beta.0"
+version = "0.4.2-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.4.1-beta.0"
+version = "0.4.2-beta.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.4.1-beta.0"
+version = "0.4.2-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.4.1-beta.0"
+version       = "0.4.2-beta.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.4.1-beta.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.4.1-beta.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.1-beta.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.4.2-beta.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.4.2-beta.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.4.2-beta.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -67,6 +67,8 @@ use super::resolve_store_root;
 pub async fn run_with_options(
     path: String,
     dry_run: bool,
+    delay: Option<f64>,
+    user_agent: Option<String>,
     mode: super::output::OutputMode,
 ) -> Result<()> {
     // `mode` honors ADR-0017. `Quiet` is a no-op here because batch's
@@ -196,7 +198,7 @@ pub async fn run_with_options(
     // Step 4: build the harness once. All spawned tasks share an `Arc` to
     // it; the harness already wraps the foundation modules in `Arc<...>` so
     // this introduces no extra cloning overhead per task.
-    let harness = Arc::new(FetchHarness::from_env()?);
+    let harness = Arc::new(FetchHarness::from_env_with_ua(user_agent.as_deref())?);
 
     // Step 5: SessionStart. Pass `None` for the ref — there is no single
     // ref to attribute the session to.
@@ -214,6 +216,7 @@ pub async fn run_with_options(
     // logged as `Resolve` rows directly off the harness's shared log.
     let mut parse_errors: usize = 0;
     let mut joins: tokio::task::JoinSet<TaskOutcome> = tokio::task::JoinSet::new();
+    let mut is_first_spawn = true;
     for input in inputs {
         let ref_ = match Ref::parse(&input) {
             Ok(r) => r,
@@ -254,6 +257,15 @@ pub async fn run_with_options(
 
         let harness_task = Arc::clone(&harness);
         let sem_task = Arc::clone(&semaphore);
+        if let Some(d) = delay {
+            if is_first_spawn {
+                is_first_spawn = false;
+            } else {
+                tokio::time::sleep(tokio::time::Duration::from_secs_f64(d)).await;
+            }
+        } else {
+            is_first_spawn = false;
+        }
         joins.spawn(async move {
             // `Semaphore::acquire_owned` only errors when the semaphore is
             // closed; we never close it. The fallback maps that

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -169,7 +169,7 @@ pub(crate) fn config_dir_utf8() -> Result<Utf8PathBuf> {
 /// when `DOIGET_OA_PUBLISHER_BASE` is set — this lets the integration tests
 /// under `tests/fetch_doi_oa_pdf_e2e.rs` exercise the full PDF leg without
 /// touching the real network.
-fn build_http_client() -> Result<HttpClient> {
+fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> {
     let arxiv = std::env::var("DOIGET_ARXIV_BASE").ok();
     let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
     let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
@@ -244,7 +244,11 @@ fn build_http_client() -> Result<HttpClient> {
             }
         }
 
-        return HttpClient::new(allowlists).context("building HTTP client");
+        return match user_agent {
+            Some(ua) => HttpClient::new_with_user_agent(allowlists, ua),
+            None => HttpClient::new(allowlists),
+        }
+        .context("building HTTP client");
     }
 
     // Test-base mode: build a relaxed client per overridden source.
@@ -345,6 +349,12 @@ impl FetchHarness {
     /// the provenance log (allocating a fresh `session_id`), and constructs
     /// the HTTP client honoring `DOIGET_*_BASE` overrides for tests.
     pub(crate) fn from_env() -> Result<Self> {
+        Self::from_env_with_ua(None)
+    }
+
+    /// Like [`from_env`](Self::from_env) but overrides the `User-Agent` on
+    /// every HTTP request. Used by `doiget batch --user-agent`.
+    pub(crate) fn from_env_with_ua(user_agent: Option<&str>) -> Result<Self> {
         let cfg = OrchestratorConfig::from_env()?;
         if let Some(parent) = cfg.log_path.parent() {
             if !parent.as_str().is_empty() {
@@ -357,7 +367,7 @@ impl FetchHarness {
             ProvenanceLog::open(cfg.log_path.clone(), session_id.clone())
                 .context("opening provenance log")?,
         );
-        let http = Arc::new(build_http_client()?);
+        let http = Arc::new(build_http_client(user_agent)?);
         let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
         let store = FsStore::new(cfg.store_root.clone()).context("opening store")?;
         let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
@@ -955,7 +965,7 @@ host = "*.uj.edu.pl"
         std::env::remove_var("DOIGET_OA_PUBLISHER_BASE");
         std::env::remove_var("DOIGET_OPENALEX_BASE");
 
-        let client = build_http_client().expect("HttpClient builds");
+        let client = build_http_client(None).expect("HttpClient builds");
         let oa = client
             .source_allowlist("oa-publisher")
             .expect("oa-publisher source registered");

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -249,6 +249,14 @@ enum Command {
         /// exit so a malformed batch is visible.
         #[arg(long)]
         dry_run: bool,
+        /// Seconds to sleep between individual fetches. Useful for hosts
+        /// that throttle below the HTTP 429 threshold (issue #326).
+        #[arg(long, value_name = "SECS")]
+        delay: Option<f64>,
+        /// Override the User-Agent header for every HTTP request in this
+        /// batch. Default: `doiget/<version> (+https://github.com/sotashimozono/doiget)`.
+        #[arg(long, value_name = "STRING")]
+        user_agent: Option<String>,
     },
     /// Show metadata for a stored entry.
     Info {
@@ -491,8 +499,14 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Fetch { ref_, dry_run }) => {
             doiget_cli::commands::fetch::run_with_options(ref_, dry_run, mode).await
         }
-        Some(Command::Batch { path, dry_run }) => {
-            doiget_cli::commands::batch::run_with_options(path, dry_run, mode).await
+        Some(Command::Batch {
+            path,
+            dry_run,
+            delay,
+            user_agent,
+        }) => {
+            doiget_cli::commands::batch::run_with_options(path, dry_run, delay, user_agent, mode)
+                .await
         }
         Some(Command::Bib { ref_ }) => doiget_cli::commands::bib::run(ref_, mode),
         Some(Command::Csl { ref_ }) => doiget_cli::commands::csl::run(ref_, mode),

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -634,6 +634,21 @@ impl HttpClient {
     /// Returns the underlying `reqwest::Error` if `ClientBuilder::build`
     /// fails (typically a TLS-backend init failure).
     pub fn new(allowlists: Vec<SourceAllowlist>) -> Result<Self, reqwest::Error> {
+        let ua = format!(
+            "doiget/{} (+https://github.com/sotashimozono/doiget)",
+            VERSION
+        );
+        Self::new_with_user_agent(allowlists, &ua)
+    }
+
+    /// Build a client with a custom `User-Agent` header.
+    ///
+    /// Used by `doiget batch --user-agent` to override the default UA for
+    /// hosts that classify the default string as a bot.
+    pub fn new_with_user_agent(
+        allowlists: Vec<SourceAllowlist>,
+        user_agent: &str,
+    ) -> Result<Self, reqwest::Error> {
         let mut clients = HashMap::with_capacity(allowlists.len());
         let mut allowlist_map = HashMap::with_capacity(allowlists.len());
         for entry in allowlists {
@@ -643,7 +658,7 @@ impl HttpClient {
             // (issue #145 pre-fetch check). `build_client` takes the
             // allowlist by value, so clone once for the side table first.
             allowlist_map.insert(source.clone(), entry.clone());
-            let client = build_client(entry)?;
+            let client = build_client(entry, user_agent)?;
             clients.insert(source, client);
         }
         Ok(Self {
@@ -1145,13 +1160,8 @@ fn is_ipv6_loopback(ip: std::net::Ipv6Addr) -> bool {
     matches!(ip.to_ipv4_mapped(), Some(v4) if v4.is_loopback())
 }
 
-fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
+fn build_client(allowlist: SourceAllowlist, ua: &str) -> Result<Client, reqwest::Error> {
     ensure_crypto_provider();
-
-    let user_agent = format!(
-        "doiget/{} (+https://github.com/sotashimozono/doiget)",
-        VERSION
-    );
 
     // Redirect policy: capture the per-source allowlist by value. The
     // closure is called for every redirect hop — there is no global
@@ -1210,7 +1220,7 @@ fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
         .connect_timeout(CONNECT_TIMEOUT)
         .timeout(TOTAL_TIMEOUT)
         .read_timeout(READ_TIMEOUT)
-        .user_agent(user_agent)
+        .user_agent(ua)
         // `tls_backend_rustls()` is the non-deprecated equivalent of the
         // older `use_rustls_tls()`. The workspace pins reqwest with
         // `rustls-no-provider` (ADR-0020 Amendment 1), so this is a


### PR DESCRIPTION
## Summary

- `doiget batch --delay <SECS>` sleeps between individual fetch dispatches — useful for hosts that throttle below the HTTP 429 threshold (APS, Springer, etc.)
- `doiget batch --user-agent <STRING>` overrides the User-Agent header for the entire batch run
- `HttpClient::new_with_user_agent` added to core for caller-supplied UA strings

## Test plan

- [ ] `cargo test --lib` passes (306 tests, no regressions)
- [ ] `doiget batch refs.txt --delay 2.0` inserts 2 s between each dispatch
- [ ] `doiget batch refs.txt --user-agent "MyBot/1.0"` sends the custom UA
- [ ] Omitting both flags preserves current behaviour exactly
- [ ] `doiget batch refs.txt --dry-run` ignores delay/user-agent (exits before harness construction)

Closes #326