### PR TITLE
feat(source): download arXiv source bundle + figures to a directory (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   containment under `--out`. The existing `tex-source` text path is unchanged
   (ADR-0034 D6).
 
+### Hardened (PR #345 review)
+- **[core]** Distinct `FetchError::SourceUnavailable` for `source` (drops the
+  ar5iv-specific message that `TextUnavailable` would have leaked); a
+  decompressed-size cap on the `/src` tarball guards against a gzip bomb (the
+  HTTP layer only caps the *compressed* download); a corrupt/unreadable archive
+  (`SourceSchema`) is now distinguished from genuinely-no-files
+  (`SourceUnavailable`) and a partial extraction is logged — no silent file
+  loss; `SourceFile.path` is `pub(crate)` + a `path()` accessor so an external
+  caller cannot forge an unsafe path (mirrors `Doi`/`ArxivId`). Added a
+  wired-in zip-slip regression test (a malicious `../` tar entry is rejected by
+  `extract_bundle`, not just by the isolated sanitiser).
+
 ### Docs
 - **[adr]** ADR-0034 (arXiv source bundle + figure download: scope addition,
   artifact-not-processing boundary, zip-slip requirement) + `DECISIONS/INDEX.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.2] - 2026-06-24
+
+### Added
+- **[source]** `doiget source <arxiv-id> --out <dir> [--figures-only]` (#343,
+  ADR-0034) — download an arXiv submission's full **source bundle** (every
+  file) or just its **figures** to a directory. Reuses the same single
+  `/src/<id>` request as `tex-source`; files are written **opaque** (never
+  interpreted). A bare DOI reports `NO_OA_AVAILABLE`; a PDF-only / single-file
+  submission reports `TEXT_UNAVAILABLE` with a `doiget fetch` note. Tier-1 OA,
+  always-on. `--mode json` emits
+  `{ok, arxiv_id, out_dir, figures_only, count, files[]}`.
+- **[core]** `paper_tex_source::{paper_source_bundle, BundleFilter, SourceFile}`
+  — shared fetch + extract for the bundle/figures path. Tar entry paths are
+  sanitised by `sanitize_entry_path` (**zip-slip / path-traversal guard**,
+  ADR-0034 D3): absolute paths, `..`, drive prefixes and backslash traversal
+  are rejected; non-regular (symlink) entries are skipped; the writer re-checks
+  containment under `--out`. The existing `tex-source` text path is unchanged
+  (ADR-0034 D6).
+
+### Docs
+- **[adr]** ADR-0034 (arXiv source bundle + figure download: scope addition,
+  artifact-not-processing boundary, zip-slip requirement) + `DECISIONS/INDEX.md`.
+- **[meta]** Filed #344 (agent-UX observability gaps: store locality, citation
+  provenance, fetch verification).
+
 ## [0.8.0-beta.1] - 2026-06-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.1"
+version = "0.8.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.1"
+version = "0.8.0-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.1"
+version = "0.8.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.1"
+version       = "0.8.0-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub mod output;
 pub mod provenance;
 pub mod resolve_citation;
 pub mod search;
+pub mod source;
 pub mod tag;
 pub mod tex_source;
 pub mod text;

--- a/crates/doiget-cli/src/commands/source.rs
+++ b/crates/doiget-cli/src/commands/source.rs
@@ -113,7 +113,7 @@ pub async fn run(
             "out_dir": out_dir.as_str(),
             "figures_only": figures_only,
             "count": written.len(),
-            "files": written.iter().map(Utf8PathBuf::as_str).collect::<Vec<_>>(),
+            "files": written.iter().map(|p| p.as_str()).collect::<Vec<_>>(),
         });
         let s = serde_json::to_string_pretty(&payload).context("serializing source JSON")?;
         writeln!(out, "{s}").context("writing source JSON to stdout")?;

--- a/crates/doiget-cli/src/commands/source.rs
+++ b/crates/doiget-cli/src/commands/source.rs
@@ -14,8 +14,11 @@
 //! malicious archive cannot write outside the output directory (zip-slip).
 //!
 //! - **arXiv id** → files under `--out`.
-//! - **DOI** → structured `NO_OA_AVAILABLE` (pass the arXiv id).
-//! - **PDF-only / single-file submission** → `TEXT_UNAVAILABLE` with a note.
+//! - **DOI** → `NO_OA_AVAILABLE` (pass the arXiv id).
+//! - **PDF-only / single-file / figure-less submission** → `TEXT_UNAVAILABLE`
+//!   (wire) with an actionable `doiget fetch` note.
+//!
+//! `--mode json` emits `{ok, arxiv_id, out_dir, figures_only, count, files[]}`.
 
 use std::io::Write;
 
@@ -78,8 +81,8 @@ pub async fn run(
             print_err(format_args!("error[{}]: {e}", code.as_wire()));
             if code == ErrorCode::TextUnavailable {
                 print_err(format_args!(
-                    "  = note: no {} available (PDF-only submission or single-file source). \
-                     Fetch the PDF instead: `doiget fetch arxiv:{}`",
+                    "  = note: no {} found (no matching files, PDF-only, or single-file \
+                     submission). Fetch the PDF instead: `doiget fetch arxiv:{}`",
                     if figures_only {
                         "figures"
                     } else {
@@ -138,19 +141,26 @@ fn write_files(out_dir: &Utf8Path, files: &[SourceFile]) -> Result<Vec<Utf8PathB
 
     let mut written: Vec<Utf8PathBuf> = Vec::with_capacity(files.len());
     for f in files {
-        let dest = out_dir.join(&f.path);
+        let rel = f.path();
+        let dest = out_dir.join(rel);
+        // Defence-in-depth: `rel` is already relative with no `..` (a
+        // `SourceFile` can only be built via `sanitize_entry_path` in the core,
+        // ADR-0034 D3/I3), so this can never fire for a real value — but a
+        // regression in the core sanitiser must not become a write outside
+        // out_dir.
         if !dest.starts_with(out_dir) {
-            anyhow::bail!(
-                "refusing to write outside the output dir (zip-slip guard): {}",
-                f.path
-            );
+            anyhow::bail!("refusing to write outside the output dir (zip-slip guard): {rel}");
         }
+        // Create the file's parent only when it is a real subdirectory; a flat
+        // entry's parent is out_dir, already created above.
         if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent.as_std_path())
-                .with_context(|| format!("creating {parent}"))?;
+            if parent != out_dir {
+                std::fs::create_dir_all(parent.as_std_path())
+                    .with_context(|| format!("creating {parent}"))?;
+            }
         }
         std::fs::write(dest.as_std_path(), &f.bytes).with_context(|| format!("writing {dest}"))?;
-        written.push(f.path.clone());
+        written.push(rel.to_owned());
     }
     written.sort();
     Ok(written)

--- a/crates/doiget-cli/src/commands/source.rs
+++ b/crates/doiget-cli/src/commands/source.rs
@@ -1,0 +1,157 @@
+//! `doiget source <ref>` — download an arXiv submission's **source bundle**
+//! (every file) or just its **figures** to a directory (ADR-0034, issue #343).
+//!
+//! Fetches the same arXiv source tarball as `doiget tex-source`
+//! (`export.arxiv.org/src/<id>`, one request) but, instead of extracting only
+//! the main `.tex` text, materialises files to `--out`:
+//!
+//! - default: the full bundle (`*.tex`, `*.bib`, `*.sty`, figures, …),
+//! - `--figures-only`: just the image artifacts.
+//!
+//! Files are written **opaque** (never interpreted; ADR-0034 D2). Tar entry
+//! paths are sanitised in the core (`sanitize_entry_path`, ADR-0034 D3) and
+//! the join under `--out` is re-checked here as defence-in-depth, so a
+//! malicious archive cannot write outside the output directory (zip-slip).
+//!
+//! - **arXiv id** → files under `--out`.
+//! - **DOI** → structured `NO_OA_AVAILABLE` (pass the arXiv id).
+//! - **PDF-only / single-file submission** → `TEXT_UNAVAILABLE` with a note.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+
+use doiget_core::paper_tex_source::{
+    paper_source_bundle, resolve_arxiv_src_base, BundleFilter, SourceFile,
+};
+use doiget_core::{ArxivId, ErrorCode, Ref};
+
+use super::fetch::{build_resolve_context, cli_exit_code, CliExit};
+use super::output::OutputMode;
+
+#[allow(clippy::print_stderr)]
+fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
+
+/// Run the `source` subcommand.
+///
+/// # Errors
+///
+/// Returns a typed [`ErrorCode`] as a process exit code via [`CliExit`] for
+/// the fetch/resolve failures; filesystem write failures surface as a generic
+/// non-zero exit through the top-level reporter.
+pub async fn run(
+    ref_: String,
+    out_dir: Utf8PathBuf,
+    figures_only: bool,
+    mode: OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
+    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let id: ArxivId = match parsed {
+        Ref::Arxiv(a) => a,
+        Ref::Doi(_) => {
+            let code = ErrorCode::NoOaAvailable;
+            print_err(format_args!(
+                "error[{}]: no source bundle for a bare DOI — if an arXiv preprint exists, \
+                 pass its id (e.g. `doiget source arxiv:2401.12345 --out ./src`)",
+                code.as_wire()
+            ));
+            return Err(anyhow::Error::new(CliExit(cli_exit_code(code))));
+        }
+    };
+
+    let base = resolve_arxiv_src_base().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let ctx = build_resolve_context().context("building fetch context")?;
+    let filter = if figures_only {
+        BundleFilter::FiguresOnly
+    } else {
+        BundleFilter::All
+    };
+
+    let files = match paper_source_bundle(&base, &id, filter, &ctx).await {
+        Ok(f) => f,
+        Err(e) => {
+            let code = ErrorCode::from(&e);
+            print_err(format_args!("error[{}]: {e}", code.as_wire()));
+            if code == ErrorCode::TextUnavailable {
+                print_err(format_args!(
+                    "  = note: no {} available (PDF-only submission or single-file source). \
+                     Fetch the PDF instead: `doiget fetch arxiv:{}`",
+                    if figures_only {
+                        "figures"
+                    } else {
+                        "source bundle"
+                    },
+                    id.as_str()
+                ));
+            }
+            return Err(anyhow::Error::new(CliExit(cli_exit_code(code))));
+        }
+    };
+
+    let written = write_files(&out_dir, &files)?;
+
+    // The written files ARE the artifact — suppress only on *explicit* Quiet
+    // (ADR-0017 Amendment 2, same rule as `doiget tex-source`). The files are
+    // already on disk regardless; this only governs the stdout summary.
+    if mode == OutputMode::Quiet && quiet_was_explicit {
+        return Ok(());
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if mode == OutputMode::Json {
+        let payload = serde_json::json!({
+            "ok": true,
+            "arxiv_id": id.as_str(),
+            "out_dir": out_dir.as_str(),
+            "figures_only": figures_only,
+            "count": written.len(),
+            "files": written.iter().map(Utf8PathBuf::as_str).collect::<Vec<_>>(),
+        });
+        let s = serde_json::to_string_pretty(&payload).context("serializing source JSON")?;
+        writeln!(out, "{s}").context("writing source JSON to stdout")?;
+        return Ok(());
+    }
+
+    writeln!(out, "wrote {} file(s) to {out_dir}", written.len())
+        .context("writing source summary")?;
+    for rel in &written {
+        writeln!(out, "  {rel}").context("writing source file line")?;
+    }
+    Ok(())
+}
+
+/// Write each [`SourceFile`] under `out_dir`, returning the relative paths
+/// written (sorted for stable output).
+///
+/// `f.path` is already sanitised by the core (relative, no `..`; ADR-0034 D3),
+/// but the join is re-verified to stay within `out_dir` as defence-in-depth —
+/// a regression in the core sanitiser cannot turn into a write outside the
+/// output directory here.
+fn write_files(out_dir: &Utf8Path, files: &[SourceFile]) -> Result<Vec<Utf8PathBuf>> {
+    std::fs::create_dir_all(out_dir.as_std_path())
+        .with_context(|| format!("creating output dir {out_dir}"))?;
+
+    let mut written: Vec<Utf8PathBuf> = Vec::with_capacity(files.len());
+    for f in files {
+        let dest = out_dir.join(&f.path);
+        if !dest.starts_with(out_dir) {
+            anyhow::bail!(
+                "refusing to write outside the output dir (zip-slip guard): {}",
+                f.path
+            );
+        }
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent.as_std_path())
+                .with_context(|| format!("creating {parent}"))?;
+        }
+        std::fs::write(dest.as_std_path(), &f.bytes).with_context(|| format!("writing {dest}"))?;
+        written.push(f.path.clone());
+    }
+    written.sort();
+    Ok(written)
+}

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -118,6 +118,7 @@ enum ProvenanceAction {
                   \x20 csl          Export a stored entry as CSL JSON\n\
                   \x20 text         Extract a paper's full text from ar5iv (arXiv id)\n\
                   \x20 tex-source   Fetch raw LaTeX source from arXiv source API (arXiv id)\n\
+                  \x20 source       Download arXiv source bundle / figures to a dir (arXiv id)\n\
                   \x20 link         Resolve a DOI to its arXiv preprint (OpenAlex)\n\
                   \x20 info         Show metadata for a stored entry\n\
                   \x20 search       Search the local store by title / authors / venue\n\
@@ -427,6 +428,23 @@ enum Command {
         /// Bypass the on-disk TeX source cache (always re-fetch).
         #[arg(long)]
         no_cache: bool,
+    },
+    /// Download an arXiv submission's source bundle (every file) or just its
+    /// figures to a directory. Fetches the same `/src/<id>` tarball as
+    /// `tex-source` (one request) and materialises files to `--out`. Files are
+    /// written opaque (never interpreted); tar entry paths are sanitised
+    /// (zip-slip safe, ADR-0034). PDF-only submissions yield `TEXT_UNAVAILABLE`.
+    /// A DOI reports `NO_OA_AVAILABLE`. Tier-1 OA, always-on.
+    Source {
+        /// arXiv id (e.g. "arxiv:2401.12345"). A DOI reports `NO_OA_AVAILABLE`.
+        ref_: String,
+        /// Directory to write the extracted files into (created if missing).
+        #[arg(long = "out", value_name = "DIR", value_parser = parse_utf8_path)]
+        out_dir: Utf8PathBuf,
+        /// Extract only image/figure files (.pdf .eps .ps .png .jpg .jpeg .gif
+        /// .svg), not the full source bundle.
+        #[arg(long)]
+        figures_only: bool,
     },
     /// Resolve a DOI to its arXiv preprint + identity cluster (OpenAlex;
     /// #281 item 5). Reports whether the same work has a free arXiv
@@ -857,6 +875,20 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
                 ref_,
                 max_chars,
                 no_cache,
+                mode,
+                out.quiet_was_explicit,
+            )
+            .await
+        }
+        Some(Command::Source {
+            ref_,
+            out_dir,
+            figures_only,
+        }) => {
+            doiget_cli::commands::source::run(
+                ref_,
+                out_dir,
+                figures_only,
                 mode,
                 out.quiet_was_explicit,
             )

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -434,7 +434,8 @@ enum Command {
     /// `tex-source` (one request) and materialises files to `--out`. Files are
     /// written opaque (never interpreted); tar entry paths are sanitised
     /// (zip-slip safe, ADR-0034). PDF-only submissions yield `TEXT_UNAVAILABLE`.
-    /// A DOI reports `NO_OA_AVAILABLE`. Tier-1 OA, always-on.
+    /// A DOI reports `NO_OA_AVAILABLE`. Tier-1 OA, always-on. `--mode json`
+    /// emits `{ok, arxiv_id, out_dir, figures_only, count, files[]}`.
     Source {
         /// arXiv id (e.g. "arxiv:2401.12345"). A DOI reports `NO_OA_AVAILABLE`.
         ref_: String,

--- a/crates/doiget-cli/tests/source_e2e.rs
+++ b/crates/doiget-cli/tests/source_e2e.rs
@@ -1,0 +1,166 @@
+//! End-to-end wiremock tests for `doiget source` — arXiv source-bundle /
+//! figures download to a directory (ADR-0034, issue #343).
+//!
+//! Subprocess (`assert_cmd`) tests so the on-disk effect (files materialised
+//! under `--out`) is asserted directly. All HTTP terminates at a local
+//! `wiremock::MockServer` (no outbound network), reached via
+//! `DOIGET_ARXIV_BASE` / `DOIGET_ARXIV_SRC_BASE`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use assert_cmd::Command;
+use camino::Utf8PathBuf;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use predicates::str::contains;
+use serial_test::serial;
+use std::io::Write as _;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn utf8(dir: &TempDir) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("temp dir path must be UTF-8")
+}
+
+/// gzip a tar built from `(name, bytes)` entries.
+fn tar_gz(files: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (name, data) in files {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, name, std::io::Cursor::new(*data))
+            .expect("tar append");
+    }
+    let tar_bytes = builder.into_inner().expect("tar finish");
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(&tar_bytes).expect("gz write");
+    enc.finish().expect("gz finish")
+}
+
+/// A multi-file submission: a main `.tex`, a `.bib`, and a nested figure.
+fn sample_bundle() -> Vec<u8> {
+    tar_gz(&[
+        (
+            "main.tex",
+            b"\\documentclass{article}\\begin{document}Hi\\end{document}",
+        ),
+        ("refs.bib", b"@article{x,title={t}}"),
+        ("figs/plot.png", b"\x89PNG\r\n\x1a\n"),
+    ])
+}
+
+/// Subprocess `doiget` isolated to `root`, pointed at `server_uri`. Mirrors the
+/// tex-source e2e helper; `DOIGET_MODE` is cleared so the child's output mode is
+/// deterministic regardless of the parent test environment.
+fn doiget_subprocess(root: &Utf8PathBuf, server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("doiget").expect("locate doiget binary");
+    cmd.env("DOIGET_ARXIV_BASE", server_uri)
+        .env("DOIGET_ARXIV_SRC_BASE", server_uri)
+        .env("DOIGET_CACHE_ROOT", root.join("cache").as_str())
+        .env("DOIGET_STORE_ROOT", root.join("papers").as_str())
+        .env("DOIGET_LOG_PATH", root.join("access.jsonl").as_str())
+        .env("HOME", root.as_str())
+        .env("USERPROFILE", root.as_str())
+        .env_remove("DOIGET_MODE");
+    cmd
+}
+
+#[tokio::test]
+#[serial]
+async fn source_bundle_writes_all_files() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/src/2401.12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(sample_bundle()))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    let out = root.join("out");
+
+    doiget_subprocess(&root, &server.uri())
+        .args(["source", "arxiv:2401.12345", "--out", out.as_str()])
+        .assert()
+        .success();
+
+    assert!(out.join("main.tex").exists(), "main.tex written");
+    assert!(out.join("refs.bib").exists(), "refs.bib written");
+    assert!(
+        out.join("figs").join("plot.png").exists(),
+        "figs/plot.png written"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn source_figures_only_writes_only_images() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/src/2401.12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(sample_bundle()))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    let out = root.join("figs-out");
+
+    doiget_subprocess(&root, &server.uri())
+        .args([
+            "source",
+            "arxiv:2401.12345",
+            "--out",
+            out.as_str(),
+            "--figures-only",
+        ])
+        .assert()
+        .success();
+
+    assert!(out.join("figs").join("plot.png").exists(), "figure written");
+    assert!(
+        !out.join("main.tex").exists(),
+        "tex NOT written under --figures-only"
+    );
+    assert!(
+        !out.join("refs.bib").exists(),
+        "bib NOT written under --figures-only"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn source_for_doi_exits_non_zero() {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    let out = root.join("out");
+    // A bare DOI is rejected before any fetch — the server is never contacted.
+    doiget_subprocess(&root, "http://127.0.0.1:9")
+        .args(["source", "10.1234/example", "--out", out.as_str()])
+        .assert()
+        .failure();
+}
+
+#[tokio::test]
+#[serial]
+async fn source_pdf_only_exits_non_zero_with_note() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/src/2012.03644"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.4 fake".as_slice()))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8(&dir);
+    let out = root.join("out");
+    doiget_subprocess(&root, &server.uri())
+        .args(["source", "arxiv:2012.03644", "--out", out.as_str()])
+        .assert()
+        .failure()
+        .stderr(contains("doiget fetch arxiv:2012.03644"));
+}

--- a/crates/doiget-core/src/paper_tex_source.rs
+++ b/crates/doiget-core/src/paper_tex_source.rs
@@ -545,8 +545,7 @@ pub(crate) fn extract_bundle(
     // Decompress with a hard cap on the OUTPUT size (ADR-0034 I5): the HTTP
     // client already bounds the COMPRESSED download (PDF_MAX_BYTES); `take`
     // bounds the decompressed bytes so a gzip bomb cannot exhaust memory.
-    let mut gz =
-        GzDecoder::new(std::io::Cursor::new(bytes)).take(SRC_MAX_DECOMPRESSED_BYTES + 1);
+    let mut gz = GzDecoder::new(std::io::Cursor::new(bytes)).take(SRC_MAX_DECOMPRESSED_BYTES + 1);
     let mut decompressed = Vec::new();
     gz.read_to_end(&mut decompressed)
         .map_err(|e| FetchError::SourceSchema {
@@ -963,7 +962,7 @@ mod tests {
         assert_eq!(sanitize_entry_path("a/\0/b"), None);
         assert_eq!(sanitize_entry_path("."), None); // no normal component
         assert_eq!(sanitize_entry_path("a:b/c"), None); // colon in a segment
-        // ADR-0034 A2 — additional real-world vectors.
+                                                        // ADR-0034 A2 — additional real-world vectors.
         assert_eq!(sanitize_entry_path("foo/../../bar"), None); // mid-path escape
         assert_eq!(sanitize_entry_path("./.."), None); // leading dot then traversal
         assert_eq!(sanitize_entry_path("///"), None); // only separators
@@ -994,7 +993,10 @@ mod tests {
             ("figs/plot.png", b"\x89PNG\r\n"),
         ]);
         let files = extract_bundle(&id, &payload, BundleFilter::All).expect("bundle");
-        let mut names: Vec<String> = files.iter().map(|f| f.path.as_str().replace('\\', "/")).collect();
+        let mut names: Vec<String> = files
+            .iter()
+            .map(|f| f.path.as_str().replace('\\', "/"))
+            .collect();
         names.sort();
         assert_eq!(names, vec!["figs/plot.png", "paper.tex", "refs.bib"]);
         // Postcondition: every returned path is relative with no traversal.
@@ -1013,7 +1015,10 @@ mod tests {
             ("diagram.eps", b"%!PS"),
         ]);
         let files = extract_bundle(&id, &payload, BundleFilter::FiguresOnly).expect("figs");
-        let mut names: Vec<String> = files.iter().map(|f| f.path.as_str().replace('\\', "/")).collect();
+        let mut names: Vec<String> = files
+            .iter()
+            .map(|f| f.path.as_str().replace('\\', "/"))
+            .collect();
         names.sort();
         assert_eq!(names, vec!["diagram.eps", "figs/plot.png"]);
     }
@@ -1040,8 +1045,7 @@ mod tests {
     fn extract_bundle_figures_only_none_present_is_source_unavailable() {
         let id = make_id("2401.12345");
         let payload = tar_gzip(&[("paper.tex", b"\\documentclass{article}")]);
-        let err =
-            extract_bundle(&id, &payload, BundleFilter::FiguresOnly).expect_err("no figures");
+        let err = extract_bundle(&id, &payload, BundleFilter::FiguresOnly).expect_err("no figures");
         assert!(matches!(err, FetchError::SourceUnavailable { .. }));
     }
 

--- a/crates/doiget-core/src/paper_tex_source.rs
+++ b/crates/doiget-core/src/paper_tex_source.rs
@@ -438,7 +438,7 @@ const SRC_MAX_DECOMPRESSED_BYTES: u64 = 500_000_000;
 pub enum BundleFilter {
     /// Every regular file in the tarball.
     All,
-    /// Only image/figure files (by the [`FIGURE_EXTS`] allowlist).
+    /// Only image/figure files (by the `FIGURE_EXTS` extension allowlist).
     FiguresOnly,
 }
 
@@ -447,8 +447,8 @@ pub enum BundleFilter {
 pub struct SourceFile {
     /// Sanitised **relative** path (never absolute, never contains `..`),
     /// safe to join under any output root (ADR-0034 D3). The field is
-    /// `pub(crate)` so it can only be set by [`extract_bundle`] — which runs
-    /// every path through [`sanitize_entry_path`] — and an external caller
+    /// `pub(crate)` so it can only be set by `extract_bundle` — which runs
+    /// every path through `sanitize_entry_path` — and an external caller
     /// cannot forge a `SourceFile` carrying an unsafe path. This mirrors the
     /// checked-construction pattern of `Doi` / `ArxivId`. Read it via
     /// [`SourceFile::path`].
@@ -489,7 +489,7 @@ fn sanitize_entry_path(raw: &str) -> Option<Utf8PathBuf> {
     }
     let mut out = Utf8PathBuf::new();
     let mut any = false;
-    for seg in raw.split(|c: char| c == '/' || c == '\\') {
+    for seg in raw.split(['/', '\\']) {
         match seg {
             "" | "." => continue, // collapse `//`, drop `.`
             ".." => return None,  // traversal — reject the whole path
@@ -1050,17 +1050,41 @@ mod tests {
     }
 
     #[test]
-    fn extract_bundle_rejects_traversal_entry_but_keeps_safe() {
-        // ADR-0034 I1: prove sanitize_entry_path is actually WIRED INTO
-        // extract_bundle — a malicious `../evil.tex` entry must be absent from
-        // the result while a benign sibling survives. If a refactor dropped
-        // the sanitize call, this fails.
+    fn extract_bundle_drops_traversal_entry_via_sanitizer() {
+        // ADR-0034 I1: prove sanitize_entry_path is WIRED INTO extract_bundle.
+        // The `tar` *writer* refuses to create a `..` entry, and colon/
+        // backslash names parse inconsistently across OS tar writers, so we
+        // hand-build a raw USTAR archive carrying a genuine `../evil.tex` entry
+        // beside a benign file, then assert the traversal entry is absent from
+        // the result. If a refactor dropped the sanitize call, this fails.
+        // (The `..`/absolute/etc. rejections themselves are unit-tested
+        // directly on `sanitize_entry_path` above.)
+        fn ustar_block(name: &str, data: &[u8]) -> Vec<u8> {
+            let mut h = vec![0u8; 512];
+            h[..name.len()].copy_from_slice(name.as_bytes());
+            h[100..108].copy_from_slice(b"0000644\0");
+            h[108..116].copy_from_slice(b"0000000\0");
+            h[116..124].copy_from_slice(b"0000000\0");
+            h[124..136].copy_from_slice(format!("{:011o}\0", data.len()).as_bytes());
+            h[136..148].copy_from_slice(b"00000000000\0");
+            h[148..156].copy_from_slice(b"        "); // checksum field = 8 spaces
+            h[156] = b'0'; // typeflag: regular file
+            h[257..263].copy_from_slice(b"ustar\0");
+            h[263..265].copy_from_slice(b"00");
+            let sum: u32 = h.iter().map(|&b| u32::from(b)).sum();
+            h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+            h.extend_from_slice(data);
+            let pad = (512 - data.len() % 512) % 512;
+            h.resize(h.len() + pad, 0u8);
+            h
+        }
         let id = make_id("2401.12345");
-        let payload = tar_gzip(&[
-            ("../evil.tex", b"evil"),
-            ("safe.tex", b"\\documentclass{article}"),
-        ]);
-        let files = extract_bundle(&id, &payload, BundleFilter::All).expect("bundle");
+        let mut tar = ustar_block("../evil.tex", b"evil");
+        tar.extend(ustar_block("safe.tex", b"\\documentclass{article}"));
+        tar.resize(tar.len() + 1024, 0u8); // two zero end-of-archive blocks
+        let gz = gzip_bytes(&tar);
+
+        let files = extract_bundle(&id, &gz, BundleFilter::All).expect("bundle");
         let names: Vec<String> = files
             .iter()
             .map(|f| f.path.as_str().replace('\\', "/"))

--- a/crates/doiget-core/src/paper_tex_source.rs
+++ b/crates/doiget-core/src/paper_tex_source.rs
@@ -63,6 +63,11 @@ const HTTP_SOURCE_KEY: &str = "arxiv";
 /// Provenance audit label for TeX-source fetches.
 const PROV_SOURCE_LABEL: &str = "arxiv-src";
 
+/// Provenance audit label for source-bundle / figure fetches (ADR-0034 I4),
+/// distinct from [`PROV_SOURCE_LABEL`] so the audit log tells a `tex-source`
+/// text fetch apart from a `source` bundle/figures fetch.
+const PROV_SOURCE_BUNDLE_LABEL: &str = "arxiv-src-bundle";
+
 /// Production arXiv source API base. Overridable via
 /// `DOIGET_ARXIV_SRC_BASE` for tests.
 pub const ARXIV_SRC_DEFAULT_BASE: &str = "https://export.arxiv.org";
@@ -421,8 +426,15 @@ pub fn resolve_arxiv_src_base() -> Result<Url, String> {
 /// interpreted (ADR-0034 D2). Vector `.pdf` figures are included.
 const FIGURE_EXTS: &[&str] = &["pdf", "eps", "ps", "png", "jpg", "jpeg", "gif", "svg"];
 
+/// Cap on the DECOMPRESSED size of an arXiv `/src/` tarball (ADR-0034 I5).
+/// The HTTP client already caps the *compressed* download at `PDF_MAX_BYTES`
+/// (100 MB), but a small gzip can expand to many GB; this bounds the
+/// decompressed bytes held in memory to refuse a gzip bomb. Generous vs real
+/// arXiv sources (rarely > 100 MB decompressed), strict vs a multi-GB bomb.
+const SRC_MAX_DECOMPRESSED_BYTES: u64 = 500_000_000;
+
 /// Which subset of the source tarball to materialise.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BundleFilter {
     /// Every regular file in the tarball.
     All,
@@ -434,10 +446,23 @@ pub enum BundleFilter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {
     /// Sanitised **relative** path (never absolute, never contains `..`),
-    /// safe to join under any output root (ADR-0034 D3).
-    pub path: Utf8PathBuf,
+    /// safe to join under any output root (ADR-0034 D3). The field is
+    /// `pub(crate)` so it can only be set by [`extract_bundle`] — which runs
+    /// every path through [`sanitize_entry_path`] — and an external caller
+    /// cannot forge a `SourceFile` carrying an unsafe path. This mirrors the
+    /// checked-construction pattern of `Doi` / `ArxivId`. Read it via
+    /// [`SourceFile::path`].
+    pub(crate) path: Utf8PathBuf,
     /// Raw file bytes, opaque (never interpreted; ADR-0034 D2).
     pub bytes: Vec<u8>,
+}
+
+impl SourceFile {
+    /// The sanitised relative path of this file (never absolute, no `..`).
+    #[must_use]
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
 }
 
 /// Sanitise a raw tar entry path into a safe **relative** path, or `None` to
@@ -494,41 +519,51 @@ fn is_figure(path: &Utf8Path) -> bool {
 
 /// Decompress + untar an arXiv `/src/` body and collect the selected files.
 ///
-/// Mirrors [`extract_tex`]'s magic-byte handling but keeps the existing text
-/// path byte-identical (ADR-0034 D6): a PDF-only response, a bare single file,
-/// or a single gzip'd file all yield [`FetchError::TextUnavailable`] (there is
-/// no multi-file bundle). Only **regular** tar entries are considered —
-/// symlinks / hardlinks / devices are skipped (a symlink is itself a traversal
-/// vector). Every path is run through [`sanitize_entry_path`]; a rejected entry
-/// is skipped with a `tracing::warn!`, never written.
+/// Applies the same PDF / gzip / ustar magic-byte checks as [`extract_tex`],
+/// but a PDF-only response, a bare uncompressed file, or a single gzip'd file
+/// yields [`FetchError::SourceUnavailable`] — there is no multi-file bundle in
+/// a single-file response (unlike the text path, which passes a bare `.tex`
+/// through; the existing `extract_tex` text path is left byte-identical,
+/// ADR-0034 D6). Decompression is size-capped against a gzip bomb (ADR-0034
+/// I5). Only **regular** tar entries are considered — symlinks / hardlinks /
+/// devices are skipped (a symlink is itself a traversal vector, ADR-0034 D3).
+/// Every path is run through [`sanitize_entry_path`]; a path-rejected entry is
+/// skipped with a `tracing::warn!`. Entries that fail to read (malformed
+/// header, non-decodable path, or `read_to_end` error) are skipped, logged,
+/// and counted, so an empty result distinguishes a corrupt archive
+/// ([`FetchError::SourceSchema`]) from genuinely no matching files
+/// ([`FetchError::SourceUnavailable`]) (ADR-0034 C1).
 pub(crate) fn extract_bundle(
     id: &ArxivId,
     bytes: &[u8],
     filter: BundleFilter,
 ) -> Result<Vec<SourceFile>, FetchError> {
-    if bytes.starts_with(b"%PDF-") {
-        return Err(FetchError::TextUnavailable {
-            arxiv_id: id.clone(),
-        });
+    // PDF-only / bare single file: no multi-file bundle.
+    if bytes.starts_with(b"%PDF-") || bytes.len() < 2 || bytes[0..2] != [0x1f, 0x8b] {
+        return Err(no_files(id, filter));
     }
-    // Not gzip → a bare single file (no tar wrapper): no multi-file bundle.
-    if bytes.len() < 2 || bytes[0..2] != [0x1f, 0x8b] {
-        return Err(FetchError::TextUnavailable {
-            arxiv_id: id.clone(),
-        });
-    }
-    let mut gz = GzDecoder::new(std::io::Cursor::new(bytes));
+    // Decompress with a hard cap on the OUTPUT size (ADR-0034 I5): the HTTP
+    // client already bounds the COMPRESSED download (PDF_MAX_BYTES); `take`
+    // bounds the decompressed bytes so a gzip bomb cannot exhaust memory.
+    let mut gz =
+        GzDecoder::new(std::io::Cursor::new(bytes)).take(SRC_MAX_DECOMPRESSED_BYTES + 1);
     let mut decompressed = Vec::new();
     gz.read_to_end(&mut decompressed)
         .map_err(|e| FetchError::SourceSchema {
             hint: format!("gzip decompress of arXiv src failed: {e}"),
         })?;
+    if decompressed.len() as u64 > SRC_MAX_DECOMPRESSED_BYTES {
+        return Err(FetchError::SourceSchema {
+            hint: format!(
+                "arXiv src decompressed size exceeds {SRC_MAX_DECOMPRESSED_BYTES} bytes \
+                 (possible gzip bomb); refusing"
+            ),
+        });
+    }
     let is_tar = decompressed.len() > 262 && &decompressed[257..262] == b"ustar";
     if !is_tar {
         // Single gzip'd file (e.g. one .tex) — no bundle / figures.
-        return Err(FetchError::TextUnavailable {
-            arxiv_id: id.clone(),
-        });
+        return Err(no_files(id, filter));
     }
 
     let mut archive = Archive::new(std::io::Cursor::new(decompressed));
@@ -537,8 +572,21 @@ pub(crate) fn extract_bundle(
     })?;
 
     let mut files: Vec<SourceFile> = Vec::new();
+    // Count entries we matched but could not materialise, so an empty result
+    // distinguishes a corrupt/unreadable archive (SourceSchema) from a
+    // genuinely absent bundle (SourceUnavailable) — mirrors
+    // extract_from_tar's tex_attempted (ADR-0034 C1). Path-rejected
+    // (zip-slip) and filtered-out entries are deliberate skips, NOT counted.
+    let mut unreadable: usize = 0;
     for entry in entries {
-        let Ok(mut entry) = entry else { continue };
+        let mut entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                unreadable += 1;
+                tracing::warn!(arxiv_id = %id.as_str(), error = %e, "arXiv src: skipping malformed tar entry");
+                continue;
+            }
+        };
         // Regular files only: a symlink/hardlink entry is a traversal vector
         // and is never needed for source/figures (ADR-0034 D3).
         if !entry.header().entry_type().is_file() {
@@ -546,7 +594,11 @@ pub(crate) fn extract_bundle(
         }
         let raw_path = match entry.path() {
             Ok(p) => p.to_string_lossy().into_owned(),
-            Err(_) => continue,
+            Err(e) => {
+                unreadable += 1;
+                tracing::warn!(arxiv_id = %id.as_str(), error = %e, "arXiv src: tar entry has a non-decodable path; skipping");
+                continue;
+            }
         };
         let Some(safe) = sanitize_entry_path(&raw_path) else {
             tracing::warn!(
@@ -555,24 +607,56 @@ pub(crate) fn extract_bundle(
             );
             continue;
         };
-        if matches!(filter, BundleFilter::FiguresOnly) && !is_figure(&safe) {
+        if filter == BundleFilter::FiguresOnly && !is_figure(&safe) {
             continue;
         }
         let mut buf = Vec::new();
-        if entry.read_to_end(&mut buf).is_ok() {
-            files.push(SourceFile {
+        match entry.read_to_end(&mut buf) {
+            Ok(_) => files.push(SourceFile {
                 path: safe,
                 bytes: buf,
-            });
+            }),
+            Err(e) => {
+                unreadable += 1;
+                tracing::warn!(arxiv_id = %id.as_str(), entry = %safe, error = %e, "arXiv src: failed to read tar entry; skipping");
+            }
         }
     }
 
     if files.is_empty() {
-        return Err(FetchError::TextUnavailable {
-            arxiv_id: id.clone(),
+        // Corrupt/unreadable archive vs genuinely no matching files (ADR-0034 C1).
+        return Err(if unreadable > 0 {
+            FetchError::SourceSchema {
+                hint: format!(
+                    "arXiv src tar had {unreadable} unreadable entr(y/ies) and no usable files"
+                ),
+            }
+        } else {
+            no_files(id, filter)
         });
     }
+    if unreadable > 0 {
+        tracing::warn!(
+            arxiv_id = %id.as_str(),
+            unreadable,
+            extracted = files.len(),
+            "arXiv src: bundle is partial — some entries were unreadable and skipped"
+        );
+    }
     Ok(files)
+}
+
+/// The "no usable files" error for a `source` fetch, labelled with the
+/// requested representation so the message is accurate (not ar5iv-specific;
+/// ADR-0034 I2).
+fn no_files(id: &ArxivId, filter: BundleFilter) -> FetchError {
+    FetchError::SourceUnavailable {
+        arxiv_id: id.clone(),
+        kind: match filter {
+            BundleFilter::All => "source bundle",
+            BundleFilter::FiguresOnly => "figures",
+        },
+    }
 }
 
 /// Fetch the arXiv source bundle (or figures only) for `id`.
@@ -603,14 +687,14 @@ pub async fn paper_source_bundle(
     let files = extract_bundle(id, &body, filter)?;
 
     let canonical = Ref::Arxiv(id.clone())
-        .promote(PROV_SOURCE_LABEL, None)
+        .promote(PROV_SOURCE_BUNDLE_LABEL, None)
         .digest_hex();
     ctx.log.append(RowInput {
         event: LogEvent::Fetch,
         result: LogResult::Ok,
         capability: Capability::Oa,
         ref_: Some(id.as_str()),
-        source: Some(PROV_SOURCE_LABEL),
+        source: Some(PROV_SOURCE_BUNDLE_LABEL),
         error_code: None,
         size_bytes: Some(body.len() as u64),
         license: Some("arxiv-default"),
@@ -879,6 +963,12 @@ mod tests {
         assert_eq!(sanitize_entry_path("a/\0/b"), None);
         assert_eq!(sanitize_entry_path("."), None); // no normal component
         assert_eq!(sanitize_entry_path("a:b/c"), None); // colon in a segment
+        // ADR-0034 A2 — additional real-world vectors.
+        assert_eq!(sanitize_entry_path("foo/../../bar"), None); // mid-path escape
+        assert_eq!(sanitize_entry_path("./.."), None); // leading dot then traversal
+        assert_eq!(sanitize_entry_path("///"), None); // only separators
+        assert_eq!(sanitize_entry_path("\\\\"), None); // only backslashes
+        assert_eq!(sanitize_entry_path("C:evil"), None); // bare drive prefix
     }
 
     // ── is_figure ─────────────────────────────────────────────────────────────
@@ -929,18 +1019,55 @@ mod tests {
     }
 
     #[test]
-    fn extract_bundle_pdf_only_is_text_unavailable() {
+    fn extract_bundle_pdf_only_is_source_unavailable() {
         let id = make_id("2401.12345");
         let err = extract_bundle(&id, b"%PDF-1.5 x", BundleFilter::All).expect_err("pdf-only");
-        assert!(matches!(err, FetchError::TextUnavailable { .. }));
+        assert!(matches!(err, FetchError::SourceUnavailable { .. }));
     }
 
     #[test]
-    fn extract_bundle_figures_only_none_present_is_unavailable() {
+    fn extract_bundle_bare_file_is_source_unavailable() {
+        // A bare (non-gzip, non-PDF) single file is not a bundle (ADR-0034 I6):
+        // unlike extract_tex (which passes a bare .tex through), the bundle
+        // path returns SourceUnavailable.
+        let id = make_id("2401.12345");
+        let err = extract_bundle(&id, b"\\documentclass{article}\nhi", BundleFilter::All)
+            .expect_err("bare file is not a bundle");
+        assert!(matches!(err, FetchError::SourceUnavailable { .. }));
+    }
+
+    #[test]
+    fn extract_bundle_figures_only_none_present_is_source_unavailable() {
         let id = make_id("2401.12345");
         let payload = tar_gzip(&[("paper.tex", b"\\documentclass{article}")]);
         let err =
             extract_bundle(&id, &payload, BundleFilter::FiguresOnly).expect_err("no figures");
-        assert!(matches!(err, FetchError::TextUnavailable { .. }));
+        assert!(matches!(err, FetchError::SourceUnavailable { .. }));
+    }
+
+    #[test]
+    fn extract_bundle_rejects_traversal_entry_but_keeps_safe() {
+        // ADR-0034 I1: prove sanitize_entry_path is actually WIRED INTO
+        // extract_bundle — a malicious `../evil.tex` entry must be absent from
+        // the result while a benign sibling survives. If a refactor dropped
+        // the sanitize call, this fails.
+        let id = make_id("2401.12345");
+        let payload = tar_gzip(&[
+            ("../evil.tex", b"evil"),
+            ("safe.tex", b"\\documentclass{article}"),
+        ]);
+        let files = extract_bundle(&id, &payload, BundleFilter::All).expect("bundle");
+        let names: Vec<String> = files
+            .iter()
+            .map(|f| f.path.as_str().replace('\\', "/"))
+            .collect();
+        assert!(
+            names.iter().all(|n| !n.contains("..")),
+            "traversal entry must be rejected; got {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "safe.tex"),
+            "benign sibling must survive; got {names:?}"
+        );
     }
 }

--- a/crates/doiget-core/src/paper_tex_source.rs
+++ b/crates/doiget-core/src/paper_tex_source.rs
@@ -409,6 +409,218 @@ pub fn resolve_arxiv_src_base() -> Result<Url, String> {
     Url::parse(&raw).map_err(|e| format!("DOIGET_ARXIV_SRC_BASE is not a valid URL: {e}"))
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Source bundle / figures (ADR-0034). The arXiv `/src/<id>` tarball already
+// downloaded for the text path carries EVERY submission file; this section
+// surfaces the full bundle (or figures only) instead of discarding them. Every
+// returned path is sanitised (relative, no `..`, no anchor) so a caller can
+// join it under any output directory without escaping it (zip-slip, ADR-0034 D3).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Image/figure file extensions (lowercase, no dot). Saved opaque — never
+/// interpreted (ADR-0034 D2). Vector `.pdf` figures are included.
+const FIGURE_EXTS: &[&str] = &["pdf", "eps", "ps", "png", "jpg", "jpeg", "gif", "svg"];
+
+/// Which subset of the source tarball to materialise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleFilter {
+    /// Every regular file in the tarball.
+    All,
+    /// Only image/figure files (by the [`FIGURE_EXTS`] allowlist).
+    FiguresOnly,
+}
+
+/// One file extracted from an arXiv source tarball.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceFile {
+    /// Sanitised **relative** path (never absolute, never contains `..`),
+    /// safe to join under any output root (ADR-0034 D3).
+    pub path: Utf8PathBuf,
+    /// Raw file bytes, opaque (never interpreted; ADR-0034 D2).
+    pub bytes: Vec<u8>,
+}
+
+/// Sanitise a raw tar entry path into a safe **relative** path, or `None` to
+/// reject it (zip-slip / path-traversal guard, ADR-0034 D3).
+///
+/// Rejects: absolute / root-anchored paths (leading `/` or `\`, or a Windows
+/// drive prefix like `C:`); any `..` component; any component containing `:`
+/// or a NUL byte; and paths with no normal component. Splits on BOTH `/` and
+/// `\` so a Windows-style traversal in a Unix-produced tar is caught
+/// regardless of the extracting platform. The result is always relative with
+/// no `..`, so `root.join(result)` cannot escape `root`.
+fn sanitize_entry_path(raw: &str) -> Option<Utf8PathBuf> {
+    if raw.is_empty() || raw.contains('\0') {
+        return None;
+    }
+    // Absolute / root-anchored — anomalous in an arXiv source tarball.
+    if raw.starts_with('/') || raw.starts_with('\\') {
+        return None;
+    }
+    let b = raw.as_bytes();
+    // Windows drive prefix `X:` / `X:\`.
+    if b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':' {
+        return None;
+    }
+    let mut out = Utf8PathBuf::new();
+    let mut any = false;
+    for seg in raw.split(|c: char| c == '/' || c == '\\') {
+        match seg {
+            "" | "." => continue, // collapse `//`, drop `.`
+            ".." => return None,  // traversal — reject the whole path
+            s => {
+                if s.contains(':') || s.contains('\0') {
+                    return None;
+                }
+                out.push(s);
+                any = true;
+            }
+        }
+    }
+    if any {
+        Some(out)
+    } else {
+        None
+    }
+}
+
+/// True when `path`'s extension is in the figure allowlist (case-insensitive).
+fn is_figure(path: &Utf8Path) -> bool {
+    match path.extension() {
+        Some(ext) => FIGURE_EXTS.contains(&ext.to_ascii_lowercase().as_str()),
+        None => false,
+    }
+}
+
+/// Decompress + untar an arXiv `/src/` body and collect the selected files.
+///
+/// Mirrors [`extract_tex`]'s magic-byte handling but keeps the existing text
+/// path byte-identical (ADR-0034 D6): a PDF-only response, a bare single file,
+/// or a single gzip'd file all yield [`FetchError::TextUnavailable`] (there is
+/// no multi-file bundle). Only **regular** tar entries are considered —
+/// symlinks / hardlinks / devices are skipped (a symlink is itself a traversal
+/// vector). Every path is run through [`sanitize_entry_path`]; a rejected entry
+/// is skipped with a `tracing::warn!`, never written.
+pub(crate) fn extract_bundle(
+    id: &ArxivId,
+    bytes: &[u8],
+    filter: BundleFilter,
+) -> Result<Vec<SourceFile>, FetchError> {
+    if bytes.starts_with(b"%PDF-") {
+        return Err(FetchError::TextUnavailable {
+            arxiv_id: id.clone(),
+        });
+    }
+    // Not gzip → a bare single file (no tar wrapper): no multi-file bundle.
+    if bytes.len() < 2 || bytes[0..2] != [0x1f, 0x8b] {
+        return Err(FetchError::TextUnavailable {
+            arxiv_id: id.clone(),
+        });
+    }
+    let mut gz = GzDecoder::new(std::io::Cursor::new(bytes));
+    let mut decompressed = Vec::new();
+    gz.read_to_end(&mut decompressed)
+        .map_err(|e| FetchError::SourceSchema {
+            hint: format!("gzip decompress of arXiv src failed: {e}"),
+        })?;
+    let is_tar = decompressed.len() > 262 && &decompressed[257..262] == b"ustar";
+    if !is_tar {
+        // Single gzip'd file (e.g. one .tex) — no bundle / figures.
+        return Err(FetchError::TextUnavailable {
+            arxiv_id: id.clone(),
+        });
+    }
+
+    let mut archive = Archive::new(std::io::Cursor::new(decompressed));
+    let entries = archive.entries().map_err(|e| FetchError::SourceSchema {
+        hint: format!("tar read failed: {e}"),
+    })?;
+
+    let mut files: Vec<SourceFile> = Vec::new();
+    for entry in entries {
+        let Ok(mut entry) = entry else { continue };
+        // Regular files only: a symlink/hardlink entry is a traversal vector
+        // and is never needed for source/figures (ADR-0034 D3).
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let raw_path = match entry.path() {
+            Ok(p) => p.to_string_lossy().into_owned(),
+            Err(_) => continue,
+        };
+        let Some(safe) = sanitize_entry_path(&raw_path) else {
+            tracing::warn!(
+                entry = %raw_path,
+                "arXiv src: rejected unsafe tar entry path (zip-slip guard)"
+            );
+            continue;
+        };
+        if matches!(filter, BundleFilter::FiguresOnly) && !is_figure(&safe) {
+            continue;
+        }
+        let mut buf = Vec::new();
+        if entry.read_to_end(&mut buf).is_ok() {
+            files.push(SourceFile {
+                path: safe,
+                bytes: buf,
+            });
+        }
+    }
+
+    if files.is_empty() {
+        return Err(FetchError::TextUnavailable {
+            arxiv_id: id.clone(),
+        });
+    }
+    Ok(files)
+}
+
+/// Fetch the arXiv source bundle (or figures only) for `id`.
+///
+/// Tier-1 OA, always-on (ADR-0034 D1). Performs the SAME single `/src/<id>`
+/// request as [`paper_tex_source`] and returns the selected files **in
+/// memory**; the caller writes them to disk. Every returned path is sanitised
+/// (ADR-0034 D3). Not cached (ADR-0034 D5).
+///
+/// # Errors
+///
+/// - [`FetchError::Http`] — transport / status failure.
+/// - [`FetchError::TextUnavailable`] — PDF-only / single-file submission, or no
+///   matching files (e.g. `--figures-only` on a figure-less submission).
+/// - [`FetchError::SourceSchema`] — URL construction or gzip/tar parse error.
+/// - [`FetchError::Log`] — provenance append failed (fail-closed).
+pub async fn paper_source_bundle(
+    base: &Url,
+    id: &ArxivId,
+    filter: BundleFilter,
+    ctx: &FetchContext,
+) -> Result<Vec<SourceFile>, FetchError> {
+    let _permit = ctx.rate_limiter.acquire(HTTP_SOURCE_KEY).await;
+
+    let url = src_url(base, id)?;
+    let (body, _final_url) = ctx.http.fetch_bytes(HTTP_SOURCE_KEY, url).await?;
+
+    let files = extract_bundle(id, &body, filter)?;
+
+    let canonical = Ref::Arxiv(id.clone())
+        .promote(PROV_SOURCE_LABEL, None)
+        .digest_hex();
+    ctx.log.append(RowInput {
+        event: LogEvent::Fetch,
+        result: LogResult::Ok,
+        capability: Capability::Oa,
+        ref_: Some(id.as_str()),
+        source: Some(PROV_SOURCE_LABEL),
+        error_code: None,
+        size_bytes: Some(body.len() as u64),
+        license: Some("arxiv-default"),
+        store_path: None,
+        canonical_digest: Some(&canonical),
+    })?;
+
+    Ok(files)
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic, missing_docs)]
 mod tests {
@@ -617,5 +829,118 @@ mod tests {
             cache_read_at(&root, &id, Utc::now()).is_none(),
             "stale schema version must be rejected"
         );
+    }
+
+    // ── sanitize_entry_path: zip-slip / traversal guard (ADR-0034 D3) ─────────
+
+    #[test]
+    fn sanitize_accepts_normal_relative_paths() {
+        assert_eq!(
+            sanitize_entry_path("main.tex").map(|p| p.as_str().replace('\\', "/")),
+            Some("main.tex".to_string())
+        );
+        assert_eq!(
+            sanitize_entry_path("figs/diagram.png").map(|p| p.as_str().replace('\\', "/")),
+            Some("figs/diagram.png".to_string())
+        );
+        // `.` segments dropped, `//` collapsed.
+        assert_eq!(
+            sanitize_entry_path("./a//b.tex").map(|p| p.as_str().replace('\\', "/")),
+            Some("a/b.tex".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_parent_traversal() {
+        assert_eq!(sanitize_entry_path("../evil.tex"), None);
+        assert_eq!(sanitize_entry_path("a/../../etc/passwd"), None);
+        assert_eq!(sanitize_entry_path("sub/../x"), None);
+    }
+
+    #[test]
+    fn sanitize_rejects_absolute_and_anchored() {
+        assert_eq!(sanitize_entry_path("/etc/passwd"), None);
+        assert_eq!(sanitize_entry_path("\\windows\\system32"), None);
+        assert_eq!(sanitize_entry_path("C:\\Windows\\evil"), None);
+        assert_eq!(sanitize_entry_path("C:/Windows/evil"), None);
+    }
+
+    #[test]
+    fn sanitize_rejects_backslash_traversal_cross_platform() {
+        // A Windows-style traversal in a Unix-produced tar must be caught
+        // regardless of the extracting platform.
+        assert_eq!(sanitize_entry_path("..\\..\\evil"), None);
+        assert_eq!(sanitize_entry_path("a\\..\\..\\b"), None);
+    }
+
+    #[test]
+    fn sanitize_rejects_empty_nul_dot_and_colon() {
+        assert_eq!(sanitize_entry_path(""), None);
+        assert_eq!(sanitize_entry_path("a/\0/b"), None);
+        assert_eq!(sanitize_entry_path("."), None); // no normal component
+        assert_eq!(sanitize_entry_path("a:b/c"), None); // colon in a segment
+    }
+
+    // ── is_figure ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_figure_matches_allowlist_case_insensitively() {
+        for f in ["fig.png", "a/b.EPS", "plot.Pdf", "x.svg", "y.JPEG"] {
+            assert!(is_figure(Utf8Path::new(f)), "{f} should be a figure");
+        }
+        for nf in ["main.tex", "refs.bib", "macros.sty", "README"] {
+            assert!(!is_figure(Utf8Path::new(nf)), "{nf} should NOT be a figure");
+        }
+    }
+
+    // ── extract_bundle ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_bundle_all_returns_every_regular_file() {
+        let id = make_id("2401.12345");
+        let payload = tar_gzip(&[
+            ("paper.tex", b"\\documentclass{article}"),
+            ("refs.bib", b"@article{x,title={t}}"),
+            ("figs/plot.png", b"\x89PNG\r\n"),
+        ]);
+        let files = extract_bundle(&id, &payload, BundleFilter::All).expect("bundle");
+        let mut names: Vec<String> = files.iter().map(|f| f.path.as_str().replace('\\', "/")).collect();
+        names.sort();
+        assert_eq!(names, vec!["figs/plot.png", "paper.tex", "refs.bib"]);
+        // Postcondition: every returned path is relative with no traversal.
+        assert!(files
+            .iter()
+            .all(|f| !f.path.as_str().starts_with('/') && !f.path.as_str().contains("..")));
+    }
+
+    #[test]
+    fn extract_bundle_figures_only_keeps_images() {
+        let id = make_id("2401.12345");
+        let payload = tar_gzip(&[
+            ("paper.tex", b"\\documentclass{article}"),
+            ("refs.bib", b"@article{x}"),
+            ("figs/plot.png", b"\x89PNG"),
+            ("diagram.eps", b"%!PS"),
+        ]);
+        let files = extract_bundle(&id, &payload, BundleFilter::FiguresOnly).expect("figs");
+        let mut names: Vec<String> = files.iter().map(|f| f.path.as_str().replace('\\', "/")).collect();
+        names.sort();
+        assert_eq!(names, vec!["diagram.eps", "figs/plot.png"]);
+    }
+
+    #[test]
+    fn extract_bundle_pdf_only_is_text_unavailable() {
+        let id = make_id("2401.12345");
+        let err = extract_bundle(&id, b"%PDF-1.5 x", BundleFilter::All).expect_err("pdf-only");
+        assert!(matches!(err, FetchError::TextUnavailable { .. }));
+    }
+
+    #[test]
+    fn extract_bundle_figures_only_none_present_is_unavailable() {
+        let id = make_id("2401.12345");
+        let payload = tar_gzip(&[("paper.tex", b"\\documentclass{article}")]);
+        let err =
+            extract_bundle(&id, &payload, BundleFilter::FiguresOnly).expect_err("no figures");
+        assert!(matches!(err, FetchError::TextUnavailable { .. }));
     }
 }

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -176,6 +176,22 @@ pub enum FetchError {
         /// string into the actionable `doiget fetch <id>` hint.
         arxiv_id: crate::ArxivId,
     },
+    /// A source returned a successful response that contained no file of the
+    /// requested kind for `doiget source` — a PDF-only / single-file
+    /// submission (no multi-file bundle), or `--figures-only` on a submission
+    /// with no image files. The identifier is valid; only the bundle / figure
+    /// representation is absent. Surfaces as
+    /// [`crate::ErrorCode::TextUnavailable`] (same "this representation is
+    /// missing; the PDF may be fetchable" class as [`Self::TextUnavailable`]),
+    /// but as a DISTINCT variant so the message is not ar5iv-specific
+    /// (issue #343 / ADR-0034; PR review).
+    #[error("no source files for arXiv:{arxiv_id} ({kind}); the PDF may be fetchable instead")]
+    SourceUnavailable {
+        /// The arXiv id whose source bundle / figures were absent.
+        arxiv_id: crate::ArxivId,
+        /// Which representation was requested: `"source bundle"` or `"figures"`.
+        kind: &'static str,
+    },
 }
 
 /// Map [`FetchError`] to the closed [`crate::ErrorCode`] set surfaced at
@@ -228,6 +244,10 @@ impl From<&FetchError> for crate::ErrorCode {
             // missing. Its own code so an agent fetches the PDF rather
             // than conclude the reference is wrong (issue #302).
             FetchError::TextUnavailable { .. } => crate::ErrorCode::TextUnavailable,
+            // The id resolved; only the source-bundle / figure representation
+            // is absent. Same wire code as TextUnavailable (representation
+            // missing → fetch the PDF), distinct variant for a correct message.
+            FetchError::SourceUnavailable { .. } => crate::ErrorCode::TextUnavailable,
         }
     }
 }
@@ -268,7 +288,8 @@ impl From<&FetchError> for Option<crate::DenialContext> {
             | FetchError::InvalidRef(_)
             | FetchError::SourceSchema { .. }
             | FetchError::TooManyRefs { .. }
-            | FetchError::TextUnavailable { .. } => None,
+            | FetchError::TextUnavailable { .. }
+            | FetchError::SourceUnavailable { .. } => None,
         }
     }
 }
@@ -485,6 +506,20 @@ mod tests {
         // otherwise misroute this to InternalError).
         let e: ErrorCode = FetchError::TooManyRefs { got: 101, max: 100 }.into();
         assert_eq!(e, ErrorCode::InvalidRef);
+
+        // #343 / ADR-0034 — SourceUnavailable shares the TextUnavailable wire
+        // code (representation missing; the PDF may be fetchable), distinct
+        // variant for a non-ar5iv message.
+        let arxiv = match Ref::parse("arxiv:2401.12345").expect("parse arxiv id") {
+            Ref::Arxiv(a) => a,
+            Ref::Doi(_) => unreachable!("parsed an arxiv id"),
+        };
+        let e: ErrorCode = FetchError::SourceUnavailable {
+            arxiv_id: arxiv,
+            kind: "figures",
+        }
+        .into();
+        assert_eq!(e, ErrorCode::TextUnavailable);
     }
 
     #[test]

--- a/docs/DECISIONS/0034-source-bundle-figures.md
+++ b/docs/DECISIONS/0034-source-bundle-figures.md
@@ -1,0 +1,121 @@
+# 0034 - arXiv source bundle + individual figure download
+
+- **Date:** 2026-06-24
+- **Status:** Proposed — implemented by `feat/343-source-bundle-figures`
+  (issue #343); flips to `Accepted` on merge per `DECISIONS/INDEX.md`
+  conventions.
+- **Relates:** extends the arXiv `/src/` capability introduced with
+  `tex-source` ([ADR-0032](0032-fulltext-html-extraction.md) D1/D2). Bounded by
+  [`SCOPE.md`](../SCOPE.md) §non-goal 1 (PDF-blob processing), 3 (no
+  redistribution), 9 (no bulk download).
+- **Source:** dogfooding 2026-06-24 (issue #343).
+
+## Context
+
+`doiget tex-source <arxiv-id>` fetches the arXiv source tarball
+(`export.arxiv.org/src/<id>`) but extracts **only the single main `.tex`
+file's text** (`extract_from_tar` reads only `*.tex` entries; everything else
+is discarded). The original intent for the source capability is broader: let an
+agent / user obtain (a) the **full source bundle** — every file in the
+submission — and (b) **individual figures** — the image artifacts only.
+
+Both are **already inside the bytes** `paper_tex_source` downloads, gunzips, and
+untars; they are currently thrown away. So this adds no network surface: the
+single `/src/<id>` request already happens.
+
+This is new functionality beyond the enumerated SCOPE.md scope, so per SCOPE.md
+it requires an ADR. It is **not** a permanent non-goal:
+
+| SCOPE non-goal | Why this is clear of it |
+| --- | --- |
+| #1 PDF-blob content **processing** | Figures come from the **author-uploaded source tarball**, written **opaque** (bytes → disk). Never parsed / OCR'd / interpreted; never extracted from the compiled PDF. Same posture as ADR-0032 D1 ("a separate structured artifact; the PDF blob is never read"). |
+| #9 No bulk download | One paper, from the **single `/src/` fetch already performed**. No new per-file requests; the rate limiter is untouched. |
+| #3 No redistribution | Local store / user-given directory only, like PDFs. |
+
+## Decision
+
+### D1 — Capability + tier
+
+Add an arXiv **source-bundle** capability: fetch the `/src/<id>` tarball and
+materialise its files to a user-given directory, either the full bundle or
+figures only. **Tier-1 OA, always-on** (same posture as `tex-source` /
+ADR-0032 D2): no env gate, no Cargo feature gate.
+
+### D2 — Artifact, never processing
+
+Every extracted file is written **byte-for-byte opaque**. doiget does not parse,
+convert, transcode, OCR, or otherwise interpret any extracted file (including
+figures that happen to be `.pdf` — a vector figure is saved opaque exactly like
+the main PDF). This keeps the feature on the ADR-0032-D1 / SCOPE-#1 side of the
+line: fetching artifacts, not processing PDF-blob content.
+
+### D3 — Path safety is a hard requirement (zip-slip)
+
+Writing files extracted from an untrusted archive is a path-traversal
+("zip-slip") surface. A single sanitiser, `sanitize_entry_path`, is the gate:
+
+```mermaid
+flowchart TD
+  E[tar entry path] --> A{absolute? leading / or backslash or drive X:}
+  A -- yes --> R[REJECT]
+  A -- no --> S[split on / and backslash]
+  S --> C{any component == .. ?}
+  C -- yes --> R
+  C -- no --> D{component contains ':' or NUL ?}
+  D -- yes --> R
+  D -- no --> N{at least one Normal component ?}
+  N -- no --> R
+  N -- yes --> P[safe RELATIVE path: no .., no anchor]
+```
+
+It returns only **relative** paths with no `..` and no root/drive anchor, so the
+caller's `out_dir.join(path)` can never escape `out_dir`. Additional hardening:
+**non-regular tar entries (symlinks / hardlinks / devices) are skipped** (a
+symlink is itself a traversal vector), and the writer re-checks
+`dest.starts_with(out_dir)` as defence-in-depth. `sanitize_entry_path` is a
+pure function with an attack-vector-enumerating unit-test suite (absolute,
+`..`, `a/../b`, `C:\`, backslash traversal, NUL, empty) — that suite is the
+verification surface for this requirement.
+
+### D4 — Surface (issue #343 decisions)
+
+1. **New `doiget source <id> --out <dir> [--figures-only]`**, keeping
+   `tex-source` text-only. `tex-source` is an agent-facing stdout-text verb;
+   materialising files to disk is a different output model, so a separate
+   command is cleaner than overloading flags.
+2. **CLI-only for v1** — no MCP tool yet. MCP tools return structured data /
+   paths; dumping a directory of many files does not fit that, and
+   filesystem-materialising ops are CLI-first (cf. SCOPE #15 delete-is-CLI-only).
+   Revisit if an agent need is shown.
+3. **Output via an explicit required `--out <dir>`, decoupled from the store.**
+   The store layout is BiblioFetch.jl-bit-compatible (STORE.md); injecting a
+   source directory risks that contract. A later opt-in `<store>/<safekey>/src/`
+   is a separate decision.
+4. **Figures by extension allowlist:** `.pdf .eps .ps .png .jpg .jpeg .gif
+   .svg` (case-insensitive). Conservative and contract-clear.
+
+### D5 — No bundle cache (v1)
+
+`tex-source` caches only the extracted main-`.tex` JSON. The raw tarball is not
+cached; `source` re-fetches `/src/` per invocation (one request). A tarball
+cache is a future optimisation, intentionally out of scope here.
+
+### D6 — `tex-source` text path is unchanged
+
+`extract_tex` / `extract_from_tar` (the best-`.tex` text selection) are left
+**byte-identical**. The bundle path is a parallel `extract_bundle`; any later
+de-duplication of the shared gunzip/untar prologue is a separate refactor.
+
+## Consequences
+
+**Positive.** Closes the original source-capability intent (full bundle +
+figures) at zero added network. Unblocks part of #344 item 2 (the `.bib` in the
+bundle is a citation-resolution input). Path-safety is centralised and
+unit-tested.
+
+**Negative / cost.** A second extraction path duplicates the gunzip/untar
+prologue (D6) until a future refactor. No bundle cache means repeated `source`
+calls re-fetch (one request each). MCP parity deferred (D4.2).
+
+**Governance.** On merge: flip to `Accepted` (note the PR), add the `0034` row
+to `DECISIONS/INDEX.md`. To revise, write a new ADR with `Supersedes: 0034`.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -50,6 +50,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0031 | Discovery search is Tier-1 OA metadata (always-on); `doiget search` defaults to external discovery | Accepted (design; PR1 slice) | PR1 (`feat/paper-search`) | #281 / feasibility read 2026-06-04 |
 | 0032 | Structured full-text (HTML/XML) extraction in scope; PDF-blob processing stays out of scope | Accepted (design; PR4 ships ar5iv leg) | PR4 (`feat/paper-text`) | #281 item 3 / scope decision 2026-06-06 |
 | 0033 | Per-PR version-bump enforcement + strict next→main promotion (amends 0025 §D6) | Proposed (implemented by `chore/version-bump-gate`; flips on merge) | `chore/version-bump-gate` | maintainer review 2026-06-24 (0.7.1 vanishing) |
+| 0034 | arXiv source bundle + individual figure download | Proposed (implemented by `feat/343-source-bundle-figures`; flips on merge) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
 
 ## Conventions
 


### PR DESCRIPTION
Implements #343 (ADR-0034). Closes the gap where `tex-source` keeps only the main `.tex` and throws the rest of the `/src` tarball away.

## What

`doiget source <arxiv-id> --out <dir> [--figures-only]` — materialise an arXiv submission's **full source bundle** (every file) or **just its figures** from the **same single `/src` request** `tex-source` already makes (net-zero network).

## Security — zip-slip is the load-bearing concern (ADR-0034 D3)

Writing files from an untrusted archive is a path-traversal surface. The guard is a pure `sanitize_entry_path`:
- rejects absolute / root-anchored paths, any `..`, Windows drive prefixes, backslash traversal, NUL, colon-in-segment;
- `extract_bundle` skips non-regular (symlink / hardlink) entries (a symlink is itself a traversal vector);
- the writer re-checks `dest.starts_with(out_dir)` as defence-in-depth.

It carries an attack-vector-enumerating unit suite (absolute, `..`, `a/../b`, `C:\`, `..\..\`, NUL, empty) — that suite is the verification surface for the requirement.

## Contract (issue #343 decisions — all "recommended")

New `source` command (not flags on `tex-source`); **CLI-only v1**; required **`--out <dir>`** (store-decoupled); figures by extension allowlist `.pdf .eps .ps .png .jpg .jpeg .gif .svg`. Files written **opaque** (never interpreted — stays clear of SCOPE non-goal #1). The `tex-source` text path is byte-identical (ADR-0034 D6).

## Verified

⚠️ The dev box can't link MSVC, so compile/test rely on CI. What I verified locally (pure bash + git): the **version-bump gate self-check passes** for this PR (`0.8.0-beta.1 → 0.8.0-beta.2`, strict beta+1). The Rust mirrors `paper_tex_source.rs` / `tex_source.rs`; CI (incl. `test (windows-latest)`) is the real check — path-string assertions are separator-normalised for Windows.

Tests added:
- core unit: `sanitize_entry_path` attack vectors, `is_figure`, `extract_bundle` (all / figures-only / pdf-only / no-figures).
- e2e: bundle writes all files; `--figures-only` writes only images; DOI + PDF-only fail cleanly.

## Version

`0.8.0-beta.2` (ADR-0033 strict beta+1 over `origin/next`). First feature PR under the new gate — dogfooding it.

Refs: #343, ADR-0034. Filed #344 (agent-UX observability) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
