### PR TITLE
feat(fetch): --link <dir> to surface the fetched PDF in the working tree (#344 Slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.6] - 2026-06-24
+
+### Added
+- **[fetch]** `doiget fetch <ref> --link <dir>` (#344 Slice 2, ADR-0035): after
+  fetching, place a link to the stored PDF in `<dir>` so it is visible in your
+  working tree. Symlink by default, copy fallback where symlinks are
+  unavailable (e.g. Windows without privilege); the central store stays the
+  single source of truth. Named from the paper's metadata
+  (`<surname><year>-<title-slug>.pdf`), or the safekey when absent. Refuses to
+  clobber an unrelated file; metadata-only fetches are skipped; a link failure
+  is a warning, not a fetch failure.
+
+### Docs
+- **[adr]** ADR-0035 (`fetch --link`; #344 problem 1) + `DECISIONS/INDEX.md`.
+
 ## [0.8.0-beta.5] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.5"
+version = "0.8.0-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.5"
+version = "0.8.0-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.5"
+version = "0.8.0-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.5"
+version       = "0.8.0-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -43,7 +43,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 
 #[cfg(feature = "citation")]
 use doiget_core::http::tier_2_allowlist;
@@ -681,6 +681,7 @@ fn emit_identity_line(outcome: &FetchPaperOutcome) {
 pub async fn run_with_options(
     input: String,
     dry_run: bool,
+    link: Option<Utf8PathBuf>,
     _mode: super::output::OutputMode,
 ) -> Result<()> {
     // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression of the
@@ -766,6 +767,12 @@ pub async fn run_with_options(
                 return Err(anyhow::Error::new(CliExit(cli_exit_code(effective))));
             }
             emit_success_line(&ref_, &outcome);
+            // #344 Slice 2: optionally surface the artifact in the user's
+            // working tree via a symlink (copy fallback). A link failure is a
+            // warning, not a fetch failure — the PDF is already in the store.
+            if let Some(dir) = link.as_deref() {
+                emit_link_result(&ref_, &outcome, dir);
+            }
             Ok(())
         }
         Err(e) => {
@@ -774,6 +781,145 @@ pub async fn run_with_options(
             Err(anyhow::Error::new(CliExit(cli_exit_code(code))))
         }
     }
+}
+
+/// `--link` (#344 Slice 2): place a link to the fetched PDF in `dir` so the
+/// artifact is visible in the user's working tree. The central store stays the
+/// single source of truth; this only adds a pointer (or, where symlinks are
+/// unavailable, a copy). Only PDF outcomes are linked — a metadata-only fetch
+/// is reported as skipped. A link failure is a warning (stderr), never a fetch
+/// failure: the artifact is already in the store.
+fn emit_link_result(ref_: &Ref, outcome: &FetchPaperOutcome, dir: &Utf8Path) {
+    let label = match ref_ {
+        Ref::Arxiv(id) => format!("arxiv:{}", id.as_str()),
+        Ref::Doi(doi) => format!("doi:{}", doi.as_str()),
+    };
+    if !matches!(
+        outcome.pdf_leg,
+        PdfLegStatus::Fetched | PdfLegStatus::PreprintFallback { .. }
+    ) {
+        print_success(format_args!(
+            "note: --link skipped for {label} (no PDF — metadata-only fetch)"
+        ));
+        return;
+    }
+    let name = fetch_link_filename(
+        &outcome.title,
+        &outcome.authors,
+        outcome.year,
+        &outcome.safekey,
+    );
+    match link_artifact(dir, &outcome.path, &name) {
+        Ok((path, kind)) => print_success(format_args!("linked {label} -> {path} ({kind})")),
+        Err(e) => print_err(format_args!("warning: --link failed for {label}: {e}")),
+    }
+}
+
+/// Build a human-readable, filesystem-safe PDF filename for `--link`:
+/// `<surname><year>-<title-slug>.pdf`
+/// (e.g. `vaswani2017-attention-is-all-you-need.pdf`), falling back to
+/// `<safekey>.pdf` when no usable metadata is available.
+fn fetch_link_filename(
+    title: &str,
+    authors: &[String],
+    year: Option<i32>,
+    safekey: &str,
+) -> String {
+    let surname = authors
+        .first()
+        .map(|a| slugify(a.split_whitespace().last().unwrap_or(a)))
+        .unwrap_or_default();
+    let year = year.map(|y| y.to_string()).unwrap_or_default();
+    let title_slug: String = slugify(title)
+        .split('-')
+        .take(6)
+        .collect::<Vec<_>>()
+        .join("-");
+    let mut stem = format!("{surname}{year}");
+    if !stem.is_empty() && !title_slug.is_empty() {
+        stem.push('-');
+    }
+    stem.push_str(&title_slug);
+    let stem: String = stem.chars().take(80).collect();
+    let stem = stem.trim_matches('-');
+    if stem.is_empty() {
+        format!("{safekey}.pdf")
+    } else {
+        format!("{stem}.pdf")
+    }
+}
+
+/// Lowercase ASCII-alphanumeric slug: every run of non-alphanumeric characters
+/// collapses to a single `-`, with no leading/trailing dashes. Pure and
+/// filesystem-safe (no path separators, no `..`).
+fn slugify(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// Place a link to `src` (the store PDF) at `dir/name`. Tries a symlink first;
+/// on failure (e.g. Windows without privilege, or a cross-device link) falls
+/// back to a copy. Replaces a prior doiget symlink, but refuses to clobber an
+/// unrelated regular file. Returns the written path and the mechanism used
+/// (`"symlink"` | `"copy"`).
+fn link_artifact(
+    dir: &Utf8Path,
+    src: &Utf8Path,
+    name: &str,
+) -> Result<(Utf8PathBuf, &'static str)> {
+    std::fs::create_dir_all(dir.as_std_path())
+        .with_context(|| format!("creating link dir {dir}"))?;
+    let dst = dir.join(name);
+    if let Ok(meta) = std::fs::symlink_metadata(dst.as_std_path()) {
+        if meta.file_type().is_symlink() {
+            std::fs::remove_file(dst.as_std_path())
+                .with_context(|| format!("replacing existing symlink {dst}"))?;
+        } else {
+            anyhow::bail!(
+                "refusing to overwrite existing file {dst} (not a doiget symlink) — \
+                 remove it or choose another --link dir"
+            );
+        }
+    }
+    match make_symlink(src, &dst) {
+        Ok(()) => Ok((dst, "symlink")),
+        Err(_) => {
+            std::fs::copy(src.as_std_path(), dst.as_std_path())
+                .with_context(|| format!("copying {src} -> {dst}"))?;
+            Ok((dst, "copy"))
+        }
+    }
+}
+
+/// Cross-platform file symlink. On platforms without symlink support the caller
+/// falls back to a copy.
+#[cfg(unix)]
+fn make_symlink(src: &Utf8Path, dst: &Utf8Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src.as_std_path(), dst.as_std_path())
+}
+
+#[cfg(windows)]
+fn make_symlink(src: &Utf8Path, dst: &Utf8Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(src.as_std_path(), dst.as_std_path())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn make_symlink(_src: &Utf8Path, _dst: &Utf8Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "symlinks unsupported on this platform",
+    ))
 }
 
 /// Single-line user-visible success message, written to stderr per ADR-0001
@@ -1289,5 +1435,81 @@ host = "*.uj.edu.pl"
                 "CLI wire token for {r:?} must equal the serde snake_case form"
             );
         }
