### PR TITLE
feat(324): batch --only-failed — skip already-fetched refs on re-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   variant signalling that the stored PDF came from arXiv, not the publisher.
   `outcome_is_clean_success` treats it as success; `Blocked` semantics
   (exit ≠ 0) are preserved when arXiv also fails.
+- **[batch]** `--only-failed` flag (issue #324): re-run a batch file and skip
+  refs whose PDF already exists in the store (`<store>/<safekey>.pdf`).
+  Metadata-only entries (`.metadata/<safekey>.toml`) are NOT skipped — they
+  represent prior `NoOaUrl` or `Blocked` outcomes that may now succeed.
+  In `--mode json`, skipped refs emit `{"ok": true, "ref": "...", "already_fetched": true}`.
+  Summary line gains a `skipped-already-fetched` count when non-zero.
 
 ## [0.7.1-beta.0] - 2026-06-20
 

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -75,6 +75,7 @@ use super::resolve_store_root;
 pub async fn run_with_options(
     path: String,
     dry_run: bool,
+    only_failed: bool,
     mode: super::output::OutputMode,
 ) -> Result<()> {
     // `mode` honors ADR-0017. `Quiet` is a no-op here because batch's
@@ -234,6 +235,9 @@ pub async fn run_with_options(
     // `(ref, error_code)` per failed entry, drained into the end-of-batch
     // stderr failure digest (issue #222).
     let mut failures: Vec<(String, &'static str)> = Vec::new();
+    // Issue #324: count of refs skipped because a PDF already exists in the
+    // store (only populated when `--only-failed` is active).
+    let mut skipped: usize = 0;
     let mut remaining = inputs.into_iter();
     loop {
         let window: Vec<String> = remaining.by_ref().take(MCP_BATCH_MAX_SIZE).collect();
@@ -280,6 +284,30 @@ pub async fn run_with_options(
                     continue;
                 }
             };
+
+            // Issue #324: --only-failed — skip refs that already have a PDF
+            // in the store so a re-run only processes not-yet-succeeded entries.
+            // A PDF at `<store>/<safekey>.pdf` is the success signal; metadata-
+            // only entries (`.metadata/<safekey>.toml`) are NOT skipped because
+            // they indicate a NoOaUrl or prior Blocked outcome that may now
+            // succeed (e.g. after an allowlist update or preprint fallback).
+            if only_failed {
+                let safekey = ref_.safekey();
+                let pdf_path =
+                    harness.cfg.store_root.join(format!("{}.pdf", safekey.as_str()));
+                if pdf_path.exists() {
+                    tracing::debug!(
+                        ref_ = %input,
+                        path = %pdf_path,
+                        "already fetched; skipping (--only-failed)"
+                    );
+                    skipped += 1;
+                    if json_mode {
+                        emit_jsonl_already_fetched(&input);
+                    }
+                    continue;
+                }
+            }
 
             let harness_task = Arc::clone(&harness);
             let sem_task = Arc::clone(&semaphore);
@@ -345,10 +373,17 @@ pub async fn run_with_options(
     // Step 10: stderr summary. ADR-0001: success / progress lines go to
     // stderr; the workspace `print_stderr` lint is `warn`, promoted to deny
     // in CI, so the localized `#[allow]` is the minimal intervention.
-    print_summary(format_args!(
-        "batch: {} OK, {} failed ({} parse errors, {} fetch errors)",
-        fetch_ok, total_errors, parse_errors, fetch_errors,
-    ));
+    if skipped > 0 {
+        print_summary(format_args!(
+            "batch: {} OK, {} failed, {} skipped-already-fetched ({} parse errors, {} fetch errors)",
+            fetch_ok, total_errors, skipped, parse_errors, fetch_errors,
+        ));
+    } else {
+        print_summary(format_args!(
+            "batch: {} OK, {} failed ({} parse errors, {} fetch errors)",
+            fetch_ok, total_errors, parse_errors, fetch_errors,
+        ));
+    }
 
     // Issue #222: a per-ref failure digest on stderr so a human / agent
     // sees WHICH refs failed and WHY (the primary error code) without
@@ -630,6 +665,20 @@ fn build_jsonl_failure(
 #[allow(clippy::print_stdout)]
 fn emit_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) {
     println!("{}", build_jsonl_failure(ref_input, code, message, None));
+}
+
+/// Emit a JSON-Lines record for a ref skipped because its PDF already exists
+/// in the store (`--only-failed`, issue #324). Uses `ok: true` + an
+/// `already_fetched: true` extension field so downstream consumers can
+/// distinguish "new success" from "pre-existing success without re-fetch".
+#[allow(clippy::print_stdout)]
+fn emit_jsonl_already_fetched(ref_input: &str) {
+    let record = serde_json::json!({
+        "ok": true,
+        "ref": ref_input,
+        "already_fetched": true,
+    });
+    println!("{record}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -293,8 +293,10 @@ pub async fn run_with_options(
             // succeed (e.g. after an allowlist update or preprint fallback).
             if only_failed {
                 let safekey = ref_.safekey();
-                let pdf_path =
-                    harness.cfg.store_root.join(format!("{}.pdf", safekey.as_str()));
+                let pdf_path = harness
+                    .cfg
+                    .store_root
+                    .join(format!("{}.pdf", safekey.as_str()));
                 if pdf_path.exists() {
                     tracing::debug!(
                         ref_ = %input,

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -253,6 +253,14 @@ enum Command {
         /// exit so a malformed batch is visible.
         #[arg(long)]
         dry_run: bool,
+        /// Skip refs that already have a PDF in the store
+        /// (`<store>/<safekey>.pdf` exists). Metadata-only entries are
+        /// NOT skipped — they may now succeed via the preprint fallback
+        /// or allowlist updates. Use after a partial batch run to
+        /// re-attempt only failures without wasting API budget on
+        /// already-fetched refs (issue #324).
+        #[arg(long)]
+        only_failed: bool,
     },
     /// Show metadata for a stored entry.
     Info {
@@ -712,8 +720,8 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Fetch { ref_, dry_run }) => {
             doiget_cli::commands::fetch::run_with_options(ref_, dry_run, mode).await
         }
-        Some(Command::Batch { path, dry_run }) => {
-            doiget_cli::commands::batch::run_with_options(path, dry_run, mode).await
+        Some(Command::Batch { path, dry_run, only_failed }) => {
+            doiget_cli::commands::batch::run_with_options(path, dry_run, only_failed, mode).await
         }
         Some(Command::Bib {
             ref_,

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -720,9 +720,11 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Fetch { ref_, dry_run }) => {
             doiget_cli::commands::fetch::run_with_options(ref_, dry_run, mode).await
         }
-        Some(Command::Batch { path, dry_run, only_failed }) => {
-            doiget_cli::commands::batch::run_with_options(path, dry_run, only_failed, mode).await
-        }
+        Some(Command::Batch {
+            path,
+            dry_run,
+            only_failed,
+        }) => doiget_cli::commands::batch::run_with_options(path, dry_run, only_failed, mode).await,
         Some(Command::Bib {
             ref_,
             all,

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -127,7 +127,7 @@ async fn batch_three_arxiv_refs_succeeds_end_to_end() {
     )
     .expect("write refs file");
 
-    batch::run_with_options(refs_path.as_str().to_string(), false, OutputMode::Human)
+    batch::run_with_options(refs_path.as_str().to_string(), false, false, OutputMode::Human)
         .await
         .expect("batch::run_with_options succeeds");
 
@@ -240,7 +240,7 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
     .expect("write refs file");
 
     let result =
-        batch::run_with_options(refs_path.as_str().to_string(), false, OutputMode::Human).await;
+        batch::run_with_options(refs_path.as_str().to_string(), false, false, OutputMode::Human).await;
     let err = result.expect_err("batch with a malformed ref must surface an error to the binary");
     // Issue #143 / `docs/ERRORS.md` §4: the batch exit code is the number
     // of failures (capped at 255), NOT a blanket 1. Exactly one entry
@@ -335,7 +335,7 @@ async fn batch_above_window_size_fetches_every_ref() {
     let refs_path = store_root.parent().unwrap().join("refs.txt");
     std::fs::write(refs_path.as_std_path(), refs_body).expect("write refs file");
 
-    batch::run_with_options(refs_path.as_str().to_string(), false, OutputMode::Human)
+    batch::run_with_options(refs_path.as_str().to_string(), false, false, OutputMode::Human)
         .await
         .expect("a batch above the window size must succeed, fetching every ref");
 


### PR DESCRIPTION
## Summary

- Adds `--only-failed` to `doiget batch` for resumable batch runs (issue #324)
- Skips refs whose PDF already exists at `<store>/<safekey>.pdf`
- Metadata-only entries are NOT skipped (may now succeed via preprint fallback or allowlist updates)
- In `--mode json`: skipped refs emit `{"ok": true, "ref": "...", "already_fetched": true}`
- Summary line: `batch: X OK, Y failed, Z skipped-already-fetched (...)`

## Test plan

- [ ] `cargo test --lib`: 497 tests, 0 failures
- [ ] `cargo build`: clean, no warnings
- [ ] Version gate: `v0.7.2-beta.0` — G0–G6 PASS
- [ ] Manual: run `doiget batch refs.txt`, then add more refs and re-run with `--only-failed` — only the new refs should be fetched
- [ ] Manual: partial batch (some 403) → re-run `--only-failed` — only failed refs re-attempted

Closes #324