### PR TITLE
feat(326): batch --delay and --user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[distribution]** `scripts/install.sh` now supports macOS Intel (#247).
   `uname -m == x86_64` on Darwin downloads `doiget-macos-x86_64` instead of
   erroring.
+- **[batch]** `--delay <SECS>` (#326): sleep between individual fetches to avoid
+  tripping per-host rate limits below the HTTP 429 threshold (APS, Springer, etc.).
+  No delay before the first fetch; `<SECS>` is a float (e.g. `--delay 1.5`).
+- **[batch]** `--user-agent <STRING>` (#326): override the default
+  `doiget/<version>` User-Agent for every HTTP request in the batch. Useful when
+  a publisher's WAF classifies the default string as a bot.
+- **[core]** `HttpClient::new_with_user_agent(allowlists, ua)` — new public
+  constructor that takes an explicit User-Agent string; `HttpClient::new` delegates
+  to it using the default `doiget/<version>` UA.
 
 ## [0.7.2-beta.0] - 2026-06-20
 

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -76,6 +76,8 @@ pub async fn run_with_options(
     path: String,
     dry_run: bool,
     only_failed: bool,
+    delay: Option<f64>,
+    user_agent: Option<String>,
     mode: super::output::OutputMode,
 ) -> Result<()> {
     // `mode` honors ADR-0017. `Quiet` is a no-op here because batch's
@@ -207,7 +209,7 @@ pub async fn run_with_options(
     // Step 4: build the harness once. All spawned tasks share an `Arc` to
     // it; the harness already wraps the foundation modules in `Arc<...>` so
     // this introduces no extra cloning overhead per task.
-    let harness = Arc::new(FetchHarness::from_env()?);
+    let harness = Arc::new(FetchHarness::from_env_with_ua(user_agent.as_deref())?);
 
     // Step 5: SessionStart. Pass `None` for the ref — there is no single
     // ref to attribute the session to.
@@ -239,6 +241,8 @@ pub async fn run_with_options(
     // store (only populated when `--only-failed` is active).
     let mut skipped: usize = 0;
     let mut remaining = inputs.into_iter();
+    // Skip delay before the very first fetch; apply between all subsequent ones.
+    let mut is_first_spawn = true;
     loop {
         let window: Vec<String> = remaining.by_ref().take(MCP_BATCH_MAX_SIZE).collect();
         if window.is_empty() {
@@ -313,6 +317,15 @@ pub async fn run_with_options(
 
             let harness_task = Arc::clone(&harness);
             let sem_task = Arc::clone(&semaphore);
+            if let Some(d) = delay {
+                if is_first_spawn {
+                    is_first_spawn = false;
+                } else {
+                    tokio::time::sleep(tokio::time::Duration::from_secs_f64(d)).await;
+                }
+            } else {
+                is_first_spawn = false;
+            }
             joins.spawn(async move {
                 // `Semaphore::acquire_owned` only errors when the semaphore
                 // is closed; we never close it. The fallback maps that

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -184,7 +184,7 @@ pub(crate) fn cache_dir_utf8() -> Result<Utf8PathBuf> {
 pub(crate) fn build_resolve_context() -> Result<FetchContext> {
     let session_id = new_session_id();
     let log_path = resolve_log_path()?;
-    let http = Arc::new(build_http_client()?);
+    let http = Arc::new(build_http_client(None)?);
     let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
     let log = Arc::new(
         ProvenanceLog::open(log_path, session_id.clone())
@@ -217,7 +217,7 @@ pub(crate) fn build_resolve_context() -> Result<FetchContext> {
 /// when `DOIGET_OA_PUBLISHER_BASE` is set — this lets the integration tests
 /// under `tests/fetch_doi_oa_pdf_e2e.rs` exercise the full PDF leg without
 /// touching the real network.
-pub(crate) fn build_http_client() -> Result<HttpClient> {
+pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> {
     let arxiv = std::env::var("DOIGET_ARXIV_BASE").ok();
     let crossref = std::env::var("DOIGET_CROSSREF_BASE").ok();
     let unpaywall = std::env::var("DOIGET_UNPAYWALL_BASE").ok();
@@ -310,7 +310,11 @@ pub(crate) fn build_http_client() -> Result<HttpClient> {
             }
         }
 
-        return HttpClient::new(allowlists).context("building HTTP client");
+        return match user_agent {
+            Some(ua) => HttpClient::new_with_user_agent(allowlists, ua),
+            None => HttpClient::new(allowlists),
+        }
+        .context("building HTTP client");
     }
 
     // Test-base mode: build a relaxed client per overridden source.
@@ -412,6 +416,12 @@ impl FetchHarness {
     /// the provenance log (allocating a fresh `session_id`), and constructs
     /// the HTTP client honoring `DOIGET_*_BASE` overrides for tests.
     pub(crate) fn from_env() -> Result<Self> {
+        Self::from_env_with_ua(None)
+    }
+
+    /// Like [`from_env`](Self::from_env) but overrides the `User-Agent` on
+    /// every HTTP request. Used by `doiget batch --user-agent`.
+    pub(crate) fn from_env_with_ua(user_agent: Option<&str>) -> Result<Self> {
         let cfg = OrchestratorConfig::from_env()?;
         if let Some(parent) = cfg.log_path.parent() {
             if !parent.as_str().is_empty() {
@@ -424,7 +434,7 @@ impl FetchHarness {
             ProvenanceLog::open(cfg.log_path.clone(), session_id.clone())
                 .context("opening provenance log")?,
         );
-        let http = Arc::new(build_http_client()?);
+        let http = Arc::new(build_http_client(user_agent)?);
         let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
         let store = FsStore::new(cfg.store_root.clone()).context("opening store")?;
         let profile = CapabilityProfile::from_env().context("resolving capability profile")?;
@@ -1038,7 +1048,7 @@ host = "*.uj.edu.pl"
         std::env::remove_var("DOIGET_OA_PUBLISHER_BASE");
         std::env::remove_var("DOIGET_OPENALEX_BASE");
 
-        let client = build_http_client().expect("HttpClient builds");
+        let client = build_http_client(None).expect("HttpClient builds");
         let oa = client
             .source_allowlist("oa-publisher")
             .expect("oa-publisher source registered");
@@ -1120,7 +1130,7 @@ host = "*.uj.edu.pl"
         std::env::remove_var("DOIGET_OA_PUBLISHER_BASE");
         std::env::remove_var("DOIGET_OPENALEX_BASE");
 
-        let client = build_http_client().expect("HttpClient builds");
+        let client = build_http_client(None).expect("HttpClient builds");
         let oa = client
             .source_allowlist("openalex")
             .expect("openalex source registered for discovery (ADR-0031 D2)");

--- a/crates/doiget-cli/src/commands/resolve_citation.rs
+++ b/crates/doiget-cli/src/commands/resolve_citation.rs
@@ -15,7 +15,7 @@ fn build_context() -> Result<FetchContext> {
     let session_id = crate::commands::fetch::new_session_id();
     let log_path = crate::commands::fetch::resolve_log_path()?;
 
-    let http = Arc::new(crate::commands::fetch::build_http_client()?);
+    let http = Arc::new(crate::commands::fetch::build_http_client(None)?);
     let rate_limiter = Arc::new(doiget_core::rate_limiter::RateLimiter::new(
         RateLimits::HARD_CODED,
     ));

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -261,6 +261,14 @@ enum Command {
         /// already-fetched refs (issue #324).
         #[arg(long)]
         only_failed: bool,
+        /// Seconds to sleep between individual fetches. Useful for hosts
+        /// that throttle below the HTTP 429 threshold (issue #326).
+        #[arg(long, value_name = "SECS")]
+        delay: Option<f64>,
+        /// Override the User-Agent header for every HTTP request in this
+        /// batch. Default: `doiget/<version> (+https://github.com/sotashimozono/doiget)`.
+        #[arg(long, value_name = "STRING")]
+        user_agent: Option<String>,
     },
     /// Show metadata for a stored entry.
     Info {
@@ -724,7 +732,19 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             path,
             dry_run,
             only_failed,
-        }) => doiget_cli::commands::batch::run_with_options(path, dry_run, only_failed, mode).await,
+            delay,
+            user_agent,
+        }) => {
+            doiget_cli::commands::batch::run_with_options(
+                path,
+                dry_run,
+                only_failed,
+                delay,
+                user_agent,
+                mode,
+            )
+            .await
+        }
         Some(Command::Bib {
             ref_,
             all,

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -127,9 +127,16 @@ async fn batch_three_arxiv_refs_succeeds_end_to_end() {
     )
     .expect("write refs file");
 
-    batch::run_with_options(refs_path.as_str().to_string(), false, false, OutputMode::Human)
-        .await
-        .expect("batch::run_with_options succeeds");
+    batch::run_with_options(
+        refs_path.as_str().to_string(),
+        false,
+        false,
+        None,
+        None,
+        OutputMode::Human,
+    )
+    .await
+    .expect("batch::run_with_options succeeds");
 
     // Step 4: assert all three PDFs landed in the store under the expected
     // safekey-derived names.
@@ -239,8 +246,15 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
     )
     .expect("write refs file");
 
-    let result =
-        batch::run_with_options(refs_path.as_str().to_string(), false, false, OutputMode::Human).await;
+    let result = batch::run_with_options(
+        refs_path.as_str().to_string(),
+        false,
+        false,
+        None,
+        None,
+        OutputMode::Human,
+    )
+    .await;
     let err = result.expect_err("batch with a malformed ref must surface an error to the binary");
     // Issue #143 / `docs/ERRORS.md` §4: the batch exit code is the number
     // of failures (capped at 255), NOT a blanket 1. Exactly one entry
@@ -335,9 +349,16 @@ async fn batch_above_window_size_fetches_every_ref() {
     let refs_path = store_root.parent().unwrap().join("refs.txt");
     std::fs::write(refs_path.as_std_path(), refs_body).expect("write refs file");
 
-    batch::run_with_options(refs_path.as_str().to_string(), false, false, OutputMode::Human)
-        .await
-        .expect("a batch above the window size must succeed, fetching every ref");
+    batch::run_with_options(
+        refs_path.as_str().to_string(),
+        false,
+        false,
+        None,
+        None,
+        OutputMode::Human,
+    )
+    .await
+    .expect("a batch above the window size must succeed, fetching every ref");
 
     // Every ref's PDF landed — nothing was dropped by an over-limit abort.
     for id in &ids {

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -683,16 +683,27 @@ impl HttpClient {
     /// Returns the underlying `reqwest::Error` if `ClientBuilder::build`
     /// fails (typically a TLS-backend init failure).
     pub fn new(allowlists: Vec<SourceAllowlist>) -> Result<Self, reqwest::Error> {
+        let ua = format!(
+            "doiget/{} (+https://github.com/sotashimozono/doiget)",
+            VERSION
+        );
+        Self::new_with_user_agent(allowlists, &ua)
+    }
+
+    /// Build a client with a custom `User-Agent` header.
+    ///
+    /// Used by `doiget batch --user-agent` to override the default UA for
+    /// hosts that classify the default string as a bot.
+    pub fn new_with_user_agent(
+        allowlists: Vec<SourceAllowlist>,
+        user_agent: &str,
+    ) -> Result<Self, reqwest::Error> {
         let mut clients = HashMap::with_capacity(allowlists.len());
         let mut allowlist_map = HashMap::with_capacity(allowlists.len());
         for entry in allowlists {
             let source = entry.source.clone();
-            // Keep the *same* allowlist value both inside the redirect
-            // closure (via `build_client`) and queryable on the client
-            // (issue #145 pre-fetch check). `build_client` takes the
-            // allowlist by value, so clone once for the side table first.
             allowlist_map.insert(source.clone(), entry.clone());
-            let client = build_client(entry)?;
+            let client = build_client(entry, user_agent)?;
             clients.insert(source, client);
         }
         Ok(Self {
@@ -1203,13 +1214,10 @@ fn is_ipv6_loopback(ip: std::net::Ipv6Addr) -> bool {
     matches!(ip.to_ipv4_mapped(), Some(v4) if v4.is_loopback())
 }
 
-fn build_client(allowlist: SourceAllowlist) -> Result<Client, reqwest::Error> {
+fn build_client(allowlist: SourceAllowlist, ua: &str) -> Result<Client, reqwest::Error> {
     ensure_crypto_provider();
 
-    let user_agent = format!(
-        "doiget/{} (+https://github.com/sotashimozono/doiget)",
-        VERSION
-    );
+    let user_agent = ua.to_string();
 
     // Redirect policy: capture the per-source allowlist by value. The
     // closure is called for every redirect hop — there is no global


### PR DESCRIPTION
## Summary

Adds user-facing cooldown knobs to `doiget batch` for publishers that throttle below the HTTP 429 threshold.

- `doiget batch refs.txt --delay 1.5` — sleep 1.5 s between fetches (skips first)
- `doiget batch refs.txt --user-agent "Mozilla/5.0 ..."` — override UA for the entire batch

Implementation:
- `HttpClient::new_with_user_agent(allowlists, ua)` — new public constructor
- `build_http_client(user_agent: Option<&str>)` — threads UA option into client
- `FetchHarness::from_env_with_ua(user_agent: Option<&str>)` — delegates `from_env` with UA override
- Per-dispatch `tokio::time::sleep` between spawns (not before the first)

Supersedes PR #329 (which was branched from a stale `next` at `0.4.2-beta.0` and could not be rebased cleanly).

Closes #326

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `doiget batch refs.txt --delay 0.5` — observable 0.5s pause between fetches in log timestamps
- [ ] `doiget batch refs.txt --user-agent "test-ua/1"` — custom UA appears in server access logs
- [ ] `doiget batch refs.txt` (no flags) — behavior unchanged