### PR TITLE
chore(release): enforce per-PR version bumps + strict next→main promotion (ADR-0033)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,63 @@
+name: version-bump
+
+# ADR-0033 — PR-time version-bump gate (BLOCKING; intended as a required check).
+#
+# Complements, and is distinct from, the other two version layers:
+#   * scripts/release-version-gate.sh — TAG time (ADR-0025 D2): is this tag
+#     releasable? Runs only on a pushed signed tag.
+#   * version-check.yml — ADVISORY (ADR-0025 Amendment 6): "would tagging the
+#     current version release?" Non-blocking; intentionally red on `main`
+#     between releases, so it can NEVER be a required check.
+#
+# This job enforces that EVERY PR *advances* [workspace.package].version per the
+# lane cadence, and unlike version-check.yml it is ALWAYS green-able by a correct
+# PR — so it is safe to mark as a required status check on `next` and `main`.
+# All logic lives in scripts/version-bump-gate.sh (one source of truth, locally
+# runnable). Rules (no labels, no exceptions):
+#   * PR → next : X.Y.Z-beta.N, strict beta.N+1 (same base) or a retarget to a
+#                 valid +1 single-step over stable with the counter reset to .1;
+#                 the base is always a +1 step over origin/main (always
+#                 promotable). The automated main → next back-merge is the only
+#                 exempt PR (it keeps -beta.N), recognised by branch shape.
+#   * PR → main : promotion only — head MUST be `next` (same repo), a clean
+#                 X.Y.Z that is exactly +1 (major|minor|patch) over origin/main.
+#
+# Third-party Actions are SHA-pinned (repo invariant / ADR-0013 supply-chain).
+
+on:
+  pull_request:
+    branches: [next, main]
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: version-bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  version-bump:
+    name: version-bump (ADR-0033 — did this PR advance the version correctly?)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head (full history for lane-branch reads)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Fetch lane branches (origin/next, origin/main)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The gate reads the current lane versions via `git show origin/<lane>`.
+          # On a PR checkout these remote refs are not guaranteed present, so
+          # fetch them explicitly (same pattern as release-plz.yml's G7 step).
+          git fetch --no-tags origin '+refs/heads/next:refs/remotes/origin/next' || true
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main' || true
+      - name: Run the version-bump gate
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CROSS_REPO: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: bash scripts/version-bump-gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.1] - 2026-06-24
+
+### Changed
+- **[release/ci]** Version management is now enforced at PR time (ADR-0033). A
+  new **blocking** `version-bump` check (`.github/workflows/version-bump.yml` +
+  `scripts/version-bump-gate.sh`) requires every PR to advance
+  `[workspace.package].version` per the lane rules: a PR to `next` bumps
+  `beta.N` by exactly +1 (or retargets the base to a valid +1 single-component
+  step over the current stable, resetting the counter to `-beta.1`); a PR to
+  `main` is promotion-only — head MUST be `next` and the version MUST be a clean
+  `X.Y.Z` exactly one major/minor/patch step over `origin/main`, never a skip.
+  The advisory `version-check` job and the tag-time release gate (ADR-0025 D2)
+  are unchanged. There are no label-based exceptions; the automated
+  `main → next` back-merge is the only (structural) carve-out.
+- **[release]** Retarget the active `next` cycle `0.7.2-beta.1 → 0.8.0-beta.1`.
+  The accumulated cycle (tex-source #327, frontier #295, tags/collections #294,
+  auto preprint fallback #325, distribution #247, …) adds new commands → a
+  **minor** bump under the project's 0.x policy. `0.7.2` over the `0.7.0` stable
+  was a +2 patch *skip* (forbidden by ADR-0033's single-step promotion rule);
+  `0.8.0` is the correct, promotable target. No `0.7.1`/`0.7.2` was ever
+  published (crates.io shows only stable `0.7.0`), so nothing is dropped.
+
+### Docs
+- **[adr]** ADR-0033 (per-PR version-bump enforcement; amends ADR-0025 §D6
+  rules 2 and 4) and a `CONTRIBUTING.md` "Version bumps (enforced)" rule.
+
 ## [0.7.2-beta.1] - 2026-06-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,8 @@ The following crates are denied workspace-wide via `deny.toml`:
 
 - **Branch from `next`, not `main`** (ADR-0025 §D6). `next` is the integration
   + beta lane; `main` is the stable lane and advances only via a `next → main`
-  promotion or a stable hotfix. Branch name format: `<type>/<short-slug>`,
+  promotion (stable fixes also flow through `next`; direct-to-`main` hotfix is
+  retired by ADR-0033). Branch name format: `<type>/<short-slug>`,
   e.g. `fix/safekey-collision`, `feat/citation-graph`,
   `docs/clarify-store-spec`.
 - Commit messages follow Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`,
@@ -128,6 +129,29 @@ The following crates are denied workspace-wide via `deny.toml`:
   signature against `.github/allowed_signers` (ADR-0025 §D2-G7 / Amendment).
 - Each PR has a single, well-scoped purpose. Multi-purpose PRs will be asked to split.
 - The PR description must reference any related ADR, Discussion, or issue.
+
+### Version bumps (enforced — ADR-0033)
+
+Every PR must advance `[workspace.package].version`; the **blocking
+`version-bump` check** (`scripts/version-bump-gate.sh`) verifies it. There are
+**no label-based exceptions**.
+
+- **PR → `next`:** bump `beta.N` by **exactly +1** (e.g. `0.8.0-beta.3 →
+  0.8.0-beta.4`). To raise the cycle's base (a fix-only cycle that grows into a
+  feature/breaking release), set it to a valid **+1 single-component step over
+  the current stable** (`origin/main`) — `patch+1`, `minor+1`, or `major+1`,
+  lower components zeroed — and reset the counter to `-beta.1`. You cannot skip
+  or hold the version, and the base must stay a single step over stable so
+  `next` is always promotable (after a promotion the first PR MUST retarget).
+- **PR → `main`:** promotion only. The PR head **must be `next`** — there is no
+  direct-to-`main` path (stable fixes also go through `next`; ADR-0033 retires
+  ADR-0025 §D6 rule 4). The version must be a **clean `X.Y.Z`** that is exactly
+  **+1 major/minor/patch** over `origin/main`, never a skip.
+- The only exempt PR is the automated **`main → next` back-merge** (it keeps
+  `next`'s `-beta.N`); it is recognised by branch shape, not a label.
+
+This is separate from the advisory `version-check` job (release-readiness
+visibility) and the tag-time release gate (ADR-0025 §D2).
 
 ## Release process
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.7.2-beta.1"
+version = "0.8.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.7.2-beta.1"
+version = "0.8.0-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.7.2-beta.1"
+version = "0.8.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.7.2-beta.1"
+version       = "0.8.0-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.7.2-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.7.2-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.7.2-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/DECISIONS/0033-version-bump-enforcement.md
+++ b/docs/DECISIONS/0033-version-bump-enforcement.md
@@ -1,0 +1,158 @@
+# 0033 - Per-PR version-bump enforcement + strict next→main promotion
+
+- **Date:** 2026-06-24
+- **Status:** Proposed — implemented by the same PR that adds this ADR
+  (`chore/version-bump-gate`); flips to `Accepted` on merge per
+  `DECISIONS/INDEX.md` conventions.
+- **Amends:** [0025](0025-tag-driven-release.md) §D6 — adds a per-PR cadence to
+  rule 2 and **retires rule 4's direct-to-`main` hotfix** path. Complements
+  ADR-0025 Amendment 6 (advisory `version-check`); the tag-time gate (D2) and
+  lanes (D3) are unchanged.
+- **Source:** maintainer release-hygiene review, 2026-06-24 (the "where did
+  0.7.1 go?" incident).
+
+## Context
+
+ADR-0025 made the **tag** the release and added a mandatory tag-time version
+gate (D2, `scripts/release-version-gate.sh`). D6 rule 2 states the *invariant*
+that `next` always carries `X.Y.Z-beta.N`, but nothing specified — or enforced —
+how that version **advances per PR**. Two real gaps followed:
+
+1. **No per-PR cadence.** On 2026-06-20 three PRs landed on `next` and the
+   version was hand-bumped with no rule: `#327 → 0.7.1-beta.0`,
+   `#325 → 0.7.2-beta.0` (the patch base also rolled), `#322 → 0.7.2-beta.1`
+   (only the counter). A stable `0.7.1` was never cut; the number simply
+   vanished into a pre-release that was overwritten.
+2. **No PR-time guard.** The tag gate runs only on a pushed tag; `version-check`
+   (Amendment 6) is advisory and compares against crates.io, which has **no
+   published betas** — so two PRs could carry the *same* `…-beta.1` and both
+   pass. Nothing forced a PR to advance beyond the previous PR's version.
+
+A third, structural problem fell out of (1): `next` ended at base `0.7.2`, which
+is a **+2 patch *skip*** over the `0.7.0` stable — not a clean single step, i.e.
+not promotable under any "increment by one" rule. The version line had drifted
+into a state that could not be released cleanly.
+
+The maintainer's requirement: make version management **mechanical, gap-free,
+and strict** — every PR advances the version by a defined amount, `main` only
+ever moves by a clean promotion from `next`, and the stable line never skips a
+number. **No labels, no exceptions.**
+
+## Decision
+
+A new **PR-time** enforcement layer — distinct from the tag-time gate (D2) and
+the advisory `version-check` — implemented as `scripts/version-bump-gate.sh`
+(one source of truth) run by `.github/workflows/version-bump.yml`, designed to
+be a **required status check** on `next` and `main`.
+
+```mermaid
+flowchart TD
+  PR[PR opened / synchronize] --> B{base branch?}
+
+  B -- next --> S{head == main<br/>same repo?}
+  S -- yes --> EX[back-merge sync:<br/>keep -beta.N — exempt]
+  S -- no --> N0{head = X.Y.Z-beta.N ?}
+  N0 -- no --> F[FAIL]
+  N0 -- yes --> N1{base is +1 single-step<br/>over origin/main ?}
+  N1 -- no --> F
+  N1 -- yes --> N2{base vs origin/next}
+  N2 -- "same base" --> N3{N == next.N + 1 ?}
+  N3 -- no --> F
+  N3 -- yes --> P[PASS]
+  N2 -- "base moved up" --> N4{N == 1 ?}
+  N4 -- no --> F
+  N4 -- yes --> P
+  N2 -- "regressed" --> F
+
+  B -- main --> M0{head.ref == next<br/>same repo?}
+  M0 -- no --> F
+  M0 -- yes --> M1{head = clean X.Y.Z ?}
+  M1 -- no --> F
+  M1 -- yes --> M2{single-step +1<br/>over origin/main ?}
+  M2 -- no --> F
+  M2 -- yes --> P
+```
+
+### D1 — Strict per-PR cadence on `next`
+
+Every PR to `next` MUST set `[workspace.package].version` to `X.Y.Z-beta.N`
+that is strictly greater than `origin/next`, and:
+
+- **same base** `X.Y.Z`: `N == origin/next.N + 1` (exactly +1 — no holds, no
+  skips). This serialises `next`: a PR that goes stale behind a newer merge must
+  re-bump, so no two merges ever share a `-beta.N`.
+- **base change** (a *retarget*, D2): the counter resets to `-beta.1`.
+
+### D2 — `next` base is always promotable
+
+In *all* cases the base `X.Y.Z` MUST be a **+1 single-component step**
+(`patch+1`, `minor+1`, or `major+1`, with the lower components zeroed) over the
+**current stable** (`origin/main`). This keeps `next` continuously promotable
+and **forces a retarget after every promotion** (immediately after a release,
+`next`'s base equals the just-published stable and is therefore *not* a step —
+the first post-promotion PR must retarget). A retarget is an ordinary PR that
+moves the base up to another valid step; it needs no label because the math
+fully constrains the legal targets.
+
+### D3 — `main` is promotion-only; direct-to-`main` hotfix is retired
+
+A PR to `main` MUST have head branch `next` **of this repository** (no fork
+PRs, no other branches). This **retires ADR-0025 §D6 rule 4** (urgent stable
+fix committed directly to `main`): under this ADR a hotfix is a normal `next`
+PR followed by a promotion. The cost is that a hotfix ships with whatever else
+is on `next`; the benefit (and intent) is the invariant **"`next` is always in
+a releasable state"** — there is no second integration path to keep coherent.
+
+### D4 — Promotion is a single +1 step; the stable line never skips
+
+A promotion's version MUST be a **clean `X.Y.Z`** (no pre-release identifier)
+that is exactly a +1 single-component step over `origin/main`. This is why the
+active cycle is **retargeted `0.7.2-beta.1 → 0.8.0-beta.1`**: `0.7.0 → 0.7.2`
+is a forbidden +2 patch skip, whereas `0.7.0 → 0.8.0` is a valid `minor+1`
+(and the cycle's new commands warrant a minor under the 0.x policy). No
+`0.7.1`/`0.7.2` was ever published, so the renumber drops nothing.
+
+### D5 — Exactly one structural carve-out: the back-merge
+
+The automated `main → next` back-merge PR (ADR-0025 Amendment 3, post-promotion
+sync) intentionally **keeps** `next`'s `-beta.N` and so does not "advance" the
+version. The gate exempts it, recognising it by **branch shape** (head is the
+canonical `main`, same repo) — **not a label**. There are no label-based
+exceptions of any kind.
+
+### D6 — Enforcement layering (three distinct gates)
+
+| Layer | When | Blocking? | Question |
+| --- | --- | --- | --- |
+| `version-bump-gate.sh` (this ADR) | PR open/sync | **yes** (required check) | did this PR advance the version per the lane cadence? |
+| `version-check.yml` (0025 Amend. 6) | PR + push | no (advisory) | would tagging the current version release? |
+| `release-version-gate.sh` (0025 D2) | pushed tag | yes (pre-publish) | is THIS tag releasable? |
+
+`version-check` stays advisory (it is *designed* to be red on `main` between
+releases and so can never be required). The tag gate is unchanged. Marking the
+`version-bump` check **required** on `next` and `main` is a branch-protection
+action performed by the maintainer (outside this repo's files).
+
+### D7 — First application
+
+This ADR's PR retargets `next` `0.7.2-beta.1 → 0.8.0-beta.1`, leaving the lane
+in a promotable state (`0.7.0 → 0.8.0` = `minor+1`) and exercising the new gate
+on its own change (a base retarget with the counter reset to `-beta.1`).
+
+## Consequences
+
+**Positive.** The version line becomes gap-free and monotone; a `0.7.1`-class
+vanishing is structurally impossible. `next` is provably promotable at all
+times. Release readiness is enforced by CI, not by maintainer discipline.
+Two PRs can no longer collide on a `-beta.N`.
+
+**Negative / cost.** A stable hotfix can no longer be isolated on `main`; it
+ships through `next` with whatever else is queued there (mitigation: keep `next`
+releasable — which is now the enforced norm). After every promotion the first
+`next` PR must retarget the base before any further beta (the gate says so
+loudly with the allowed targets). The maintainer must add the `version-bump`
+check to branch protection for the gate to actually block.
+
+**Governance.** On merge: flip this ADR to `Accepted` (note the PR), update the
+`0033` row and the `0025` annotation in `DECISIONS/INDEX.md`. To revise this
+decision, write a new ADR with `Supersedes: 0033` per `CONTRIBUTING.md`.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -41,7 +41,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0022 | Dry-run mode for fetch operations | Accepted | Slice 2 | #12 |
 | 0023 | Structured `denial_context` on error envelopes | Accepted | Slices 1/2 | #12 |
 | 0024 | CanonicalRef implementation + provenance log v1 → v2 migration | Accepted | Slice 4 | Slice 4 |
-| 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
+| 0025 | Tag-driven release with version gate + beta/stable lanes | Accepted (Amend. 5 2026-05-19: D6 `next`-primary; Amend. 6 2026-05-19: advisory `version-check` job, D1 unchanged; **Amended by 0033** 2026-06-24: per-PR version-bump gate, D6 rule 4 direct hotfix retired) | PR #166 / Amend. 5 / Amend. 6 | maintainer review 2026-05-17 |
 | 0026 | DOI suffix charset extension: permit `:` (SECURITY.md §1.1) | Accepted | #194 | #194 dogfood |
 | 0027 | redirect-allowlist: add physics-society / diamond-OA hosts to `oa-publisher` | Accepted | #193 | #193 dogfood |
 | 0028 | User-extensible capability gate (ToS+verified-curation posture; impersonation out-of-scope) | Accepted (design; slice TBD) | TBD | #220 / #223 |
@@ -49,6 +49,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0030 | Bibliography input adapters (.bib / CSL-JSON) in `doiget-core`; new MCP tool `doiget_batch_from_bibliography` | Accepted (design; slice TBD) | TBD | #222 / Zotero distribution review 2026-05-20 |
 | 0031 | Discovery search is Tier-1 OA metadata (always-on); `doiget search` defaults to external discovery | Accepted (design; PR1 slice) | PR1 (`feat/paper-search`) | #281 / feasibility read 2026-06-04 |
 | 0032 | Structured full-text (HTML/XML) extraction in scope; PDF-blob processing stays out of scope | Accepted (design; PR4 ships ar5iv leg) | PR4 (`feat/paper-text`) | #281 item 3 / scope decision 2026-06-06 |
+| 0033 | Per-PR version-bump enforcement + strict next→main promotion (amends 0025 §D6) | Proposed (implemented by `chore/version-bump-gate`; flips on merge) | `chore/version-bump-gate` | maintainer review 2026-06-24 (0.7.1 vanishing) |
 
 ## Conventions
 

--- a/scripts/version-bump-gate.sh
+++ b/scripts/version-bump-gate.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# version-bump-gate.sh — PR-time version-bump gate (ADR-0033).
+#
+# This is the THIRD, distinct version-enforcement layer in the project:
+#   1. scripts/release-version-gate.sh  — TAG time (ADR-0025 D2, G0–G7): is THIS
+#      tag releasable? (manifest/lock/CHANGELOG/crates.io/signature/lane).
+#   2. .github/workflows/version-check.yml — ADVISORY (ADR-0025 Amendment 6):
+#      "would tagging the current version release?" — non-blocking visibility.
+#   3. THIS — PR time (ADR-0033): did THIS PR *advance* the version correctly,
+#      per the lane cadence? Designed to be a BLOCKING required check.
+#
+# Why a separate layer: the tag gate runs only on a pushed tag, and version-check
+# is advisory and compares against crates.io (which has no published betas), so
+# nothing ever forced a PR to bump beyond the *previous PR's* version. That gap
+# let `next` roll 0.7.1-beta.0 → 0.7.2-beta.0 → 0.7.2-beta.1 with no rule, and
+# left `next` carrying a base (0.7.2) that is a +2 *skip* over the 0.7.0 stable —
+# not even promotable under a single-step rule. ADR-0033 closes the gap.
+#
+# Rules enforced (no labels, no exceptions — ADR-0033):
+#   * PR → next : version is X.Y.Z-beta.N AND strictly greater than origin/next.
+#                 - same base  : N == origin/next.N + 1   (strict +1 cadence).
+#                 - base moved : a "retarget" — the new base MUST be a valid +1
+#                                single-component step over the current stable
+#                                and the counter MUST reset to beta.1.
+#                 - in BOTH cases the base must be a +1 single-step over
+#                   origin/main (keeps `next` always promotable; forces a
+#                   retarget after every promotion).
+#   * PR → main : promotion only — head branch MUST be `next` (same repo), the
+#                 version MUST be a clean X.Y.Z, and exactly a +1 single-
+#                 component step (major|minor|patch) over origin/main. No skips.
+#   * The ONLY exempt PR is the automated main → next back-merge (it keeps
+#     next's -beta.N): recognised by branch SHAPE (head == main, same repo),
+#     never by a label.
+#
+# House style mirrors scripts/release-version-gate.sh: dependency-light bash
+# (no jq / python / toml tooling), one actionable `::error::` per failure, abort
+# on the first failure. Inputs come from the workflow as env vars.
+#
+# Inputs (env):
+#   BASE_REF    target branch of the PR (next|main)             [required]
+#   HEAD_REF    PR source branch name                           [required for main / backmerge]
+#   CROSS_REPO  "true" when the PR head repo != base repo        [default: false]
+# Reads:
+#   ./Cargo.toml                 the PROPOSED [workspace.package].version (PR head)
+#   origin/next, origin/main     current lane versions (the workflow fetches them)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CARGO_TOML="$REPO_ROOT/Cargo.toml"
+
+fail() { echo "::error::$*" >&2; exit 1; }
+pass() { echo "PASS $*"; }
+
+BASE_REF="${BASE_REF:-}"
+HEAD_REF="${HEAD_REF:-}"
+CROSS_REPO="${CROSS_REPO:-false}"
+[ -n "$BASE_REF" ] || fail "version-bump: BASE_REF (PR target branch) not set"
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+# First `version = "..."` inside [workspace.package] (awk; no toml tooling —
+# identical extraction to release-version-gate.sh G1). Reads stdin.
+read_wp_version() {
+  awk '
+    /^\[workspace\.package\]/ { in_wp = 1; next }
+    /^\[/ { in_wp = 0 }
+    in_wp && /^[[:space:]]*version[[:space:]]*=/ {
+      line = $0; sub(/^[^"]*"/, "", line); sub(/".*$/, "", line); print line; exit
+    }'
+}
+
+# Version at a git ref (empty if the ref or file is absent — caller checks).
+git_ref_version() {
+  local out=""
+  out="$(git -C "$REPO_ROOT" show "$1:Cargo.toml" 2>/dev/null || true)"
+  printf '%s' "$out" | read_wp_version
+}
+
+# Strict parse — the ONLY forms doiget uses: X.Y.Z or X.Y.Z-beta.N. Sets the
+# globals _MAJ _MIN _PAT _ISPRE (0/1) _PREN (beta number; -1 when stable).
+# Returns 1 on any other shape (e.g. -rc.N, +build, missing component).
+parse_version() {
+  local v="$1"
+  if [[ "$v" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    _MAJ="${BASH_REMATCH[1]}"; _MIN="${BASH_REMATCH[2]}"; _PAT="${BASH_REMATCH[3]}"
+    _ISPRE=0; _PREN=-1
+  elif [[ "$v" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-beta\.([0-9]+)$ ]]; then
+    _MAJ="${BASH_REMATCH[1]}"; _MIN="${BASH_REMATCH[2]}"; _PAT="${BASH_REMATCH[3]}"
+    _ISPRE=1; _PREN="${BASH_REMATCH[4]}"
+  else
+    return 1
+  fi
+}
+
+# Compare X.Y.Z cores: echo 0 if a>b, 1 if a==b, 2 if a<b.
+core_cmp3() {
+  if [ "$1" -gt "$4" ]; then echo 0; return; fi
+  if [ "$1" -lt "$4" ]; then echo 2; return; fi
+  if [ "$2" -gt "$5" ]; then echo 0; return; fi
+  if [ "$2" -lt "$5" ]; then echo 2; return; fi
+  if [ "$3" -gt "$6" ]; then echo 0; return; fi
+  if [ "$3" -lt "$6" ]; then echo 2; return; fi
+  echo 1
+}
+
+# Is candidate X.Y.Z exactly one +1 step (with zero-resets) over stable A.B.C?
+# args: cMAJ cMIN cPAT sMAJ sMIN sPAT  → return 0 (yes) / 1 (no)
+is_single_step() {
+  local cM=$1 cm=$2 cp=$3 sM=$4 sm=$5 sp=$6
+  [ "$cM" -eq "$sM" ] && [ "$cm" -eq "$sm" ] && [ "$cp" -eq $((sp + 1)) ] && return 0   # patch+1
+  [ "$cM" -eq "$sM" ] && [ "$cm" -eq $((sm + 1)) ] && [ "$cp" -eq 0 ] && return 0       # minor+1
+  [ "$cM" -eq $((sM + 1)) ] && [ "$cm" -eq 0 ] && [ "$cp" -eq 0 ] && return 0           # major+1
+  return 1
+}
+
+# Human-readable list of the allowed steps over a stable core (for error text).
+allowed_steps() { echo "$1.$2.$(($3 + 1)) (patch), $1.$(($2 + 1)).0 (minor), $(($1 + 1)).0.0 (major)"; }
+
+# ---------------------------------------------------------------------------
+# Read the proposed (PR head) version.
+# ---------------------------------------------------------------------------
+[ -f "$CARGO_TOML" ] || fail "version-bump: $CARGO_TOML not found"
+HEAD_V="$(read_wp_version < "$CARGO_TOML")"
+[ -n "$HEAD_V" ] || fail "version-bump: could not read [workspace.package].version from Cargo.toml"
+parse_version "$HEAD_V" \
+  || fail "version-bump: head version '$HEAD_V' is not X.Y.Z or X.Y.Z-beta.N — doiget uses only the 'beta' pre-release identifier (ADR-0033 / ADR-0025 D3)"
+hMAJ=$_MAJ; hMIN=$_MIN; hPAT=$_PAT; hISPRE=$_ISPRE; hPREN=$_PREN
+
+echo "version-bump gate (ADR-0033): PR head version='$HEAD_V', base='$BASE_REF', head-branch='${HEAD_REF:-?}', cross-repo='$CROSS_REPO'"
+
+case "$BASE_REF" in
+  next)
+    # -- structural carve-out: the automated main → next back-merge keeps next's
+    #    -beta.N (ADR-0025 D6 / Amendment 3). It is NOT a feature PR; recognised
+    #    by branch shape (head == canonical main, same repo), never a label. --
+    if [ "$HEAD_REF" = "main" ] && [ "$CROSS_REPO" != "true" ]; then
+      pass "main → next sync (back-merge) — version bump intentionally not required (ADR-0025 D6 / ADR-0033)"
+      exit 0
+    fi
+
+    [ "$hISPRE" = "1" ] \
+      || fail "version-bump: a PR to 'next' must carry a beta version X.Y.Z-beta.N (the beta lane); got '$HEAD_V' (ADR-0025 D6.2)"
+
+    NEXT_V="$(git_ref_version origin/next)"
+    [ -n "$NEXT_V" ] || fail "version-bump: could not read Cargo.toml version at origin/next — the workflow must fetch it (fetch-depth: 0 + refs/heads/next)"
+    MAIN_V="$(git_ref_version origin/main)"
+    [ -n "$MAIN_V" ] || fail "version-bump: could not read Cargo.toml version at origin/main — the workflow must fetch it (refs/heads/main)"
+    parse_version "$NEXT_V" || fail "version-bump: origin/next version '$NEXT_V' is malformed"
+    nMAJ=$_MAJ; nMIN=$_MIN; nPAT=$_PAT; nPREN=$_PREN
+    parse_version "$MAIN_V" || fail "version-bump: origin/main version '$MAIN_V' is malformed (main must be a clean stable X.Y.Z)"
+    sMAJ=$_MAJ; sMIN=$_MIN; sPAT=$_PAT
+
+    # The base (X.Y.Z) must always be a +1 single-step over the current stable,
+    # so `next` is ALWAYS promotable and a retarget is forced after a promotion.
+    if ! is_single_step "$hMAJ" "$hMIN" "$hPAT" "$sMAJ" "$sMIN" "$sPAT"; then
+      fail "version-bump: next base $hMAJ.$hMIN.$hPAT is not a +1 single-component step over the current stable $MAIN_V (origin/main). Allowed: $(allowed_steps "$sMAJ" "$sMIN" "$sPAT"). After a promotion you MUST retarget next before landing more betas. (ADR-0033)"
+    fi
+
+    ccmp="$(core_cmp3 "$hMAJ" "$hMIN" "$hPAT" "$nMAJ" "$nMIN" "$nPAT")"
+    if [ "$ccmp" = "2" ]; then
+      fail "version-bump: head base $hMAJ.$hMIN.$hPAT REGRESSES below origin/next $nMAJ.$nMIN.$nPAT — next must only move forward (ADR-0033)"
+    elif [ "$ccmp" = "1" ]; then
+      # Same base → strict beta.N + 1.
+      [ "$hPREN" -eq $((nPREN + 1)) ] \
+        || fail "version-bump: a PR to 'next' must bump beta by EXACTLY +1 — expected $hMAJ.$hMIN.$hPAT-beta.$((nPREN + 1)) (origin/next is $NEXT_V), got $HEAD_V (ADR-0033 strict cadence)"
+      pass "version-bump: $HEAD_V is strict beta+1 over origin/next ($NEXT_V); base is a valid step over stable $MAIN_V"
+    else
+      # Base moved UP → retarget. Counter resets to beta.1.
+      [ "$hPREN" -eq 1 ] \
+        || fail "version-bump: a base retarget ($nMAJ.$nMIN.$nPAT → $hMAJ.$hMIN.$hPAT) must reset the counter to -beta.1; got -beta.$hPREN (ADR-0033)"
+      pass "version-bump: retarget $nMAJ.$nMIN.$nPAT → $hMAJ.$hMIN.$hPAT-beta.1 (valid +1 step over stable $MAIN_V); cadence reset"
+    fi
+    ;;
+
+  main)
+    # Promotion only. main NEVER takes a direct PR — stable fixes also route
+    # through next + promotion (ADR-0033 retires ADR-0025 D6 rule 4's direct
+    # hotfix). No labels, no exceptions.
+    if [ "$CROSS_REPO" = "true" ]; then
+      fail "version-bump: 'main' accepts promotions only from THIS repo's 'next' branch — a fork PR to main is rejected (ADR-0033)"
+    fi
+    if [ "$HEAD_REF" != "next" ]; then
+      fail "version-bump: 'main' accepts PRs ONLY from 'next' (got head '$HEAD_REF'). There is no direct-to-main path — stable hotfixes also go via next + promotion (ADR-0033 retires ADR-0025 D6 rule 4)."
+    fi
+    if [ "$hISPRE" != "0" ]; then
+      fail "version-bump: a promotion to 'main' (stable) must carry a CLEAN X.Y.Z — strip the -beta.N before opening the next → main PR; got '$HEAD_V' (ADR-0025 D6.2)"
+    fi
+    MAIN_V="$(git_ref_version origin/main)"
+    [ -n "$MAIN_V" ] || fail "version-bump: could not read Cargo.toml version at origin/main — the workflow must fetch it (fetch-depth: 0 + refs/heads/main)"
+    parse_version "$MAIN_V" || fail "version-bump: origin/main version '$MAIN_V' is malformed (main must be a clean stable X.Y.Z)"
+    sMAJ=$_MAJ; sMIN=$_MIN; sPAT=$_PAT
+    if ! is_single_step "$hMAJ" "$hMIN" "$hPAT" "$sMAJ" "$sMIN" "$sPAT"; then
+      fail "version-bump: promotion must bump the stable line by EXACTLY +1 (major|minor|patch) over origin/main ($MAIN_V) — NO skips. Allowed: $(allowed_steps "$sMAJ" "$sMIN" "$sPAT"). Got $HEAD_V. (ADR-0033)"
+    fi
+    pass "version-bump: promotion $MAIN_V → $HEAD_V is a valid +1 single-component step (ADR-0033)"
+    ;;
+
+  *)
+    # Not a release lane — the workflow only triggers on next|main, so this is a
+    # defensive no-op rather than a failure.
+    echo "version-bump: base '$BASE_REF' is not a release lane (next|main) — gate not applicable; PASS"
+    ;;
+esac
+
+echo
+echo "version-bump gate PASSED ($HEAD_V → base '$BASE_REF')"


### PR DESCRIPTION
## What & why

`next` had rolled `0.7.1-beta.0 → 0.7.2-beta.0 → 0.7.2-beta.1` with no rule, and was left at base `0.7.2` — a **+2 patch skip** over the `0.7.0` stable, i.e. **not promotable** under any single-step rule. Root cause: nothing enforces a version bump *at PR time*. The tag-time gate (ADR-0025 D2) runs only on a pushed tag, and `version-check` is advisory and compares against crates.io (no published betas), so two PRs could even share a `-beta.N`.

This adds a third, **PR-time, blocking** enforcement layer.

## Rules (no labels, no exceptions — ADR-0033)

- **PR → `next`:** `X.Y.Z-beta.N`, strict `beta.N + 1` (same base) — or a retarget to a valid **+1 single-component step over the current stable** with the counter reset to `-beta.1`. The base is always a +1 step over `origin/main`, so `next` stays promotable.
- **PR → `main`:** promotion only — head **must be `next`** (same repo), a **clean `X.Y.Z`** exactly **+1 major/minor/patch** over `origin/main`, never a skip. Retires ADR-0025 §D6 rule 4's direct-to-`main` hotfix (hotfixes route via `next`).
- The automated **`main → next` back-merge** is the only (structural) carve-out — recognised by branch shape, not a label.

## Changes

- `scripts/version-bump-gate.sh` + `.github/workflows/version-bump.yml` — the gate (one source of truth; locally runnable). Distinct from the tag-time gate (ADR-0025 D2) and the advisory `version-check`.
- `docs/DECISIONS/0033-version-bump-enforcement.md` (amends ADR-0025 §D6) + `DECISIONS/INDEX.md` + a `CONTRIBUTING.md` rule.
- **Retarget `next` `0.7.2-beta.1 → 0.8.0-beta.1`** — minor (the cycle adds new commands: tex-source #327, frontier #295, tags #294, preprint fallback #325, distribution #247); `0.7.2` was an unpromotable +2 skip over `0.7.0`. No `0.7.1`/`0.7.2` was ever published, so nothing is dropped.

## Verified locally (no cargo needed — pure bash + git)

| scenario | result |
|---|---|
| this PR: retarget `0.7.2 → 0.8.0-beta.1` to `next` | ✅ PASS |
| skip base `0.9.0-beta.1` to `next` | ❌ FAIL (not a single step) |
| clean `0.8.0` to `next` | ❌ FAIL (must be beta) |
| promotion `0.8.0` / `0.7.1` `next → main` | ✅ PASS |
| skip promotion `0.8.5` `next → main` | ❌ FAIL |
| beta `0.8.0-beta.1` `next → main` | ❌ FAIL (must be clean) |
| non-`next` head → `main` | ❌ FAIL |
| `main → next` back-merge | ✅ PASS (exempt) |

## ⚠️ Action required by maintainer

The gate only *blocks* once it is a **required status check**. After merge, add **`version-bump`** to branch-protection required checks on **both `next` and `main`** (per our split, you're handling branch protection). It is always green-able by a correct PR, so it is safe to require (unlike `version-check`, which is intentionally red on `main` between releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
