### PR TITLE
feat: trust_academic_repos config flag with curated academic host set (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   represent prior `NoOaUrl` or `Blocked` outcomes that may now succeed.
   In `--mode json`, skipped refs emit `{"ok": true, "ref": "...", "already_fetched": true}`.
   Summary line gains a `skipped-already-fetched` count when non-zero.
+- **[core]** `trust_academic_repos` config flag (`[network] trust_academic_repos = true`
+  in `config.toml`) that activates a curated set of 15 single-suffix academic host
+  wildcards (`.ac.uk`, `.ac.jp`, `.edu.au`, `.edu.cn`, `.edu.br`, etc.) without
+  requiring manual `[[network.additional_hosts]]` entries (#323).
+- **[core]** `academic_repo_hosts()` public function in `doiget_core::user_extension`
+  returning the built-in academic patterns; callers can compose or extend the set.
+- **[core]** `UserExtensionConfig` struct (replaces the bare `Vec<UserExtensionHost>`
+  previously returned by `load()`) exposing `additional_hosts` and
+  `trust_academic_repos` fields.
+- **[cli]** `config doctor` check now reports `trust_academic_repos` status alongside
+  the user-extension host count.
+
+### Changed
+- **[core]** `user_extension::load()` return type changed from
+  `Result<Vec<UserExtensionHost>, _>` to `Result<UserExtensionConfig, _>` (semver
+  minor bump). Callers access hosts via `cfg.additional_hosts`.
 
 ## [0.7.1-beta.0] - 2026-06-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.2-beta.0"
+version       = "0.7.2-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -614,7 +614,7 @@ fn user_extension_count() -> usize {
     };
     let path = cfg_dir.join("doiget").join("config.toml");
     match doiget_core::user_extension::load(&path) {
-        Ok(hosts) => hosts.len(),
+        Ok(cfg) => cfg.additional_hosts.len(),
         Err(_) => 0,
     }
 }

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -181,8 +181,12 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
             // `Ok(vec![])` for not-found, so the OK arm always reports
             // a count.
             match doiget_core::user_extension::load(&cfg.config_path) {
-                Ok(hosts) => check(
-                    &format!("user-extension hosts loaded: {}", hosts.len()),
+                Ok(cfg_ext) => check(
+                    &format!(
+                        "user-extension hosts loaded: {} (trust_academic_repos={})",
+                        cfg_ext.additional_hosts.len(),
+                        cfg_ext.trust_academic_repos
+                    ),
                     true,
                     &mut all_ok,
                 ),

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -279,18 +279,24 @@ pub(crate) fn build_http_client() -> Result<HttpClient> {
             Ok(cfg_dir) => {
                 let path = cfg_dir.join("doiget").join("config.toml");
                 match doiget_core::user_extension::load(&path) {
-                    Ok(user_hosts) if !user_hosts.is_empty() => {
-                        tracing::info!(
-                            count = user_hosts.len(),
-                            path = %path,
-                            "merging user-extension allowlist hosts (ADR-0028 D2)"
-                        );
-                        doiget_core::user_extension::merge_into_allowlists(
-                            &mut allowlists,
-                            &user_hosts,
-                        );
+                    Ok(cfg) => {
+                        let mut hosts = cfg.additional_hosts;
+                        if cfg.trust_academic_repos {
+                            hosts.extend(doiget_core::user_extension::academic_repo_hosts());
+                        }
+                        if !hosts.is_empty() {
+                            tracing::info!(
+                                count = hosts.len(),
+                                trust_academic_repos = cfg.trust_academic_repos,
+                                path = %path,
+                                "merging user-extension allowlist hosts (ADR-0028 D2)"
+                            );
+                            doiget_core::user_extension::merge_into_allowlists(
+                                &mut allowlists,
+                                &hosts,
+                            );
+                        }
                     }
-                    Ok(_) => {}
                     Err(e) => {
                         tracing::warn!(
                             error = %e,

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1357,7 +1357,12 @@ async fn try_arxiv_preprint_fallback(
     oa_pdf_bytes: Option<Vec<u8>>,
     profile: &CapabilityProfile,
     ctx: &FetchContext,
-) -> (PdfLegStatus, Option<Vec<u8>>, Option<ArxivId>, Option<String>) {
+) -> (
+    PdfLegStatus,
+    Option<Vec<u8>>,
+    Option<ArxivId>,
+    Option<String>,
+) {
     let (arxiv_id_str, original_block) = match &pdf_leg {
         PdfLegStatus::Blocked {
             suggested_arxiv_id: Some(s),

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -255,7 +255,9 @@ impl std::fmt::Display for InvalidPatternIssue {
 pub fn load(config_path: &Utf8Path) -> Result<UserExtensionConfig, UserExtensionError> {
     let text = match std::fs::read_to_string(config_path.as_std_path()) {
         Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(UserExtensionConfig::default()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(UserExtensionConfig::default())
+        }
         Err(e) => {
             return Err(UserExtensionError::Io {
                 path: config_path.to_string(),
@@ -734,7 +736,10 @@ mod tests {
         assert_eq!(got.additional_hosts[0].host.as_str(), "ruj.uj.edu.pl");
         assert!(got.additional_hosts[0].note.is_none());
         assert_eq!(got.additional_hosts[1].host.as_str(), "*.aps.org");
-        assert_eq!(got.additional_hosts[1].note.as_deref(), Some("user override"));
+        assert_eq!(
+            got.additional_hosts[1].note.as_deref(),
+            Some("user override")
+        );
     }
 
     #[test]
@@ -939,7 +944,10 @@ host = "*.uj.edu.pl"
     #[test]
     fn academic_repo_hosts_are_valid_patterns() {
         let hosts = academic_repo_hosts();
-        assert!(!hosts.is_empty(), "at least one academic host pattern expected");
+        assert!(
+            !hosts.is_empty(),
+            "at least one academic host pattern expected"
+        );
         // Every returned entry must round-trip through HostPattern::new
         for h in &hosts {
             assert!(

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -252,10 +252,10 @@ impl std::fmt::Display for InvalidPatternIssue {
 /// - [`UserExtensionError::InvalidPatterns`] for invalid patterns;
 ///   the variant carries *every* offending entry, not just the first
 ///   (review pass I6).
-pub fn load(config_path: &Utf8Path) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
+pub fn load(config_path: &Utf8Path) -> Result<UserExtensionConfig, UserExtensionError> {
     let text = match std::fs::read_to_string(config_path.as_std_path()) {
         Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(UserExtensionConfig::default()),
         Err(e) => {
             return Err(UserExtensionError::Io {
                 path: config_path.to_string(),
@@ -283,6 +283,10 @@ struct RawConfig {
 struct RawNetwork {
     #[serde(default)]
     additional_hosts: Vec<RawHost>,
+    /// `[network] trust_academic_repos = true` — activates the built-in curated
+    /// academic institution allowlist (issue #323). See [`academic_repo_hosts`].
+    #[serde(default)]
+    trust_academic_repos: bool,
     #[serde(flatten)]
     _other: serde::de::IgnoredAny,
 }
@@ -298,17 +302,73 @@ struct RawHost {
     note: Option<String>,
 }
 
+/// Parsed result from a `config.toml` user-extension section (issue #323).
+///
+/// Returned by [`load`]; callers merge [`Self::additional_hosts`] into the
+/// allowlist unconditionally, and optionally merge [`academic_repo_hosts`]
+/// when [`Self::trust_academic_repos`] is `true`.
+#[derive(Debug, Default)]
+pub struct UserExtensionConfig {
+    /// Hosts from `[[network.additional_hosts]]`.
+    pub additional_hosts: Vec<UserExtensionHost>,
+    /// `true` when `[network] trust_academic_repos = true` is set in
+    /// `config.toml`. Callers that respect this flag SHOULD merge
+    /// [`academic_repo_hosts`] into their allowlist.
+    pub trust_academic_repos: bool,
+}
+
+/// Returns the built-in curated set of academic institution host patterns.
+///
+/// Activated via `[network] trust_academic_repos = true` in `config.toml`
+/// (issue #323). Each entry is a single-suffix wildcard matching the
+/// TLD-style registration block used by institutions in that country.
+///
+/// All patterns are valid per [`validate_pattern`] (single-suffix wildcards
+/// only; no multi-segment globs). The set is intentionally conservative —
+/// covering major national academic TLD patterns used for institutional
+/// Green OA repositories — while keeping the security posture minimal.
+pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
+    const PATTERNS: &[(&str, &str)] = &[
+        ("*.ac.uk", "UK academic institutions (Universities UK)"),
+        ("*.ac.jp", "Japanese academic institutions (NII)"),
+        ("*.go.jp", "Japanese government repositories"),
+        ("*.edu.au", "Australian universities (TEQSA)"),
+        ("*.edu.cn", "Chinese universities (MoE)"),
+        ("*.ac.cn", "Chinese academic institutions"),
+        ("*.edu.pl", "Polish universities (MEiN)"),
+        ("*.ac.nz", "New Zealand universities"),
+        ("*.ac.za", "South African universities (DHET)"),
+        ("*.ac.in", "Indian academic institutions"),
+        ("*.edu.br", "Brazilian universities (CAPES)"),
+        ("*.edu.tw", "Taiwanese universities (MoE)"),
+        ("*.edu.tr", "Turkish universities (YÖK)"),
+        ("*.edu.ar", "Argentine universities (SPU)"),
+        ("*.edu.mx", "Mexican universities (SEP)"),
+    ];
+    PATTERNS
+        .iter()
+        .filter_map(|(pat, note)| {
+            HostPattern::new(*pat).ok().map(|host| UserExtensionHost {
+                host,
+                note: Some(note.to_string()),
+            })
+        })
+        .collect()
+}
+
 /// Parse a `config.toml` body string. Pure function; the path is used
 /// only for error messages.
 fn parse_str(
     text: &str,
     config_path: &Utf8Path,
-) -> Result<Vec<UserExtensionHost>, UserExtensionError> {
+) -> Result<UserExtensionConfig, UserExtensionError> {
     let raw: RawConfig = toml::from_str(text).map_err(|e| UserExtensionError::Parse {
         path: config_path.to_string(),
         source: e,
     })?;
-    let raw_hosts = raw.network.unwrap_or_default().additional_hosts;
+    let raw_net = raw.network.unwrap_or_default();
+    let trust_academic_repos = raw_net.trust_academic_repos;
+    let raw_hosts = raw_net.additional_hosts;
 
     // Two-phase: collect ALL invalid patterns rather than failing on
     // the first. Saves the user an iterative edit-run-error cycle
@@ -333,7 +393,10 @@ fn parse_str(
             issues,
         });
     }
-    Ok(validated)
+    Ok(UserExtensionConfig {
+        additional_hosts: validated,
+        trust_academic_repos,
+    })
 }
 
 /// Validate a host pattern per ADR-0028 D2-1.
@@ -591,7 +654,9 @@ mod tests {
 
     #[test]
     fn parse_empty_config_returns_no_hosts() {
-        assert_eq!(parse_str("", p("config.toml")).unwrap(), vec![]);
+        let cfg = parse_str("", p("config.toml")).unwrap();
+        assert_eq!(cfg.additional_hosts, vec![]);
+        assert!(!cfg.trust_academic_repos);
     }
 
     #[test]
@@ -600,7 +665,9 @@ mod tests {
             [store]
             root = "/tmp"
         "#;
-        assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+        let cfg = parse_str(toml, p("config.toml")).unwrap();
+        assert_eq!(cfg.additional_hosts, vec![]);
+        assert!(!cfg.trust_academic_repos);
     }
 
     #[test]
@@ -614,7 +681,9 @@ mod tests {
             contact_email = "x@y.org"
             cooldown_ms = 250
         "#;
-        assert_eq!(parse_str(toml, p("config.toml")).unwrap(), vec![]);
+        let cfg = parse_str(toml, p("config.toml")).unwrap();
+        assert_eq!(cfg.additional_hosts, vec![]);
+        assert!(!cfg.trust_academic_repos);
     }
 
     #[test]
@@ -642,10 +711,10 @@ mod tests {
             note = "Jagiellonian University Repository"
         "#;
         let got = parse_str(toml, p("config.toml")).unwrap();
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
+        assert_eq!(got.additional_hosts.len(), 1);
+        assert_eq!(got.additional_hosts[0].host.as_str(), "ruj.uj.edu.pl");
         assert_eq!(
-            got[0].note.as_deref(),
+            got.additional_hosts[0].note.as_deref(),
             Some("Jagiellonian University Repository")
         );
     }
@@ -661,11 +730,11 @@ mod tests {
             note = "user override"
         "#;
         let got = parse_str(toml, p("config.toml")).unwrap();
-        assert_eq!(got.len(), 2);
-        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
-        assert!(got[0].note.is_none());
-        assert_eq!(got[1].host.as_str(), "*.aps.org");
-        assert_eq!(got[1].note.as_deref(), Some("user override"));
+        assert_eq!(got.additional_hosts.len(), 2);
+        assert_eq!(got.additional_hosts[0].host.as_str(), "ruj.uj.edu.pl");
+        assert!(got.additional_hosts[0].note.is_none());
+        assert_eq!(got.additional_hosts[1].host.as_str(), "*.aps.org");
+        assert_eq!(got.additional_hosts[1].note.as_deref(), Some("user override"));
     }
 
     #[test]
@@ -713,7 +782,8 @@ mod tests {
         let td = tempfile::TempDir::new().unwrap();
         let path = Utf8Path::from_path(td.path()).unwrap().join("missing.toml");
         let got = load(&path).expect("missing file MUST be Ok(empty)");
-        assert_eq!(got, vec![]);
+        assert_eq!(got.additional_hosts, vec![]);
+        assert!(!got.trust_academic_repos);
     }
 
     #[test]
@@ -731,8 +801,8 @@ note = "Jagiellonian"
         )
         .unwrap();
         let got = load(&path).expect("ok");
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].host.as_str(), "ruj.uj.edu.pl");
+        assert_eq!(got.additional_hosts.len(), 1);
+        assert_eq!(got.additional_hosts[0].host.as_str(), "ruj.uj.edu.pl");
     }
 
     // ---- merge_into_allowlists -------------------------------------
@@ -840,7 +910,7 @@ host = "*.uj.edu.pl"
         )
         .unwrap();
         let mut allowlists = vec![SourceAllowlist::new("oa-publisher", vec![])];
-        merge_into_allowlists(&mut allowlists, &parsed);
+        merge_into_allowlists(&mut allowlists, &parsed.additional_hosts);
         let oa = allowlists
             .iter()
             .find(|a| a.source == "oa-publisher")
@@ -848,5 +918,47 @@ host = "*.uj.edu.pl"
         assert!(oa.matches("ruj.uj.edu.pl"));
         assert!(oa.matches("alpha.uj.edu.pl"));
         assert!(!oa.matches("ruj.uj.edu.ru"));
+    }
+
+    // ---- trust_academic_repos ----------------------------------------
+
+    #[test]
+    fn parse_trust_academic_repos_false_by_default() {
+        let cfg = parse_str("[network]\ncooldown_ms = 100", p("config.toml")).unwrap();
+        assert!(!cfg.trust_academic_repos);
+    }
+
+    #[test]
+    fn parse_trust_academic_repos_true_when_set() {
+        let toml = "[network]\ntrust_academic_repos = true";
+        let cfg = parse_str(toml, p("config.toml")).unwrap();
+        assert!(cfg.trust_academic_repos);
+        assert_eq!(cfg.additional_hosts, vec![]);
+    }
+
+    #[test]
+    fn academic_repo_hosts_are_valid_patterns() {
+        let hosts = academic_repo_hosts();
+        assert!(!hosts.is_empty(), "at least one academic host pattern expected");
+        // Every returned entry must round-trip through HostPattern::new
+        for h in &hosts {
+            assert!(
+                h.host.as_str().starts_with("*."),
+                "academic patterns are single-suffix wildcards: {}",
+                h.host.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn academic_repo_hosts_match_expected_domains() {
+        let hosts = academic_repo_hosts();
+        let patterns: Vec<&str> = hosts.iter().map(|h| h.host.as_str()).collect();
+        for expected in &["*.ac.uk", "*.ac.jp", "*.edu.au", "*.edu.cn", "*.edu.br"] {
+            assert!(
+                patterns.contains(expected),
+                "expected academic pattern {expected} not found"
+            );
+        }
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3293,18 +3293,24 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
             Ok(cfg_dir) => {
                 let path = cfg_dir.join("doiget").join("config.toml");
                 match doiget_core::user_extension::load(&path) {
-                    Ok(user_hosts) if !user_hosts.is_empty() => {
-                        tracing::info!(
-                            count = user_hosts.len(),
-                            path = %path,
-                            "merging user-extension allowlist hosts (ADR-0028 D2)"
-                        );
-                        doiget_core::user_extension::merge_into_allowlists(
-                            &mut allowlists,
-                            &user_hosts,
-                        );
+                    Ok(cfg) => {
+                        let mut hosts = cfg.additional_hosts;
+                        if cfg.trust_academic_repos {
+                            hosts.extend(doiget_core::user_extension::academic_repo_hosts());
+                        }
+                        if !hosts.is_empty() {
+                            tracing::info!(
+                                count = hosts.len(),
+                                trust_academic_repos = cfg.trust_academic_repos,
+                                path = %path,
+                                "merging user-extension allowlist hosts (ADR-0028 D2)"
+                            );
+                            doiget_core::user_extension::merge_into_allowlists(
+                                &mut allowlists,
+                                &hosts,
+                            );
+                        }
                     }
-                    Ok(_) => {}
                     Err(e) => {
                         tracing::warn!(
                             error = %e,


### PR DESCRIPTION
## Summary

- Adds `[network] trust_academic_repos = true` to `config.toml` to activate 15 built-in single-suffix academic host wildcards (`.ac.uk`, `.ac.jp`, `.edu.au`, `.edu.cn`, `.edu.br`, etc.) without requiring manual `[[network.additional_hosts]]` entries
- Introduces `UserExtensionConfig` struct (replaces bare `Vec<UserExtensionHost>` from `load()`) exposing `additional_hosts` and `trust_academic_repos` fields
- Adds `academic_repo_hosts()` public function returning the curated patterns — composable for future callers
- CLI and MCP `build_http_client` blocks extended with academic hosts when flag is set
- `config doctor` check now reports `trust_academic_repos` status alongside the host count

Closes #323

## Test plan

- [x] All 35 `user_extension` unit tests pass (`cargo test -p doiget-core --lib -- user_extension`)
- [x] 4 new tests: `parse_trust_academic_repos_false_by_default`, `parse_trust_academic_repos_true_when_set`, `academic_repo_hosts_are_valid_patterns`, `academic_repo_hosts_match_expected_domains`
- [x] `cargo check --workspace` clean
- [x] `cargo build --workspace` clean (Cargo.lock updated to 0.7.1-beta.1)
- [ ] Manual: set `trust_academic_repos = true` in `config.toml` and confirm `doiget config doctor` reports the flag; confirm fetch of a `.ac.uk` OA URL succeeds