### PR TITLE
feat: tags / collections / annotation on stored entries (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,31 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ### Changed
 - **[core]** `PaperHit` and `PaperSearchResults` drop the `Eq` derive
   (retained `PartialEq`); `f64` fields preclude a total equality relation.
+- **[store / tags]** `DoigetExtension` gains three additive optional fields:
+  `tags: Vec<String>`, `collections: Vec<String>`, `annotation: Option<String>`
+  (#294). Stored in `[doiget].tags`, `[doiget].collections`, and
+  `[doiget].annotation`; omitted from the TOML when empty / absent (no schema
+  bump per `docs/STORE.md` §7 additive policy). Existing metadata is read
+  transparently by older builds (unknown fields are tolerated per §8).
+- **[cli / tag]** `doiget tag <ref> [<tag>...]` — add one or more tags to a
+  stored entry (idempotent). `--remove <tag>` removes. `--collection <col>`
+  joins a collection; `--remove-collection <col>` leaves. `--list` prints
+  current tags, collections, and annotation (#294).
+- **[cli / annotate]** `doiget annotate <ref> <text>` — attach a freeform
+  note to a stored entry; replaces any previous annotation. `--clear` removes
+  it (#294).
+- **[cli / search]** `doiget search --local --tag <t>` — filter local-store
+  results to entries tagged with `<t>` (case-sensitive). Empty query matches
+  all tagged entries (#294).
+- **[mcp / tag]** `doiget_tag` MCP tool — add / remove tags and collections
+  on a stored entry. Inputs: `ref`, `add[]`, `remove[]`, `collection_add[]`,
+  `collection_remove[]`. Output: `{ ok, ref, tags, collections }` (#294).
+- **[mcp / annotate]** `doiget_annotate` MCP tool — set or clear the
+  freeform annotation on a stored entry. Inputs: `ref`, `text`, `clear`
+  (bool). Output: `{ ok, ref, annotation }` (#294).
+- **[core]** `FsStore::search_by_tag(tag, query, limit)` — scan
+  `.metadata/*.toml` for entries whose `[doiget].tags` contains `tag`,
+  optionally also filtering by substring query (#294).
 
 ## [0.7.1-beta.0] - 2026-06-20
 

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub mod output;
 pub mod provenance;
 pub mod resolve_citation;
 pub mod search;
+pub mod tag;
 pub mod tex_source;
 pub mod text;
 pub mod verify;

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -110,38 +110,54 @@ fn print_err(args: std::fmt::Arguments<'_>) {
 ///
 /// `local` selects the store scan; otherwise external discovery runs
 /// (the default; `--external` is its explicit form and is already
-/// resolved away by clap's `conflicts_with`). `ext` carries the
-/// external-only flags and is ignored on the local path.
+/// resolved away by clap's `conflicts_with`). `tag` is a local-only
+/// filter; `ext` carries the external-only flags and is ignored on the
+/// local path.
 ///
 /// # Errors
 ///
 /// Propagates store-open / scan failures (local) or surfaces a typed
 /// [`ErrorCode`] as a process exit code (external); an empty query is a
-/// usage error.
+/// usage error unless `--local --tag` is given.
 pub async fn run(
     query: String,
     local: bool,
+    tag: Option<String>,
     ext: ExternalArgs,
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    if query.trim().is_empty() {
+    let tag_filter = tag.as_deref();
+    if query.trim().is_empty() && !(local && tag_filter.is_some()) {
         anyhow::bail!("search query is empty");
     }
     if local {
-        run_local(&query, mode, quiet_was_explicit)
+        run_local(&query, tag_filter, mode, quiet_was_explicit)
     } else {
         run_external(&query, ext, mode, quiet_was_explicit).await
     }
 }
 
-/// Local-store substring scan (legacy behaviour, now behind `--local`).
-fn run_local(query: &str, mode: OutputMode, quiet_was_explicit: bool) -> Result<()> {
+/// Local-store substring scan. When `tag_filter` is `Some(t)` the scan is
+/// delegated to `FsStore::search_by_tag` which matches on `[doiget].tags`
+/// first; an empty `query` matches all tagged entries in that case.
+fn run_local(
+    query: &str,
+    tag_filter: Option<&str>,
+    mode: OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
-    let entries = store
-        .search(query, LOCAL_DEFAULT_LIMIT)
-        .with_context(|| format!("search failed for query {query:?}"))?;
+    let entries = if let Some(tag) = tag_filter {
+        store
+            .search_by_tag(tag, query, LOCAL_DEFAULT_LIMIT)
+            .with_context(|| format!("tag search failed for tag {tag:?}"))?
+    } else {
+        store
+            .search(query, LOCAL_DEFAULT_LIMIT)
+            .with_context(|| format!("search failed for query {query:?}"))?
+    };
 
     // Artifact-class (ADR-0017 Amendment 2 / #301): suppress only on
     // explicit Quiet; the non-TTY implicit fallback still emits.
@@ -382,6 +398,7 @@ mod tests {
         let err = run(
             "q".into(),
             false,
+            None,
             ext(0, None, None),
             OutputMode::Quiet,
             true,
@@ -396,6 +413,7 @@ mod tests {
         let err = run(
             "q".into(),
             false,
+            None,
             ext(201, None, None),
             OutputMode::Quiet,
             true,
@@ -410,6 +428,7 @@ mod tests {
         let err = run(
             "q".into(),
             false,
+            None,
             ext(25, Some(2025), Some(2010)),
             OutputMode::Quiet,
             true,

--- a/crates/doiget-cli/src/commands/tag.rs
+++ b/crates/doiget-cli/src/commands/tag.rs
@@ -1,0 +1,177 @@
+//! `doiget tag <ref> [tags...]` and `doiget annotate <ref> <text>` subcommands.
+//!
+//! `doiget tag` adds / removes tags and collection membership on a stored
+//! entry by mutating the `[doiget].tags` and `[doiget].collections` arrays in
+//! the metadata TOML (issue #294). All mutations are idempotent.
+//!
+//! `doiget annotate` sets or clears the `[doiget].annotation` freeform string.
+//!
+//! Both commands require the entry to be in the store first (they only mutate
+//! the `[doiget]` table; they never fetch or download anything).
+
+use std::io::Write;
+
+use anyhow::{bail, Context, Result};
+
+use doiget_core::store::{FsStore, Store};
+use doiget_core::Ref;
+
+use super::output::OutputMode;
+use super::resolve_store_root;
+
+/// Run the `tag` subcommand: add/remove tags or collections on a stored entry.
+///
+/// `add` — tags to add (idempotent).
+/// `remove` — tags to remove.
+/// `collection_add` — collections to join (idempotent).
+/// `collection_remove` — collections to leave.
+/// `list` — print current tags / collections / annotation then exit.
+pub fn run(
+    ref_str: String,
+    add: Vec<String>,
+    remove: Vec<String>,
+    collection_add: Vec<String>,
+    collection_remove: Vec<String>,
+    list: bool,
+    mode: OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
+    let ref_ = Ref::parse(&ref_str).with_context(|| format!("invalid ref: {ref_str}"))?;
+    let safekey = ref_.safekey();
+
+    let store_root = resolve_store_root()?;
+    let store = FsStore::new(store_root)?;
+
+    let mut metadata = store
+        .read(&safekey)
+        .with_context(|| format!("failed to read store entry for {ref_str}"))?
+        .with_context(|| {
+            format!("no store entry for {ref_str}; run `doiget fetch {ref_str}` first")
+        })?;
+
+    {
+        let ext = metadata.doiget.as_mut().with_context(|| {
+            format!(
+                "entry {ref_str} has no [doiget] table; \
+                 run `doiget fetch {ref_str}` first"
+            )
+        })?;
+
+        if list {
+            if mode == OutputMode::Quiet && quiet_was_explicit {
+                return Ok(());
+            }
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            if mode == OutputMode::Json {
+                let v = serde_json::json!({
+                    "ref": ref_str,
+                    "tags": &ext.tags,
+                    "collections": &ext.collections,
+                    "annotation": &ext.annotation,
+                });
+                let s = serde_json::to_string_pretty(&v)
+                    .context("failed to serialize tag info to JSON")?;
+                writeln!(out, "{s}").context("failed to write tag info JSON to stdout")?;
+            } else {
+                let tags_str = if ext.tags.is_empty() {
+                    "-".to_string()
+                } else {
+                    ext.tags.join(", ")
+                };
+                let cols_str = if ext.collections.is_empty() {
+                    "-".to_string()
+                } else {
+                    ext.collections.join(", ")
+                };
+                let ann_str = ext.annotation.as_deref().unwrap_or("-");
+                writeln!(out, "tags:        {tags_str}").context("stdout write")?;
+                writeln!(out, "collections: {cols_str}").context("stdout write")?;
+                writeln!(out, "annotation:  {ann_str}").context("stdout write")?;
+            }
+            return Ok(());
+        }
+
+        if add.is_empty()
+            && remove.is_empty()
+            && collection_add.is_empty()
+            && collection_remove.is_empty()
+        {
+            bail!(
+                "no action specified; provide <tag>... to add, \
+                 or use --remove / --collection / --list"
+            );
+        }
+
+        for t in &add {
+            if !ext.tags.contains(t) {
+                ext.tags.push(t.clone());
+            }
+        }
+        for t in &remove {
+            ext.tags.retain(|x| x != t);
+        }
+        for c in &collection_add {
+            if !ext.collections.contains(c) {
+                ext.collections.push(c.clone());
+            }
+        }
+        for c in &collection_remove {
+            ext.collections.retain(|x| x != c);
+        }
+    }
+
+    store
+        .write(&safekey, &metadata, None)
+        .with_context(|| format!("failed to write updated metadata for {ref_str}"))?;
+
+    Ok(())
+}
+
+/// Run the `annotate` subcommand: set or clear the freeform annotation on a
+/// stored entry. Exactly one of `text` (Some) or `clear = true` must be given.
+pub fn run_annotate(ref_str: String, text: Option<String>, clear: bool) -> Result<()> {
+    if !clear && text.is_none() {
+        bail!("provide annotation <text> or --clear");
+    }
+
+    let ref_ = Ref::parse(&ref_str).with_context(|| format!("invalid ref: {ref_str}"))?;
+    let safekey = ref_.safekey();
+
+    let store_root = resolve_store_root()?;
+    let store = FsStore::new(store_root)?;
+
+    let mut metadata = store
+        .read(&safekey)
+        .with_context(|| format!("failed to read store entry for {ref_str}"))?
+        .with_context(|| {
+            format!("no store entry for {ref_str}; run `doiget fetch {ref_str}` first")
+        })?;
+
+    {
+        let ext = metadata.doiget.as_mut().with_context(|| {
+            format!(
+                "entry {ref_str} has no [doiget] table; \
+                 run `doiget fetch {ref_str}` first"
+            )
+        })?;
+
+        if clear {
+            ext.annotation = None;
+        } else if let Some(t) = text {
+            if t.is_empty() {
+                bail!(
+                    "annotation text must not be empty; \
+                     use --clear to remove the annotation"
+                );
+            }
+            ext.annotation = Some(t);
+        }
+    }
+
+    store
+        .write(&safekey, &metadata, None)
+        .with_context(|| format!("failed to write updated metadata for {ref_str}"))?;
+
+    Ok(())
+}

--- a/crates/doiget-cli/src/commands/tag.rs
+++ b/crates/doiget-cli/src/commands/tag.rs
@@ -26,6 +26,7 @@ use super::resolve_store_root;
 /// `collection_add` — collections to join (idempotent).
 /// `collection_remove` — collections to leave.
 /// `list` — print current tags / collections / annotation then exit.
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     ref_str: String,
     add: Vec<String>,

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -287,6 +287,7 @@ enum Command {
     /// (title / authors / venue) instead.
     Search {
         /// Query string (a topic for discovery, or a substring for `--local`).
+        /// May be empty when `--local --tag` is given (matches all tagged entries).
         query: String,
         /// Scan the local store instead of external discovery.
         #[arg(long, conflicts_with = "external")]
@@ -295,6 +296,10 @@ enum Command {
         /// exclusive with `--local`).
         #[arg(long, conflicts_with = "local")]
         external: bool,
+        /// Filter local-store results to entries tagged with this tag
+        /// (case-sensitive). Requires `--local`.
+        #[arg(long, requires = "local")]
+        tag: Option<String>,
         /// External: maximum results. Must be 1..=200 (OpenAlex's per-page
         /// cap); an out-of-range value is rejected, not clamped.
         #[arg(long, default_value_t = 25)]
@@ -474,6 +479,40 @@ enum Command {
         /// Promote warnings to errors so any finding fails the run.
         #[arg(long)]
         strict: bool,
+    },
+    /// Assign or remove tags and collections on a stored entry (#294).
+    ///
+    /// Positional `<tag>...` arguments add tags. Use `--remove` to remove.
+    /// Use `--collection` / `--remove-collection` for collection membership.
+    /// Use `--list` to show current tags, collections, and annotation.
+    Tag {
+        /// DOI or arXiv id.
+        ref_: String,
+        /// Tags to add (idempotent). Positional — may repeat.
+        #[arg(value_name = "TAG")]
+        tags: Vec<String>,
+        /// Tags to remove.
+        #[arg(long = "remove", value_name = "TAG")]
+        remove: Vec<String>,
+        /// Collections to join (idempotent).
+        #[arg(long = "collection", value_name = "COL")]
+        collection: Vec<String>,
+        /// Collections to leave.
+        #[arg(long = "remove-collection", value_name = "COL")]
+        remove_collection: Vec<String>,
+        /// Show current tags, collections, and annotation; no mutation.
+        #[arg(long)]
+        list: bool,
+    },
+    /// Set or clear the freeform annotation for a stored entry (#294).
+    Annotate {
+        /// DOI or arXiv id.
+        ref_: String,
+        /// Annotation text (replaces any previous annotation).
+        text: Option<String>,
+        /// Clear the annotation (remove it from the TOML).
+        #[arg(long)]
+        clear: bool,
     },
     /// Resolve a bibliographic citation string to ranked DOI candidates.
     #[command(name = "resolve-citation")]
@@ -698,6 +737,7 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             query,
             local,
             external: _,
+            tag,
             limit,
             from_year,
             to_year,
@@ -723,7 +763,8 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
                 publisher,
                 sort,
             };
-            doiget_cli::commands::search::run(query, local, ext, mode, out.quiet_was_explicit).await
+            doiget_cli::commands::search::run(query, local, tag, ext, mode, out.quiet_was_explicit)
+                .await
         }
         Some(Command::Version { check }) => doiget_cli::commands::version::run(check, mode).await,
         Some(Command::Verify {
@@ -732,6 +773,26 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             strict,
         }) => doiget_cli::commands::verify::run(path, format, strict, mode).await,
         Some(Command::Lint { path, strict }) => doiget_cli::commands::lint::run(path, strict, mode),
+        Some(Command::Tag {
+            ref_,
+            tags,
+            remove,
+            collection,
+            remove_collection,
+            list,
+        }) => doiget_cli::commands::tag::run(
+            ref_,
+            tags,
+            remove,
+            collection,
+            remove_collection,
+            list,
+            mode,
+            out.quiet_was_explicit,
+        ),
+        Some(Command::Annotate { ref_, text, clear }) => {
+            doiget_cli::commands::tag::run_annotate(ref_, text, clear)
+        }
         Some(Command::ResolveCitation { query, limit }) => {
             doiget_cli::commands::resolve_citation::run(query, limit, mode).await
         }

--- a/crates/doiget-cli/tests/bib_e2e.rs
+++ b/crates/doiget-cli/tests/bib_e2e.rs
@@ -74,6 +74,9 @@ fn fixture(type_: Option<&str>) -> Metadata {
             oa_status: None,
             size_bytes: 1234,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     }

--- a/crates/doiget-cli/tests/csl_e2e.rs
+++ b/crates/doiget-cli/tests/csl_e2e.rs
@@ -82,6 +82,9 @@ fn journal_article_fixture() -> (Safekey, Metadata) {
             oa_status: None,
             size_bytes: 1234,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };
@@ -126,6 +129,9 @@ fn comma_form_fixture() -> (Safekey, Metadata) {
             oa_status: None,
             size_bytes: 0,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -75,6 +75,9 @@ fn fixture(doi_suffix: &str, title: &str, year: i32, fetched_year: i32) -> (Safe
             oa_status: None,
             size_bytes: 1234,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -85,6 +85,9 @@ fn fixture(doi_suffix: &str, title: &str, authors: Vec<String>) -> (Safekey, Met
             oa_status: None,
             size_bytes: 1234,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };

--- a/crates/doiget-cli/tests/search_external_e2e.rs
+++ b/crates/doiget-cli/tests/search_external_e2e.rs
@@ -114,6 +114,7 @@ async fn external_search_runs_and_logs_openalex_fetch() {
     let res = run(
         "tropical tensor networks".to_string(),
         false, // local = false → external discovery
+        None,
         ext,
         OutputMode::Quiet,
         true,
@@ -189,6 +190,7 @@ async fn external_search_min_fwci_and_percentile_become_filter_clauses() {
     let res = run(
         "tropical tensor networks".to_string(),
         false,
+        None,
         ext,
         OutputMode::Quiet,
         true,

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -1198,7 +1198,7 @@ pub async fn frontier_view(
         .filter(|h| {
             query
                 .min_year
-                .map_or(true, |y| h.year.map_or(false, |hy| hy >= y))
+                .is_none_or(|y| h.year.is_some_and(|hy| hy >= y))
         })
         .collect();
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -367,6 +367,9 @@ fn build_metadata_only_metadata(ref_: &Ref, outcome: &MetadataOnlyOutcome) -> Me
             oa_status: outcome.oa_status.clone(),
             size_bytes: 0,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     }
@@ -1013,6 +1016,9 @@ async fn fetch_paper_arxiv(
             oa_status: Some("green".to_string()),
             size_bytes,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };
@@ -1303,6 +1309,9 @@ async fn fetch_paper_doi(
             oa_status: oa_status.clone(),
             size_bytes,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };

--- a/crates/doiget-core/src/store/fs_store.rs
+++ b/crates/doiget-core/src/store/fs_store.rs
@@ -144,7 +144,7 @@ impl FsStore {
             let has_tag = md
                 .doiget
                 .as_ref()
-                .map_or(false, |d| d.tags.iter().any(|t| t == tag));
+                .is_some_and(|d| d.tags.iter().any(|t| t == tag));
             if !has_tag {
                 continue;
             }

--- a/crates/doiget-core/src/store/fs_store.rs
+++ b/crates/doiget-core/src/store/fs_store.rs
@@ -123,6 +123,55 @@ impl FsStore {
         guard_safekey(key.as_str())?;
         Ok(self.root.join(format!("{}.pdf", key.as_str())))
     }
+
+    /// Return up to `limit` entries whose `[doiget].tags` list contains `tag`
+    /// (case-sensitive exact match). If `query` is non-empty, also apply a
+    /// case-insensitive substring filter over title / authors / venue /
+    /// publisher. An empty `query` matches all tagged entries.
+    pub fn search_by_tag(
+        &self,
+        tag: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<EntryInfo>, StoreError> {
+        let q = query.to_lowercase();
+        let mut hits = Vec::new();
+        for path in metadata_files(&self.metadata_dir)? {
+            let raw = std::fs::read_to_string(path.as_std_path())?;
+            let Ok(md) = toml::from_str::<Metadata>(&raw) else {
+                continue;
+            };
+            let has_tag = md
+                .doiget
+                .as_ref()
+                .map_or(false, |d| d.tags.iter().any(|t| t == tag));
+            if !has_tag {
+                continue;
+            }
+            if !q.is_empty() {
+                let haystacks = [
+                    md.title.to_lowercase(),
+                    md.authors.join(" ").to_lowercase(),
+                    md.venue.clone().unwrap_or_default().to_lowercase(),
+                    md.publisher.clone().unwrap_or_default().to_lowercase(),
+                ];
+                if !haystacks.iter().any(|h| h.contains(&q)) {
+                    continue;
+                }
+            }
+            let safekey = safekey_from_metadata_filename(&path);
+            hits.push(EntryInfo {
+                safekey,
+                title: md.title,
+                year: md.year,
+                fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+            });
+            if hits.len() >= limit {
+                break;
+            }
+        }
+        Ok(hits)
+    }
 }
 
 impl Store for FsStore {
@@ -805,6 +854,9 @@ mod tests {
                 oa_status: Some("gold".to_string()),
                 size_bytes: 1234567,
                 mcp_call_id: Some("01JCKZ7Q0000000000000000AB".to_string()),
+                tags: Vec::new(),
+                collections: Vec::new(),
+                annotation: None,
             }),
             other: BTreeMap::new(),
         }

--- a/crates/doiget-core/src/store/metadata.rs
+++ b/crates/doiget-core/src/store/metadata.rs
@@ -122,4 +122,17 @@ pub struct DoigetExtension {
     /// ULID of the originating MCP call, if the fetch came in via MCP.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mcp_call_id: Option<String>,
+    /// User-assigned tags for this paper (e.g. `["ml", "gw-physics"]`).
+    /// Additive optional field — does not bump `schema_version`
+    /// (`docs/STORE.md` §7 additive policy). Set via `doiget tag` (#294).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<String>,
+    /// Collection membership (e.g. `["project-A", "reading-list"]`).
+    /// Additive optional field. Set via `doiget tag --collection` (#294).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub collections: Vec<String>,
+    /// Freeform agent annotation note for this paper.
+    /// Additive optional field. Set via `doiget annotate` (#294).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub annotation: Option<String>,
 }

--- a/crates/doiget-core/src/store/render.rs
+++ b/crates/doiget-core/src/store/render.rs
@@ -355,6 +355,9 @@ mod tests {
                 oa_status: None,
                 size_bytes: 1234,
                 mcp_call_id: None,
+                tags: Vec::new(),
+                collections: Vec::new(),
+                annotation: None,
             }),
             other: BTreeMap::new(),
         }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2140,6 +2140,229 @@ impl Server {
             "results": results,
         })))
     }
+
+    /// `doiget_tag` — add / remove tags and collection membership on a stored
+    /// entry. Mutates `[doiget].tags` and `[doiget].collections` in the
+    /// metadata TOML (issue #294). All mutations are idempotent.
+    ///
+    /// The entry must already be in the store (fetched via `doiget_fetch_paper`
+    /// or equivalent). No network I/O is performed.
+    #[tool(
+        description = "WHEN TO USE: Add or remove tags / collections on a stored paper entry for local knowledge-base organisation (#294).\n\
+                       INPUTS: ref (DOI or arXiv id); add (array of tags to add, optional); remove (array of tags to remove, optional); collection_add (array of collections to join, optional); collection_remove (array of collections to leave, optional).\n\
+                       OUTPUTS: { ok: true, ref, tags, collections } OR { ok: false, error }.\n\
+                       COSTS: 0 network requests; one store read + write.\n\
+                       SIDE EFFECTS: Overwrites [doiget].tags / [doiget].collections in <store>/.metadata/<safekey>.toml.\n\
+                       LIMITS: Entry must already exist in the store. Tags are case-sensitive; idempotent add/remove."
+    )]
+    async fn doiget_tag(
+        &self,
+        Parameters(input): Parameters<TagInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InvalidRef,
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+        let safekey = ref_.safekey();
+
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    "could not resolve store root",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
+        let mut metadata = match store.read(&safekey) {
+            Ok(Some(m)) => m,
+            Ok(None) => {
+                return Ok(CallToolResult::structured(json!({
+                    "ok": false,
+                    "error": format!("no store entry for {}; fetch the paper first", input.ref_),
+                })));
+            }
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("store read failed: {e}"),
+                )));
+            }
+        };
+
+        let ext = match metadata.doiget.as_mut() {
+            Some(d) => d,
+            None => {
+                return Ok(CallToolResult::structured(json!({
+                    "ok": false,
+                    "error": format!("entry {} has no [doiget] table; fetch it first", input.ref_),
+                })));
+            }
+        };
+
+        for t in &input.add {
+            if !ext.tags.contains(t) {
+                ext.tags.push(t.clone());
+            }
+        }
+        for t in &input.remove {
+            ext.tags.retain(|x| x != t);
+        }
+        for c in &input.collection_add {
+            if !ext.collections.contains(c) {
+                ext.collections.push(c.clone());
+            }
+        }
+        for c in &input.collection_remove {
+            ext.collections.retain(|x| x != c);
+        }
+
+        let tags = ext.tags.clone();
+        let collections = ext.collections.clone();
+
+        match store.write(&safekey, &metadata, None) {
+            Ok(()) => Ok(CallToolResult::structured(json!({
+                "ok": true,
+                "ref": input.ref_,
+                "tags": tags,
+                "collections": collections,
+            }))),
+            Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                Some(&input.ref_),
+                ErrorCode::StoreError,
+                &format!("store write failed: {e}"),
+            ))),
+        }
+    }
+
+    /// `doiget_annotate` — set or clear the freeform annotation on a stored
+    /// paper entry. Mutates `[doiget].annotation` in the metadata TOML
+    /// (issue #294).
+    ///
+    /// The entry must already be in the store. No network I/O is performed.
+    #[tool(
+        description = "WHEN TO USE: Attach or clear a freeform annotation / note on a stored paper for local knowledge-base organisation (#294).\n\
+                       INPUTS: ref (DOI or arXiv id); text (string — the annotation; omit or set to null to clear); clear (bool, default false — explicitly clear the annotation).\n\
+                       OUTPUTS: { ok: true, ref, annotation } OR { ok: false, error }.\n\
+                       COSTS: 0 network requests; one store read + write.\n\
+                       SIDE EFFECTS: Overwrites [doiget].annotation in <store>/.metadata/<safekey>.toml.\n\
+                       LIMITS: Entry must already exist in the store. Setting text overrides any existing annotation."
+    )]
+    async fn doiget_annotate(
+        &self,
+        Parameters(input): Parameters<AnnotateInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let ref_ = match Ref::parse(&input.ref_) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InvalidRef,
+                    &format!("invalid ref: {e}"),
+                )));
+            }
+        };
+        let safekey = ref_.safekey();
+
+        let store_root = match resolve_store_root() {
+            Some(p) => p,
+            None => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::InternalError,
+                    "could not resolve store root",
+                )));
+            }
+        };
+        let store = match FsStore::new(store_root.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("opening store at {store_root}: {e}"),
+                )));
+            }
+        };
+
+        let mut metadata = match store.read(&safekey) {
+            Ok(Some(m)) => m,
+            Ok(None) => {
+                return Ok(CallToolResult::structured(json!({
+                    "ok": false,
+                    "error": format!("no store entry for {}; fetch the paper first", input.ref_),
+                })));
+            }
+            Err(e) => {
+                return Ok(CallToolResult::structured(read_path_error_envelope(
+                    Some(&input.ref_),
+                    ErrorCode::StoreError,
+                    &format!("store read failed: {e}"),
+                )));
+            }
+        };
+
+        let ext = match metadata.doiget.as_mut() {
+            Some(d) => d,
+            None => {
+                return Ok(CallToolResult::structured(json!({
+                    "ok": false,
+                    "error": format!("entry {} has no [doiget] table; fetch it first", input.ref_),
+                })));
+            }
+        };
+
+        if input.clear.unwrap_or(false) {
+            ext.annotation = None;
+        } else if let Some(ref text) = input.text {
+            if text.is_empty() {
+                return Ok(CallToolResult::structured(json!({
+                    "ok": false,
+                    "error": "annotation text must not be empty; set clear:true to remove it",
+                })));
+            }
+            ext.annotation = Some(text.clone());
+        } else {
+            return Ok(CallToolResult::structured(json!({
+                "ok": false,
+                "error": "provide 'text' to set an annotation, or 'clear: true' to remove it",
+            })));
+        }
+
+        let annotation = ext.annotation.clone();
+
+        match store.write(&safekey, &metadata, None) {
+            Ok(()) => Ok(CallToolResult::structured(json!({
+                "ok": true,
+                "ref": input.ref_,
+                "annotation": annotation,
+            }))),
+            Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
+                Some(&input.ref_),
+                ErrorCode::StoreError,
+                &format!("store write failed: {e}"),
+            ))),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2444,6 +2667,49 @@ pub struct BatchResolveCitationsInput {
 
 fn default_resolve_limit() -> u8 {
     5
+}
+
+/// JSON-schema-derived input for the `doiget_tag` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct TagInput {
+    /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
+    /// `INVALID_REF`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+    /// Tags to add (idempotent, case-sensitive).
+    #[serde(default)]
+    pub add: Vec<String>,
+    /// Tags to remove.
+    #[serde(default)]
+    pub remove: Vec<String>,
+    /// Collections to join (idempotent, case-sensitive).
+    #[serde(default)]
+    pub collection_add: Vec<String>,
+    /// Collections to leave.
+    #[serde(default)]
+    pub collection_remove: Vec<String>,
+}
+
+/// JSON-schema-derived input for the `doiget_annotate` MCP tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct AnnotateInput {
+    /// DOI or arXiv id. Validated via `Ref::parse`; failures surface as
+    /// `INVALID_REF`.
+    #[serde(rename = "ref")]
+    #[schemars(rename = "ref")]
+    pub ref_: String,
+    /// Annotation text. Replaces any existing annotation. Omit or set to
+    /// null together with `clear: true` to remove the annotation.
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Set to `true` to clear (remove) the annotation instead of setting it.
+    #[serde(default)]
+    pub clear: Option<bool>,
 }
 
 /// Hard cap on refs accepted by a single `doiget_bibtex_export` /

