### PR TITLE
feat: config doctor remediation tips on failed checks (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   `outcome_is_clean_success` treats it as success; `Blocked` semantics
   (exit ≠ 0) are preserved when arXiv also fails.
 
+### Changed
+- **[cli]** `doiget config doctor` now prints a `tip:` remediation line on
+  stderr for each failed check, naming the exact env var to set or the
+  config file path to fix (#322). Stdout remains clean (no change to the
+  empty-stdout-on-pass contract). Tips cover: missing `store_root` / `log_dir`
+  parents (`DOIGET_STORE_ROOT`, `DOIGET_LOG_PATH`), unset contact email
+  (`DOIGET_CONTACT_EMAIL`), and malformed `config.toml` (resolved path shown).
+
 ## [0.7.1-beta.0] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.2-beta.0"
+version       = "0.7.2-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -186,7 +186,7 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                 Some(
                     "set DOIGET_CONTACT_EMAIL to your email address\n               \
                      e.g. export DOIGET_CONTACT_EMAIL=you@institution.edu\n               \
-                     (required for the polite User-Agent header and Unpaywall API)"
+                     (required for the polite User-Agent header and Unpaywall API)",
                 ),
                 &mut all_ok,
             );
@@ -463,7 +463,12 @@ mod tests {
         assert!(flag, "all_ok must stay true for a passing check");
 
         // Failing check with tip — all_ok must flip.
-        check("failing check", false, Some("set DOIGET_CONTACT_EMAIL"), &mut flag);
+        check(
+            "failing check",
+            false,
+            Some("set DOIGET_CONTACT_EMAIL"),
+            &mut flag,
+        );
         assert!(!flag, "all_ok must flip to false on a failing check");
     }
 

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -158,19 +158,36 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
         },
         "doctor" => {
             let mut all_ok = true;
+            let store_parent = cfg.store_root.parent().map(|p| p.as_str()).unwrap_or("");
             check(
                 "store_root parent exists",
                 cfg.store_root.parent().map(|p| p.exists()).unwrap_or(true),
+                Some(&format!(
+                    "create the parent directory or override via \
+                     DOIGET_STORE_ROOT\n               \
+                     missing parent: {store_parent}"
+                )),
                 &mut all_ok,
             );
+            let log_parent = cfg.log_dir.parent().map(|p| p.as_str()).unwrap_or("");
             check(
                 "log_dir parent exists",
                 cfg.log_dir.parent().map(|p| p.exists()).unwrap_or(true),
+                Some(&format!(
+                    "create the parent directory or override via \
+                     DOIGET_LOG_PATH\n               \
+                     missing parent: {log_parent}"
+                )),
                 &mut all_ok,
             );
             check(
                 "contact_email set",
                 cfg.contact_email.is_some(),
+                Some(
+                    "set DOIGET_CONTACT_EMAIL to your email address\n               \
+                     e.g. export DOIGET_CONTACT_EMAIL=you@institution.edu\n               \
+                     (required for the polite User-Agent header and Unpaywall API)"
+                ),
                 &mut all_ok,
             );
             // ADR-0028 D2: surface user-extension allowlist health. A
@@ -184,11 +201,17 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                 Ok(hosts) => check(
                     &format!("user-extension hosts loaded: {}", hosts.len()),
                     true,
+                    None,
                     &mut all_ok,
                 ),
                 Err(e) => check(
                     &format!("user-extension config invalid: {e}"),
                     false,
+                    Some(&format!(
+                        "fix {} — see docs/CONFIG.md §3 for the \
+                         [[network.additional_hosts]] schema",
+                        cfg.config_path
+                    )),
                     &mut all_ok,
                 ),
             }
@@ -227,11 +250,18 @@ fn eprintln_err(msg: &str) {
 /// Emit one `[ ok ]` / `[FAIL]` checklist line to stderr and update the
 /// running pass/fail flag. Stderr is used so that `doiget config doctor`
 /// stdout stays empty for green runs (script-friendly).
+///
+/// When `ok` is `false` and `tip` is `Some`, a remediation tip is printed
+/// on the next line, indented so it is visually attached to the failed
+/// check (issue #322).
 #[allow(clippy::print_stderr)]
-fn check(label: &str, ok: bool, all_ok: &mut bool) {
+fn check(label: &str, ok: bool, tip: Option<&str>, all_ok: &mut bool) {
     let mark = if ok { "[ ok ]" } else { "[FAIL]" };
     eprintln!("{mark} {label}");
     if !ok {
+        if let Some(t) = tip {
+            eprintln!("       tip: {t}");
+        }
         *all_ok = false;
     }
 }
@@ -420,6 +450,21 @@ mod tests {
             .downcast_ref::<CliExit>()
             .expect("failing doctor must carry a CliExit");
         assert_eq!(cli_exit.0, 2);
+    }
+
+    /// Issue #322: `check` must emit a `tip:` line to stderr when the
+    /// check fails and a tip is provided. Passing `ok=true` must NOT
+    /// emit the tip line even when one is supplied.
+    #[test]
+    fn check_emits_tip_on_failure_only() {
+        let mut flag = true;
+        // Passing check — tip must be swallowed.
+        check("passing check", true, Some("should not appear"), &mut flag);
+        assert!(flag, "all_ok must stay true for a passing check");
+
+        // Failing check with tip — all_ok must flip.
+        check("failing check", false, Some("set DOIGET_CONTACT_EMAIL"), &mut flag);
+        assert!(!flag, "all_ok must flip to false on a failing check");
     }
 
     #[test]

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1357,7 +1357,12 @@ async fn try_arxiv_preprint_fallback(
     oa_pdf_bytes: Option<Vec<u8>>,
     profile: &CapabilityProfile,
     ctx: &FetchContext,
-) -> (PdfLegStatus, Option<Vec<u8>>, Option<ArxivId>, Option<String>) {
+) -> (
+    PdfLegStatus,
+    Option<Vec<u8>>,
+    Option<ArxivId>,
+    Option<String>,
+) {
     let (arxiv_id_str, original_block) = match &pdf_leg {
         PdfLegStatus::Blocked {
             suggested_arxiv_id: Some(s),


### PR DESCRIPTION
## Summary

- Each `[FAIL]` line in `doiget config doctor` now prints a `tip:` line to stderr naming the exact env var to set or config file path to fix (#322)
- Stdout remains clean — no change to the empty-stdout-on-pass contract
- Tips cover all four checks: missing `store_root` parent (`DOIGET_STORE_ROOT`), missing `log_dir` parent (`DOIGET_LOG_PATH`), unset contact email (`DOIGET_CONTACT_EMAIL`), malformed `config.toml` (resolved path shown)

Example output on a failing run:
```
[FAIL] contact_email set
       tip: set DOIGET_CONTACT_EMAIL to your email address
            e.g. export DOIGET_CONTACT_EMAIL=you@institution.edu
            (required for the polite User-Agent header and Unpaywall API)
```

Closes #322

## Test plan

- [x] All 7 `commands::config` unit tests pass
- [x] New `check_emits_tip_on_failure_only` test verifies tip is emitted on failure and suppressed on pass
- [x] `cargo check --workspace` clean
- [x] `cargo build --workspace` clean (Cargo.lock updated to 0.7.1-beta.1)
- [ ] Manual: run `doiget config doctor` with `DOIGET_CONTACT_EMAIL` unset and confirm tip line appears on stderr