+    }
+
+    // ── #344 Slice 2: --link helpers ──────────────────────────────────────
+
+    #[test]
+    fn slugify_lowercases_and_collapses_non_alnum() {
+        assert_eq!(
+            slugify("Attention Is All You Need"),
+            "attention-is-all-you-need"
+        );
+        assert_eq!(slugify("Foo/Bar: Baz!!"), "foo-bar-baz");
+        assert_eq!(slugify("  spaced  "), "spaced");
+        assert_eq!(slugify("!!!"), ""); // no alphanumerics → empty
+    }
+
+    #[test]
+    fn fetch_link_filename_builds_readable_name() {
+        let name = fetch_link_filename(
+            "Attention Is All You Need",
+            &["Ashish Vaswani".to_string()],
+            Some(2017),
+            "arxiv_1706.03762",
+        );
+        assert_eq!(name, "vaswani2017-attention-is-all-you-need.pdf");
+    }
+
+    #[test]
+    fn fetch_link_filename_falls_back_to_safekey() {
+        // No usable metadata (empty title, no authors/year) → safekey.pdf.
+        assert_eq!(
+            fetch_link_filename("", &[], None, "doi_10.1234_x"),
+            "doi_10.1234_x.pdf"
+        );
+        // A title that slugifies to nothing also falls back.
+        assert_eq!(
+            fetch_link_filename("…—", &[], None, "doi_10.1234_y"),
+            "doi_10.1234_y.pdf"
+        );
+    }
+
+    #[test]
+    fn link_artifact_creates_readable_artifact() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8Path::from_path(td.path()).expect("utf8");
+        let src = dir.join("src.pdf");
+        std::fs::write(src.as_std_path(), b"%PDF-DATA").expect("write src");
+
+        let (dst, _kind) = link_artifact(dir, &src, "out.pdf").expect("link");
+        assert!(dst.exists(), "linked artifact must exist: {dst}");
+        assert_eq!(
+            std::fs::read(dst.as_std_path()).expect("read dst"),
+            b"%PDF-DATA",
+            "linked artifact (symlink or copy) must resolve to the source bytes"
+        );
+    }
+
+    #[test]
+    fn link_artifact_refuses_to_clobber_unrelated_file() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8Path::from_path(td.path()).expect("utf8");
+        let src = dir.join("src.pdf");
+        std::fs::write(src.as_std_path(), b"%PDF-DATA").expect("write src");
+        // A pre-existing, unrelated regular file at the target name.
+        let taken = dir.join("taken.pdf");
+        std::fs::write(taken.as_std_path(), b"USER-DATA").expect("write taken");
+
+        let err = link_artifact(dir, &src, "taken.pdf").expect_err("must refuse");
+        assert!(
+            err.to_string().contains("refusing to overwrite"),
+            "error must explain the refusal: {err}"
+        );
+        assert_eq!(
+            std::fs::read(taken.as_std_path()).expect("read taken"),
+            b"USER-DATA",
+            "the user's file must be left untouched"
+        );
     }
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -243,6 +243,14 @@ enum Command {
         /// the single host the real fetch would hit (ADR-0022 §4).
         #[arg(long)]
         dry_run: bool,
+        /// After fetching, also place a link to the PDF in DIR (created if
+        /// missing) so it is visible in your working tree. Uses a symlink,
+        /// falling back to a copy where symlinks are unavailable (e.g. Windows
+        /// without privilege). Named from the paper's metadata (e.g.
+        /// `vaswani2017-attention-is-all-you-need.pdf`), or the safekey when
+        /// metadata is absent. Metadata-only fetches (no PDF) are skipped. (#344)
+        #[arg(long, value_name = "DIR", value_parser = parse_utf8_path)]
+        link: Option<Utf8PathBuf>,
     },
     /// Fetch many refs from a newline-separated text file.
     Batch {
@@ -818,9 +826,11 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::BatchResolveCitations { limit }) => {
             doiget_cli::commands::resolve_citation::run_batch(limit, mode).await
         }
