### PR TITLE
release: 0.8.0 — strip beta for the next→main promotion (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-24
+
+Promotes the cumulative `0.8.0-beta.1`–`0.8.0-beta.8` line to a stable release
+(next → main, #352). Highlights since 0.7.0:
+
+- **[fetch]** Agent-observability cluster (#344): identity confirmation on
+  fetch (title / authors / year on stderr + the MCP `doiget_fetch_paper`
+  envelope), `fetch --link <dir>` to surface the stored PDF into the working
+  tree, and the **default store root moved from `~/papers` to `./papers`** (the
+  current working directory) so fetched papers are visible where work happens
+  (ADR-0035 / ADR-0036; 0036 amends the ADR-0004 co-location default — set
+  `DOIGET_STORE_ROOT` to restore a central / BiblioFetch-shared store).
+- **[source]** `doiget source <arxiv-id> --out <dir> [--figures-only]`: arXiv
+  source-bundle / figure download, opaque and zip-slip + gzip-bomb guarded
+  (ADR-0034). New `tex-source`, `frontier`, and `tag`/`annotate` commands plus
+  an automatic arXiv-preprint fallback (#325) also land in this cycle.
+- **[release]** Per-PR `version-bump` gate + strict `next → main` promotion
+  (ADR-0033); `flake.nix` Nix Flakes integration (#247).
+- **[hardening]** Promotion-review (#352) fixes: capped tex-source
+  decompression (gzip-bomb), sanitised + loud tar extraction, a narrowed
+  academic-repo allowlist, and silent-failure diagnostics.
+
+See the `0.8.0-beta.*` sections below for per-change detail.
+
 ## [0.8.0-beta.8] - 2026-06-24
 
 Hardening from the `next → main` (0.8.0) promotion review (#352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0-beta.8"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0-beta.8"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0-beta.8"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0-beta.8"
+version       = "0.8.0"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.0" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/DECISIONS/0033-version-bump-enforcement.md
+++ b/docs/DECISIONS/0033-version-bump-enforcement.md
@@ -1,9 +1,8 @@
 # 0033 - Per-PR version-bump enforcement + strict next→main promotion
 
 - **Date:** 2026-06-24
-- **Status:** Proposed — implemented by the same PR that adds this ADR
-  (`chore/version-bump-gate`); flips to `Accepted` on merge per
-  `DECISIONS/INDEX.md` conventions.
+- **Status:** Accepted — implemented by `chore/version-bump-gate`; promoted in
+  0.8.0 (#352).
 - **Amends:** [0025](0025-tag-driven-release.md) §D6 — adds a per-PR cadence to
   rule 2 and **retires rule 4's direct-to-`main` hotfix** path. Complements
   ADR-0025 Amendment 6 (advisory `version-check`); the tag-time gate (D2) and

--- a/docs/DECISIONS/0034-source-bundle-figures.md
+++ b/docs/DECISIONS/0034-source-bundle-figures.md
@@ -1,9 +1,8 @@
 # 0034 - arXiv source bundle + individual figure download
 
 - **Date:** 2026-06-24
-- **Status:** Proposed — implemented by `feat/343-source-bundle-figures`
-  (issue #343); flips to `Accepted` on merge per `DECISIONS/INDEX.md`
-  conventions.
+- **Status:** Accepted — implemented by `feat/343-source-bundle-figures`
+  (issue #343); promoted in 0.8.0 (#352).
 - **Relates:** extends the arXiv `/src/` capability introduced with
   `tex-source` ([ADR-0032](0032-fulltext-html-extraction.md) D1/D2). Bounded by
   [`SCOPE.md`](../SCOPE.md) §non-goal 1 (PDF-blob processing), 3 (no

--- a/docs/DECISIONS/0035-fetch-link.md
+++ b/docs/DECISIONS/0035-fetch-link.md
@@ -1,8 +1,8 @@
 # 0035 - `fetch --link`: surface fetched artifacts into the working tree
 
 - **Date:** 2026-06-24
-- **Status:** Proposed — implemented by `feat/344-fetch-link` (issue #344
-  Slice 2); flips to `Accepted` on merge per `DECISIONS/INDEX.md` conventions.
+- **Status:** Accepted — implemented by `feat/344-fetch-link` (issue #344
+  Slice 2); promoted in 0.8.0 (#352).
 - **Relates:** issue #344 (agent-driven UX) problem 1 (store locality). Bounded
   by [`SCOPE.md`](../SCOPE.md) §non-goal 3 (no redistribution / share-vault).
 - **Source:** dogfooding 2026-06-24 (#344).

--- a/docs/DECISIONS/0036-default-store-cwd.md
+++ b/docs/DECISIONS/0036-default-store-cwd.md
@@ -1,7 +1,7 @@
 # 0036 - Default store root is `./papers` (current working directory)
 
 - **Date:** 2026-06-24
-- **Status:** Proposed (implemented by `feat/344-default-store-cwd`; flips to Accepted on merge)
+- **Status:** Accepted (implemented by `feat/344-default-store-cwd`; promoted in 0.8.0, #352)
 - **Supersedes:** -  (amends [0004](0004-bibliofetch-coexistence.md): the *co-location* default only — the shared on-disk *format* contract in [`STORE.md`](../STORE.md) is unchanged)
 - **Source:** #344 problem 1 / dogfood 2026-06-24
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -49,10 +49,10 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0030 | Bibliography input adapters (.bib / CSL-JSON) in `doiget-core`; new MCP tool `doiget_batch_from_bibliography` | Accepted (design; slice TBD) | TBD | #222 / Zotero distribution review 2026-05-20 |
 | 0031 | Discovery search is Tier-1 OA metadata (always-on); `doiget search` defaults to external discovery | Accepted (design; PR1 slice) | PR1 (`feat/paper-search`) | #281 / feasibility read 2026-06-04 |
 | 0032 | Structured full-text (HTML/XML) extraction in scope; PDF-blob processing stays out of scope | Accepted (design; PR4 ships ar5iv leg) | PR4 (`feat/paper-text`) | #281 item 3 / scope decision 2026-06-06 |
-| 0033 | Per-PR version-bump enforcement + strict next→main promotion (amends 0025 §D6) | Proposed (implemented by `chore/version-bump-gate`; flips on merge) | `chore/version-bump-gate` | maintainer review 2026-06-24 (0.7.1 vanishing) |
-| 0034 | arXiv source bundle + individual figure download | Proposed (implemented by `feat/343-source-bundle-figures`; flips on merge) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
-| 0035 | `fetch --link`: surface fetched artifacts into the working tree | Proposed (implemented by `feat/344-fetch-link`; flips on merge) | `feat/344-fetch-link` | #344 / dogfood 2026-06-24 |
-| 0036 | Default store root → `./papers` (cwd); amends 0004 co-location | Proposed (implemented by `feat/344-default-store-cwd`; flips on merge) | `feat/344-default-store-cwd` | #344 problem 1 / dogfood 2026-06-24 |
+| 0033 | Per-PR version-bump enforcement + strict next→main promotion (amends 0025 §D6) | Accepted (0.8.0, #352) | `chore/version-bump-gate` | maintainer review 2026-06-24 (0.7.1 vanishing) |
+| 0034 | arXiv source bundle + individual figure download | Accepted (0.8.0, #352) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
+| 0035 | `fetch --link`: surface fetched artifacts into the working tree | Accepted (0.8.0, #352) | `feat/344-fetch-link` | #344 / dogfood 2026-06-24 |
+| 0036 | Default store root → `./papers` (cwd); amends 0004 co-location | Accepted (0.8.0, #352) | `feat/344-default-store-cwd` | #344 problem 1 / dogfood 2026-06-24 |
 
 ## Conventions
 


### PR DESCRIPTION
The **0.8.0 release cut**: strips the beta off `next` so the `next → main`
promotion (#352) can carry a clean `0.8.0`. Merge this first, then #352.

## Contents (`0819cd3`)
- `Cargo.toml` + `Cargo.lock`: `0.8.0-beta.8 → 0.8.0`.
- `CHANGELOG.md`: curated `## [0.8.0]` summary (per-change beta detail kept below).
- ADR-0033 / 0034 / 0035 / 0036: `Proposed → Accepted` (+ `DECISIONS/INDEX.md`).
- No code touched → no `site/content` re-sync needed.

## ⚠️ `version-bump` check will be RED here — expected
The ADR-0033 gate requires a **beta** version for any PR→`next`:

> `version-bump: a PR to 'next' must carry a beta version X.Y.Z-beta.N; got '0.8.0'`

A clean `X.Y.Z` is only valid on a `next → main` promotion, never on a normal
PR→`next`. This release-cut PR is the **one deliberate clean-version exception**
— there is no gated path to land the beta-strip on `next`, so merging this is
the manual release cut. (If `version-bump` is a required check on `next`, it
needs an admin override / a release-cut carve-out.)

## Verified locally
- `release-version-gate.sh v0.8.0`: **G0–G6 PASS** (CHANGELOG `## [0.8.0]`
  non-empty, `Cargo.lock` in sync, `0.8.0` unpublished on crates.io).
- After merge, `next` = `0.8.0` → #352's `version-bump` (promotion) flips to
  **green** (`0.7.0 → 0.8.0`, +1 minor).

## Sequence
1. Merge **this** → `next` (`next` becomes `0.8.0`).
2. Merge **#352** (`next → main`) → `main` becomes `0.8.0`.
3. Push the **signed `v0.8.0` tag** on `main` → release-plz publishes to
   crates.io (your manual step — I won't tag).