### PR TITLE
chore(supply-chain): bump cargo vet exemptions to match lockfile (bytes/camino)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.3] - 2026-06-24
+
+### Fixed
+- **[supply-chain]** Bump `cargo vet` exemptions to match the current lockfile —
+  `bytes 1.11.1 → 1.12.0`, `camino 1.2.2 → 1.2.3` — which had drifted after a
+  dependency bump (the `cargo vet` job was red: "2 unvetted dependencies"). No
+  code change.
+
 ## [0.8.0-beta.2] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.2"
+version       = "0.8.0-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -99,11 +99,11 @@ version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
-version = "1.11.1"
+version = "1.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.camino]]
-version = "1.2.2"
+version = "1.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]


### PR DESCRIPTION
The `cargo vet` job is red on `next` — **2 unvetted dependencies** after a dependency bump left the exemptions behind:

```
bytes:1.12.0  missing ["safe-to-deploy"]
camino:1.2.3  missing ["safe-to-deploy"]
```

`supply-chain/config.toml` still exempted `bytes 1.11.1` / `camino 1.2.2`. This bumps both exemptions to the locked versions ([[reference]] the standard "dep bump → bump the vet exemption" maintenance step). No code change.

## Verified locally

`cargo vet --locked` → **"Vetting Succeeded (83 fully audited, 6 partially audited, 232 exempted)"**. cargo vet does not link, so it runs even in the MSVC-linker-less dev env — this is a real local confirmation, not just CI.

Version `0.8.0-beta.2 → 0.8.0-beta.3` (ADR-0033 strict beta+1 over `origin/next`; `version-bump` gate self-check passes).

Surfaced during the #345 review/CI pass; pre-existing on `next` (not caused by the source-bundle feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