--- a/crates/doiget-mcp/tests/bibtex_csl_export_e2e.rs
+++ b/crates/doiget-mcp/tests/bibtex_csl_export_e2e.rs
@@ -90,6 +90,9 @@ fn seed_store() -> (tempfile::TempDir, camino::Utf8PathBuf) {
             oa_status: None,
             size_bytes: 1234,
             mcp_call_id: None,
+            tags: Vec::new(),
+            collections: Vec::new(),
+            annotation: None,
         }),
         other: BTreeMap::new(),
     };


### PR DESCRIPTION
## Summary

- **`DoigetExtension`** gains 3 additive fields: `tags: Vec<String>`, `collections: Vec<String>`, `annotation: Option<String>` — omitted from TOML when empty/absent, no schema bump (`STORE.md` §7 additive policy).
- **`doiget tag <ref> [<tag>...]`** — add tags (idempotent). `--remove` removes. `--collection` / `--remove-collection` for collection membership. `--list` shows current state.
- **`doiget annotate <ref> <text>`** — set freeform note; `--clear` removes it.
- **`doiget search --local --tag <t>`** — filter local results by tag (empty query = all tagged entries).
- **MCP** `doiget_tag` + `doiget_annotate` tools with structured `{ ok, ref, tags/annotation }` envelopes.
- **`FsStore::search_by_tag(tag, query, limit)`** — linear scan (same O(N) pattern as `FsStore::search`).

## Test plan

- [ ] `cargo test --workspace` passes (all existing tests updated for new struct fields)
- [ ] `doiget tag <doi> ml --list` shows tag; `doiget tag <doi> --remove ml` drops it
- [ ] `doiget annotate <doi> "key finding"` then `doiget info <doi>` shows annotation in `[doiget]` table
- [ ] `doiget search --local --tag ml` returns only tagged entries
- [ ] `doiget search --local --tag ml "tensor"` applies both tag and text filters
- [ ] MCP `doiget_tag` / `doiget_annotate` tool calls return `{ ok: true }` envelopes

Closes #294