### PR TITLE
feat(325): auto preprint fallback — DOI 403 → arXiv PDF under DOI safekey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.2-beta.0] - 2026-06-20
+
+### Added
+- **[fetch]** Auto preprint fallback (issue #325): when a DOI OA PDF fetch is
+  blocked (403, allowlist denial, magic-byte mismatch) and Unpaywall's response
+  includes an arXiv preprint URL, `doiget fetch` now automatically retrieves
+  the arXiv PDF and stores it under the DOI entry instead of returning an error.
+  The stored metadata includes both `doi` and `arxiv_id`; `[doiget].source` is
+  set to `"arxiv"`. Observable: `tracing::info!` at fallback attempt and
+  success; the CLI success line names the arXiv ID used; the MCP
+  `pdf_leg.status` wire value is `"preprint_fallback"`.
+- **[core]** `PdfLegStatus::PreprintFallback { arxiv_id, original_block }` — new
+  variant signalling that the stored PDF came from arXiv, not the publisher.
+  `outcome_is_clean_success` treats it as success; `Blocked` semantics
+  (exit ≠ 0) are preserved when arXiv also fails.
+
 ## [0.7.1-beta.0] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.1-beta.0"
+version = "0.7.2-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.1-beta.0"
+version = "0.7.2-beta.0"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.1-beta.0"
+version = "0.7.2-beta.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.1-beta.0"
+version       = "0.7.2-beta.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.7.1-beta.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.7.1-beta.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.1-beta.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -524,11 +524,11 @@ impl FetchHarness {
 }
 
 /// `true` iff the outcome represents a clean fetch: `Fetched` (full
-/// PDF) or `NoOaUrl` (metadata-only by design). A `Blocked` PDF leg
-/// is a failure for SessionEnd / exit-code purposes — an OA PDF was
-/// discovered but could not be retrieved — even though the metadata
-/// TOML did land on disk. Pulled out so both `run_with_options` and
-/// `commands::batch` agree on the failure boundary.
+/// PDF), `NoOaUrl` (metadata-only by design), or `PreprintFallback`
+/// (OA blocked but arXiv preprint auto-fetched — issue #325).
+/// A `Blocked` PDF leg is a failure for SessionEnd / exit-code purposes.
+/// Pulled out so both `run_with_options` and `commands::batch` agree on
+/// the failure boundary.
 pub(crate) fn outcome_is_clean_success(outcome: &FetchPaperOutcome) -> bool {
     !matches!(outcome.pdf_leg, PdfLegStatus::Blocked { .. })
 }
@@ -554,6 +554,13 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
             print_success(format_args!(
                 "fetched {} (metadata-only: no OA PDF available) -> {}",
                 label, outcome.path
+            ));
+        }
+        // Issue #325: publisher PDF was blocked, arXiv preprint auto-fetched.
+        PdfLegStatus::PreprintFallback { arxiv_id, .. } => {
+            print_success(format_args!(
+                "fetched {} ({} bytes) via arXiv preprint arxiv:{} -> {}",
+                label, outcome.size_bytes, arxiv_id, outcome.path
             ));
         }
         // Issue #145: `Blocked` is NO LONGER a success outcome. It is

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -740,6 +740,18 @@ pub enum PdfLegStatus {
         /// metadata includes an arXiv alternative but the PDF leg was blocked.
         suggested_arxiv_id: Option<String>,
     },
+    /// The OA publisher PDF was blocked (403, allowlist denial, etc.) but
+    /// the `suggested_arxiv_id` pointed to an arXiv preprint that was
+    /// successfully fetched and stored under the DOI entry (issue #325).
+    /// The stored PDF came from arXiv, not the publisher; callers SHOULD
+    /// surface a note so the user knows the file is a preprint.
+    PreprintFallback {
+        /// The arXiv ID that was successfully fetched as fallback.
+        arxiv_id: String,
+        /// The OA-publisher error that triggered the fallback (for logs
+        /// and audit trail context).
+        original_block: String,
+    },
 }
 
 /// What `fetch_paper` wrote to disk and how.
