### PR TITLE
fix: 0.8.0 promotion review hardening (#352 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0-beta.8] - 2026-06-24
+
+Hardening from the `next → main` (0.8.0) promotion review (#352).
+
+### Fixed
+- **[core/security]** Cap arXiv `/src` decompression on the `tex-source` text
+  path (`extract_tex`) against a gzip bomb — it previously passed **no** cap, so
+  a crafted payload within the HTTP compressed-size limit could OOM the process
+  (now reachable via the MCP `doiget_paper_tex_source` tool). Real submissions
+  are far below the 500 MB cap; supersedes ADR-0034 D6's "byte-identical" note
+  for pathological inputs only.
+- **[core]** `extract_from_tar` now runs each entry path through
+  `sanitize_entry_path` (a crafted `../`-name can no longer surface in
+  `main_file`) and logs skipped/unreadable entries instead of dropping them
+  silently — mirroring `extract_bundle`. Scoring uses `saturating_add` (the
+  prior `i64` sum was unsound; its "~1 GB" doc bound was wrong).
+- **[core]** `{arxiv,crossref,unpaywall}_source_from_env` log a `warn` when a
+  `DOIGET_*_BASE` env var is an invalid URL instead of silently using the
+  production base.
+- **[cli]** `doiget frontier` warns when the store root can't be resolved
+  instead of silently skipping the already-fetched exclusion filter.
+
+### Changed
+- **[core]** Narrow the `trust_academic_repos` allowlist entry `*.go.jp`
+  (government-wide) → `*.jst.go.jp` (J-STAGE / JST academic platform) — the
+  intended academic OA host, not the whole Japanese government namespace.
+- **[core]** `SourceFile` and `UserExtensionConfig` gain `#[non_exhaustive]`
+  (additive public-API hygiene before the 0.8.0 stable lock).
+
+### Docs
+- **[store]** STORE.md: MCP `doiget serve` resolves the default store root from
+  the server process's cwd (indeterminate for a daemon) — set
+  `DOIGET_STORE_ROOT`. Scrubbed remaining stale `~/papers` / "HOME/USERPROFILE"
+  comments (config.rs, mcp) and strengthened the MCP `resolve_store_root` test
+  to assert `<cwd>/papers`.
+
+### Notes
+- Deferred to a fast-follow before the `v0.8.0` tag (kept out to keep this PR
+  focused/green): `arxiv_id: String → ArxivId` on `PaperTexSource` /
+  `PdfLegStatus::PreprintFallback`; `#[non_exhaustive]` on `PaperTexSource` /
+  `Metadata` / `DoigetExtension` (need constructors — external struct literals);
+  e2e coverage for `frontier_view`, `tag`/`annotate`, `fetch --link`
+  metadata-only skip, and the arXiv preprint fallback.
+
 ## [0.8.0-beta.7] - 2026-06-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.7"
+version = "0.8.0-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.7"
+version = "0.8.0-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.7"
+version = "0.8.0-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.7"
+version       = "0.8.0-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -55,10 +55,10 @@ pub struct ResolvedConfig {
 impl ResolvedConfig {
     /// Resolve the live config from process environment + platform defaults.
     ///
-    /// Errors only if neither a home directory nor a config directory can
-    /// be determined for the current user (e.g. an unknown / locked-down
-    /// platform); on every realistic POSIX or Windows host this returns
-    /// `Ok` even with no `DOIGET_*` env vars set.
+    /// Errors only if the platform config directory (`dirs::config_dir()`) or
+    /// the current working directory cannot be determined or is non-UTF-8
+    /// (an unknown / locked-down platform); on every realistic POSIX or
+    /// Windows host this returns `Ok` even with no `DOIGET_*` env vars set.
     pub fn from_env() -> Result<Self> {
         // `dirs::config_dir()` returns `std::path::PathBuf`; hoist it into
         // `Utf8PathBuf` immediately at the OS boundary so the rest of the
@@ -356,7 +356,7 @@ mod tests {
         // succeeds on Windows too (where "/tmp/foo" is a relative path on
         // the current drive — still UTF-8, still fine for this assertion).
         let _override = EnvGuard::set("DOIGET_STORE_ROOT", "/tmp/foo");
-        let cfg = ResolvedConfig::from_env().expect("home dir must resolve on test host");
+        let cfg = ResolvedConfig::from_env().expect("config resolves on test host");
         assert_eq!(cfg.store_root.as_str(), "/tmp/foo");
     }
 
@@ -370,7 +370,7 @@ mod tests {
     fn log_path_follows_doiget_log_path_env() {
         let _g = unset_all_doiget_config_env();
         let _override = EnvGuard::set("DOIGET_LOG_PATH", "/var/lib/doiget/access.jsonl");
-        let cfg = ResolvedConfig::from_env().expect("home dir must resolve on test host");
+        let cfg = ResolvedConfig::from_env().expect("config resolves on test host");
         assert_eq!(
             cfg.log_path.as_str(),
             "/var/lib/doiget/access.jsonl",
@@ -406,10 +406,10 @@ mod tests {
     fn doctor_passes_with_contact_email() {
         let _g = unset_all_doiget_config_env();
         let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
-        // home_dir() / config_dir() resolve to real, existing parents on
-        // every supported test host (CI runners always have $HOME).
+        // config_dir() and the cwd resolve to real, existing parents on every
+        // supported test host (store root defaults to <cwd>/papers, ADR-0036).
         run("doctor".into(), crate::commands::output::OutputMode::Human)
-            .expect("doctor should pass with contact email + real home dir");
+            .expect("doctor should pass with contact email + valid config dir and cwd");
     }
 
     /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -873,6 +873,11 @@ fn slugify(s: &str) -> String {
 /// back to a copy. Replaces a prior doiget symlink, but refuses to clobber an
 /// unrelated regular file. Returns the written path and the mechanism used
 /// (`"symlink"` | `"copy"`).
+///
+/// The symlink-vs-file check and the subsequent replace are not atomic: a
+/// concurrent process swapping the entry between the two syscalls is an
+/// accepted, out-of-scope race — the `--link` dir is the user's own working
+/// directory, assumed single-writer (review #352).
 fn link_artifact(
     dir: &Utf8Path,
     src: &Utf8Path,

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -74,19 +74,29 @@ pub async fn run(
     };
 
     // Filter out papers already in the local store.
-    if let Ok(store_root) = resolve_store_root() {
-        results.hits.retain(|hit| {
-            let Some(ref doi_s) = hit.doi else {
-                return true;
-            };
-            let Ok(d) = doiget_core::Doi::parse(doi_s) else {
-                return true;
-            };
-            let safekey = doiget_core::Ref::Doi(d).safekey();
-            !store_root
-                .join(format!("{}.pdf", safekey.as_str()))
-                .exists()
-        });
+    match resolve_store_root() {
+        Ok(store_root) => {
+            results.hits.retain(|hit| {
+                let Some(ref doi_s) = hit.doi else {
+                    return true;
+                };
+                let Ok(d) = doiget_core::Doi::parse(doi_s) else {
+                    return true;
+                };
+                let safekey = doiget_core::Ref::Doi(d).safekey();
+                !store_root
+                    .join(format!("{}.pdf", safekey.as_str()))
+                    .exists()
+            });
+        }
+        Err(e) => {
+            // Don't silently present already-fetched papers as "frontier":
+            // tell the user the store-exclusion filter was skipped (review #352).
+            eprintln!(
+                "warning: could not resolve the local store root ({e}); \
+                 frontier results are NOT filtered against already-fetched papers"
+            );
+        }
     }
 
     if mode == OutputMode::Quiet && quiet_was_explicit {

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -563,8 +563,13 @@ fn contact_email_from_env() -> String {
 
 fn arxiv_source_from_env() -> ArxivSource {
     if let Ok(s) = std::env::var("DOIGET_ARXIV_BASE") {
-        if let Ok(url) = url::Url::parse(&s) {
-            return ArxivSource::with_base(url);
+        match url::Url::parse(&s) {
+            Ok(url) => return ArxivSource::with_base(url),
+            Err(e) => tracing::warn!(
+                value = %s,
+                error = %e,
+                "DOIGET_ARXIV_BASE is not a valid URL; using the default arXiv base"
+            ),
         }
     }
     ArxivSource::new()
@@ -572,8 +577,13 @@ fn arxiv_source_from_env() -> ArxivSource {
 
 fn crossref_source_from_env(contact: &str) -> CrossrefSource {
     if let Ok(s) = std::env::var("DOIGET_CROSSREF_BASE") {
-        if let Ok(url) = url::Url::parse(&s) {
-            return CrossrefSource::with_base(url, contact.to_string());
+        match url::Url::parse(&s) {
+            Ok(url) => return CrossrefSource::with_base(url, contact.to_string()),
+            Err(e) => tracing::warn!(
+                value = %s,
+                error = %e,
+                "DOIGET_CROSSREF_BASE is not a valid URL; using the default Crossref base"
+            ),
         }
     }
     CrossrefSource::new(contact.to_string())
@@ -581,8 +591,13 @@ fn crossref_source_from_env(contact: &str) -> CrossrefSource {
 
 fn unpaywall_source_from_env(contact: &str) -> UnpaywallSource {
     if let Ok(s) = std::env::var("DOIGET_UNPAYWALL_BASE") {
-        if let Ok(url) = url::Url::parse(&s) {
-            return UnpaywallSource::with_base(url, contact.to_string());
+        match url::Url::parse(&s) {
+            Ok(url) => return UnpaywallSource::with_base(url, contact.to_string()),
+            Err(e) => tracing::warn!(
+                value = %s,
+                error = %e,
+                "DOIGET_UNPAYWALL_BASE is not a valid URL; using the default Unpaywall base"
+            ),
         }
     }
     UnpaywallSource::new(contact.to_string())

--- a/crates/doiget-core/src/paper_tex_source.rs
+++ b/crates/doiget-core/src/paper_tex_source.rs
@@ -212,6 +212,7 @@ fn src_url(base: &Url, id: &ArxivId) -> Result<Url, FetchError> {
 /// magic bytes. Shared by the text path ([`extract_tex`]) and the bundle path
 /// ([`extract_bundle`]) so the gzip + ustar detection lives in one place
 /// (issue #346); each caller maps the variants to its own result type.
+#[derive(Debug)]
 enum SrcPayload {
     /// `%PDF-` magic — a PDF-only submission (no source).
     PdfOnly,

--- a/crates/doiget-core/src/paper_tex_source.rs
+++ b/crates/doiget-core/src/paper_tex_source.rs
@@ -281,11 +281,15 @@ fn classify_src(bytes: &[u8], max_decompressed: Option<u64>) -> Result<SrcPayloa
 ///
 /// Returns an [`ExtractedTex`] with `main_file` and `content`.
 pub(crate) fn extract_tex(id: &ArxivId, bytes: &[u8]) -> Result<ExtractedTex, FetchError> {
-    // No size cap on the text path (`None`) — ADR-0034 D6: behaviour stays
-    // byte-identical to the pre-#346 inline form. The single-file arm covers
-    // both a bare uncompressed `.tex` (arXiv occasionally serves one for
-    // trivial submissions) and a single gzip'd `.tex`.
-    match classify_src(bytes, None)? {
+    // Cap decompression against a gzip bomb (review #352): the HTTP layer only
+    // bounds the *compressed* body, so an unbounded `read_to_end` here could
+    // OOM on a crafted `/src` payload — now reachable via the MCP
+    // `doiget_paper_tex_source` tool. Real arXiv sources are far below the cap,
+    // so this supersedes ADR-0034 D6's "byte-identical" note for pathological
+    // inputs only. The single-file arm covers both a bare uncompressed `.tex`
+    // (arXiv occasionally serves one for trivial submissions) and a single
+    // gzip'd `.tex`.
+    match classify_src(bytes, Some(SRC_MAX_DECOMPRESSED_BYTES))? {
         SrcPayload::PdfOnly => Err(FetchError::TextUnavailable {
             arxiv_id: id.clone(),
         }),
@@ -312,11 +316,13 @@ pub(crate) fn extract_tex(id: &ArxivId, bytes: &[u8]) -> Result<ExtractedTex, Fe
 ///         + (1 if filename ends with `main.tex`) × 100_000
 ///         + byte_count_of_file
 ///
-/// The weights are sized to dominate any realistic file size: a `.tex` file
-/// with `\documentclass` always beats one without it unless the file exceeds
-/// ~1 GB (byte count overflows `i64`), which is not a realistic `.tex` size.
-/// Within tied `\documentclass` files, `main.tex` always wins unless the
-/// competing file exceeds 100 KB — also not a realistic sub-file size.
+/// The weights dominate realistic file sizes: a `\documentclass` file beats a
+/// non-`\documentclass` one unless the latter is ~1 MB larger, and within
+/// `\documentclass` files `main.tex` wins unless a rival is ~100 KB larger —
+/// neither happens for real sub-files. The sum uses `saturating_add` so it
+/// stays total-order-safe even for a pathological size the decompression cap
+/// would already reject (the previous note claiming "~1 GB overflows i64" was
+/// wrong — `i64::MAX` is ~9.2 EB; review #352).
 fn extract_from_tar(id: &ArxivId, bytes: &[u8]) -> Result<ExtractedTex, FetchError> {
     let mut archive = Archive::new(std::io::Cursor::new(bytes));
     let entries = archive.entries().map_err(|e| FetchError::SourceSchema {
@@ -327,20 +333,47 @@ fn extract_from_tar(id: &ArxivId, bytes: &[u8]) -> Result<ExtractedTex, FetchErr
     // Track .tex entries attempted (even if read failed) so that a corrupt
     // archive is distinguishable from a PDF-only submission.
     let mut tex_attempted: usize = 0;
+    // Entries skipped because the header/path could not be parsed, the path was
+    // unsafe, or the body failed to read. Logged below so a partial extraction
+    // is never silent (mirrors `extract_bundle`'s discipline; review #352).
+    let mut unreadable: usize = 0;
     for entry in entries {
-        let Ok(mut entry) = entry else { continue };
-        let path = match entry.path() {
+        let Ok(mut entry) = entry else {
+            unreadable += 1;
+            continue;
+        };
+        let raw = match entry.path() {
             Ok(p) => p.to_string_lossy().to_string(),
-            Err(_) => continue,
+            Err(_) => {
+                unreadable += 1;
+                continue;
+            }
+        };
+        // Use the sanitised relative path for `main_file`: the text path never
+        // writes files, but the name flows into the CLI output / MCP envelope,
+        // so a crafted `../`-style entry name must never be surfaced to a
+        // caller (review #352).
+        let Some(path) = sanitize_entry_path(&raw).map(|p| p.to_string()) else {
+            tracing::warn!(arxiv_id = %id.as_str(), entry = %raw, "skipping unsafe arXiv src entry path");
+            continue;
         };
         if !path.ends_with(".tex") {
             continue;
         }
         tex_attempted += 1;
         let mut content = String::new();
-        if entry.read_to_string(&mut content).is_ok() && !content.trim().is_empty() {
-            tex_files.push((path, content));
+        match entry.read_to_string(&mut content) {
+            Ok(_) if !content.trim().is_empty() => tex_files.push((path, content)),
+            Ok(_) => {} // empty .tex — legitimately skipped, not a failure
+            Err(_) => unreadable += 1,
         }
+    }
+    if unreadable > 0 {
+        tracing::warn!(
+            arxiv_id = %id.as_str(),
+            unreadable,
+            "some arXiv src tar entries were unreadable/unsafe and were skipped"
+        );
     }
 
     if tex_files.is_empty() {
@@ -363,7 +396,7 @@ fn extract_from_tar(id: &ArxivId, bytes: &[u8]) -> Result<ExtractedTex, FetchErr
         let docclass = i64::from(content.contains(r"\documentclass")) * 1_000_000;
         let is_main = i64::from(name.ends_with("main.tex") || name == "main.tex") * 100_000;
         let size = i64::try_from(content.len()).unwrap_or(i64::MAX);
-        docclass + is_main + size
+        docclass.saturating_add(is_main).saturating_add(size)
     });
 
     match best {
@@ -486,6 +519,7 @@ pub enum BundleFilter {
 
 /// One file extracted from an arXiv source tarball.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct SourceFile {
     /// Sanitised **relative** path (never absolute, never contains `..`),
     /// safe to join under any output root (ADR-0034 D3). The field is
@@ -826,6 +860,32 @@ mod tests {
         let ext = extract_tex(&id, &gz).expect("extract");
         assert!(ext.main_file.is_none(), "single gzip has no tar filename");
         assert!(ext.content.contains("\\documentclass"));
+    }
+
+    // ── classify_src: gzip-bomb decompression cap (review #352) ───────────────
+
+    #[test]
+    fn classify_src_rejects_decompression_over_cap() {
+        // A body decompressing to more than the cap MUST be rejected
+        // (`SourceSchema`), never silently accepted — this is the gzip-bomb
+        // guard. Pins the wiring so a regression that drops the cap (e.g.
+        // passes `None` on the text path again) fails loudly. Uses a tiny cap
+        // so the test needs no large allocation.
+        let big = vec![b'x'; 10_000];
+        let gz = gzip_bytes(&big);
+        let err = classify_src(&gz, Some(1_000)).expect_err("over-cap must be rejected");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_src_accepts_decompression_within_cap() {
+        let small = vec![b'x'; 500];
+        let gz = gzip_bytes(&small);
+        let payload = classify_src(&gz, Some(1_000)).expect("within cap");
+        assert!(matches!(payload, SrcPayload::SingleFile(_)));
     }
 
     // ── extract_from_tar: selection heuristic ────────────────────────────────

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -310,6 +310,7 @@ struct RawHost {
 /// allowlist unconditionally, and optionally merge [`academic_repo_hosts`]
 /// when [`Self::trust_academic_repos`] is `true`.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct UserExtensionConfig {
     /// Hosts from `[[network.additional_hosts]]`.
     pub additional_hosts: Vec<UserExtensionHost>,
@@ -333,7 +334,7 @@ pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
     const PATTERNS: &[(&str, &str)] = &[
         ("*.ac.uk", "UK academic institutions (Universities UK)"),
         ("*.ac.jp", "Japanese academic institutions (NII)"),
-        ("*.go.jp", "Japanese government repositories"),
+        ("*.jst.go.jp", "J-STAGE / JST academic platform (Japan)"),
         ("*.edu.au", "Australian universities (TEQSA)"),
         ("*.edu.cn", "Chinese universities (MoE)"),
         ("*.ac.cn", "Chinese academic institutions"),

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -245,9 +245,9 @@ impl Server {
         if input.dry_run {
             // Use the same store-root resolver as `doiget_health` so the
             // path projections in `plan.target_*` match what the live
-            // fetch would write to. When neither HOME nor USERPROFILE
-            // resolves (locked-down hosts), fall back to a sentinel
-            // path so the preview still has a complete shape — the
+            // fetch would write to. When the cwd can't be resolved (the
+            // `None` case — e.g. a non-UTF-8 working directory), fall back to
+            // `./papers` so the preview still has a complete shape — the
             // dry-run is a preview, not a writability probe.
             let store_root = resolve_store_root().unwrap_or_else(|| Utf8PathBuf::from("./papers"));
             let plan = build_fetch_plan(&ref_, &store_root);
@@ -3929,7 +3929,21 @@ mod tests {
         // root on a normal host — `DOIGET_STORE_ROOT` when set, else the cwd
         // default, since current_dir() is always available. We deliberately
         // don't mutate env (the test process is shared with other tests).
-        assert!(resolve_store_root().is_some());
+        let got = resolve_store_root();
+        assert!(
+            got.is_some(),
+            "resolve_store_root must resolve on a normal host"
+        );
+        // When DOIGET_STORE_ROOT is unset, the default MUST be `<cwd>/papers`
+        // (not a `~/papers` home fallback) — a read-only env check (no
+        // mutation) that catches a regression to the old default (review #352).
+        if std::env::var_os("DOIGET_STORE_ROOT").is_none() {
+            let expected =
+                camino::Utf8PathBuf::from_path_buf(std::env::current_dir().expect("cwd available"))
+                    .expect("cwd is valid UTF-8")
+                    .join("papers");
+            assert_eq!(got, Some(expected));
+        }
     }
 
     /// ADR-0028 D2: `build_http_client_for_fetch` MUST merge user-

--- a/docs/STORE.md
+++ b/docs/STORE.md
@@ -19,6 +19,12 @@ implementation-specific — doiget defaults to `./papers` (under the current wor
 directory; [ADR-0036](DECISIONS/0036-default-store-cwd.md)), BiblioFetch.jl to
 `~/papers/`. The layout *under* the root, specified in this document, is identical for
 both; point them at the same root (e.g. `DOIGET_STORE_ROOT=~/papers`) to share one store.
+
+> **MCP `doiget serve`:** the default is resolved relative to the *server process's*
+> working directory, which is indeterminate for a long-running daemon (e.g. a service
+> manager may launch it in `/`). MCP users SHOULD set `DOIGET_STORE_ROOT` explicitly so
+> the store does not silently vary by launch directory.
+
 The `<safekey>` is computed from the DOI / arXiv id by the algorithm in
 [`SAFEKEY.md`](SAFEKEY.md).
 

--- a/site/content/developer/store.md
+++ b/site/content/developer/store.md
@@ -25,6 +25,12 @@ implementation-specific — doiget defaults to `./papers` (under the current wor
 directory; [ADR-0036](DECISIONS/0036-default-store-cwd.md)), BiblioFetch.jl to
 `~/papers/`. The layout *under* the root, specified in this document, is identical for
 both; point them at the same root (e.g. `DOIGET_STORE_ROOT=~/papers`) to share one store.
+
+> **MCP `doiget serve`:** the default is resolved relative to the *server process's*
+> working directory, which is indeterminate for a long-running daemon (e.g. a service
+> manager may launch it in `/`). MCP users SHOULD set `DOIGET_STORE_ROOT` explicitly so
+> the store does not silently vary by launch directory.
+
 The `<safekey>` is computed from the DOI / arXiv id by the algorithm in
 [`SAFEKEY.md`](SAFEKEY.md).
 


### PR DESCRIPTION
Addresses the `/review-pr` findings on the `next → main` 0.8.0 promotion (#352).
`0.8.0-beta.7 → 0.8.0-beta.8`. **No auto-merge** (your review/merge).

## Critical
- **gzip-bomb on the tex-source text path** — `extract_tex` passed **no**
  decompression cap (`classify_src(.., None)`), so a crafted `/src` payload
  within the HTTP compressed-size limit could OOM, now reachable via the MCP
  `doiget_paper_tex_source` tool. Capped at `SRC_MAX_DECOMPRESSED_BYTES` like
  `extract_bundle`; + a `classify_src` cap regression test.

## Important — fixed
- `extract_from_tar`: sanitize entry paths (no `../` in `main_file`) + log
  skipped/unreadable entries (was silent); `saturating_add` in the scorer (the
  `i64` sum was unsound; "~1 GB" doc bound was wrong).
- `{arxiv,crossref,unpaywall}_source_from_env`: `warn` on an invalid
  `DOIGET_*_BASE` instead of silent production fallthrough.
- `doiget frontier`: `warn` when the store root can't be resolved instead of
  silently skipping the already-fetched exclusion filter.
- Narrow `trust_academic_repos` `*.go.jp` → `*.jst.go.jp` (J-STAGE), not the
  whole Japanese government namespace.
- `#[non_exhaustive]` on `SourceFile` + `UserExtensionConfig`.
- Scrub stale `~/papers` / HOME-USERPROFILE comments (config.rs, mcp);
  strengthen the MCP `resolve_store_root` test to assert `<cwd>/papers`.
- STORE.md: MCP `doiget serve` resolves the store root from the daemon cwd —
  set `DOIGET_STORE_ROOT` (the cwd-dependent-store gap).

## Deferred to a fast-follow before the `v0.8.0` tag
Kept out to keep this PR focused and CI-green (I can't compile locally):
- `arxiv_id: String → ArxivId` newtype on `PaperTexSource` /
  `PdfLegStatus::PreprintFallback` (blast radius incl. `paper_text.rs`).
- `#[non_exhaustive]` on `PaperTexSource` / `Metadata` / `DoigetExtension`
  (need constructors — external test-fixture struct literals).
- e2e coverage: `frontier_view`, `tag`/`annotate`, `fetch --link`
  metadata-only skip, arXiv preprint fallback.

## Dismissed at review
- `starts_with` "symlink bypass" CRITICAL → not a tarball escape
  (`sanitize_entry_path` blocks it) and not introduced here; the `--link`
  TOCTOU is a documented, accepted single-writer race.

Refs #352. Merge this into `next`, then the 0.8.0 finalization (strip beta →
`0.8.0`, `## [0.8.0]` CHANGELOG, ADR statuses) on #352.