### PR TITLE
feat(247): Nix Flakes + macOS Intel distribution channel

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -309,6 +309,11 @@ jobs:
             artifact: doiget-macos-aarch64
             ext: ""
             target: ""
+          # Intel macOS runner (last GitHub-hosted x86_64 macOS runner, ADR-0025).
+          - os: macos-13
+            artifact: doiget-macos-x86_64
+            ext: ""
+            target: ""
           - os: windows-latest
             artifact: doiget-windows-x86_64
             ext: ".exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.7.2-beta.1] - 2026-06-20
+
+### Added
+- **[distribution]** `flake.nix` — Nix Flakes integration (#247). Provides
+  `packages.doiget` (built with `rustPlatform.buildRustPackage`, `oa-only`
+  feature, Rust 1.86 toolchain), `apps.doiget` for `nix run`, and
+  `devShells.default` with `cargo-deny`, `cargo-nextest`, `cargo-llvm-cov`,
+  and `taplo`. Uses `rust-overlay` to pin the toolchain; `doCheck = false` in
+  the Nix sandbox (network tests skipped).
+- **[distribution]** macOS Intel (`doiget-macos-x86_64`) added to the release
+  CI matrix (#247). The `macos-13` GitHub Actions runner builds natively for
+  `x86_64-apple-darwin`; the signed binary and `.sha256` sidecar are uploaded
+  to every GitHub Release.
+- **[distribution]** `scripts/install.sh` now supports macOS Intel (#247).
+  `uname -m == x86_64` on Darwin downloads `doiget-macos-x86_64` instead of
+  erroring.
+
 ## [0.7.2-beta.0] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.2-beta.0"
+version = "0.7.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.2-beta.0"
+version       = "0.7.2-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1357,7 +1357,12 @@ async fn try_arxiv_preprint_fallback(
     oa_pdf_bytes: Option<Vec<u8>>,
     profile: &CapabilityProfile,
     ctx: &FetchContext,
-) -> (PdfLegStatus, Option<Vec<u8>>, Option<ArxivId>, Option<String>) {
+) -> (
+    PdfLegStatus,
+    Option<Vec<u8>>,
+    Option<ArxivId>,
+    Option<String>,
+) {
     let (arxiv_id_str, original_block) = match &pdf_leg {
         PdfLegStatus::Blocked {
             suggested_arxiv_id: Some(s),

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "doiget — open-access academic paper fetcher and stdio MCP server";
+
+  inputs = {
+    nixpkgs.url     = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url   = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs     = import nixpkgs { inherit system overlays; };
+
+        # Pin to the workspace MSRV declared in Cargo.toml.
+        rustToolchain = pkgs.rust-bin.stable."1.86.0".default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
+
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          perl          # ring crate's build script needs perl
+        ];
+
+        buildInputs = with pkgs; lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+
+        doiget = pkgs.rustPlatform.buildRustPackage {
+          pname   = "doiget";
+          # Keep in sync with [workspace.package] version in Cargo.toml.
+          version = "0.7.2-beta.1";
+
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # Build only the CLI binary with the public Tier-1 OA feature set.
+          cargoBuildFlags = [
+            "-p" "doiget-cli"
+            "--no-default-features"
+            "--features" "oa-only"
+          ];
+
+          inherit nativeBuildInputs buildInputs;
+
+          # Tests that hit the network are skipped in the Nix sandbox.
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = "Open-access academic paper fetcher and stdio MCP server";
+            homepage    = "https://github.com/sotashimozono/doiget";
+            license     = licenses.mit;
+            maintainers = [];
+            platforms   = platforms.unix ++ platforms.windows;
+            mainProgram = "doiget";
+          };
+        };
+      in
+      {
+        # `nix build` / `nix profile install`
+        packages.default = doiget;
+        packages.doiget  = doiget;
+
+        # `nix run . -- fetch <doi>`
+        apps.default = flake-utils.lib.mkApp { drv = doiget; };
+        apps.doiget  = flake-utils.lib.mkApp { drv = doiget; };
+
+        # `nix develop`
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs;
+          nativeBuildInputs = nativeBuildInputs ++ (with pkgs; [
+            cargo-deny
+            cargo-nextest
+            cargo-llvm-cov
+            taplo         # TOML formatter / linter used in CI
+          ]);
+          RUST_BACKTRACE = "1";
+        };
+      }
+    );
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,7 +37,7 @@ case "$os" in
   Darwin)
     case "$arch" in
       arm64 | aarch64) asset="doiget-macos-aarch64" ;;
-      x86_64) err "macos-x86_64 (Intel) is not published yet — use 'cargo binstall doiget' or 'cargo install doiget' (target tracked in #247)" ;;
+      x86_64) asset="doiget-macos-x86_64" ;;
       *) err "unsupported macOS architecture: $arch" ;;
     esac
     ;;


### PR DESCRIPTION
## Summary

- Add `flake.nix` — Nix Flakes integration: `packages.doiget`, `apps.doiget` (`nix run`), and `devShells.default` (cargo-deny, nextest, llvm-cov, taplo), Rust 1.86 via rust-overlay, `oa-only` feature flag
- Add `macos-13` runner to the `sign` CI matrix for a native `x86_64-apple-darwin` build published as `doiget-macos-x86_64`
- Enable macOS Intel in `scripts/install.sh` (previously a stub error directing users to `cargo install`)
- Bump version `0.7.2-beta.0` → `0.7.2-beta.1`

Closes #247

## Test plan

- [ ] `nix flake check` (syntax/schema validation)
- [ ] `nix build .` on a Nix-capable machine builds `doiget` binary
- [ ] `nix develop` drops into a shell with cargo, taplo, cargo-nextest etc.
- [ ] Release CI on next tag: confirm `doiget-macos-x86_64` asset appears in the GitHub Release
- [ ] `curl -fsSL .../install.sh | sh` on macOS Intel downloads `doiget-macos-x86_64`