### PR TITLE
feat(store): default store root → ./papers (cwd) (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.7] - 2026-06-24
+
+### Changed
+- **[store/config]** **Default store root changed from `~/papers` to `./papers`**
+  (`papers/` under the current working directory) — #344 problem 1, ADR-0036.
+  Fetched artifacts now land where you (or an agent) are working, instead of a
+  far-off home directory where they are easy to miss. `DOIGET_STORE_ROOT` /
+  `--store-root` / `config.toml` overrides are unchanged; set
+  `DOIGET_STORE_ROOT=~/papers` to restore the old central library (which also
+  restores BiblioFetch.jl co-location). `ResolvedConfig::from_env` now reuses the
+  CLI store-root resolver, so `config show` / `doctor` cannot drift from where
+  artifacts actually land. **Contract note:** doiget and BiblioFetch.jl no longer
+  co-locate by default; the shared on-disk *format* (STORE.md) is unchanged.
+
+### Docs
+- **[adr]** ADR-0036 (default store root → cwd; amends ADR-0004 co-location) +
+  amended ADR-0004 status + `DECISIONS/INDEX.md`. Updated STORE.md / CONFIG.md /
+  SCOPE.md default-root references.
+
 ## [0.8.0-beta.6] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.6"
+version = "0.8.0-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.6"
+version = "0.8.0-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.6"
+version = "0.8.0-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.6"
+version       = "0.8.0-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ See [docs/SOURCES.md](docs/SOURCES.md).
 ## Coexistence with BiblioFetch.jl
 
 doiget and BiblioFetch.jl share the same on-disk store format (TOML metadata + PDF files
-under `~/papers/`). The shared schema, locking protocol, and atomic write contract are
+under a configurable store root). doiget defaults to `./papers` (under the current working
+directory; ADR-0036), BiblioFetch.jl to `~/papers/`; point both at the same root (e.g.
+`DOIGET_STORE_ROOT=~/papers`) to share one store. The shared schema, locking protocol, and
+atomic write contract are
 specified in [docs/STORE.md](docs/STORE.md). Reference test vectors for the shared safekey
 algorithm are in [docs/SAFEKEY.md](docs/SAFEKEY.md).
 

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -237,7 +237,7 @@ const MODES: &[&str] = &["human", "json", "quiet", "mcp"];
 const ENV_VARS: &[EnvVar] = &[
     EnvVar {
         name: "DOIGET_STORE_ROOT",
-        default: "$HOME/papers",
+        default: "./papers (under the current working dir)",
         help: "Root of the on-disk paper store. CONFIG.md §4.",
     },
     EnvVar {

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -32,7 +32,7 @@ use super::fetch::CliExit;
 /// read, undocumented `DOIGET_LOG_DIR` has been dropped.
 #[derive(Debug, serde::Serialize)]
 pub struct ResolvedConfig {
-    /// Root of the on-disk paper store. Default: `$HOME/papers`.
+    /// Root of the on-disk paper store. Default: `./papers` (under the cwd).
     pub store_root: Utf8PathBuf,
     /// Directory holding doiget's append-only logs. Derived from
     /// `log_path`'s parent so it always agrees with the writer.
@@ -60,20 +60,19 @@ impl ResolvedConfig {
     /// platform); on every realistic POSIX or Windows host this returns
     /// `Ok` even with no `DOIGET_*` env vars set.
     pub fn from_env() -> Result<Self> {
-        // `dirs::home_dir()` / `dirs::config_dir()` return `std::path::PathBuf`;
-        // hoist them into `Utf8PathBuf` immediately at the OS boundary so the
-        // rest of the function (and the public struct) stays UTF-8-only per
-        // the workspace `disallowed-types` clippy rule. A non-UTF-8 home dir
-        // is exotic and unsupported; surface it as an explicit error.
-        let home =
-            Utf8PathBuf::try_from(dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?)?;
+        // `dirs::config_dir()` returns `std::path::PathBuf`; hoist it into
+        // `Utf8PathBuf` immediately at the OS boundary so the rest of the
+        // function (and the public struct) stays UTF-8-only per the workspace
+        // `disallowed-types` clippy rule.
         let cfg = Utf8PathBuf::try_from(
             dirs::config_dir().ok_or_else(|| anyhow::anyhow!("no config dir"))?,
         )?;
 
-        let store_root = std::env::var("DOIGET_STORE_ROOT")
-            .map(Utf8PathBuf::from)
-            .unwrap_or_else(|_| home.join("papers"));
+        // Store root: identical resolution to where artifacts actually land
+        // (`super::resolve_store_root`) so `config show` / `doctor` never drifts
+        // from the writer — `DOIGET_STORE_ROOT` else `./papers` under the cwd
+        // (#344 / ADR-0036).
+        let store_root = super::resolve_store_root()?;
 
         // Issue #142: resolve the log path the SAME way the writer does
         // (`commands::fetch::resolve_log_path` / `commands::audit_log`):
@@ -330,12 +329,12 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn from_env_uses_home_default_when_unset() {
+    fn from_env_uses_cwd_default_when_unset() {
         let _g = unset_all_doiget_config_env();
-        let cfg = ResolvedConfig::from_env().expect("home dir must resolve on test host");
+        let cfg = ResolvedConfig::from_env().expect("config resolves on test host");
         assert!(
             cfg.store_root.as_str().ends_with("papers"),
-            "store_root should fall back to <home>/papers when DOIGET_STORE_ROOT is unset; got {}",
+            "store_root should fall back to ./papers (cwd) when DOIGET_STORE_ROOT is unset; got {}",
             cfg.store_root
         );
         assert_eq!(cfg.contact_email, None);

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -332,9 +332,16 @@ mod tests {
     fn from_env_uses_cwd_default_when_unset() {
         let _g = unset_all_doiget_config_env();
         let cfg = ResolvedConfig::from_env().expect("config resolves on test host");
-        assert!(
-            cfg.store_root.as_str().ends_with("papers"),
-            "store_root should fall back to ./papers (cwd) when DOIGET_STORE_ROOT is unset; got {}",
+        // The default must be `<cwd>/papers` (ADR-0036), NOT `<home>/papers` —
+        // assert the full path so a regression back to the home directory is
+        // actually caught (a bare `ends_with("papers")` passes for both).
+        let cwd =
+            camino::Utf8PathBuf::from_path_buf(std::env::current_dir().expect("cwd is available"))
+                .expect("cwd is valid UTF-8");
+        assert_eq!(
+            cfg.store_root,
+            cwd.join("papers"),
+            "store_root should default to <cwd>/papers when DOIGET_STORE_ROOT is unset; got {}",
             cfg.store_root
         );
         assert_eq!(cfg.contact_email, None);

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -31,7 +31,7 @@
 //!
 //! | Env var | Default | Purpose |
 //! |---|---|---|
-//! | `DOIGET_STORE_ROOT` | `$HOME/papers` (or `%USERPROFILE%\papers` on Windows) | Filesystem store root |
+//! | `DOIGET_STORE_ROOT` | `./papers` (under the current working dir) | Filesystem store root |
 //! | `DOIGET_LOG_PATH` | `<config>/doiget/access.jsonl` | Provenance log file |
 //! | `DOIGET_CONTACT_EMAIL` | `doiget@localhost` | Polite-pool contact email (User-Agent and Crossref) |
 //! | `DOIGET_UNPAYWALL_EMAIL` | (= contact email) | Unpaywall query-string email |

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -59,22 +59,27 @@ use camino::Utf8PathBuf;
 /// config-file resolution lands with the `config` subcommand):
 ///
 /// 1. `DOIGET_STORE_ROOT` environment variable, if set and non-empty.
-/// 2. Fallback to `$HOME/papers` (POSIX) or `%USERPROFILE%\papers` (Windows).
+/// 2. Fallback to `./papers` — `papers/` directly under the current working
+///    directory (#344 / ADR-0036), so fetched artifacts are visible where the
+///    user (or an LLM agent) is working rather than hidden in a far-off home
+///    directory. For a central, shared library set `DOIGET_STORE_ROOT`
+///    (e.g. `~/papers`, which also restores BiblioFetch.jl co-location —
+///    ADR-0004).
 ///
 /// The env-var hook is sufficient for both real use and integration tests
 /// — tests set `DOIGET_STORE_ROOT` to a `tempfile::TempDir` to keep the
-/// real `~/papers/` untouched.
+/// real working directory untouched.
 pub(crate) fn resolve_store_root() -> Result<Utf8PathBuf> {
     if let Ok(s) = std::env::var("DOIGET_STORE_ROOT") {
         if !s.is_empty() {
             return Ok(Utf8PathBuf::from(s));
         }
     }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .context(
-            "could not determine home directory: \
-             neither HOME nor USERPROFILE is set, and DOIGET_STORE_ROOT was not provided",
-        )?;
-    Ok(Utf8PathBuf::from(home).join("papers"))
+    let cwd = std::env::current_dir().context(
+        "could not determine the current working directory for the default store root \
+         (set DOIGET_STORE_ROOT to choose an explicit store location)",
+    )?;
+    Utf8PathBuf::from_path_buf(cwd)
+        .map(|d| d.join("papers"))
+        .map_err(|p| anyhow::anyhow!("current directory path is not UTF-8: {}", p.display()))
 }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -159,7 +159,7 @@ struct Cli {
 
     /// Override the on-disk paper store root. CONFIG.md §5 / #211.
     /// Precedence: this flag > `DOIGET_STORE_ROOT` env > default
-    /// (`$HOME/papers` on POSIX, `%USERPROFILE%\papers` on Windows).
+    /// (`./papers` — `papers/` under the current working directory; ADR-0036).
     /// Wins by overwriting `DOIGET_STORE_ROOT` for the lifetime of
     /// this process before any command resolver reads it. Empty
     /// strings and NUL bytes are rejected at parse time by

--- a/crates/doiget-core/src/store/mod.rs
+++ b/crates/doiget-core/src/store/mod.rs
@@ -8,16 +8,17 @@
 //!
 //! - [`Store`] — the trait surface implementations expose.
 //! - [`FsStore`] — filesystem-backed implementation rooted at a configurable
-//!   directory (default `~/papers/`).
+//!   directory (default `./papers`, under the cwd; ADR-0036).
 //! - [`Metadata`] / [`DoigetExtension`] — the on-disk schema, mirrored from
 //!   `docs/STORE.md` §2.
 //!
 //! ## Cross-tool coexistence
 //!
-//! `~/papers/` is a shared resource between doiget and BiblioFetch.jl. Both
-//! tools follow the lock protocol in `docs/STORE.md` §4 and the atomic-write
-//! sequence in §5. Per §6, doiget MUST NOT overwrite reserved top-level
-//! fields previously written by another tool — see [`FsStore::write`].
+//! The store can be shared between doiget and BiblioFetch.jl when both are
+//! pointed at the same root (they no longer co-locate by default — ADR-0036).
+//! Both tools follow the lock protocol in `docs/STORE.md` §4 and the
+//! atomic-write sequence in §5. Per §6, doiget MUST NOT overwrite reserved
+//! top-level fields previously written by another tool — see [`FsStore::write`].
 
 mod fs_store;
 pub mod metadata;

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -287,7 +287,7 @@ impl Server {
                 return Ok(CallToolResult::structured(metadata_only_error_envelope(
                     Some(&input.ref_),
                     ErrorCode::StoreError,
-                    "store root could not be resolved (set DOIGET_STORE_ROOT or $HOME)",
+                    "store root could not be resolved (set DOIGET_STORE_ROOT, or run from a directory with a valid UTF-8 path)",
                 )));
             }
         };
@@ -552,7 +552,7 @@ impl Server {
                 return Ok(CallToolResult::structured(fetch_paper_error_envelope(
                     Some(&input.ref_),
                     ErrorCode::InternalError,
-                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                    "could not resolve store root (set DOIGET_STORE_ROOT, or run from a directory with a valid UTF-8 path)",
                 )));
             }
         };
@@ -709,7 +709,7 @@ impl Server {
             None => {
                 return Ok(CallToolResult::structured(batch_fetch_error_envelope(
                     ErrorCode::InternalError,
-                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                    "could not resolve store root (set DOIGET_STORE_ROOT, or run from a directory with a valid UTF-8 path)",
                 )));
             }
         };
@@ -966,7 +966,7 @@ impl Server {
             None => {
                 return Ok(CallToolResult::structured(batch_fetch_error_envelope(
                     ErrorCode::InternalError,
-                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                    "could not resolve store root (set DOIGET_STORE_ROOT, or run from a directory with a valid UTF-8 path)",
                 )));
             }
         };
@@ -1081,7 +1081,7 @@ impl Server {
                 return Ok(CallToolResult::structured(read_path_error_envelope(
                     Some(&input.ref_),
                     ErrorCode::InternalError,
-                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                    "could not resolve store root (set DOIGET_STORE_ROOT, or run from a directory with a valid UTF-8 path)",
                 )));
             }
         };
@@ -2751,7 +2751,7 @@ impl Server {
                 return CallToolResult::structured(read_path_error_envelope(
                     None,
                     ErrorCode::InternalError,
-                    "could not resolve store root (neither DOIGET_STORE_ROOT, HOME, nor USERPROFILE is set)",
+                    "could not resolve store root (set DOIGET_STORE_ROOT, or run from a directory with a valid UTF-8 path)",
                 ));
             }
         };
@@ -3727,10 +3727,11 @@ impl ServerHandler for Server {
 /// applies (`docs/CONFIG.md` §4):
 ///
 /// 1. `DOIGET_STORE_ROOT` env var (when non-empty).
-/// 2. `$HOME/papers` (POSIX) or `%USERPROFILE%\papers` (Windows).
+/// 2. `./papers` — `papers/` under the current working directory
+///    (#344 / ADR-0036).
 ///
-/// Returns `None` when neither hook resolves — e.g. a locked-down host
-/// with no `HOME` and no `USERPROFILE`. Callers downgrade that to
+/// Returns `None` only when the current working directory can't be
+/// determined or isn't valid UTF-8. Callers downgrade that to
 /// `store_writable: false` rather than erroring the whole tool call.
 ///
 /// # Why duplicate the CLI logic?
@@ -3924,13 +3925,11 @@ mod tests {
 
     #[test]
     fn resolve_store_root_returns_some_on_normal_host() {
-        // On any realistic POSIX or Windows host either HOME or
-        // USERPROFILE is set, so resolve_store_root is `Some(_)` even
-        // without DOIGET_STORE_ROOT. We deliberately don't mutate env
-        // (the test process is shared with other tests).
-        if std::env::var_os("HOME").is_some() || std::env::var_os("USERPROFILE").is_some() {
-            assert!(resolve_store_root().is_some());
-        }
+        // The default is `<cwd>/papers` (ADR-0036): either branch yields a
+        // root on a normal host — `DOIGET_STORE_ROOT` when set, else the cwd
+        // default, since current_dir() is always available. We deliberately
+        // don't mutate env (the test process is shared with other tests).
+        assert!(resolve_store_root().is_some());
     }
 
     /// ADR-0028 D2: `build_http_client_for_fetch` MUST merge user-

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3745,10 +3745,13 @@ fn resolve_store_root() -> Option<Utf8PathBuf> {
             return Some(Utf8PathBuf::from(s));
         }
     }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .ok()?;
-    Some(Utf8PathBuf::from(home).join("papers"))
+    // Default: `papers/` under the current working directory (#344 / ADR-0036),
+    // so an agent's fetches land where the work is; set DOIGET_STORE_ROOT for a
+    // central library.
+    let cwd = std::env::current_dir().ok()?;
+    Utf8PathBuf::from_path_buf(cwd)
+        .ok()
+        .map(|d| d.join("papers"))
 }
 
 /// Best-effort writability probe for the resolved store root.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,7 +37,7 @@ flowchart TB
     TDM -.-> Fetcher
 
     Fetcher --> Log[Provenance Log<br/>JSON Lines + SHA256 hash chain<br/>fail-closed]
-    Fetcher --> Store[Store<br/>~/papers/ + TOML metadata<br/>BiblioFetch.jl 互換]
+    Fetcher --> Store[Store<br/>./papers default + TOML metadata<br/>BiblioFetch.jl 互換]
 
     classDef hot fill:#fbb,stroke:#900
     classDef oa fill:#bfb,stroke:#060

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -17,7 +17,7 @@ A value set higher in the chain overrides any value set lower.
 
 | Key | Default |
 |---|---|
-| `store.root` | POSIX: `$HOME/papers`. Windows: `%USERPROFILE%\papers`. |
+| `store.root` | `./papers` — `papers/` under the current working directory (ADR-0036). Set `DOIGET_STORE_ROOT` for a central library. |
 | `cache.root` | POSIX: `$HOME/.cache/doiget`. Windows: `%LOCALAPPDATA%\doiget\cache`. |
 | `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
 | `log.retention_days` | `90` |

--- a/docs/DECISIONS/0004-bibliofetch-coexistence.md
+++ b/docs/DECISIONS/0004-bibliofetch-coexistence.md
@@ -1,7 +1,7 @@
 # 0004 - BiblioFetch.jl coexistence — shared store contract
 
 - **Date:** 2026-05-05
-- **Status:** Accepted — implemented; Store contract in `doiget-core/src/store/` (Phase 1) + BiblioFetch round-trip preservation test (CHANGELOG `0.1.2`, issue #121)
+- **Status:** Accepted — implemented; Store contract in `doiget-core/src/store/` (Phase 1) + BiblioFetch round-trip preservation test (CHANGELOG `0.1.2`, issue #121). **Amended by [0036](0036-default-store-cwd.md)** (2026-06-24): the default store root moved to `./papers` (under the cwd), so doiget and BiblioFetch.jl no longer co-locate *by default*; the shared on-disk *format* contract below is unchanged.
 - **Supersedes:** -
 - **Source:** Discussion #1 / #2
 

--- a/docs/DECISIONS/0036-default-store-cwd.md
+++ b/docs/DECISIONS/0036-default-store-cwd.md
@@ -1,0 +1,77 @@
+# 0036 - Default store root is `./papers` (current working directory)
+
+- **Date:** 2026-06-24
+- **Status:** Proposed (implemented by `feat/344-default-store-cwd`; flips to Accepted on merge)
+- **Supersedes:** -  (amends [0004](0004-bibliofetch-coexistence.md): the *co-location* default only — the shared on-disk *format* contract in [`STORE.md`](../STORE.md) is unchanged)
+- **Source:** #344 problem 1 / dogfood 2026-06-24
+
+## Context
+
+ADR-0004 set the default store root to `~/papers` so that doiget and
+BiblioFetch.jl co-locate their stores out of the box (a single shared
+library under the home directory).
+
+Dogfooding doiget as an LLM-agent tool surfaced a recurring failure mode
+(#344, problem 1): an agent runs `doiget fetch …`, the PDF lands in
+`~/papers` (`%USERPROFILE%\papers`), and **neither the agent nor the human
+sees it** — the working directory where they are actually operating shows
+nothing. The artifact is "successfully fetched" yet invisible at the place
+work happens. `fetch --link` (ADR-0035) mitigates this by surfacing a link
+into an explicit `--dir`, but the *default* still hides the primary store
+far from the cwd, so the happy path stays surprising.
+
+The root location is **not** part of the shared store contract: STORE.md
+specifies the layout *under* a root (`<root>/<safekey>.pdf` +
+`<root>/.metadata/…`), the safekey algorithm, the lock protocol, and the
+atomic-write sequence. Where the root *is* has always been per-tool
+configuration ([`CONFIG.md`](../CONFIG.md) §2). So the default can change
+without touching the bytes-on-disk contract.
+
+## Decision
+
+The built-in default store root becomes **`./papers`** — `papers/`
+directly under the current working directory — for both the CLI and the
+MCP server (`resolve_store_root` in `doiget-cli/src/commands/mod.rs` and
+`doiget-mcp/src/lib.rs`; `ResolvedConfig::from_env` now reuses the CLI
+resolver, so `config show` / `doctor` never drift from the writer).
+
+Resolution order is otherwise unchanged: `DOIGET_STORE_ROOT` env >
+`--store-root` flag > config file > this default. A user who wants a
+single central library sets `DOIGET_STORE_ROOT=~/papers` (or `store.root`
+in `config.toml`), which also restores BiblioFetch.jl co-location.
+
+This **amends ADR-0004**: doiget and BiblioFetch.jl no longer co-locate
+their stores *by default*. The shared on-disk *format* (STORE.md) — the
+actual coexistence contract — is unchanged; pointing both tools at the
+same root still yields a fully shared, round-trip-compatible store.
+
+## Consequences
+
+**Positive.**
+
+- Fetched artifacts are visible where work happens; the agent failure mode
+  in #344 is closed at the default, not only via `--link`.
+- The default is self-explanatory: `ls papers/` in the project directory.
+- No contract change to STORE.md; the safekey / lock / atomic-write specs
+  and the cross-tool round-trip CI test are untouched.
+
+**Negative / accepted.**
+
+- **BiblioFetch.jl co-location breaks by default.** A user running both
+  tools who relied on the implicit `~/papers` shared library must now set
+  `DOIGET_STORE_ROOT=~/papers` explicitly. The maintainer accepts this
+  (does not use BiblioFetch.jl); a tracking note is filed on the
+  BiblioFetch side if warranted.
+- A `papers/` directory now appears in whatever directory doiget is first
+  run from. This is intentional (visibility) but means a user fetching
+  from many directories accrues several small stores unless they set
+  `DOIGET_STORE_ROOT`. Documented in CONFIG.md / STORE.md.
+- Relative default: the store "moves" with the cwd. Acceptable because the
+  override is a one-liner and the default optimizes for the common
+  per-project agent workflow.
+
+**Tests.** Integration / e2e tests already set `DOIGET_STORE_ROOT` to a
+`tempfile::TempDir`, so they are unaffected by the default change; the
+`config` unit test asserting the unset default now expects `./papers`.
+
+To revise this decision, write a new ADR with `Supersedes: 0036`.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -20,7 +20,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0001 | MCP transport is stdio only | Accepted | posture-lint + Slice 9 stdout-purity | #4 |
 | 0002 | TDM sources are compile-time feature-gated | Accepted | Slices 17/18/19 | #5 |
 | 0003 | PDF content processing is permanently out of scope | Accepted (Amended by 0032: narrowed to PDF-*blob* processing; structured HTML/XML full-text is in scope) | standing policy (SCOPE.md #1 + posture-lint) | #9 |
-| 0004 | BiblioFetch.jl coexistence — shared store contract | Accepted | Phase 1 store + #121 (`0.1.2`) | #1 / #2 |
+| 0004 | BiblioFetch.jl coexistence — shared store contract | Accepted (Amended by 0036: default root no longer `~/papers`; shared *format* contract unchanged) | Phase 1 store + #121 (`0.1.2`) | #1 / #2 |
 | 0005 | CapabilityProfile gates source invocation at the type level | Accepted | PR #64/#65 (Phase 1) | #16 / #17 |
 | 0006 | Provenance log is JSON Lines + SHA-256 hash chain (fail-closed) | Accepted | PR #61 + Slice 4 | #12 / #17 |
 | 0007 | safekey algorithm with 100 reference test vectors | Accepted | PR #39 + Slice 3 | #1 §Contract 4 / #17 |
@@ -52,6 +52,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0033 | Per-PR version-bump enforcement + strict next→main promotion (amends 0025 §D6) | Proposed (implemented by `chore/version-bump-gate`; flips on merge) | `chore/version-bump-gate` | maintainer review 2026-06-24 (0.7.1 vanishing) |
 | 0034 | arXiv source bundle + individual figure download | Proposed (implemented by `feat/343-source-bundle-figures`; flips on merge) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
 | 0035 | `fetch --link`: surface fetched artifacts into the working tree | Proposed (implemented by `feat/344-fetch-link`; flips on merge) | `feat/344-fetch-link` | #344 / dogfood 2026-06-24 |
+| 0036 | Default store root → `./papers` (cwd); amends 0004 co-location | Proposed (implemented by `feat/344-default-store-cwd`; flips on merge) | `feat/344-default-store-cwd` | #344 problem 1 / dogfood 2026-06-24 |
 
 ## Conventions
 

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -12,8 +12,9 @@ A single-binary CLI plus stdio MCP server that:
 2. Fetches PDFs through Open Access sources by default; opens additional metadata sources
    and gated TDM sources only when the user has explicitly opted in
    at build time and runtime.
-3. Stores fetched papers in a `~/papers/` layout that is bit-compatible with BiblioFetch.jl
-   (see [`STORE.md`](STORE.md)).
+3. Stores fetched papers in a layout that is bit-compatible with BiblioFetch.jl
+   (see [`STORE.md`](STORE.md)); the default store root is `./papers` under the current
+   working directory (ADR-0036), overridable via `DOIGET_STORE_ROOT` / `--store-root`.
 4. Exposes a stdio MCP server with a fixed set of structured tools to agent hosts (see
    [`MCP_TOOLS.md`](MCP_TOOLS.md)).
 5. Verifies that the DOI / arXiv references in a bibliography file (`.bib` / CSL-JSON /
@@ -161,7 +162,9 @@ doiget composes with content-processing tools rather than incorporating them:
   [marker](https://github.com/VikParuchuri/marker), or other dedicated tools. See
   `INTEGRATION/chain-with-paperqa.md`.
 - For Julia REPL workflows: use BiblioFetch.jl directly; doiget and BiblioFetch.jl share
-  the on-disk store format ([`STORE.md`](STORE.md)).
+  the on-disk store format ([`STORE.md`](STORE.md)). The *format* is shared; since
+  ADR-0036 the default *root* differs per tool, so point both at the same root (e.g.
+  `DOIGET_STORE_ROOT=~/papers`) to co-locate one store.
 
 ## Why these are non-goals
 

--- a/docs/STORE.md
+++ b/docs/STORE.md
@@ -7,14 +7,18 @@
 ## 1. Layout
 
 ```
-~/papers/
+<store-root>/
 ├── <safekey>.pdf                    # PDF blob (immutable after write)
 └── .metadata/
     ├── <safekey>.toml               # metadata
     └── <safekey>.toml.lock          # advisory lock file (see §3)
 ```
 
-Store root path is configurable per [`CONFIG.md`](CONFIG.md). Default: `~/papers/`.
+Store root path is configurable per [`CONFIG.md`](CONFIG.md). The default root is
+implementation-specific — doiget defaults to `./papers` (under the current working
+directory; [ADR-0036](DECISIONS/0036-default-store-cwd.md)), BiblioFetch.jl to
+`~/papers/`. The layout *under* the root, specified in this document, is identical for
+both; point them at the same root (e.g. `DOIGET_STORE_ROOT=~/papers`) to share one store.
 The `<safekey>` is computed from the DOI / arXiv id by the algorithm in
 [`SAFEKEY.md`](SAFEKEY.md).
 
@@ -88,7 +92,7 @@ Lock acquisition timeout: **5 seconds**. On timeout, return `StoreError::LockTim
 
 Locks are advisory; a third-party process that ignores the lock can corrupt the store.
 Both doiget and BiblioFetch.jl honor the lock. Anyone integrating a third tool with
-`~/papers/` is expected to follow the same contract.
+the shared store is expected to follow the same contract.
 
 The lock file itself is created on demand (`O_CREAT | O_RDWR`) and is never deleted
 during normal operation. It may be safely deleted when no process holds it.

--- a/site/content/contribute/architecture.md
+++ b/site/content/contribute/architecture.md
@@ -43,7 +43,7 @@ flowchart TB
     TDM -.-> Fetcher
 
     Fetcher --> Log[Provenance Log<br/>JSON Lines + SHA256 hash chain<br/>fail-closed]
-    Fetcher --> Store[Store<br/>~/papers/ + TOML metadata<br/>BiblioFetch.jl 互換]
+    Fetcher --> Store[Store<br/>./papers default + TOML metadata<br/>BiblioFetch.jl 互換]
 
     classDef hot fill:#fbb,stroke:#900
     classDef oa fill:#bfb,stroke:#060

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -23,7 +23,7 @@ A value set higher in the chain overrides any value set lower.
 
 | Key | Default |
 |---|---|
-| `store.root` | POSIX: `$HOME/papers`. Windows: `%USERPROFILE%\papers`. |
+| `store.root` | `./papers` — `papers/` under the current working directory (ADR-0036). Set `DOIGET_STORE_ROOT` for a central library. |
 | `cache.root` | POSIX: `$HOME/.cache/doiget`. Windows: `%LOCALAPPDATA%\doiget\cache`. |
 | `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
 | `log.retention_days` | `90` |

--- a/site/content/developer/store.md
+++ b/site/content/developer/store.md
@@ -13,14 +13,18 @@ weight = 210
 ## 1. Layout
 
 ```
-~/papers/
+<store-root>/
 ├── <safekey>.pdf                    # PDF blob (immutable after write)
 └── .metadata/
     ├── <safekey>.toml               # metadata
     └── <safekey>.toml.lock          # advisory lock file (see §3)
 ```
 
-Store root path is configurable per [`CONFIG.md`](CONFIG.md). Default: `~/papers/`.
+Store root path is configurable per [`CONFIG.md`](CONFIG.md). The default root is
+implementation-specific — doiget defaults to `./papers` (under the current working
+directory; [ADR-0036](DECISIONS/0036-default-store-cwd.md)), BiblioFetch.jl to
+`~/papers/`. The layout *under* the root, specified in this document, is identical for
+both; point them at the same root (e.g. `DOIGET_STORE_ROOT=~/papers`) to share one store.
 The `<safekey>` is computed from the DOI / arXiv id by the algorithm in
 [`SAFEKEY.md`](SAFEKEY.md).
 
@@ -94,7 +98,7 @@ Lock acquisition timeout: **5 seconds**. On timeout, return `StoreError::LockTim
 
 Locks are advisory; a third-party process that ignores the lock can corrupt the store.
 Both doiget and BiblioFetch.jl honor the lock. Anyone integrating a third tool with
-`~/papers/` is expected to follow the same contract.
+the shared store is expected to follow the same contract.
 
 The lock file itself is created on demand (`O_CREAT | O_RDWR`) and is never deleted
 during normal operation. It may be safely deleted when no process holds it.

--- a/site/content/use/scope.md
+++ b/site/content/use/scope.md
@@ -18,8 +18,9 @@ A single-binary CLI plus stdio MCP server that:
 2. Fetches PDFs through Open Access sources by default; opens additional metadata sources
    and gated TDM sources only when the user has explicitly opted in
    at build time and runtime.
-3. Stores fetched papers in a `~/papers/` layout that is bit-compatible with BiblioFetch.jl
-   (see [`STORE.md`](STORE.md)).
+3. Stores fetched papers in a layout that is bit-compatible with BiblioFetch.jl
+   (see [`STORE.md`](STORE.md)); the default store root is `./papers` under the current
+   working directory (ADR-0036), overridable via `DOIGET_STORE_ROOT` / `--store-root`.
 4. Exposes a stdio MCP server with a fixed set of structured tools to agent hosts (see
    [`MCP_TOOLS.md`](MCP_TOOLS.md)).
 5. Verifies that the DOI / arXiv references in a bibliography file (`.bib` / CSL-JSON /
@@ -167,7 +168,9 @@ doiget composes with content-processing tools rather than incorporating them:
   [marker](https://github.com/VikParuchuri/marker), or other dedicated tools. See
   `INTEGRATION/chain-with-paperqa.md`.
 - For Julia REPL workflows: use BiblioFetch.jl directly; doiget and BiblioFetch.jl share
-  the on-disk store format ([`STORE.md`](STORE.md)).
+  the on-disk store format ([`STORE.md`](STORE.md)). The *format* is shared; since
+  ADR-0036 the default *root* differs per tool, so point both at the same root (e.g.
+  `DOIGET_STORE_ROOT=~/papers`) to co-locate one store.
 
 ## Why these are non-goals
 


### PR DESCRIPTION
## What & why

`doiget fetch` stored papers under `~/papers` (`%USERPROFILE%\papers`) by
default. When driving doiget as an LLM-agent tool, the PDF lands there and
is **invisible in the working directory** where the agent (and the human)
are actually operating — #344, problem 1. "Successfully fetched", yet
nowhere to be seen.

This changes the built-in default store root to **`./papers`** — `papers/`
directly under the current working directory.

## Changes

- `resolve_store_root` in **doiget-cli** and **doiget-mcp** now falls back
  to `current_dir()/papers` (was `$HOME/papers`).
- `ResolvedConfig::from_env` reuses the CLI resolver, so `config show` /
  `config doctor` can never drift from where artifacts actually land.
- Resolution order is **unchanged**: `DOIGET_STORE_ROOT` > `--store-root`
  > `config.toml` > default. A central library is one env var away:
  `DOIGET_STORE_ROOT=~/papers`.
- Version `0.8.0-beta.6` → `0.8.0-beta.7` (ADR-0033 per-PR bump gate).
- Docs: **ADR-0036** (amends ADR-0004 co-location) + amended ADR-0004 +
  `DECISIONS/INDEX.md`; STORE.md / CONFIG.md / SCOPE.md default-root refs.

## ⚠️ Contract change — please review

ADR-0004 made `~/papers` the default so doiget and BiblioFetch.jl
co-locate out of the box. **That co-location default is dropped.**
ADR-0036 amends ADR-0004:

- The shared on-disk **format** (STORE.md: safekey, lock protocol,
  atomic-write, schema) is **unchanged** — pointing both tools at the same
  root still yields a fully round-trip-compatible shared store.
- Only the **default location** differs now. A BiblioFetch.jl user sets
  `DOIGET_STORE_ROOT=~/papers` to restore co-location.

Maintainer has accepted this break (does not use BiblioFetch.jl).

## Tests

Integration / e2e tests set `DOIGET_STORE_ROOT` to a tempdir, so they are
unaffected. The `config` unit test asserting the unset default is renamed
`from_env_uses_cwd_default_when_unset`.

---

Not auto-merging — contract change, manual review.

Refs #344 (problem 1: fetched papers invisible in the working dir). The
citation-provenance slice of #344 was abandoned by decision; #344's
remaining actionable scope is this default-path fix plus the already-merged
identity (#349) and `--link` (#350) slices.