### PR TITLE
feat(fetch): identity confirmation — title/authors/year on fetch (#344 Slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.5] - 2026-06-24
+
+### Added
+- **[fetch]** Identity confirmation on fetch (#344 Slice 1): `doiget fetch` now
+  prints a second stderr line — `     "<title>" by <author> et al. (<year>)
+  [<source>/<oa_status>]` — and the MCP `doiget_fetch_paper` success envelope
+  gains `title` / `authors` / `year`. Lets an agent (or human) confirm the
+  RIGHT paper landed in one call, without a follow-up `doiget info`. Mirrored
+  from the already-resolved/stored metadata — no extra fetch. Applies to
+  metadata-only fetches too.
+- **[core]** `FetchPaperOutcome` gains `title` / `authors` / `year`
+  (`#[non_exhaustive]`; additive).
+
 ## [0.8.0-beta.4] - 2026-06-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.4"
+version = "0.8.0-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.4"
+version = "0.8.0-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.4"
+version = "0.8.0-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.4"
+version       = "0.8.0-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -621,6 +621,34 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
             }
         }
     }
+
+    // #344: an identity-confirmation line so a caller can verify the RIGHT
+    // paper landed without a second `doiget info` call. Skipped for the
+    // Blocked fail-closed arm (it rendered an `error[CODE]:` line above, not
+    // a success).
+    if !matches!(outcome.pdf_leg, PdfLegStatus::Blocked { .. }) {
+        emit_identity_line(outcome);
+    }
+}
+
+/// Render the #344 identity line on stderr:
+/// `     "<title>" by <author> et al. (<year>)  [<source>/<oa>]`.
+/// Empty pieces are omitted; an unknown OA status renders as `?`.
+fn emit_identity_line(outcome: &FetchPaperOutcome) {
+    let by = match outcome.authors.as_slice() {
+        [] => String::new(),
+        [a] => format!(" by {a}"),
+        [a, ..] => format!(" by {a} et al."),
+    };
+    let year = match outcome.year {
+        Some(y) => format!(" ({y})"),
+        None => String::new(),
+    };
+    let oa = outcome.oa_status.as_deref().unwrap_or("?");
+    print_success(format_args!(
+        "     \"{}\"{}{}  [{}/{}]",
+        outcome.title, by, year, outcome.source, oa
+    ));
 }
 
 /// Run the `doiget fetch <ref>` subcommand.

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -820,6 +820,14 @@ pub struct FetchPaperOutcome {
     /// metadata-only fallback this is under the metadata source key
     /// (`"crossref"` / `"unpaywall"`). Always populated.
     pub canonical_digest: String,
+    /// Title of the fetched work, mirrored from the resolved metadata so a
+    /// caller can confirm the RIGHT paper landed in one call (#344). A ref-id
+    /// placeholder when the resolver supplied no title.
+    pub title: String,
+    /// Authors of the fetched work (empty when the resolver supplied none).
+    pub authors: Vec<String>,
+    /// Publication year, when known (#344 identity confirmation).
+    pub year: Option<i32>,
 }
 
 impl FetchPaperOutcome {
@@ -855,6 +863,9 @@ impl FetchPaperOutcome {
             // 32 bytes of `0x00` → a stable, non-secret digest stub
             // that's still 64 chars of lowercase hex.
             canonical_digest: "00".repeat(32),
+            title: String::new(),
+            authors: Vec::new(),
+            year: None,
         }
     }
 }
@@ -1048,6 +1059,9 @@ async fn fetch_paper_arxiv(
         pdf_leg: PdfLegStatus::Fetched,
         safekey: safekey.as_str().to_string(),
         canonical_digest,
+        title: metadata.title.clone(),
+        authors: metadata.authors.clone(),
+        year: metadata.year,
     })
 }
 
@@ -1347,6 +1361,9 @@ async fn fetch_paper_doi(
         pdf_leg,
         safekey: safekey.as_str().to_string(),
         canonical_digest,
+        title: metadata.title.clone(),
+        authors: metadata.authors.clone(),
+        year: metadata.year,
     })
 }
 

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3096,6 +3096,12 @@ fn fetch_paper_success_envelope(outcome: &FetchPaperOutcome, ref_str: &str) -> V
         "path": outcome.path,
         "size_bytes": outcome.size_bytes,
         "schema_version": outcome.schema_version,
+        // #344 identity confirmation: title / authors / year mirrored from the
+        // stored metadata so an agent can verify the RIGHT paper in one call,
+        // without a follow-up `doiget_info`.
+        "title": outcome.title,
+        "authors": outcome.authors,
+        "year": outcome.year,
         // Issue #118: never a silent metadata-only success.
         "pdf": pdf_leg_json(&outcome.pdf_leg),
     })

--- a/crates/doiget-mcp/tests/fetch_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/fetch_paper_e2e.rs
@@ -205,6 +205,23 @@ async fn fetch_paper_arxiv_happy_path_writes_pdf_and_returns_envelope() -> anyho
     let bytes = std::fs::read(on_disk).expect("read PDF");
     assert_eq!(bytes, SAMPLE_PDF_BODY);
 
+    // #344 (Slice 1): identity fields are surfaced on the success envelope so
+    // an agent can confirm the RIGHT paper in one call (no follow-up
+    // doiget_info). Values depend on the resolver's metadata (no Atom mock
+    // here), so assert the keys are present and well-typed.
+    assert!(
+        structured.get("title").is_some(),
+        "title key present: {structured:?}"
+    );
+    assert!(
+        structured["authors"].is_array(),
+        "authors is an array: {structured:?}"
+    );
+    assert!(
+        structured.get("year").is_some(),
+        "year key present (may be null): {structured:?}"
+    );
+
     client.cancel().await?;
     server_handle.await??;
     drop(env);


### PR DESCRIPTION
**#344 Slice 1** — fetch identity confirmation.

## Problem
A fetch reported only `path` + `size_bytes`; to confirm the *right* paper landed (catch a miscited DOI, a wrong-version preprint, etc.) an agent had to make a second `doiget info` call.

## Change (surface already-resolved metadata — no extra fetch)
- `FetchPaperOutcome` gains `title` / `authors` / `year` (`#[non_exhaustive]`; additive), populated from the `Metadata` the orchestrator already writes to the store TOML.
- `doiget fetch` prints a second **stderr** identity line:
  `     "<title>" by <author> et al. (<year>)  [<source>/<oa_status>]`
- MCP `doiget_fetch_paper` success envelope gains `title` / `authors` / `year`.
- Applies to metadata-only fetches too (identity helps even with no PDF).

## Tests
Extended the MCP arxiv happy-path e2e to assert the envelope carries `title` (string) / `authors` (array) / `year` (present, may be null). Values depend on resolver metadata, so the test asserts presence + type (robust without an Atom mock).

Version `0.8.0-beta.4 → 0.8.0-beta.5` (gate +1, self-check green). `cargo fmt` clean.

Slices **2** (`fetch --link <dir>` locality) and **3** (citation provenance, own ADR) remain in #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