@@ -1074,7 +1086,7 @@ async fn fetch_paper_doi(
     // derived metadata.
     let unpaywall = unpaywall_source_from_env(&unpaywall_contact);
     let upw_result = unpaywall.fetch(ref_, profile, ctx).await;
-    let (license, source_label, oa_chain, oa_status) = match upw_result {
+    let (mut license, source_label, oa_chain, oa_status) = match upw_result {
         Ok(r) => {
             let chain = extract_oa_url_chain(r.metadata_json.as_ref());
             // OA status describes the WORK (gold/green/closed/…), not the
@@ -1222,6 +1234,15 @@ async fn fetch_paper_doi(
         }
     };
 
+    // Issue #325: auto preprint fallback. If the OA chain was blocked but
+    // Unpaywall hinted at an arXiv preprint, attempt that fetch and store
+    // it under the DOI safekey instead of returning Blocked.
+    let (pdf_leg, pdf_bytes, arxiv_id_for_metadata, fallback_license) =
+        try_arxiv_preprint_fallback(doi, pdf_leg, pdf_bytes, profile, ctx).await;
+    if let Some(fl) = fallback_license {
+        license = fl;
+    }
+
     // Issue #120: Crossref is non-fatal, but if it failed AND the OA
     // PDF leg produced nothing, writing a DOI-only stub entry would
     // mask a total failure and violate the "explain why" promise.
@@ -1232,11 +1253,17 @@ async fn fetch_paper_doi(
         }
     }
 
+    let is_preprint_fallback = matches!(pdf_leg, PdfLegStatus::PreprintFallback { .. });
     let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_bytes {
         Some(bytes) => {
             let staged = stage_pdf_to_tempfile(bytes)?;
+            let label = if is_preprint_fallback {
+                "arxiv".to_string()
+            } else {
+                "oa-publisher".to_string()
+            };
             (
-                "oa-publisher".to_string(),
+                label,
                 bytes.len() as u64,
                 Some(format!("{}.pdf", safekey.as_str())),
                 Some(staged),
@@ -1251,7 +1278,7 @@ async fn fetch_paper_doi(
         authors: extracted.authors,
         year: extracted.year,
         doi: Some(doi.clone()),
-        arxiv_id: None,
+        arxiv_id: arxiv_id_for_metadata,
         // DOI-fetch path: no arXiv id, so no arXiv categories.
         arxiv_categories: Vec::new(),
         abstract_: None,
@@ -1312,6 +1339,94 @@ async fn fetch_paper_doi(
         safekey: safekey.as_str().to_string(),
         canonical_digest,
     })
+}
+
+/// Auto preprint fallback (issue #325). Called after the DOI OA PDF chain
+/// walk. When `pdf_leg` is `PdfLegStatus::Blocked` with a
+/// `suggested_arxiv_id`, the arXiv source is tried; on success the caller
+/// receives the PDF bytes, the parsed [`ArxivId`], the arXiv license, and
+/// a [`PdfLegStatus::PreprintFallback`] leg status so the PDF is stored
+/// under the DOI safekey with full audit provenance.
+///
+/// When no fallback is applicable (leg is not `Blocked`, or no
+/// `suggested_arxiv_id`), `pdf_leg` and `oa_pdf_bytes` are returned
+/// unchanged. On any fetch failure the original `Blocked` leg is kept.
+async fn try_arxiv_preprint_fallback(
+    doi: &Doi,
+    pdf_leg: PdfLegStatus,
+    oa_pdf_bytes: Option<Vec<u8>>,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+) -> (PdfLegStatus, Option<Vec<u8>>, Option<ArxivId>, Option<String>) {
+    let (arxiv_id_str, original_block) = match &pdf_leg {
+        PdfLegStatus::Blocked {
+            suggested_arxiv_id: Some(s),
+            message,
+            ..
+        } => (s.clone(), message.clone()),
+        _ => return (pdf_leg, oa_pdf_bytes, None, None),
+    };
+
+    let arxiv_id = match ArxivId::parse(&arxiv_id_str) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                arxiv_id = %arxiv_id_str,
+                doi = %doi.as_str(),
+                "preprint fallback: could not parse suggested_arxiv_id; keeping Blocked"
+            );
+            return (pdf_leg, oa_pdf_bytes, None, None);
+        }
+    };
+
+    tracing::info!(
+        doi = %doi.as_str(),
+        arxiv_id = %arxiv_id.as_str(),
+        "OA PDF blocked; attempting arXiv preprint fallback (issue #325)"
+    );
+
+    let arxiv_ref = Ref::Arxiv(arxiv_id.clone());
+    let arxiv_source = arxiv_source_from_env();
+    match arxiv_source.fetch(&arxiv_ref, profile, ctx).await {
+        Ok(result) => match result.pdf_bytes {
+            Some(bytes) => {
+                tracing::info!(
+                    doi = %doi.as_str(),
+                    arxiv_id = %arxiv_id.as_str(),
+                    size = bytes.len(),
+                    "arXiv preprint fallback succeeded; storing under DOI safekey (issue #325)"
+                );
+                let license = result.license;
+                (
+                    PdfLegStatus::PreprintFallback {
+                        arxiv_id: arxiv_id.as_str().to_string(),
+                        original_block,
+                    },
+                    Some(bytes.to_vec()),
+                    Some(arxiv_id),
+                    Some(license),
+                )
+            }
+            None => {
+                tracing::warn!(
+                    doi = %doi.as_str(),
+                    arxiv_id = %arxiv_id.as_str(),
+                    "preprint fallback: arXiv source returned no PDF bytes; keeping Blocked"
+                );
+                (pdf_leg, oa_pdf_bytes, None, None)
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                doi = %doi.as_str(),
+                arxiv_id = %arxiv_id.as_str(),
+                "preprint fallback: arXiv fetch also failed; keeping Blocked"
+            );
+            (pdf_leg, oa_pdf_bytes, None, None)
+        }
+    }
 }
 
 /// Stage PDF bytes to a tempfile so the existing `Store::write` atomic-

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2794,6 +2794,15 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
             }
             Value::Object(o)
         }