-        Some(Command::Fetch { ref_, dry_run }) => {
-            doiget_cli::commands::fetch::run_with_options(ref_, dry_run, mode).await
-        }
+        Some(Command::Fetch {
+            ref_,
+            dry_run,
+            link,
+        }) => doiget_cli::commands::fetch::run_with_options(ref_, dry_run, link, mode).await,
         Some(Command::Batch {
             path,
             dry_run,

--- a/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_arxiv_e2e.rs
@@ -81,9 +81,14 @@ async fn arxiv_2401_12345_end_to_end() {
 
     // Step 3: run the orchestrator end-to-end. No child binary; no real
     // network traffic.
-    fetch::run_with_options("arxiv:2401.12345".to_string(), false, OutputMode::Human)
-        .await
-        .expect("fetch::run_with_options succeeds");
+    fetch::run_with_options(
+        "arxiv:2401.12345".to_string(),
+        false,
+        None,
+        OutputMode::Human,
+    )
+    .await
+    .expect("fetch::run_with_options succeeds");
 
     // Step 4: assert the on-disk PDF.
     let pdf_path = store_root.join("arxiv_2401.12345.pdf");
@@ -203,9 +208,14 @@ async fn arxiv_fetch_stores_real_atom_metadata() {
     env.set("DOIGET_LOG_PATH", temp_root.join("log.jsonl").as_str());
     env.set("DOIGET_ARXIV_BASE", &server.uri());
 
-    fetch::run_with_options("arxiv:2401.12345".to_string(), false, OutputMode::Human)
-        .await
-        .expect("fetch succeeds");
+    fetch::run_with_options(
+        "arxiv:2401.12345".to_string(),
+        false,
+        None,
+        OutputMode::Human,
+    )
+    .await
+    .expect("fetch succeeds");
 
     let meta_path = store_root.join(".metadata").join("arxiv_2401.12345.toml");
     let meta_raw = std::fs::read_to_string(meta_path.as_std_path()).expect("read metadata toml");

--- a/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_doi_oa_pdf_e2e.rs
@@ -152,7 +152,7 @@ async fn fetch_doi_oa_pdf_happy_path() {
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
     // Step 3: run the orchestrator end-to-end. No real network traffic.
-    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, None, OutputMode::Human)
         .await
         .expect("fetch::run_with_options succeeds");
 
@@ -337,7 +337,7 @@ async fn fetch_doi_oa_pdf_falls_back_to_metadata_when_host_off_allowlist() {
     // assertions below remain (the pre-fetch denial emits the same
     // closed-set `NETWORK_ERROR` provenance row as a redirect-time
     // denial; the process EXIT code is the reclassified value).
-    let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
+    let err = fetch::run_with_options(format!("doi:{}", TEST_DOI), false, None, OutputMode::Human)
         .await
         .expect_err("a blocked OA PDF leg must NOT be a silent success (issue #145)");
     let cli_exit = err
@@ -450,7 +450,7 @@ async fn fetch_doi_crossref_down_unpaywall_oa_still_yields_pdf() {
     env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", base_uri));
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
-    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, None, OutputMode::Human)
         .await
         .expect("fetch must succeed via Unpaywall even though Crossref failed");
 
@@ -555,7 +555,7 @@ async fn fetch_doi_oa_chain_falls_back_to_secondary_when_best_returns_403() {
     env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", base_uri));
     env.set("DOIGET_OA_PUBLISHER_BASE", &base_uri);
 
-    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, OutputMode::Human)
+    fetch::run_with_options(format!("doi:{}", TEST_DOI), false, None, OutputMode::Human)
         .await
         .expect("chain walker must succeed on the fallback candidate");
 

--- a/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_dry_run_e2e.rs
@@ -61,7 +61,7 @@ async fn dry_run_fetch_doi_returns_ok_without_side_effects() {
     // crossref/unpaywall/oa-publisher hosts is not stubbed). The fact
     // that this call returns Ok proves the dry-run path short-circuits
     // before any network call.
-    let result = run_with_options("10.1234/foo".to_string(), true, OutputMode::Human).await;
+    let result = run_with_options("10.1234/foo".to_string(), true, None, OutputMode::Human).await;
     result.expect("dry-run fetch::run_with_options succeeds");
 
     // Step 3: assert the on-disk side-effects are empty. The store
@@ -113,7 +113,13 @@ async fn dry_run_fetch_arxiv_returns_ok_without_side_effects() {
     env.set("DOIGET_STORE_ROOT", store_root.as_str());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
 
-    let result = run_with_options("arxiv:2401.12345".to_string(), true, OutputMode::Human).await;
+    let result = run_with_options(
+        "arxiv:2401.12345".to_string(),
+        true,
+        None,
+        OutputMode::Human,
+    )
+    .await;
     result.expect("dry-run arxiv fetch::run_with_options succeeds");
 
     assert!(

--- a/crates/doiget-cli/tests/fetch_link_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_link_e2e.rs
@@ -1,0 +1,89 @@
+//! End-to-end test for `doiget fetch --link <dir>` (#344 Slice 2).
+//!
+//! Drives `fetch::run_with_options(.., link = Some(dir), ..)` in-process (no
+//! child spawn), with a wiremock-served arXiv PDF (no outbound network), and
+//! asserts the artifact is materialised in the link dir — as a symlink, or a
+//! copy where symlinks are unavailable; both resolve to the PDF bytes. The
+//! linked filename is metadata-derived or the safekey, so the assertion checks
+//! content (and that exactly one PDF landed), not the exact name. The slug
+//! naming and the refuse-to-clobber behaviour are unit-tested in `fetch.rs`.
+//!
+//! ## Network purity
+//! No outbound calls: all HTTP terminates at a `wiremock::MockServer`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use camino::{Utf8Path, Utf8PathBuf};
+use doiget_cli::commands::fetch;
+use doiget_cli::commands::output::OutputMode;
+use serial_test::serial;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::env_guard::EnvGuard;
+
+#[tokio::test]
+#[serial]
+async fn fetch_link_materialises_pdf_in_link_dir() {
+    let server = MockServer::start().await;
+    let body = b"%PDF-1.7\n%link-fixture\n".to_vec();
+    Mock::given(method("GET"))
+        .and(path("/pdf/2401.12345.pdf"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&server)
+        .await;
+
+    let td = TempDir::new().expect("tempdir");
+    let temp_root: Utf8PathBuf = Utf8Path::from_path(td.path())
+        .expect("temp dir is utf-8")
+        .to_path_buf();
+    let store_root = temp_root.join("papers");
+    let log_path = temp_root.join("log.jsonl");
+    let link_dir = temp_root.join("workspace");
+
+    let env = EnvGuard::new(&[
+        "DOIGET_STORE_ROOT",
+        "DOIGET_LOG_PATH",
+        "DOIGET_ARXIV_BASE",
+        "DOIGET_CROSSREF_BASE",
+        "DOIGET_UNPAYWALL_BASE",
+        "DOIGET_CONTACT_EMAIL",
+        "DOIGET_UNPAYWALL_EMAIL",
+    ]);
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_ARXIV_BASE", &server.uri());
+
+    fetch::run_with_options(
+        "arxiv:2401.12345".to_string(),
+        false,
+        Some(link_dir.clone()),
+        OutputMode::Human,
+    )
+    .await
+    .expect("fetch --link succeeds");
+
+    // The store still holds the canonical PDF (single source of truth).
+    let store_pdf = store_root.join("arxiv_2401.12345.pdf");
+    assert!(store_pdf.exists(), "store PDF must exist: {store_pdf}");
+
+    // The link dir holds exactly one .pdf (symlink or copy) resolving to the
+    // same bytes. Name is metadata-derived or safekey → assert content, not name.
+    let entries: Vec<Utf8PathBuf> = std::fs::read_dir(link_dir.as_std_path())
+        .expect("link dir exists")
+        .flatten()
+        .filter_map(|e| Utf8PathBuf::from_path_buf(e.path()).ok())
+        .filter(|p| p.extension() == Some("pdf"))
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one linked PDF; got {entries:?}");
+    let linked_bytes = std::fs::read(entries[0].as_std_path()).expect("read linked pdf");
+    assert_eq!(
+        linked_bytes, body,
+        "linked artifact (symlink or copy) must resolve to the PDF bytes"
+    );
+
+    drop(env);
+    drop(td);
+}

--- a/docs/DECISIONS/0035-fetch-link.md
+++ b/docs/DECISIONS/0035-fetch-link.md
@@ -1,0 +1,90 @@
+# 0035 - `fetch --link`: surface fetched artifacts into the working tree
+
+- **Date:** 2026-06-24
+- **Status:** Proposed — implemented by `feat/344-fetch-link` (issue #344
+  Slice 2); flips to `Accepted` on merge per `DECISIONS/INDEX.md` conventions.
+- **Relates:** issue #344 (agent-driven UX) problem 1 (store locality). Bounded
+  by [`SCOPE.md`](../SCOPE.md) §non-goal 3 (no redistribution / share-vault).
+- **Source:** dogfooding 2026-06-24 (#344).
+
+## Context
+
+doiget fetches into a single central store (`~/papers/<safekey>.pdf`,
+[`STORE.md`](../STORE.md)). When an LLM agent drives doiget, the human is
+usually working somewhere else — a project dir, an Obsidian vault — and **cannot
+see what the agent just pulled**: the artifact lives "elsewhere" and never
+surfaces where the work happens (#344 problem 1).
+
+This is new CLI surface, so per SCOPE.md it needs an ADR. It is **not** a
+permanent non-goal: §non-goal 3 forbids redistribution / a cross-**user**
+share-vault; placing a link for the **same user** in their own working tree is
+local visibility, not redistribution.
+
+## Decision
+
+Add `doiget fetch <ref> --link <dir>`: after a successful fetch, place a link to
+the stored PDF in `<dir>` (created if missing).
+
+```mermaid
+flowchart TD
+  F["fetch --link DIR"] --> O[normal fetch → store PDF]
+  O --> P{PDF present?}
+  P -- no, metadata-only --> SK[skip + note]
+  P -- yes --> N["name = slug(metadata) or safekey"]
+  N --> E{DIR/name exists?}
+  E -- our symlink --> R[replace]
+  E -- unrelated regular file --> RF[refuse, warn, leave untouched]
+  E -- none --> L[symlink]
+  L -- fails (Win priv / cross-dev) --> C[copy fallback]
+  L --> RP[report path + mechanism]
+  C --> RP
+```
+
+### D1 — The store stays the single source of truth
+
+`--link` adds a **pointer** (symlink), never a second canonical copy. Where
+symlinks are unavailable (Windows without privilege, cross-device) it falls back
+to a **copy** and says which it used. The store entry is unchanged.
+
+### D2 — Readable, filesystem-safe name
+
+The link is named from the (already-resolved, #344 Slice 1) metadata —
+`<surname><year>-<title-slug>.pdf`
+(e.g. `vaswani2017-attention-is-all-you-need.pdf`) — because the whole point is
+human visibility; a `safekey`-named file is barely more legible than the store.
+The slug is lowercase ASCII-alphanumeric with `-` separators (no path
+separators, no `..`). When metadata is absent it falls back to `<safekey>.pdf`.
+
+### D3 — Never clobber the user's files
+
+If the target name already exists: a prior doiget **symlink** is replaced
+(idempotent re-link); an **unrelated regular file** is **refused** (warning, the
+file is left untouched) — doiget did not create it, so it does not overwrite it.
+(Consequence: after a copy-fallback, a re-link refuses until the copy is
+removed; an acceptable v1 edge, surfaced in the message.)
+
+### D4 — PDF-only; link failure is non-fatal
+
+Only PDF outcomes are linked; a metadata-only fetch reports "skipped". A link
+failure is a **warning on stderr**, never a fetch failure — the artifact is
+already safely in the store, and the link is a convenience.
+
+### D5 — Scope: CLI `fetch` only (v1)
+
+`batch --link` and an MCP equivalent are deferred (filesystem-materialising ops
+are CLI-first, cf. SCOPE §non-goal 15). `--link` + `--dry-run` is a no-op (dry
+run fetches nothing).
+
+## Consequences
+
+**Positive.** Closes #344 problem 1: the fetched artifact is visible in the
+user's working tree with a legible name, at near-zero cost (reuses the stored
+PDF + Slice 1 metadata). The store contract is untouched.
+
+**Negative / cost.** Symlink vs copy differs by platform (reported, not hidden).
+Copy-fallback re-link is non-idempotent (D3). Readable names can collide across
+papers with the same surname/year/title-prefix — the refuse-to-clobber rule
+turns a collision into a visible warning rather than data loss.
+
+**Governance.** On merge: flip to `Accepted`, add the `0035` row to
+`DECISIONS/INDEX.md`. To revise, write a new ADR with `Supersedes: 0035`.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -51,6 +51,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0032 | Structured full-text (HTML/XML) extraction in scope; PDF-blob processing stays out of scope | Accepted (design; PR4 ships ar5iv leg) | PR4 (`feat/paper-text`) | #281 item 3 / scope decision 2026-06-06 |
 | 0033 | Per-PR version-bump enforcement + strict next→main promotion (amends 0025 §D6) | Proposed (implemented by `chore/version-bump-gate`; flips on merge) | `chore/version-bump-gate` | maintainer review 2026-06-24 (0.7.1 vanishing) |
 | 0034 | arXiv source bundle + individual figure download | Proposed (implemented by `feat/343-source-bundle-figures`; flips on merge) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
+| 0035 | `fetch --link`: surface fetched artifacts into the working tree | Proposed (implemented by `feat/344-fetch-link`; flips on merge) | `feat/344-fetch-link` | #344 / dogfood 2026-06-24 |
 
 ## Conventions
 


### PR DESCRIPTION
**#344 Slice 2** — store locality.

## Problem
An agent fetches into the central store (`~/papers/<safekey>.pdf`); the human working in a project dir / vault **can't see** what was pulled.

## Change
`doiget fetch <ref> --link <dir>` places a link to the stored PDF in `<dir>` (created if missing):
- **symlink** by default; **copy fallback** where symlinks are unavailable (Windows without privilege, cross-device) — reports which was used.
- **readable name** from metadata (`<surname><year>-<title-slug>.pdf`, reusing Slice 1's title/authors/year), falling back to `<safekey>.pdf`.
- the **store stays the single source of truth**; **refuses to clobber** an unrelated file; **metadata-only** fetches are skipped; a link failure is a **warning, not a fetch failure**.

`run_with_options` gains a `link` param (all callers updated). CLI `fetch` only for v1 (`batch`/MCP deferred). ADR-0035 (SCOPE non-goal #3 = cross-*user* redistribution; same-user local link is not that).

## Tests
- unit (`fetch.rs`): `slugify`, `fetch_link_filename` (readable + safekey fallback), `link_artifact` (happy + refuse-to-clobber).
- e2e (`fetch_link_e2e`): `fetch --link` materialises a PDF in the dir (content-asserted; symlink-or-copy agnostic, so it holds on Windows too).

Version `0.8.0-beta.5 → 0.8.0-beta.6` (gate +1, self-check green). `cargo fmt` clean.

Remaining in #344: Slice 3 (citation provenance, own ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
