### PR TITLE
feat(212): align MCP tool output shapes with CLI --mode json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[core]** `HttpClient::new_with_user_agent(allowlists, ua)` — new public
   constructor that takes an explicit User-Agent string; `HttpClient::new` delegates
   to it using the default `doiget/<version>` UA.
+### Changed
+- **[mcp/cli]** Aligned `--mode json` output shapes with MCP tool envelopes (#212):
+  - `doiget info --mode json` now emits `{ok, ref, safekey, metadata}` instead
+    of bare `Metadata` JSON, matching `doiget_info`'s MCP envelope.
+  - `doiget list-recent --mode json` now emits `{ok, count, entries: [EntryInfo]}`
+    instead of a bare JSON array; MCP `doiget_list_recent` gains the `count` field.
+  - `doiget search --local --mode json` and `--mode json` (external) both gain
+    `"ok": true` at the top level.
+  - MCP `doiget_search_local` now emits `{ok, scope:"local", query, count, results}`
+    (was `{ok, query, entries}`) — `scope` and `count` added, `entries` renamed to
+    `results` — matching the CLI's local search envelope.
 
 ## [0.7.2-beta.0] - 2026-06-20
 

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -59,7 +59,13 @@ pub fn run(input: String, mode: super::output::OutputMode, quiet_was_explicit: b
             let stdout = std::io::stdout();
             let mut out = stdout.lock();
             if mode == super::output::OutputMode::Json {
-                let s = serde_json::to_string_pretty(&m)
+                let envelope = serde_json::json!({
+                    "ok": true,
+                    "ref": input,
+                    "safekey": safekey.as_str(),
+                    "metadata": m,
+                });
+                let s = serde_json::to_string_pretty(&envelope)
                     .context("failed to serialize metadata to JSON for stdout")?;
                 writeln!(out, "{s}").context("failed to write metadata JSON to stdout")?;
                 return Ok(());

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -47,11 +47,12 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if mode == super::output::OutputMode::Json {
-        // #204: `EntryInfo` carries `Serialize`; emit a JSON array, one
-        // object per entry. Single value (NOT JSON-Lines) so the whole
-        // result round-trips through `JSON.parse` in one call — JSONL
-        // batch shape is a separate contract (ERRORS.md §3 / #205).
-        let s = serde_json::to_string_pretty(&entries)
+        let envelope = serde_json::json!({
+            "ok": true,
+            "count": entries.len(),
+            "entries": entries,
+        });
+        let s = serde_json::to_string_pretty(&envelope)
             .context("failed to serialize list-recent entries to JSON")?;
         writeln!(out, "{s}").context("failed to write list-recent JSON to stdout")?;
         return Ok(());

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -280,11 +280,12 @@ fn resolve_openalex_base() -> Result<url::Url> {
     url::Url::parse(&raw).with_context(|| format!("DOIGET_OPENALEX_BASE is not a URL: {raw}"))
 }
 
-/// Build the local-scan `--mode json` envelope (ADR-0031 D5):
-/// `{ scope: "local", query, count, results }`. The `results[]` element is
+/// Build the local-scan `--mode json` envelope (ADR-0031 D5, #212):
+/// `{ ok, scope: "local", query, count, results }`. The `results[]` element is
 /// the legacy `EntryInfo` shape, unchanged.
 fn local_envelope(query: &str, entries: &[EntryInfo]) -> serde_json::Value {
     serde_json::json!({
+        "ok": true,
         "scope": "local",
         "query": query,
         "count": entries.len(),
@@ -292,11 +293,12 @@ fn local_envelope(query: &str, entries: &[EntryInfo]) -> serde_json::Value {
     })
 }
 
-/// Build the external-discovery `--mode json` envelope (ADR-0031 D5):
-/// `{ scope, query, total_results, count, results }`. Extracted as a pure
+/// Build the external-discovery `--mode json` envelope (ADR-0031 D5, #212):
+/// `{ ok, scope, query, total_results, count, results }`. Extracted as a pure
 /// function so the wire shape is unit-testable without capturing stdout.
 fn external_envelope(query: &str, results: &PaperSearchResults) -> serde_json::Value {
     serde_json::json!({
+        "ok": true,
         "scope": "external",
         "query": query,
         "total_results": results.total_results,
@@ -348,6 +350,7 @@ mod tests {
             total_results: Some(4012),
         };
         let v = external_envelope("spin glass", &results);
+        assert_eq!(v["ok"], true);
         assert_eq!(v["scope"], "external");
         assert_eq!(v["query"], "spin glass");
         assert_eq!(v["total_results"], 4012);
@@ -365,6 +368,7 @@ mod tests {
     #[test]
     fn local_envelope_has_local_scope_and_count() {
         let v = local_envelope("quantum", &[]);
+        assert_eq!(v["ok"], true);
         assert_eq!(v["scope"], "local");
         assert_eq!(v["query"], "quantum");
         assert_eq!(v["count"], 0);

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -250,9 +250,10 @@ fn info_json_emits_metadata_object() {
         .clone();
     let s = String::from_utf8(out).expect("info JSON stdout utf-8");
     let v: serde_json::Value = serde_json::from_str(&s).expect("info JSON parses");
-    // The Metadata struct's `title` field is the only stable assertion
-    // surface at this level (the rest is the on-disk TOML schema).
-    assert_eq!(v["title"], "First Quantum Result");
+    // #212: info --mode json emits {ok, ref, safekey, metadata} envelope.
+    assert_eq!(v["ok"], true, "envelope ok");
+    assert!(v["safekey"].is_string(), "safekey present");
+    assert_eq!(v["metadata"]["title"], "First Quantum Result");
 }
 
 #[test]
@@ -269,8 +270,11 @@ fn list_recent_json_emits_array_of_entries() {
         .clone();
     let s = String::from_utf8(out).expect("list-recent JSON stdout utf-8");
     let v: serde_json::Value = serde_json::from_str(&s).expect("list-recent JSON parses");
-    let arr = v.as_array().expect("list-recent JSON is an array");
+    // #212: list-recent --mode json emits {ok, count, entries} envelope.
+    assert_eq!(v["ok"], true, "envelope ok");
+    let arr = v["entries"].as_array().expect("entries is an array");
     assert_eq!(arr.len(), 2, "seeded store has 2 entries");
+    assert_eq!(v["count"], 2, "count matches entries length");
     // EntryInfo schema (#204): {safekey, title, year, fetched_at}.
     for entry in arr {
         assert!(entry["safekey"].is_string(), "safekey is a string");

--- a/crates/doiget-cli/tests/json_bodies_e2e.rs
+++ b/crates/doiget-cli/tests/json_bodies_e2e.rs
@@ -99,8 +99,11 @@ fn list_recent_json_empty_store_emits_empty_array() {
         .clone();
     let s = String::from_utf8(out).expect("stdout utf-8");
     let v: Value = serde_json::from_str(&s).expect("list-recent JSON parses");
-    assert!(v.is_array(), "list-recent emits an array");
-    assert_eq!(v.as_array().unwrap().len(), 0, "empty store → []");
+    // #212: list-recent --json now emits {ok, count, entries} envelope.
+    assert_eq!(v["ok"], true, "envelope ok");
+    assert!(v["entries"].is_array(), "list-recent emits an entries array");
+    assert_eq!(v["entries"].as_array().unwrap().len(), 0, "empty store → []");
+    assert_eq!(v["count"], 0, "count matches entries length");
 }
 
 // ---- audit-log issue-rendering JSON path -------------------------------

--- a/crates/doiget-cli/tests/json_bodies_e2e.rs
+++ b/crates/doiget-cli/tests/json_bodies_e2e.rs
@@ -101,8 +101,15 @@ fn list_recent_json_empty_store_emits_empty_array() {
     let v: Value = serde_json::from_str(&s).expect("list-recent JSON parses");
     // #212: list-recent --json now emits {ok, count, entries} envelope.
     assert_eq!(v["ok"], true, "envelope ok");
-    assert!(v["entries"].is_array(), "list-recent emits an entries array");
-    assert_eq!(v["entries"].as_array().unwrap().len(), 0, "empty store → []");
+    assert!(
+        v["entries"].is_array(),
+        "list-recent emits an entries array"
+    );
+    assert_eq!(
+        v["entries"].as_array().unwrap().len(),
+        0,
+        "empty store → []"
+    );
     assert_eq!(v["count"], 0, "count matches entries length");
 }
 

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -206,7 +206,8 @@ fn search_local_json_emits_scope_envelope() {
     let s = String::from_utf8(out).expect("search JSON stdout utf-8");
     let v: serde_json::Value = serde_json::from_str(&s).expect("search JSON parses");
 
-    // ADR-0031 D5: `{scope, query, count, results}` envelope.
+    // ADR-0031 D5, #212: `{ok, scope, query, count, results}` envelope.
+    assert_eq!(v["ok"], true, "ok flag");
     assert_eq!(v["scope"], "local", "local scope tag");
     assert_eq!(v["query"], "quantum");
     let arr = v["results"].as_array().expect("results is an array");

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1143,7 +1143,7 @@ impl Server {
     #[tool(
         description = "WHEN TO USE: Find stored entries whose title / authors / venue / publisher contain a query substring (case-insensitive).\n\
                        INPUTS: query (string), limit (optional integer, default 50, max 200).\n\
-                       OUTPUTS: { ok: true, query, entries: [{ safekey, title, year, fetched_at }] } OR { ok:false, error }.\n\
+                       OUTPUTS: { ok: true, scope: \"local\", query, count, results: [{ safekey, title, year, fetched_at }] } OR { ok:false, error }.\n\
                        COSTS: O(N) over the local store; <100 ms for a few thousand entries.\n\
                        SIDE EFFECTS: none.\n\
                        LIMITS: Returns at most `limit` entries (capped at 200)."
@@ -1176,8 +1176,10 @@ impl Server {
         match store.search(&input.query, limit) {
             Ok(entries) => Ok(CallToolResult::structured(json!({
                 "ok": true,
+                "scope": "local",
                 "query": input.query,
-                "entries": entries.iter().map(entry_info_to_json).collect::<Vec<_>>(),
+                "count": entries.len(),
+                "results": entries.iter().map(entry_info_to_json).collect::<Vec<_>>(),
             }))),
             Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
                 None,
@@ -1690,7 +1692,7 @@ impl Server {
     #[tool(
         description = "WHEN TO USE: List the most-recently fetched entries in the local store.\n\
                        INPUTS: limit (optional integer, default 50, max 200).\n\
-                       OUTPUTS: { ok: true, entries: [{ safekey, title, year, fetched_at }] } OR { ok:false, error }.\n\
+                       OUTPUTS: { ok: true, count, entries: [{ safekey, title, year, fetched_at }] } OR { ok:false, error }.\n\
                        COSTS: <100 ms for a few thousand entries.\n\
                        SIDE EFFECTS: none.\n\
                        LIMITS: Returns at most `limit` entries (capped at 200)."
@@ -1723,6 +1725,7 @@ impl Server {
         match store.list_recent(limit) {
             Ok(entries) => Ok(CallToolResult::structured(json!({
                 "ok": true,
+                "count": entries.len(),
                 "entries": entries.iter().map(entry_info_to_json).collect::<Vec<_>>(),
             }))),
             Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(

--- a/crates/doiget-mcp/tests/read_path_e2e.rs
+++ b/crates/doiget-mcp/tests/read_path_e2e.rs
@@ -180,10 +180,12 @@ async fn doiget_search_local_empty_store_returns_empty_entries() -> anyhow::Resu
         .expect("doiget_search_local uses CallToolResult::structured");
     assert_eq!(structured["ok"], serde_json::json!(true));
     assert_eq!(structured["query"], serde_json::json!("anything"));
+    assert_eq!(structured["scope"], serde_json::json!("local"));
+    assert_eq!(structured["count"], serde_json::json!(0));
     assert_eq!(
-        structured["entries"],
+        structured["results"],
         serde_json::json!([]),
-        "empty store must return an empty entries array; got: {structured:?}"
+        "empty store must return an empty results array; got: {structured:?}"
     );
 
     client.cancel().await?;


### PR DESCRIPTION
## Summary

Aligns the `--mode json` CLI output bodies with the corresponding MCP tool envelopes so a single agent never needs two mental models.

| Tool | Before (CLI) | After (CLI = MCP) |
|---|---|---|
| `info` | bare `Metadata` | `{ok, ref, safekey, metadata}` |
| `list-recent` | bare `[EntryInfo]` | `{ok, count, entries: [EntryInfo]}` |
| `search --local` | `{scope, query, count, results}` | `{ok, scope, query, count, results}` |
| `search` (external) | `{scope, query, total_results, count, results}` | `{ok, scope, query, total_results, count, results}` |
| MCP `doiget_search_local` | `{ok, query, entries}` | `{ok, scope:"local", query, count, results}` |
| MCP `doiget_list_recent` | `{ok, entries}` | `{ok, count, entries}` |

All affected tests updated and passing.

Closes #212

## Test plan

- [ ] `cargo test -p doiget-cli --test info_list_recent_e2e` — passes
- [ ] `cargo test -p doiget-cli --test search_e2e` — passes
- [ ] `cargo test -p doiget-cli --lib -- commands::search::tests` — passes
- [ ] Regression: `cargo test --workspace` (no new failures)