+        // Issue #325: publisher blocked but arXiv preprint auto-fetched.
+        PdfLegStatus::PreprintFallback {
+            arxiv_id,
+            original_block,
+        } => json!({
+            "status": "preprint_fallback",
+            "arxiv_id": arxiv_id,
+            "original_block": original_block,
+        }),
         // `PdfLegStatus` is `#[non_exhaustive]`; a future variant
         // surfaces as a forward-compatible neutral status rather than
         // failing the build in this downstream crate.


### PR DESCRIPTION
## Summary

- Adds `PdfLegStatus::PreprintFallback { arxiv_id, original_block }` variant to signal the PDF came from arXiv, not the publisher
- When DOI OA PDF is blocked (403/allowlist/magic-byte) **and** Unpaywall's response includes an arXiv URL, `fetch_paper_doi` automatically fetches the arXiv preprint and stores it under the DOI safekey
- Metadata includes both `doi` and `arxiv_id`; `[doiget].source` is `"arxiv"`
- Observable: `tracing::info!` at fallback attempt + result; CLI success line names the arXiv ID; MCP `pdf_leg.status` = `"preprint_fallback"`
- If arXiv also fails, original `Blocked` leg is kept unchanged

## Test plan

- [ ] Unit tests pass (`cargo test --lib`): 497 tests, 0 failures
- [ ] `cargo build` clean, no warnings
- [ ] Version gate: `v0.7.2-beta.0` — all G0–G6 PASS
- [ ] Manual: `doiget fetch doi:<doi-with-blocked-oa>` where Unpaywall returns an arXiv URL — should store PDF at `<store>/<doi-safekey>.pdf` with note "via arXiv preprint"
- [ ] Manual: arXiv also fails → should still report `CAPABILITY_DENIED`

Closes #325