### PR TITLE
feat: frontier view — doiget frontier surfaces unread citing papers (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   empty-stdout-on-pass contract). Tips cover: missing `store_root` / `log_dir`
   parents (`DOIGET_STORE_ROOT`, `DOIGET_LOG_PATH`), unset contact email
   (`DOIGET_CONTACT_EMAIL`), and malformed `config.toml` (resolved path shown).
+- **[cli]** `doiget frontier <doi>` — gap-spotting frontier view that surfaces
+  papers citing the seed DOI, ranked by age-normalized impact (`fwci`
+  descending), with papers already in the local store filtered out (#295).
+  Flags: `--limit N` (1–200, default 25), `--from-year YYYY`.
+  `--mode json` emits `{ seed_doi, seed_title, seed_openalex_id,
+  total_citing, count, results: [PaperHit…] }`.
+- **[core]** `FrontierQuery` and `FrontierResults` types in
+  `doiget_core::discovery`.
+- **[core]** `frontier_view()` async function in `doiget_core::discovery`:
+  resolves the seed DOI via OpenAlex, queries `filter=cites:<seed_id>` with
+  `sort=fwci:desc`, and returns hits sorted by `fwci` → `year` → `cited_by_count`.
+- **[core]** `PaperHit` now carries `fwci: Option<f64>` and
+  `cited_by_percentile_year_min: Option<u8>` (both already in the OpenAlex
+  `select=` field list; now parsed and surfaced). These fields are emitted in
+  all `search` and `frontier` JSON output.
+
+### Changed
+- **[core]** `PaperHit` and `PaperSearchResults` drop the `Eq` derive
+  (retained `PartialEq`); `f64` fields preclude a total equality relation.
 
 ## [0.7.1-beta.0] - 2026-06-20
 

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -1,0 +1,134 @@
+//! `doiget frontier <doi>` — gap-spotting frontier view (#295).
+//!
+//! Surfaces papers that **cite the seed DOI**, ranked by age-normalized
+//! impact (`fwci` descending). Papers already present in the local store
+//! are filtered out by default so only unread candidates are shown.
+//!
+//! ## Output
+//!
+//! - **Human mode**: tab-separated table `fwci | year | oa | doi | title`.
+//! - **JSON mode**: `{ seed_doi, seed_title, seed_openalex_id, total_citing,
+//!   count, results: [PaperHit...] }`.
+//!
+//! ## Store exclusion
+//!
+//! Each candidate DOI is mapped to its safekey and checked against
+//! `<store_root>/<safekey>.pdf`. Matches are silently dropped (the purpose
+//! of frontier is to surface the *unread* portion of the neighbourhood).
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use doiget_core::discovery::{frontier_view, FrontierQuery, FrontierResults};
+use doiget_core::ErrorCode;
+
+use super::fetch::{cli_exit_code, CliExit, FetchHarness};
+use super::output::OutputMode;
+use super::resolve_store_root;
+
+/// OpenAlex API base; overridable via `DOIGET_OPENALEX_BASE` (tests).
+const OPENALEX_DEFAULT_BASE: &str = "https://api.openalex.org";
+
+/// Entry point for `doiget frontier <doi>`.
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+pub async fn run(
+    doi_str: String,
+    limit: usize,
+    from_year: Option<i32>,
+    mode: OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
+    let seed_doi = doiget_core::Doi::parse(&doi_str)
+        .map_err(|e| anyhow::anyhow!("invalid seed DOI {doi_str:?}: {e}"))?;
+
+    let base = {
+        let raw = std::env::var("DOIGET_OPENALEX_BASE")
+            .unwrap_or_else(|_| OPENALEX_DEFAULT_BASE.to_string());
+        url::Url::parse(&raw)
+            .with_context(|| format!("DOIGET_OPENALEX_BASE is not a URL: {raw}"))?
+    };
+    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+
+    let harness = FetchHarness::from_env().context("building fetch harness")?;
+    harness
+        .log_session_start(Some(&doi_str))
+        .context("logging session start")?;
+    let ctx = harness.fetch_context();
+
+    let query = FrontierQuery {
+        seed_doi: seed_doi.clone(),
+        limit: limit.clamp(1, 200),
+        min_year: from_year,
+    };
+
+    let outcome = frontier_view(&query, &base, &contact_email, &ctx).await;
+    harness.log_session_end(outcome.is_ok(), Some(&doi_str));
+
+    let mut results = match outcome {
+        Ok(r) => r,
+        Err(e) => {
+            let code = ErrorCode::from(&e);
+            eprintln!("error[{}]: {e}", code.as_wire());
+            return Err(anyhow::Error::new(CliExit(cli_exit_code(code))));
+        }
+    };
+
+    // Filter out papers already in the local store.
+    if let Ok(store_root) = resolve_store_root() {
+        results.hits.retain(|hit| {
+            let Some(ref doi_s) = hit.doi else {
+                return true;
+            };
+            let Ok(d) = doiget_core::Doi::parse(doi_s) else {
+                return true;
+            };
+            let safekey = doiget_core::Ref::Doi(d).safekey();
+            !store_root
+                .join(format!("{}.pdf", safekey.as_str()))
+                .exists()
+        });
+    }
+
+    if mode == OutputMode::Quiet && quiet_was_explicit {
+        return Ok(());
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    if mode == OutputMode::Json {
+        let envelope = json_envelope(&doi_str, &results);
+        let s = serde_json::to_string(&envelope)
+            .context("serialise frontier results to JSON")?;
+        writeln!(out, "{s}").context("write frontier JSON to stdout")?;
+        return Ok(());
+    }
+
+    // Human table: fwci first (the age-normalized signal that matters most),
+    // then year / oa / doi / title.
+    writeln!(out, "fwci\tyear\toa\tdoi\ttitle")
+        .context("write frontier header")?;
+    for hit in &results.hits {
+        let fwci = hit
+            .fwci
+            .map(|f| format!("{f:.2}"))
+            .unwrap_or_else(|| "-".into());
+        let year = hit.year.map(|y| y.to_string()).unwrap_or_else(|| "-".into());
+        let oa = hit.oa_status.as_deref().unwrap_or("-");
+        let doi = hit.doi.as_deref().unwrap_or("-");
+        writeln!(out, "{fwci}\t{year}\t{oa}\t{doi}\t{}", hit.title)
+            .context("write frontier row")?;
+    }
+    Ok(())
+}
+
+fn json_envelope(seed_doi: &str, results: &FrontierResults) -> serde_json::Value {
+    serde_json::json!({
+        "seed_doi": seed_doi,
+        "seed_title": results.seed_title,
+        "seed_openalex_id": results.seed_openalex_id,
+        "total_citing": results.total_citing,
+        "count": results.hits.len(),
+        "results": results.hits,
+    })
+}

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -98,22 +98,23 @@ pub async fn run(
 
     if mode == OutputMode::Json {
         let envelope = json_envelope(&doi_str, &results);
-        let s = serde_json::to_string(&envelope)
-            .context("serialise frontier results to JSON")?;
+        let s = serde_json::to_string(&envelope).context("serialise frontier results to JSON")?;
         writeln!(out, "{s}").context("write frontier JSON to stdout")?;
         return Ok(());
     }
 
     // Human table: fwci first (the age-normalized signal that matters most),
     // then year / oa / doi / title.
-    writeln!(out, "fwci\tyear\toa\tdoi\ttitle")
-        .context("write frontier header")?;
+    writeln!(out, "fwci\tyear\toa\tdoi\ttitle").context("write frontier header")?;
     for hit in &results.hits {
         let fwci = hit
             .fwci
             .map(|f| format!("{f:.2}"))
             .unwrap_or_else(|| "-".into());
-        let year = hit.year.map(|y| y.to_string()).unwrap_or_else(|| "-".into());
+        let year = hit
+            .year
+            .map(|y| y.to_string())
+            .unwrap_or_else(|| "-".into());
         let oa = hit.oa_status.as_deref().unwrap_or("-");
         let doi = hit.doi.as_deref().unwrap_or("-");
         writeln!(out, "{fwci}\t{year}\t{oa}\t{doi}\t{}", hit.title)

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod cite;
 pub mod config;
 pub mod csl;
 pub mod fetch;
+pub mod frontier;
 pub mod info;
 pub mod link;
 pub mod lint;

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -319,6 +319,8 @@ mod tests {
             abstract_: Some("abs".to_string()),
             cited_by_count: 3,
             oa_status: Some("gold".to_string()),
+            fwci: Some(2.5),
+            cited_by_percentile_year_min: Some(85),
             source: DiscoverySource::OpenAlex,
         }
     }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -387,6 +387,19 @@ enum Command {
         #[arg(long)]
         no_cache: bool,
     },
+    /// Discover the frontier neighbourhood of a seed paper: surfaces papers
+    /// that **cite the seed**, ranked by age-normalized impact (fwci),
+    /// excluding papers already in the local store (#295).
+    Frontier {
+        /// Seed DOI (e.g. "10.1103/PhysRevB.1").
+        doi: String,
+        /// Maximum results to return (1–200; default 25).
+        #[arg(long, default_value_t = 25)]
+        limit: usize,
+        /// Only include works published on or after this year.
+        #[arg(long)]
+        from_year: Option<i32>,
+    },
     /// Fetch the raw LaTeX source of an arXiv paper directly from the arXiv
     /// source API (`export.arxiv.org/src/<id>`). More reliable than `text`
     /// (ar5iv HTML) for papers not yet processed by LaTeXML. PDF-only
@@ -744,6 +757,14 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             no_cache,
         }) => {
             doiget_cli::commands::text::run(ref_, max_chars, no_cache, mode, out.quiet_was_explicit)
+                .await
+        }
+        Some(Command::Frontier {
+            doi,
+            limit,
+            from_year,
+        }) => {
+            doiget_cli::commands::frontier::run(doi, limit, from_year, mode, out.quiet_was_explicit)
                 .await
         }
         Some(Command::TexSource {

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -257,7 +257,7 @@ pub enum DiscoverySource {
 /// (e.g. no DOI for a dataset, no abstract for an Elsevier-gated
 /// abstract). Absent fields serialize to JSON `null` (not skipped) so
 /// the wire shape is stable for agents.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct PaperHit {
     /// Bare DOI (lower-cased, `https://doi.org/` prefix stripped), or
     /// `None` when the record has no DOI.
@@ -287,13 +287,22 @@ pub struct PaperHit {
     /// OpenAlex open-access status (`gold` / `green` / `hybrid` /
     /// `bronze` / `closed`), or `None`.
     pub oa_status: Option<String>,
+    /// OpenAlex `fwci` (Field-Weighted Citation Impact). A value > 1.0
+    /// means above-average impact for the paper's field and year. `None`
+    /// when OpenAlex has not yet computed a value for the work.
+    pub fwci: Option<f64>,
+    /// OpenAlex `cited_by_percentile_year.min` — the paper's minimum
+    /// percentile rank among same-year works in the same field (0–100).
+    /// `None` when OpenAlex has not computed the percentile. A value of
+    /// 90 means "top 10% of same-year works in its field" (#295).
+    pub cited_by_percentile_year_min: Option<u8>,
     /// Discovery backend that produced this hit (PR1: always
     /// [`DiscoverySource::OpenAlex`]). Serializes to `"openalex"`.
     pub source: DiscoverySource,
 }
 
 /// The result of a discovery search: the hits plus the upstream total.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct PaperSearchResults {
     /// The candidate papers (length ≤ `query.limit`).
     pub results: Vec<PaperHit>,
@@ -771,6 +780,14 @@ fn work_to_hit(work: &serde_json::Value) -> PaperHit {
         .and_then(serde_json::Value::as_array)
         .and_then(|locs| locs.iter().find_map(extract_arxiv_from_location));
 
+    let fwci = work.get("fwci").and_then(serde_json::Value::as_f64);
+
+    let cited_by_percentile_year_min = work
+        .get("cited_by_percentile_year")
+        .and_then(|p| p.get("min"))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|v| u8::try_from(v).ok());
+
     PaperHit {
         doi,
         openalex_id,
@@ -782,6 +799,8 @@ fn work_to_hit(work: &serde_json::Value) -> PaperHit {
         abstract_,
         cited_by_count,
         oa_status,
+        fwci,
+        cited_by_percentile_year_min,
         source: DiscoverySource::OpenAlex,
     }
 }
@@ -1022,6 +1041,177 @@ fn work_to_links(work: &serde_json::Value) -> PaperLinks {
         openalex_id,
         title,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Frontier view (#295)
+// ---------------------------------------------------------------------------
+
+/// Parameters for `frontier_view`: the gap-spotting view that surfaces
+/// candidate papers structurally connected to a seed but not yet noticed.
+///
+/// Phase 1 (this PR): finds papers that **cite the seed** sorted by
+/// age-normalized impact (`fwci` desc). Phase 2 will add bibliographic-
+/// coupling candidates (papers sharing references with the seed).
+#[derive(Debug, Clone)]
+pub struct FrontierQuery {
+    /// The anchor paper whose citing neighbourhood forms the candidate set.
+    pub seed_doi: crate::Doi,
+    /// Maximum results returned (clamped to `1..=MAX_PER_PAGE`).
+    /// Defaults to [`DEFAULT_LIMIT`].
+    pub limit: usize,
+    /// When set, only include works published on or after this year.
+    pub min_year: Option<i32>,
+}
+
+impl FrontierQuery {
+    /// Construct a new query for the given seed DOI with default limits.
+    pub fn new(seed_doi: crate::Doi) -> Self {
+        Self {
+            seed_doi,
+            limit: DEFAULT_LIMIT,
+            min_year: None,
+        }
+    }
+}
+
+/// Results of a `frontier_view` query.
+#[derive(Debug, Clone, Serialize)]
+pub struct FrontierResults {
+    /// Ranked candidate papers (length ≤ `query.limit`).
+    ///
+    /// Sorted by `fwci` descending (nulls last), then by `year` descending,
+    /// then by `cited_by_count` descending for stable ordering.
+    pub hits: Vec<PaperHit>,
+    /// OpenAlex Work ID of the seed paper (`W…` prefix stripped).
+    pub seed_openalex_id: String,
+    /// Title of the seed paper, when available from OpenAlex.
+    pub seed_title: Option<String>,
+    /// Total number of citing works in OpenAlex (usually larger than
+    /// `hits.len()`). `None` if the API response omitted the count.
+    pub total_citing: Option<u64>,
+}
+
+/// Surface the frontier neighbourhood of `seed_doi`: papers that cite the
+/// seed, ranked by age-normalized impact, ready for the agent to triage.
+///
+/// ## Algorithm (Phase 1)
+///
+/// 1. Resolve the seed DOI to an OpenAlex Work ID via a direct DOI lookup
+///    (`/works/https://doi.org/<doi>`).
+/// 2. Query `/works?filter=cites:<seed_id>` to fetch citing papers.
+///    Unlike free-text search, `filter=cites:` constrains the result set to
+///    papers that actually build on the seed, so `sort=fwci:desc` is safe
+///    here (no off-topic papers; the topicality concern from #290 does not
+///    apply). Phase 2 will add bibliographic-coupling candidates.
+/// 3. Sort locally by `fwci` desc (nulls last) → `year` desc → `cited_by_count` desc.
+/// 4. Apply `min_year` filter if provided.
+///
+/// Returns `FrontierResults` containing the ranked hits. The caller is
+/// responsible for excluding papers already in the local store (the core
+/// function is store-agnostic).
+pub async fn frontier_view(
+    query: &FrontierQuery,
+    base: &Url,
+    contact_email: &str,
+    ctx: &FetchContext,
+) -> Result<FrontierResults, FetchError> {
+    let limit = query.limit.clamp(1, MAX_PER_PAGE);
+
+    // Step 1: resolve seed DOI to OpenAlex Work ID via filter=doi: (the
+    // query-param form handles the DOI's `/` and `:` without manual
+    // encoding — same pattern as `build_doi_lookup_url`).
+    let seed_url = {
+        let mut u = base.join("/works").map_err(|e| FetchError::SourceSchema {
+            hint: format!("frontier seed URL construction failed: {e}"),
+        })?;
+        {
+            let mut qp = u.query_pairs_mut();
+            qp.append_pair("filter", &format!("doi:{}", query.seed_doi.as_str()));
+            qp.append_pair("per-page", "1");
+            qp.append_pair("select", "id,title,display_name");
+            if !contact_email.is_empty() {
+                qp.append_pair("mailto", contact_email);
+            }
+        }
+        u
+    };
+    let (seed_resp, _) = openalex_get(&seed_url, ctx).await?;
+    let seed_results = seed_resp
+        .get("results")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| missing_results_array("frontier/seed", &seed_resp))?;
+    let seed_work = seed_results
+        .first()
+        .ok_or_else(|| FetchError::NotFound {
+            hint: format!("no OpenAlex work matched seed doi '{}'", query.seed_doi.as_str()),
+        })?;
+    let seed_openalex_id = seed_work
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .map(strip_openalex_prefix)
+        .ok_or_else(|| FetchError::SourceSchema {
+            hint: format!("seed OpenAlex record for '{}' has no id", query.seed_doi.as_str()),
+        })?
+        .to_string();
+    let seed_title = seed_work
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            seed_work
+                .get("display_name")
+                .and_then(serde_json::Value::as_str)
+        })
+        .map(str::to_string);
+
+    // Step 2: fetch citing papers with fwci sort.
+    let mut citing_url = base.clone();
+    citing_url.set_path("/works");
+    {
+        let mut pairs = citing_url.query_pairs_mut();
+        pairs.append_pair("filter", &format!("cites:{seed_openalex_id}"));
+        pairs.append_pair("select", SELECT_FIELDS);
+        pairs.append_pair("sort", "fwci:desc");
+        pairs.append_pair("per-page", &limit.to_string());
+        if !contact_email.is_empty() {
+            pairs.append_pair("mailto", contact_email);
+        }
+    }
+    let (citing_resp, _) = openalex_get(&citing_url, ctx).await?;
+    let total_citing = citing_resp
+        .get("meta")
+        .and_then(|m| m.get("count"))
+        .and_then(serde_json::Value::as_u64);
+    let results_arr = citing_resp
+        .get("results")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| missing_results_array("frontier/cites", &citing_resp))?;
+
+    // Step 3: parse, apply min_year filter, and sort.
+    let mut hits: Vec<PaperHit> = results_arr
+        .iter()
+        .map(work_to_hit)
+        .filter(|h| query.min_year.map_or(true, |y| h.year.map_or(false, |hy| hy >= y)))
+        .collect();
+
+    hits.sort_by(|a, b| {
+        let fwci_ord = match (a.fwci, b.fwci) {
+            (Some(fa), Some(fb)) => fb.partial_cmp(&fa).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        };
+        fwci_ord
+            .then_with(|| b.year.cmp(&a.year))
+            .then_with(|| b.cited_by_count.cmp(&a.cited_by_count))
+    });
+
+    Ok(FrontierResults {
+        hits,
+        seed_openalex_id,
+        seed_title,
+        total_citing,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -1141,17 +1141,21 @@ pub async fn frontier_view(
         .get("results")
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| missing_results_array("frontier/seed", &seed_resp))?;
-    let seed_work = seed_results
-        .first()
-        .ok_or_else(|| FetchError::NotFound {
-            hint: format!("no OpenAlex work matched seed doi '{}'", query.seed_doi.as_str()),
-        })?;
+    let seed_work = seed_results.first().ok_or_else(|| FetchError::NotFound {
+        hint: format!(
+            "no OpenAlex work matched seed doi '{}'",
+            query.seed_doi.as_str()
+        ),
+    })?;
     let seed_openalex_id = seed_work
         .get("id")
         .and_then(serde_json::Value::as_str)
         .map(strip_openalex_prefix)
         .ok_or_else(|| FetchError::SourceSchema {
-            hint: format!("seed OpenAlex record for '{}' has no id", query.seed_doi.as_str()),
+            hint: format!(
+                "seed OpenAlex record for '{}' has no id",
+                query.seed_doi.as_str()
+            ),
         })?
         .to_string();
     let seed_title = seed_work
@@ -1191,7 +1195,11 @@ pub async fn frontier_view(
     let mut hits: Vec<PaperHit> = results_arr
         .iter()
         .map(work_to_hit)
-        .filter(|h| query.min_year.map_or(true, |y| h.year.map_or(false, |hy| hy >= y)))
+        .filter(|h| {
+            query
+                .min_year
+                .map_or(true, |y| h.year.map_or(false, |hy| hy >= y))
+        })
         .collect();
 
     hits.sort_by(|a, b| {


### PR DESCRIPTION
## Summary

- Adds `doiget frontier <doi>` command that surfaces papers citing the seed DOI, ranked by age-normalized impact (`fwci` desc), with papers already in the local store filtered out (#295)
- Adds `fwci` and `cited_by_percentile_year_min` fields to `PaperHit` (already requested from OpenAlex; now parsed and surfaced in all `search` and `frontier` JSON output)
- Implements `frontier_view()`, `FrontierQuery`, and `FrontierResults` in `doiget_core::discovery`

**Algorithm (Phase 1):** resolve seed DOI → OpenAlex Work ID → query `filter=cites:<seed_id>&sort=fwci:desc` → sort by `fwci` → `year` → `cited_by_count` → filter out locally stored papers.

Phase 2 (future): bibliographic coupling candidates (papers sharing references with the seed).

Closes #295

## Test plan

- [x] All 30 `discovery` unit tests pass
- [x] `cargo check --workspace` and `cargo build --workspace` clean
- [ ] Manual: `doiget frontier 10.1103/PhysRevLett.116.061102` (LIGO GW detection) — should list citing papers ranked by fwci with `--mode json` output
- [ ] Manual: verify `--from-year 2023` filter reduces output
- [ ] Manual: after `doiget fetch <doi>` for a hit, re-running `doiget frontier` should exclude that paper